### PR TITLE
fix(web): report a mismatched checkpoint run tag as its own anchor failure reason

### DIFF
--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -57,7 +57,11 @@ INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED = (
 # identity checks that make it a valid anchor -- with one shape excluded: a
 # row that fails only the partition check, and only because the field is
 # absent, is a pre-existing row rather than a corrupt one and increments a
-# counter instead (see that resolver's own judgment table). Deliberately not
+# counter instead (see that resolver's own judgment table). A second shape
+# narrows the reason without excluding it: a row that fails only the
+# partition check because the field names a different run still registers
+# this same signal, carrying its own detail string distinct from the
+# generic corrupt one (also in that judgment table). Deliberately not
 # paired with a clear site, the same reasoning as INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE
 # above: a corrupt anchor is a property of a persisted trace_events row, and
 # no in-process registry can observe that row being fixed. Auto-clearing

--- a/src/xagent/web/services/task_interaction_anchor.py
+++ b/src/xagent/web/services/task_interaction_anchor.py
@@ -41,7 +41,9 @@ Three of the six outcomes above increment a counter
 ``COUNTER_ANCHOR_ABSENT_LEGACY_CHECKPOINT_TYPE`` for step 5;
 ``interaction_rollout.py``). Step 4's true-corrupt path has no counter; it
 registers ``INTERACTION_ANCHOR_CORRUPT``, an ops degradation signal rather
-than a rate metric -- see that signal's own paragraph below. Step 4's
+than a rate metric, now covering two distinct reasons under the same
+signal name -- the generic corrupt verdict and the narrower
+mismatched-run-tag one -- see that signal's own paragraph below. Step 4's
 other path, the missing-run-partition reclassification described above,
 does increment a counter: the same ``COUNTER_ANCHOR_ABSENT_LEGACY_CHECKPOINT_TYPE``
 step 5 uses when the row's ``checkpoint_type`` is a legacy one (both
@@ -185,24 +187,47 @@ cautious. The single statement that writes a checkpoint pointer carries
 a ``Task.run_id`` equality condition, and the row's run tag is stamped
 from the same lease (``stage_trace_event_row``,
 ``trace_event_staging.py``), so pointer and tag agree at the moment the
-pointer is written; every writer that mints a different non-null run id
-clears both pointer columns in the same statement. What can still reach
-this branch is a pointer into another task's row (which fails ownership
-too, and reports the generic reason instead), a hand-edited or
-mis-migrated row, or a future checkpoint writer that bypasses
-``stage_trace_event_row`` -- each of those is genuinely inconsistent
-data, not a timing artifact, which is why this reports an alarm with a
-specific reason rather than a quiet retry.
+pointer is written. Not every writer that later mints a new run id
+clears both pointer columns in that same statement, though:
+``apply_task_control_transition`` (``task_execution_controller.py``)
+mints a fresh ``run_id`` whenever the task's current one reads
+``None`` -- reached from resume handling in both
+``task_interaction_service.py`` and ``websocket.py`` -- without
+touching either pointer column at all. ``websocket.py``'s own resume
+call site leaves the pointer in place on purpose there, because it is
+the anchor the resume means to read from; what changes underneath it
+is the run id the pointer is now compared against. What can reach this
+branch, then, is not only a hand-edited or mis-migrated row: it is
+also that ordinary resume; the 2026-08 migration's backfill UPDATE
+(``src/xagent/migrations/versions/20260804_add_task_checkpoint_trace_event_anchor.py``),
+which fills ``last_checkpoint_trace_event_id`` from a task's legacy
+event-id column with no run-partition condition of its own; a pointer
+into another task's row (which fails ownership too, and reports the
+generic reason instead); a hand-edited row; or a future checkpoint
+writer that bypasses ``stage_trace_event_row``.
+
+This still reports an alarm rather than a quiet retry, because none of
+those paths make the row itself wrong: the row is self-consistent, it
+simply names a run other than the task's current one, and this
+resolver has no re-probe to defer that verdict to. The read
+direction's own boundary re-probe (described above) only re-checks a
+verdict reached while holding a *widened* partition; this resolver
+never resolves or holds one, so there is no stale widening decision
+here to wait out. Registering the alarm rather than retrying also
+surfaces how often this path is actually taken:
+``INTERACTION_ANCHOR_CORRUPT`` is an ops degradation signal, not a
+rate metric, precisely so a nonzero rate here is visible on
+``/health`` instead of disappearing into a retry loop.
 
 Reporting a specific alarm here instead of a retryable outcome rests on
 one precondition this function does not itself enforce: callers must
 hold a lock on the task row they pass in, so the run identity read at
 step 4 cannot change out from under the comparison. A caller that does
 not hold that lock could be comparing against a run identity that has
-already moved on, which would make the "genuinely inconsistent" reading
-above unsound for it. This is written as a precondition rather than an
-observed fact because this resolver has no production caller yet to
-check it against.
+already moved on, which would make the "self-consistent, wrong run"
+reading above stale rather than sound. This is written as a
+precondition rather than an observed fact because this resolver has no
+production caller yet to check it against.
 
 ``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED`` (``ops_signals.py``) is a
 signal owned by ``interaction_handoff``, not by this function: it is

--- a/src/xagent/web/services/task_interaction_anchor.py
+++ b/src/xagent/web/services/task_interaction_anchor.py
@@ -220,11 +220,8 @@ run identity changed between resolution and staging.
 
 Zero production callers as of this module's introduction: a static test
 (``tests/web/services/test_task_interaction_anchor.py``) asserts that no
-production module calls ``resolve_interaction_anchor``, mirroring the
-existing gate for ``task_interaction_staging.py``'s two entry points
-without extending that gate itself -- this module is not one of the two
-names it scans for. See that test's own docstring for the removal
-condition.
+production module calls ``resolve_interaction_anchor``. See that test's
+own docstring for the removal condition.
 
 Two kinds of pre-existing row are missing the run-partition field and so
 fail the run-partition self-consistency check, though neither one

--- a/src/xagent/web/services/task_interaction_anchor.py
+++ b/src/xagent/web/services/task_interaction_anchor.py
@@ -106,11 +106,12 @@ the right verdict for it depends on the ordering defect tracked in
 #2023. #2023 converges the three; this module and lease recovery do not
 wait on it.
 
-Why the write side does not widen step 5 to accept an absent run field the
-way the read side's boundary re-probe does is itself worth writing down,
-not just the fact that the two disagree. The anchor this function stages
-carries ``resume_run_partition=str(task.run_id)`` -- the task's ``run_id``,
-never the checkpoint row's own run field. The interaction table's
+Why step 4's reclassification treats a missing run-partition field as
+absence rather than widening it into a resolved anchor is itself worth
+writing down, not just the fact that this function stops there. The
+anchor this function stages carries
+``resume_run_partition=str(task.run_id)`` -- the task's ``run_id``, never
+the checkpoint row's own run field. The interaction table's
 ``resume_run_partition`` column is ``nullable=False`` and carries a
 ``<> ''`` CHECK (``ck_task_interaction_requests_resume_run_partition_nonempty``,
 ``models/task_interaction.py``), so every row this function stages persists
@@ -119,12 +120,12 @@ that value non-null. The read direction, ``_resolve_read_direction_anchor``
 against the trace row's *own* run field; a row with no run field at all has
 nothing to compare against but ``None``, which never equals a non-null
 stored value, so the read side classifies that row ``anchor_dangling``.
-Widening step 5 here would therefore not make that class of task
-answerable: every anchor it staged for such a row would read back
-``anchor_dangling``, land in the unanswerable tier, and project the
-question text without its response controls -- the task would move from
-resolving through the legacy transcript path today to displaying a
-question nobody can answer.
+Staging an anchor for this row shape instead of treating it as absence
+would therefore not make that class of task answerable: every anchor
+staged for such a row would read back ``anchor_dangling``, land in the
+unanswerable tier, and project the question text without its response
+controls -- the task would move from resolving through the legacy
+transcript path today to displaying a question nobody can answer.
 
 Today, a row missing the run-partition field classifies as absence, not
 corrupt (step 4's reclassification above), incrementing
@@ -138,12 +139,12 @@ has a real cost, not none: a waiting task whose only checkpoint predates
 the run-partition field is never materialized into a structured
 interaction through this path. Materializing that class of task is a
 separate matter (#1078), not this one. Making both sides agree on the same
-row would require changing both at once: the read side's own comparison
-(which is against the non-null value stored on the interaction row, not
-against a task's possibly-null ``run_id``) and the boundary re-probe step
-it runs that this function has no equivalent of -- changing only one side
-always leaves some rows this function stages unresolvable on the other's
-next read.
+row would require changing the read side's own comparison too, not this
+function alone -- it is against the non-null value stored on the
+interaction row, not against a task's possibly-null ``run_id``. Staging a
+wider anchor here without also changing that comparison always leaves
+some rows this function stages unresolvable on the read side's next
+read.
 
 ``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED`` (``ops_signals.py``) is a
 signal owned by ``interaction_handoff``, not by this function: it is

--- a/src/xagent/web/services/task_interaction_anchor.py
+++ b/src/xagent/web/services/task_interaction_anchor.py
@@ -225,6 +225,7 @@ from .ops_signals import INTERACTION_ANCHOR_CORRUPT, register_degradation
 from .task_interaction_staging import InteractionAnchor
 from .trace_event_staging import (
     failed_checkpoint_row_conditions,
+    is_mismatched_run_partition_only,
     is_missing_run_partition_only,
 )
 
@@ -349,6 +350,16 @@ def resolve_interaction_anchor(db: Session, task: Task) -> InteractionAnchor | N
         execution_id=execution_id,
     )
     if failed:
+        # A narrower question is asked before falling through to the
+        # generic corrupt verdict: is the run-partition match the only
+        # failed condition, and if so, did it fail because the field is
+        # absent (a pre-existing row) or because it names a different run
+        # (a checkpoint written under another run)? The two predicates are
+        # mutually exclusive by construction (see each one's own
+        # docstring, trace_event_staging.py), so this is not a priority
+        # order between competing answers -- but the mismatched-partition
+        # branch must still run before the final generic-corrupt fallback,
+        # or its dedicated reason would never be reached.
         if is_missing_run_partition_only(failed, row_data):
             row_checkpoint_type = row_data.get("checkpoint_type")
             if row_checkpoint_type in LEGACY_CHECKPOINT_TYPES:
@@ -371,6 +382,20 @@ def resolve_interaction_anchor(db: Session, task: Task) -> InteractionAnchor | N
                     pointer_id,
                 )
                 increment_counter(COUNTER_ANCHOR_ABSENT_MISSING_RUN_PARTITION)
+            return None
+        if is_mismatched_run_partition_only(failed, row_data):
+            register_degradation(
+                INTERACTION_ANCHOR_CORRUPT,
+                f"task {task.id}: checkpoint pointer {pointer_id} names a "
+                "checkpoint written under a different run than this "
+                "task's current run",
+            )
+            logger.error(
+                "task %s's checkpoint pointer %s names a checkpoint from "
+                "another run; no interaction anchor to resolve",
+                task.id,
+                pointer_id,
+            )
             return None
         register_degradation(
             INTERACTION_ANCHOR_CORRUPT,

--- a/src/xagent/web/services/task_interaction_anchor.py
+++ b/src/xagent/web/services/task_interaction_anchor.py
@@ -14,13 +14,22 @@ not an implementation detail (see the corrupt-before-legacy note below):
 3. the pointer names no live ``trace_events`` row -> unavailable, reported
    to the caller as absence (see below for why).
 4. the row exists but fails any of six self-consistency conditions ->
-   corrupt, unless the only condition it fails is the run-partition match
-   and its run field is absent entirely rather than merely mismatched --
-   that shape reclassifies as absence, not corrupt. That check is not a
-   second copy of the conditions: it reads the set of failed condition
-   names this table's own predicate returns, and asks whether that set is
-   exactly {run partition} and the field is absent
-   (``is_missing_run_partition_only``, ``trace_event_staging.py``).
+   corrupt, with two narrower questions asked first. If the only
+   condition it fails is the run-partition match and its run field is
+   absent entirely rather than merely mismatched, that shape reclassifies
+   as absence, not corrupt
+   (``is_missing_run_partition_only``, ``trace_event_staging.py``). If
+   the only condition it fails is the run-partition match and its run
+   field instead names a *different* run, that shape still reports no
+   anchor, but with its own reason -- a checkpoint written under another
+   run -- rather than the generic corrupt reason
+   (``is_mismatched_run_partition_only``, ``trace_event_staging.py``).
+   Neither check is a second copy of the conditions: both read the set of
+   failed condition names this table's own predicate returns and ask
+   whether that set is exactly {run partition}, differing only in
+   whether the field reads as absent or as present with the wrong value.
+   Any other failure, alone or in combination, reports the generic
+   corrupt reason.
 5. the row passes all six conditions but its ``checkpoint_type`` is a
    legacy type -> absence, not corrupt.
 6. the row passes all six conditions and its ``checkpoint_type`` is the
@@ -145,6 +154,55 @@ interaction row, not against a task's possibly-null ``run_id``. Staging a
 wider anchor here without also changing that comparison always leaves
 some rows this function stages unresolvable on the read side's next
 read.
+
+A row whose only failed condition is the run-partition match, but whose
+run field names a *different* run rather than reading as absent, is not
+the same pre-existing shape described above. Its outcome is still "no
+anchor, nothing published this round" -- the same ``None`` this
+function returns for every other failure -- only the reported reason
+changes: ``is_mismatched_run_partition_only``
+(``trace_event_staging.py``) answers this narrower question the way
+``is_missing_run_partition_only`` answers the absent-field one, and step
+4's true-corrupt path still registers ``INTERACTION_ANCHOR_CORRUPT`` for
+it, carrying its own detail string and its own log line rather than the
+generic one. This changes the classification, not the retryability:
+nothing this function reports comes with a "retry" outcome to attach it
+to.
+
+This resolver does not adopt the read direction's re-probe for that
+shape, because the re-probe answers a question this resolver never
+asks. The read side's re-probe runs only while a read holds a *widened*
+partition (``DatabaseTraceHandler._root_checkpoint_read_partition`` can
+be ``None``, ``trace_handlers.py``), and it asks whether the snapshot
+that widening decision was based on has since gone stale. This resolver
+never resolves a partition and never holds a widened one, so that
+question has no subject here; and its own contract has nowhere for a
+retryable outcome to go, since returning ``None`` already means the
+caller publishes nothing this round.
+
+Keeping an alarm for a mismatched run tag is deliberate, not merely
+cautious. The single statement that writes a checkpoint pointer carries
+a ``Task.run_id`` equality condition, and the row's run tag is stamped
+from the same lease (``stage_trace_event_row``,
+``trace_event_staging.py``), so pointer and tag agree at the moment the
+pointer is written; every writer that mints a different non-null run id
+clears both pointer columns in the same statement. What can still reach
+this branch is a pointer into another task's row (which fails ownership
+too, and reports the generic reason instead), a hand-edited or
+mis-migrated row, or a future checkpoint writer that bypasses
+``stage_trace_event_row`` -- each of those is genuinely inconsistent
+data, not a timing artifact, which is why this reports an alarm with a
+specific reason rather than a quiet retry.
+
+Reporting a specific alarm here instead of a retryable outcome rests on
+one precondition this function does not itself enforce: callers must
+hold a lock on the task row they pass in, so the run identity read at
+step 4 cannot change out from under the comparison. A caller that does
+not hold that lock could be comparing against a run identity that has
+already moved on, which would make the "genuinely inconsistent" reading
+above unsound for it. This is written as a precondition rather than an
+observed fact because this resolver has no production caller yet to
+check it against.
 
 ``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED`` (``ops_signals.py``) is a
 signal owned by ``interaction_handoff``, not by this function: it is
@@ -273,8 +331,15 @@ def resolve_interaction_anchor(db: Session, task: Task) -> InteractionAnchor | N
        checkpoint now exists, because a row and its tag are written
        together and that combination therefore means its partition
        decision went stale, not that the data is inconsistent. This
-       resolver has no such step. Aligning the two is #2122; this resolver
-       has no production callers today, so the divergence has no live
+       resolver has no such step, and neither divergence is reconciled:
+       the two sides do not share partition semantics, and that is
+       deliberate for the reasons the module docstring's own paragraphs
+       on this resolver's partition judgment give. A row whose run field
+       names a different run than ``task.run_id`` reports its own reason
+       rather than the generic corrupt one; a row whose run field is
+       absent reports absence; every other failed condition, alone or
+       combined, still reports the generic corrupt reason. This resolver
+       has no production callers today, so neither divergence has a live
        impact yet.
     6. ``row_execution_id and row_execution_id != execution_id`` --
        execution identity mismatch. An empty ``row_execution_id`` (a legacy
@@ -303,14 +368,23 @@ def resolve_interaction_anchor(db: Session, task: Task) -> InteractionAnchor | N
     (``ck_task_interaction_requests_resume_execution_id_nonempty``,
     ``models/task_interaction.py``) that must never be empty.
 
-    When any condition fails, the body asks a narrower question before
-    deciding the row is corrupt: is the run-partition match the only failed
-    condition, and did it fail because the row's run field is absent rather
-    than wrong? ``is_missing_run_partition_only`` (``trace_event_staging.py``)
-    answers it from the same failure set. A row of that shape is a
-    pre-existing row whose checkpoint predates the run-partition field (see
-    the module docstring's paragraph on the two kinds), not a corrupt one,
-    and is reclassified as absence instead.
+    When any condition fails, the body asks two narrower questions before
+    falling through to the generic corrupt verdict, both answered from the
+    same failure set. First: is the run-partition match the only failed
+    condition, and did it fail because the row's run field is absent
+    rather than wrong? ``is_missing_run_partition_only``
+    (``trace_event_staging.py``) answers it. A row of that shape is a
+    pre-existing row whose checkpoint predates the run-partition field
+    (see the module docstring's paragraph on the two kinds), not a corrupt
+    one, and is reclassified as absence instead. Second, only reached when
+    the first answers no: is the run-partition match still the only
+    failed condition, but this time because the field names a *different*
+    run? ``is_mismatched_run_partition_only`` (``trace_event_staging.py``)
+    answers it. A row of that shape still reports no anchor, but with its
+    own reason rather than the generic corrupt one (see the module
+    docstring's paragraph on why that reason is kept, and why it is not
+    treated as retryable the way the read direction's re-probe treats a
+    stale widening decision).
     """
 
     if task.run_id is None:

--- a/src/xagent/web/services/task_interaction_anchor.py
+++ b/src/xagent/web/services/task_interaction_anchor.py
@@ -106,6 +106,45 @@ the right verdict for it depends on the ordering defect tracked in
 #2023. #2023 converges the three; this module and lease recovery do not
 wait on it.
 
+Why the write side does not widen step 5 to accept an absent run field the
+way the read side's boundary re-probe does is itself worth writing down,
+not just the fact that the two disagree. The anchor this function stages
+carries ``resume_run_partition=str(task.run_id)`` -- the task's ``run_id``,
+never the checkpoint row's own run field. The interaction table's
+``resume_run_partition`` column is ``nullable=False`` and carries a
+``<> ''`` CHECK (``ck_task_interaction_requests_resume_run_partition_nonempty``,
+``models/task_interaction.py``), so every row this function stages persists
+that value non-null. The read direction, ``_resolve_read_direction_anchor``
+(``task_interaction_service.py``), then compares that stored non-null value
+against the trace row's *own* run field; a row with no run field at all has
+nothing to compare against but ``None``, which never equals a non-null
+stored value, so the read side classifies that row ``anchor_dangling``.
+Widening step 5 here would therefore not make that class of task
+answerable: every anchor it staged for such a row would read back
+``anchor_dangling``, land in the unanswerable tier, and project the
+question text without its response controls -- the task would move from
+resolving through the legacy transcript path today to displaying a
+question nobody can answer.
+
+Today, a row missing the run-partition field classifies as absence, not
+corrupt (step 4's reclassification above), incrementing
+``COUNTER_ANCHOR_ABSENT_MISSING_RUN_PARTITION`` for a current-type row or
+``COUNTER_ANCHOR_ABSENT_LEGACY_CHECKPOINT_TYPE`` for a legacy-type one,
+alongside an info log -- pinned by
+``test_current_type_row_without_run_partition_field_classifies_absence``
+and ``test_legacy_type_row_without_run_partition_field_classifies_absence``
+(``tests/web/services/test_task_interaction_anchor.py``). Leaving it there
+has a real cost, not none: a waiting task whose only checkpoint predates
+the run-partition field is never materialized into a structured
+interaction through this path. Materializing that class of task is a
+separate matter (#1078), not this one. Making both sides agree on the same
+row would require changing both at once: the read side's own comparison
+(which is against the non-null value stored on the interaction row, not
+against a task's possibly-null ``run_id``) and the boundary re-probe step
+it runs that this function has no equivalent of -- changing only one side
+always leaves some rows this function stages unresolvable on the other's
+next read.
+
 ``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED`` (``ops_signals.py``) is a
 signal owned by ``interaction_handoff``, not by this function: it is
 registered when that context manager swallows

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -2249,6 +2249,21 @@ def _resolve_read_direction_anchor(
     ``CHECKPOINT_PK_ANCHOR_DANGLING`` -- that constant's registration in
     this module describes only the read direction; the two sides do not
     share a signal budget any more than they share a resolver.
+
+    The same divergence has a second half, on a row missing its run field
+    entirely rather than merely carrying a different one. The partition
+    comparison noted above already reads the stored, always non-null
+    ``resume_run_partition`` against the trace row's own run field, not a
+    task's possibly-null ``run_id``; when that field is absent altogether
+    the comparison still runs, and an absent field never equals a non-null
+    stored value, so this resolver reports ``anchor_dangling`` for every
+    such row. This is exactly why the write-direction resolver
+    (``resolve_interaction_anchor``, ``task_interaction_anchor.py``)
+    deliberately does not widen its own judgment of the same row shape:
+    doing so would only stage anchors this resolver then rejects on the
+    next read as ``anchor_dangling``, not anchors it could resolve.
+    Unifying the two would require changing both sides together, not one
+    alone -- see that resolver's own docstring for the full account.
     """
 
     if row.resume_trace_event_id is None:

--- a/src/xagent/web/services/trace_event_staging.py
+++ b/src/xagent/web/services/trace_event_staging.py
@@ -360,7 +360,10 @@ def is_missing_run_partition_only(
     Both conditions are load-bearing. Dropping the "only" makes a row that
     is wrong in some other way as well look pre-existing; dropping the
     "absent" makes a row carrying a genuinely wrong partition look
-    pre-existing. Each has its own test.
+    pre-existing. Each has its own test. ``is_mismatched_run_partition_only``
+    below answers the complementary question -- the run field present but
+    wrong, rather than absent -- within the same ``{run partition}``-only
+    failure set.
 
     ``failed`` must be the result of ``failed_checkpoint_row_conditions``
     called on this same ``row_data``; nothing in the signature enforces that
@@ -371,4 +374,34 @@ def is_missing_run_partition_only(
 
     return failed == {CHECKPOINT_ROW_RUN_PARTITION} and (
         row_data.get(TASK_RUN_ID_TRACE_FIELD) is None
+    )
+
+
+def is_mismatched_run_partition_only(
+    failed: frozenset[str], row_data: dict[str, Any]
+) -> bool:
+    """True when the only condition ``row_data``'s row failed is the
+    run-partition match, and it failed because the run field holds a
+    different value rather than reading as absent.
+
+    The exact complement of ``is_missing_run_partition_only`` above within
+    ``failed == {CHECKPOINT_ROW_RUN_PARTITION}``: the two are mutually
+    exclusive and together cover every row whose only failed condition is
+    the partition, so a caller that asks both and neither answers true is
+    looking at a row that failed something else as well.
+
+    A row of this shape is not a pre-existing row: the run field was
+    written, and it names a run this row is not being read against.
+    Callers that report an alarm for an inconsistent row and a quiet
+    outcome for a pre-existing one need this half to tell the two apart --
+    the "absent" half above is not the negation of "wrong", because a row
+    failing some *other* condition as well is neither.
+
+    Same pairing requirement as the predicate above: ``failed`` must be the
+    result of ``failed_checkpoint_row_conditions`` called on this same
+    ``row_data``.
+    """
+
+    return failed == {CHECKPOINT_ROW_RUN_PARTITION} and (
+        row_data.get(TASK_RUN_ID_TRACE_FIELD) is not None
     )

--- a/src/xagent/web/services/trace_event_staging.py
+++ b/src/xagent/web/services/trace_event_staging.py
@@ -397,6 +397,12 @@ def is_mismatched_run_partition_only(
     the "absent" half above is not the negation of "wrong", because a row
     failing some *other* condition as well is neither.
 
+    ``is not None`` also counts a falsy-but-present value (``""``, ``0``,
+    ``False``) as mismatched rather than absent, the same way the sibling
+    predicate's ``is None`` would not catch one either. No live writer
+    stores one of those in this field today, so that reading is untested
+    here rather than defended against.
+
     Same pairing requirement as the predicate above: ``failed`` must be the
     result of ``failed_checkpoint_row_conditions`` called on this same
     ``row_data``.

--- a/tests/web/services/test_checkpoint_row_conditions.py
+++ b/tests/web/services/test_checkpoint_row_conditions.py
@@ -26,6 +26,7 @@ from xagent.web.services.trace_event_staging import (
     CHECKPOINT_ROW_RUN_PARTITION,
     CHECKPOINT_ROW_TASK_OWNERSHIP,
     failed_checkpoint_row_conditions,
+    is_mismatched_run_partition_only,
     is_missing_run_partition_only,
 )
 
@@ -200,6 +201,33 @@ def test_explicit_json_null_run_field_reads_as_absent() -> None:
     failed = _failed(_row(), data)
     assert failed == {CHECKPOINT_ROW_RUN_PARTITION}
     assert is_missing_run_partition_only(failed, data) is True
+
+
+def test_only_run_partition_mismatched_is_true_for_the_wrong_value_shape() -> None:
+    data = _data(**{TASK_RUN_ID_TRACE_FIELD: "run-b"})
+    failed = _failed(_row(), data)
+    assert is_mismatched_run_partition_only(failed, data) is True
+
+
+def test_only_run_partition_mismatched_is_false_when_the_field_is_absent() -> None:
+    """The two predicates are mutually exclusive: a row whose run field is
+    absent (rather than merely wrong) answers the "missing" predicate, not
+    this one -- pinned in the same cell so the split cannot drift."""
+
+    data = _data()
+    del data[TASK_RUN_ID_TRACE_FIELD]
+    failed = _failed(_row(), data)
+    assert is_mismatched_run_partition_only(failed, data) is False
+    assert is_missing_run_partition_only(failed, data) is True
+
+
+def test_only_run_partition_mismatched_is_false_when_something_else_also_fails() -> (
+    None
+):
+    row = _row(task_id=_TASK_ID + 1)
+    data = _data(**{TASK_RUN_ID_TRACE_FIELD: "run-b"})
+    failed = _failed(row, data)
+    assert is_mismatched_run_partition_only(failed, data) is False
 
 
 _SHARED_PREDICATE = "failed_checkpoint_row_conditions"

--- a/tests/web/services/test_task_interaction_anchor.py
+++ b/tests/web/services/test_task_interaction_anchor.py
@@ -245,8 +245,12 @@ def test_ta2_dangling_pointer_is_absence_and_counted(
 
 
 # ---------------------------------------------------------------------------
-# The row exists but fails one of six self-consistency conditions ->
-# corrupt. Six parametrized cells, one broken condition each.
+# The row exists but fails one of the self-consistency conditions -> corrupt.
+# Five parametrized cells, one broken condition each. A run-partition break
+# is not one of these cells: a row whose run field names the wrong run has
+# its own cell below (test_ta13), separate from a row whose run field is
+# absent entirely (test_legacy_type_row_without_run_partition_field_...
+# and test_current_type_row_without_run_partition_field_..., further down).
 # ---------------------------------------------------------------------------
 
 _CONDITION_BREAKS: dict[str, dict[str, Any]] = {
@@ -254,7 +258,6 @@ _CONDITION_BREAKS: dict[str, dict[str, Any]] = {
     "event_type": {"event_type": "system_update_partial"},
     "build_partition": {"build_id": "build-x"},
     "checkpoint_type": {"checkpoint_type": "not_a_checkpoint_type"},
-    "run_partition": {"run_partition": "run-b"},
     "execution_identity": {"execution_id": "execution-mismatch"},
 }
 
@@ -289,8 +292,82 @@ def test_ta3_corrupt_conditions(
     assert ir.counters_snapshot() == {}
     # Step 4's judgment-table entry is a logger.error call -- same rationale
     # as the dangling-pointer case's warning pin above, applied uniformly
-    # across all six parametrized conditions since they all fall through
+    # across all five parametrized conditions since they all fall through
     # the same log call site.
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1, caplog.records
+    assert errors[0].msg == "task %s's checkpoint pointer %s failed anchor validation"
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# A row whose only failed condition is the run-partition match, but whose
+# run field names a different run than the task's own, reports its own
+# reason rather than the generic corrupt one used above -- the direct
+# reason resolve_interaction_anchor's write direction keeps for this shape
+# instead of adopting the read direction's retryable re-probe. The outcome
+# is still "no anchor, nothing published this round", three-way mutually
+# exclusive with the missing-field shape (which reclassifies as absence,
+# tested separately below) and the generic corrupt shape (tested above).
+# ---------------------------------------------------------------------------
+
+
+def test_ta13_run_tag_present_but_mismatched_reports_its_own_reason(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(
+        logging.ERROR, logger="xagent.web.services.task_interaction_anchor"
+    )
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    task, _row = _build_scenario(db, run_partition="run-b")
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert ops_signals.INTERACTION_ANCHOR_CORRUPT in ops_signals.active_degradations()
+    # Same signal name as the generic corrupt cells above -- reused, not a
+    # new one -- and still no counter for this outcome.
+    assert ir.counters_snapshot() == {}
+    detail = ops_signals.active_degradations()[ops_signals.INTERACTION_ANCHOR_CORRUPT]
+    assert "a different run" in detail
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1, caplog.records
+    assert errors[0].msg == (
+        "task %s's checkpoint pointer %s names a checkpoint from "
+        "another run; no interaction anchor to resolve"
+    )
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# The dedicated mismatched-run-tag reason above applies only when the run
+# partition is the *sole* failed condition. A row that also fails another
+# condition (here, ownership) still reports the generic corrupt reason --
+# the mirror-image boundary of
+# test_cross_task_row_without_run_partition_field_still_classifies_corrupt
+# below, which pins the same boundary on the missing-field side.
+# ---------------------------------------------------------------------------
+
+
+def test_ta14_any_other_failed_condition_keeps_the_generic_corrupt_reason(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(
+        logging.ERROR, logger="xagent.web.services.task_interaction_anchor"
+    )
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    other = _make_task(db, run_id=None)
+    task, _row = _build_scenario(db, row_task_id=other.id, run_partition="run-b")
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert ops_signals.INTERACTION_ANCHOR_CORRUPT in ops_signals.active_degradations()
+    assert ir.counters_snapshot() == {}
+    detail = ops_signals.active_degradations()[ops_signals.INTERACTION_ANCHOR_CORRUPT]
+    assert "a different run" not in detail
     errors = [r for r in caplog.records if r.levelno == logging.ERROR]
     assert len(errors) == 1, caplog.records
     assert errors[0].msg == "task %s's checkpoint pointer %s failed anchor validation"
@@ -700,6 +777,11 @@ def _outcome_corrupt(db: Session) -> Task:
     return task
 
 
+def _outcome_run_tag_mismatch(db: Session) -> Task:
+    task, _row = _build_scenario(db, run_partition="run-b")
+    return task
+
+
 def _outcome_missing_partition_legacy_type(db: Session) -> Task:
     legacy_type = next(iter(LEGACY_CHECKPOINT_TYPES))
     task, _row = _build_scenario(db, checkpoint_type=legacy_type, run_partition=None)
@@ -734,6 +816,7 @@ _OUTCOME_CELLS: dict[str, tuple[Any, dict[str, int]]] = {
         {ir.COUNTER_ANCHOR_UNAVAILABLE_DANGLING_POINTER: 1},
     ),
     "step4_corrupt": (_outcome_corrupt, {}),
+    "step4d_run_tag_mismatch": (_outcome_run_tag_mismatch, {}),
     "step4b_missing_partition_legacy_type": (
         _outcome_missing_partition_legacy_type,
         {ir.COUNTER_ANCHOR_ABSENT_LEGACY_CHECKPOINT_TYPE: 1},
@@ -759,7 +842,7 @@ def test_ta12_outcome_counter_matrix(tmp_path: Path, outcome: str) -> None:
 
     resolve_interaction_anchor(db, task)
 
-    if outcome == "step4_corrupt":
+    if outcome in {"step4_corrupt", "step4d_run_tag_mismatch"}:
         assert ops_signals.INTERACTION_ANCHOR_CORRUPT in (
             ops_signals.active_degradations()
         )

--- a/tests/web/services/test_task_interaction_anchor.py
+++ b/tests/web/services/test_task_interaction_anchor.py
@@ -375,6 +375,47 @@ def test_ta14_any_other_failed_condition_keeps_the_generic_corrupt_reason(
 
 
 # ---------------------------------------------------------------------------
+# Step 4 (the six self-consistency conditions, including the run-partition
+# match) must run before step 5 (the legacy-checkpoint-type check) even
+# when the row's only failure is the mismatched run tag, not just when it
+# is the missing-field shape -- the module docstring's ordering note
+# ("Step 4 must run before step 5") does not carve out an exception for
+# legacy-type rows on this side either. This cell is the mismatched-run-tag
+# counterpart of that ordering pin.
+# ---------------------------------------------------------------------------
+
+
+def test_ta13b_legacy_checkpoint_type_with_mismatched_run_tag_still_reports_mismatch(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(
+        logging.ERROR, logger="xagent.web.services.task_interaction_anchor"
+    )
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    legacy_type = next(iter(LEGACY_CHECKPOINT_TYPES))
+    task, _row = _build_scenario(db, checkpoint_type=legacy_type, run_partition="run-b")
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert ops_signals.INTERACTION_ANCHOR_CORRUPT in ops_signals.active_degradations()
+    # The legacy-type absence path (step 5) increments a counter; the
+    # mismatched-run-tag path (step 4) does not. If step 5 ran first, this
+    # would read {ir.COUNTER_ANCHOR_ABSENT_LEGACY_CHECKPOINT_TYPE: 1} instead.
+    assert ir.counters_snapshot() == {}
+    detail = ops_signals.active_degradations()[ops_signals.INTERACTION_ANCHOR_CORRUPT]
+    assert "a different run" in detail
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1, caplog.records
+    assert errors[0].msg == (
+        "task %s's checkpoint pointer %s names a checkpoint from "
+        "another run; no interaction anchor to resolve"
+    )
+    db.close()
+
+
+# ---------------------------------------------------------------------------
 # The row's data column holds something other than a dict -- the shape
 # resolve_interaction_anchor's isinstance(row.data, dict) guard exists to
 # handle without raising. A list payload coerces to an empty dict inside

--- a/tests/web/services/test_task_interaction_anchor.py
+++ b/tests/web/services/test_task_interaction_anchor.py
@@ -880,10 +880,14 @@ def _anchor_production_uses(source: str) -> bool:
 
 
 def test_ta11_resolve_interaction_anchor_has_zero_production_callers() -> None:
-    """This is a fresh assertion, not an extension of
-    ``test_interaction_staging_production_gate.py``'s gate: that gate scans
-    only for ``stage_interaction_request`` and ``interaction_handoff`` by
-    name (``GATED_NAMES``), and this function is not one of them.
+    """This is a fresh assertion, not an extension of an existing
+    ``GATED_NAMES``-style production-caller gate: both
+    ``test_task_interaction_service_create_gate.py`` and
+    ``test_clarification_publication_gate.py`` scan for their own
+    module's names only (``create``/``respond`` on
+    ``task_interaction_service``, and the clarification-draft
+    primitives, respectively), and ``resolve_interaction_anchor`` is not
+    one of them.
 
     The zero here is scoped to this module's introduction, not a permanent
     invariant to preserve by construction: the change that wires the first

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -1522,23 +1522,29 @@ def _make_trace_event(
     db: Session,
     *,
     task_id: int,
-    run_partition: str = "run-a",
+    run_partition: str | None = "run-a",
     execution_id: str = "exec-1",
     event_type: str = str(CHECKPOINT_EVENT_TYPE),
     checkpoint_type: str = "agent_execution_checkpoint",
     build_id: str | None = None,
 ) -> int:
+    # ``run_partition=None`` omits the run-field key entirely rather than
+    # writing it as ``None`` -- the two are equivalent under
+    # ``row_data.get(TASK_RUN_ID_TRACE_FIELD)``, but an absent key is the
+    # actual shape a pre-run-partition-field checkpoint row carries.
+    data: dict[str, Any] = {
+        "checkpoint_type": checkpoint_type,
+        "execution_id": execution_id,
+    }
+    if run_partition is not None:
+        data[TASK_RUN_ID_TRACE_FIELD] = run_partition
     event = TraceEvent(
         task_id=task_id,
         event_id=f"trace-event-{task_id}",
         event_type=event_type,
         timestamp=_now(),
         build_id=build_id,
-        data={
-            TASK_RUN_ID_TRACE_FIELD: run_partition,
-            "checkpoint_type": checkpoint_type,
-            "execution_id": execution_id,
-        },
+        data=data,
     )
     db.add(event)
     db.commit()
@@ -2046,6 +2052,30 @@ def test_t3_prime_anchor_dangling_for_each_remaining_validity_condition(
         resume_event_id=resume_event_id,
     )
 
+    view = svc.materialize_compatibility_view(_db, _seeded_task)
+    assert view.tier == "unanswerable"
+    assert view.reason == "anchor_dangling"
+    assert CHECKPOINT_PK_ANCHOR_DANGLING in active_degradations()
+
+
+def test_t3_prime_anchor_dangling_when_the_trace_row_has_no_run_field(
+    _db: Session, _seeded_task: int
+) -> None:
+    """A trace row with no run field at all -- not merely a different one,
+    the shape above already covers that -- paired with the interaction
+    row's stored ``resume_run_partition``, which is non-null by construction
+    (the column is ``nullable=False`` with a ``<> ''`` CHECK). A missing
+    run field never equals a non-null stored value, so this comparison
+    always fails for this shape. This is the concrete row the write
+    direction's resolver (``resolve_interaction_anchor``,
+    ``task_interaction_anchor.py``) does not widen its own judgment to
+    accept: doing so would only stage anchors that read back
+    ``anchor_dangling`` here, not anchors this reader could resolve."""
+
+    trace_event_id = _make_trace_event(_db, task_id=_seeded_task, run_partition=None)
+    _make_active_interaction_row(
+        _db, task_id=_seeded_task, resume_trace_event_id=trace_event_id
+    )
     view = svc.materialize_compatibility_view(_db, _seeded_task)
     assert view.tier == "unanswerable"
     assert view.reason == "anchor_dangling"


### PR DESCRIPTION
## What

`resolve_interaction_anchor` (`task_interaction_anchor.py`) splits step 4 of its
judgment table into three branches instead of two. A pointed-to `trace_events`
row whose only failed condition is the run partition, and that failed because the
row's run field holds a *different* value rather than being absent, now reports
its own reason -- a checkpoint written under another run -- with its own detail
string and its own log line. It keeps the same signal name
(`INTERACTION_ANCHOR_CORRUPT`), the same outcome (no anchor, nothing published
this round) and the same counter panel (none): only the reason an operator reads
changes. The absent-field shape still reclassifies as absence, and every other
failed condition, alone or combined, still reports the generic corrupt reason.

The write direction also keeps its judgment of a row with no run field at all,
and both docstrings now carry the full reason for that, with the read direction's
own half recorded on its side.

One known scope boundary on the shared predicate this builds on: `_BY_PK_RESOLVERS`
in `test_checkpoint_row_conditions.py`, the test that pins both by-primary-key
resolvers to `failed_checkpoint_row_conditions`, covers `_load_pk_anchored_checkpoint`
(`trace_handlers.py`) and `resolve_interaction_anchor` (`task_interaction_anchor.py`)
-- not the third row-validity judgment in the codebase, `_resolve_read_direction_anchor`
(`task_interaction_service.py`), which still hand-rolls its own inline run-partition
comparison. That exclusion is deliberate, not an oversight: `_resolve_read_direction_anchor`
compares the interaction row's own stored `resume_run_partition` against the trace
row's run field, not `task.run_id` against it, so folding it into the shared
predicate would need a seventh condition parameterized on which value it compares
against, not just another caller of the existing six. This PR closes #2122 for the
two by-primary-key resolvers; the third judgment remains its own inline comparison,
tracked as a separate blind spot rather than folded in here.

## Why

Two questions were open about this resolver's partition judgment, and answering
both is what closes the report.

**Should the write direction widen the way the read direction does?** No, and not
as a matter of taste. The anchor this resolver stages carries
`resume_run_partition=str(task.run_id)` -- the task's run id, never the row's own
run field -- and the interaction table's column is `nullable=False` with a
`<> ''` CHECK, so every staged value persists non-null. The read direction then
compares that stored non-null value against the trace row's *own* run field, so a
row with no run field always reads back `anchor_dangling`: it lands in the
unanswerable tier and projects the question text without its response controls.
Widening this side alone would not make that class of task answerable; it would
turn "resolves through the legacy transcript today" into "displays a question
nobody can answer". Unifying the two would mean changing the read direction's
comparison as well, not this resolver alone.

**Should this resolver distinguish a stale partition decision from real
corruption?** It distinguishes the *classification*, not the retryability, and
does not copy the read path's re-probe. That re-probe runs only while the reader
holds a widened partition, and it asks whether the snapshot its widening decision
was based on has gone stale. This resolver never resolves a partition and never
holds a widened one, so that question has no subject here. Nor is there anywhere
for a retryable outcome to go: this resolver's contract is an anchor or `None`,
and `None` means nothing is published this round.

Keeping the alarm for this shape is deliberate, and the reasoning is narrower
than "only inconsistent data can get here". The single statement that writes a
checkpoint pointer carries a `Task.run_id` equality condition, and the row's run
tag is stamped from the same lease, so pointer and tag agree when the pointer is
written. Most writers that mint a different non-null run id clear both pointer
columns in the same statement, but not all of them: `apply_task_control_transition`
mints a fresh run id on resume and leaves the pointer columns untouched, so between
that resume and the new run's first checkpoint write the pointer still names the
previous run's row. This branch is therefore reachable on an ordinary resume, not
only through cross-task pointers, hand-edited rows, or a future writer that bypasses
`stage_trace_event_row`. The alarm is still the right disposition: the row itself
is self-consistent and merely belongs to another run, this resolver never holds a
widened partition so there is no partition decision to re-probe, and a specific
reason makes the real frequency of this path visible instead of hiding it behind
a quiet retry.

**Two corrections to the report itself.** The guard it names,
`test_row_validity_conditions_match_trace_handlers_structurally`, no longer
exists: it was removed together with the extraction of the shared predicate in
#2057. And the two code excerpts it quotes, each side computing its own
`partition_matches`, are not what either side looks like today -- both now call
the one `failed_checkpoint_row_conditions`, so there is only one partition
comparison to compare against itself. What remains of the divergence is which
`run_id` each side passes into that shared predicate, and the read side's extra
re-probe step. That guard is not rebuilt here: the two hand-copied disjunctions it
once compared no longer exist on either side to compare, and what still needs
guarding -- that neither by-primary-key resolver goes back to a private inlined
copy -- is already asserted by
`test_both_by_pk_resolvers_read_the_shared_predicate`. The report's third
suggestion is therefore answered rather than implemented as a new guard. The
remaining asymmetry has two halves, held in two different places: that this
resolver neither resolves a partition nor holds a widened one is recorded in its
own docstring, and the observable consequence of not re-probing -- its own reason,
no anchor, no counter, no retryable outcome -- is asserted by this change's
behavioral tests.

## Verification

- `pytest tests/web/services/test_task_interaction_service.py -q`: 363 tests,
  exit code 0.
- `pytest tests/web/services/test_task_interaction_anchor.py -q`: 30 tests
  (28 before this change, plus the two new cells), exit code 0.
- `pytest tests/web/services/test_checkpoint_row_conditions.py -q`: 22 tests
  (19 before this change, plus the new predicate's three cells), exit code 0.
- `pytest tests/web/test_agent_checkpoint_stream.py -q`: 106 tests, exit code 0.
- `pytest tests/web/services/ -q`: exit code 0.
- Mutation check 1: relaxing the read direction's partition comparison to accept
  an absent run field turns exactly one of the eight `t3_prime` cells red -- the
  new dangling-anchor cell -- and the other seven stay green.
- Mutation check 2: removing the new mismatch branch, so a mismatched run tag
  falls back to the generic corrupt reason, turns exactly one of the 30 cells in
  `test_task_interaction_anchor.py` red -- the new mismatch cell -- and the other
  29 stay green.
- `_BY_PK_RESOLVERS` in `test_checkpoint_row_conditions.py` covers 2 of the 3
  row-validity judgments in the codebase (`_load_pk_anchored_checkpoint`,
  `resolve_interaction_anchor`); `_resolve_read_direction_anchor`
  (`task_interaction_service.py`) is intentionally excluded (see What) and still
  uses its own inline comparison.
- `ruff check` and `ruff format --check` pass on all five changed files.

Closes #2122
