### PR TITLE
ref(kb): drop the dead legacy cleanup-cascade helper (#715)

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/version_management/promote_version_main.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/promote_version_main.py
@@ -6,14 +6,9 @@ to main versions with cascade cleanup.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
-from ..core.exceptions import VersionManagementError
 from ..core.schemas import StepType
-from .cascade_cleaner import _cleanup_cascade_impl as cleanup_cascade
-
-logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ..kb import KBVersionCompatibilityFacade
@@ -23,70 +18,6 @@ def _get_version_compatibility_facade() -> "KBVersionCompatibilityFacade":
     from ..kb import get_kb_coordinator
 
     return get_kb_coordinator().version_compatibility
-
-
-def _call_cleanup_cascade(
-    collection: str,
-    doc_id: str,
-    step_type: StepType,
-    technical_id: str,
-    old_technical_id: Optional[str] = None,
-    model_tag: Optional[str] = None,
-    preview_only: bool = True,
-    confirm: bool = False,
-) -> Dict[str, Any]:
-    """
-    Helper to call cleanup_cascade to compute deleted counts or execute cleanup.
-
-    Args:
-        collection: Collection name
-        doc_id: Document ID
-        step_type: Processing stage type
-        technical_id: Technical ID of the new main version
-        old_technical_id: Technical ID of the old main version (if exists)
-        model_tag: Model tag for embed step type
-        preview_only: If True, only return preview without executing
-        confirm: If True, execute the promotion
-
-    Returns:
-        Dictionary of deleted counts
-    """
-    if step_type == StepType.PARSE:
-        return cleanup_cascade(
-            collection=collection,
-            doc_id=doc_id,
-            scope="parse",
-            new_parse_hash=technical_id,
-            old_parse_hash=old_technical_id,
-            preview_only=preview_only,
-            confirm=confirm,
-        )
-    elif step_type == StepType.CHUNK:
-        return cleanup_cascade(
-            collection=collection,
-            doc_id=doc_id,
-            scope="chunk",
-            new_parse_hash=technical_id,
-            old_parse_hash=old_technical_id,
-            preview_only=preview_only,
-            confirm=confirm,
-        )
-    elif step_type == StepType.EMBED:
-        if not model_tag:
-            raise VersionManagementError("model_tag is required for embed step")
-        return cleanup_cascade(
-            collection=collection,
-            doc_id=doc_id,
-            scope="embeddings",
-            model_tag=model_tag,
-            preview_only=preview_only,
-            confirm=confirm,
-        )
-    else:
-        step_type_str = (
-            step_type.value if isinstance(step_type, StepType) else str(step_type)
-        )
-        raise VersionManagementError(f"Invalid step_type: {step_type_str}")
 
 
 def promote_version_main(

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_handle_version.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_handle_version.py
@@ -16,6 +16,8 @@ from typing import Any, Dict, List, Optional
 
 import pytest
 
+from xagent.core.tools.core.RAG_tools.core.exceptions import VersionManagementError
+from xagent.core.tools.core.RAG_tools.core.schemas import StepType
 from xagent.core.tools.core.RAG_tools.kb.collection_handle import (
     LanceDBCollectionHandle,
 )
@@ -594,6 +596,9 @@ class _FakeVectorIndexStoreWithCleanup(_FakeVectorIndexStore):
             "scope": scope,
             "is_admin": is_admin,
             "user_id": user_id,
+            "new_parse_hash": new_parse_hash,
+            "old_parse_hash": old_parse_hash,
+            "model_tag": model_tag,
         }
         return dict(self.cleanup_return)
 
@@ -700,6 +705,69 @@ class TestCleanupCascadeHandle:
         )
         assert fake_vis.last_cleanup_args is not None
         assert fake_vis.last_cleanup_args["scope"] == "chunk"
+
+    # ── _call_cleanup_cascade_for_step: the step_type → scope mapping ─────────
+    # Nothing executed this helper before: promote_version_main's own tests
+    # patch it out, and the cleanup_*_cascade tests above go in one level down.
+
+    @pytest.mark.parametrize(
+        ("step_type", "expected_scope"),
+        [(StepType.PARSE, "parse"), (StepType.CHUNK, "chunk")],
+    )
+    def test_cascade_for_step_maps_step_type_to_scope(
+        self, step_type: StepType, expected_scope: str
+    ) -> None:
+        """parse/chunk steps route to their scope and carry both hashes."""
+        handle, fake_vis = make_handle_with_cleanup_store("step_scope_coll")
+
+        handle._call_cleanup_cascade_for_step(
+            "doc1",
+            step_type,
+            technical_id="newhash",
+            old_technical_id="oldhash",
+            preview_only=True,
+        )
+
+        assert fake_vis.last_cleanup_args is not None
+        assert fake_vis.last_cleanup_args["scope"] == expected_scope
+        assert fake_vis.last_cleanup_args["new_parse_hash"] == "newhash"
+        assert fake_vis.last_cleanup_args["old_parse_hash"] == "oldhash"
+
+    def test_cascade_for_step_embed_passes_model_tag(self) -> None:
+        """The embed step routes to the embeddings scope and forwards model_tag."""
+        handle, fake_vis = make_handle_with_cleanup_store("step_embed_coll")
+
+        handle._call_cleanup_cascade_for_step(
+            "doc1",
+            StepType.EMBED,
+            technical_id="embed-hash",
+            model_tag="bge_large",
+            preview_only=True,
+        )
+
+        assert fake_vis.last_cleanup_args is not None
+        assert fake_vis.last_cleanup_args["scope"] == "embeddings"
+        assert fake_vis.last_cleanup_args["model_tag"] == "bge_large"
+
+    def test_cascade_for_step_embed_without_model_tag_raises(self) -> None:
+        """Embed cleanup cannot pick a table without a model tag."""
+        handle, fake_vis = make_handle_with_cleanup_store("step_embed_bad_coll")
+
+        with pytest.raises(VersionManagementError, match="model_tag is required"):
+            handle._call_cleanup_cascade_for_step(
+                "doc1", StepType.EMBED, technical_id="embed-hash"
+            )
+
+        assert fake_vis.last_cleanup_args is None, "no cleanup may be attempted"
+
+    def test_cascade_for_step_rejects_unknown_step_type(self) -> None:
+        """An unmapped step_type is refused, and names itself in the error."""
+        handle, fake_vis = make_handle_with_cleanup_store("step_bad_coll")
+
+        with pytest.raises(VersionManagementError, match="Invalid step_type: bogus"):
+            handle._call_cleanup_cascade_for_step("doc1", "bogus", technical_id="hash")
+
+        assert fake_vis.last_cleanup_args is None, "no cleanup may be attempted"
 
 
 # ── Task 6: promote_version_main handle tests ─────────────────────────────────

--- a/tests/core/tools/core/RAG_tools/version_management/test_promote_version_main.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_promote_version_main.py
@@ -494,38 +494,6 @@ class TestPromoteVersionMain:
                 assert result["main_pointer"]["model_tag"] == "bge_large"
                 assert result["main_pointer"]["technical_id"] == "parse_hash1"
 
-    def test_embed_cleanup_uses_embeddings_scope(self):
-        """Embed promotion cleanup passes the cleaner-supported embeddings scope."""
-        import importlib
-
-        promote_version_main_module = importlib.import_module(
-            "xagent.core.tools.core.RAG_tools.version_management.promote_version_main"
-        )
-        mock_cleanup_cascade = MagicMock(return_value={"embeddings": 3})
-
-        with patch.object(
-            promote_version_main_module, "cleanup_cascade", mock_cleanup_cascade
-        ):
-            result = promote_version_main_module._call_cleanup_cascade(
-                collection="test_collection",
-                doc_id="test_doc",
-                step_type=StepType.EMBED,
-                technical_id="embed-hash",
-                model_tag="bge_large",
-                preview_only=False,
-                confirm=True,
-            )
-
-        assert result == {"embeddings": 3}
-        mock_cleanup_cascade.assert_called_once_with(
-            collection="test_collection",
-            doc_id="test_doc",
-            scope="embeddings",
-            model_tag="bge_large",
-            preview_only=False,
-            confirm=True,
-        )
-
     def test_wraps_unexpected_exceptions(self):
         """Test that unexpected exceptions are wrapped in VersionManagementError.
 


### PR DESCRIPTION
## Invariant

No cascade-cleanup implementation remains in `version_management/` without a production caller.

## Background

H08 (`627248bd`) removed `_list_candidates_impl` and `_promote_version_main_impl` along with their fallback chains, but left `_call_cleanup_cascade` behind. It has zero production callers — the only thing keeping it alive was a test written specifically to exercise it, and a test does not constitute a requirement.

The live equivalent is `collection_handle._call_cleanup_cascade_for_step`, which matches it one-for-one: parse/chunk/embed → scope mapping, `model_tag` required for embed, and an error on any other step type.

That helper had **no** test executing it — `promote_version_main`'s own tests patch it out, and the `cleanup_*_cascade` tests sit one level below it — so this PR adds direct coverage for the mapping and both error branches (`test_collection_handle_version.py::TestCleanupCascadeHandle`). Verified by mutation: deleting the `model_tag` guard fails `test_cascade_for_step_embed_without_model_tag_raises`, and replacing the invalid-step-type raise with a silent `return {}` fails `test_cascade_for_step_rejects_unknown_step_type`. The fake cleanup store now also records the hashes and `model_tag` it receives, so forwarding is asserted rather than assumed.

## Entry points

None. This is a pure deletion with no behavior change.

## Not included

- The 11 remaining `coordinator is not None` → legacy `_impl` fallbacks in `KBVersionCompatibilityFacade` (main-pointer and cascade-cleaner families). #715 scopes itself to "the now-unused `coordinator is None` fallbacks **that import them**", where *them* means the two impls H08 already deleted. Those other fallbacks belong to different #494 slices.
- `cascade_cleaner._cleanup_cascade_impl` itself, still used by `kb/version_compatibility.py:423`.

## Change breakdown

Source −69, tests −32 for the removed legacy test, +68 for the new handle coverage. `StepType` is kept — `promote_version_main`'s own signature still uses it.

## Validation

- `RAG_tools/version_management`, `RAG_tools/kb`, `RAG_tools/storage` suites all pass.
- `pre-commit run --files` clean across every hook (ruff check, ruff format, mypy, isort, codespell, end-of-file-fixer, trailing-whitespace).

Closes #715
