### PR TITLE
fix(web): give create()'s unclassified handoff degradation its own reason word

### DIFF
--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -901,10 +901,18 @@ CreateOutcome = (
     | CreateStale
 )
 
-# The full closed vocabulary create() can ever return a reason from. 12
+# The full closed vocabulary create() can ever return a reason from. 13
 # reasons total (the "Created" / None pair is not a reason string and is
 # counted separately). Do not update this number by recounting the set
 # literal below -- it is pinned as part of the vocabulary's contract.
+#
+# handoff_degraded_unclassified names the case where interaction_handoff
+# swallowed one of its six exceptions but the recorded handoff.degraded_as
+# is neither mapped by _DEGRADED_AS_OUTCOME nor set at all -- an
+# unidentified degradation, not a real conflict. It is kept distinct from
+# slot_taken because "an unrecognized failure happened" and "another
+# requester already won the slot" are different facts, and an operator
+# reading the outcome must be able to tell them apart.
 CREATE_OUTCOME_REASON_WORDS: frozenset[str] = frozenset(
     {
         "unknown_kind",
@@ -919,11 +927,12 @@ CREATE_OUTCOME_REASON_WORDS: frozenset[str] = frozenset(
         "idempotency_key_reused",
         "anchor_dangling",
         "run_ended",
+        "handoff_degraded_unclassified",
     }
 )
 
 # The (outcome type, reason) pairs this function body has a code path that
-# returns. 9 of the 12 words in CREATE_OUTCOME_REASON_WORDS are producible
+# returns. 10 of the 13 words in CREATE_OUTCOME_REASON_WORDS are producible
 # by that definition; the other three (checkpoint_unavailable,
 # anchor_dangling, run_ended) stay in the closed word list without a
 # producing code path here today:
@@ -972,7 +981,9 @@ CREATE_OUTCOME_PRODUCIBLE_REASONS: dict[type, frozenset[str]] = {
     ),
     CreateUnauthorized: frozenset({"not_task_principal"}),
     CreateUnavailable: frozenset({"task_missing"}),
-    CreateConflict: frozenset({"slot_taken", "idempotency_key_reused"}),
+    CreateConflict: frozenset(
+        {"slot_taken", "idempotency_key_reused", "handoff_degraded_unclassified"}
+    ),
     CreateStale: frozenset({"anchor_run_mismatch"}),
 }
 
@@ -1485,7 +1496,8 @@ def _assert_write_point_admissible(
 # refuses an out-of-vocabulary task.source before a finalizer would ever
 # call this seam. A caller that cannot provide either property must not
 # use this path. If either exception somehow fires anyway, create() falls
-# back to the single default classification below (slot_taken).
+# back to the single default classification below
+# (handoff_degraded_unclassified).
 _DEGRADED_AS_OUTCOME: dict[type[BaseException], "CreateOutcome"] = {
     InteractionSlotTaken: CreateConflict(reason="slot_taken"),
     InteractionRequestClosed: CreateConflict(reason="idempotency_key_reused"),
@@ -1783,8 +1795,10 @@ def create(
     must not use this path. When ``interaction_handoff``'s ``with`` block
     exits with ``handoff.staged`` still ``None`` and ``handoff.degraded_as``
     is one of these two, or is unrecognized, this function reports
-    ``CreateConflict(reason="slot_taken")``, the single default
-    classification for that state.
+    ``CreateConflict(reason="handoff_degraded_unclassified")``, the single
+    default classification for that state -- kept out of
+    ``"slot_taken"`` because an unidentified degradation and a real
+    conflict are different facts a caller must be able to tell apart.
     """
 
     if (
@@ -1986,7 +2000,11 @@ def create(
         # place handoff.staged itself is read -- and _DEGRADED_AS_OUTCOME
         # maps four of the six to a distinct outcome each. The remaining
         # two (see that dict's own docstring), and an unset/unrecognized
-        # degraded_as, fall through to this default.
+        # degraded_as, fall through to this default. The default now
+        # carries its own reason word, handoff_degraded_unclassified,
+        # rather than reusing slot_taken's: an unidentified degradation is
+        # not the same fact as a real conflict, and the two must stay
+        # distinguishable in the reported outcome.
         #
         # issubclass, not an exact-type key lookup: the ``except _SWALLOWED``
         # clause that produced this value matches subclasses, so a future
@@ -2012,7 +2030,7 @@ def create(
             if handoff.degraded_as is not None
             else None
         )
-        return mapped_outcome or CreateConflict(reason="slot_taken")
+        return mapped_outcome or CreateConflict(reason="handoff_degraded_unclassified")
 
     receipt = CreatedInteractionReceipt(
         interaction_id=handoff.staged.staged_db_id,

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -145,13 +145,18 @@ from xagent.web.models.user import User
 from xagent.web.services import task_interaction_service as svc
 from xagent.web.services.ops_signals import (
     CHECKPOINT_PK_ANCHOR_DANGLING,
+    INTERACTION_HANDOFF_DEGRADED,
     INTERACTION_READ_PAYLOAD_UNREADABLE,
     INTERACTION_READ_PROTOCOL_UNRECOGNIZED,
     active_degradations,
     clear_degradation,
 )
 from xagent.web.services.task_clarification_draft import CLARIFICATION_REQUEST_TTL
-from xagent.web.services.task_interaction_staging import InteractionAnchor
+from xagent.web.services.task_interaction_staging import (
+    InteractionAnchor,
+    InteractionAttemptMismatch,
+    InteractionOriginUnknown,
+)
 from xagent.web.services.task_lease_service import TASK_RUN_ID_TRACE_FIELD, TaskLease
 
 
@@ -5794,28 +5799,48 @@ def test_degraded_as_subclass_maps_to_the_parents_outcome(
     assert _db.query(TaskInteractionRequest).count() == 0
 
 
+@pytest.mark.parametrize(
+    "unmapped_exc",
+    [
+        pytest.param(InteractionOriginUnknown, id="origin_unknown"),
+        pytest.param(InteractionAttemptMismatch, id="attempt_mismatch"),
+    ],
+)
 def test_unmapped_degraded_as_maps_to_the_unclassified_outcome(
-    _db: Session, _system_call_ctx: dict[str, Any]
+    _db: Session,
+    _system_call_ctx: dict[str, Any],
+    unmapped_exc: type[Exception],
 ) -> None:
     """An unrecognized degradation gets its own reason word, not the
-    real-conflict one. InteractionOriginUnknown is one of the two swallowed
-    exceptions _DEGRADED_AS_OUTCOME does not map, so it exercises the
-    default classification, which now reports
-    handoff_degraded_unclassified rather than reusing slot_taken.
+    real-conflict one. InteractionOriginUnknown and
+    InteractionAttemptMismatch are exactly the two swallowed exceptions
+    _DEGRADED_AS_OUTCOME does not map, so both exercise the default
+    classification, which now reports handoff_degraded_unclassified rather
+    than reusing slot_taken. Both are covered because the default is the
+    only place either type's outcome is decided -- neither is reachable
+    from a wired caller (see _DEGRADED_AS_OUTCOME's own comment), so this
+    test is the only statement of what create() reports for them.
+
+    The registered degradation is asserted, not just the outcome: an
+    unset degraded_as -- which is what a stage_interaction_request that
+    the patch below silently failed to intercept would leave behind --
+    reports the same reason word by design, so the outcome alone cannot
+    tell "the swallow happened and fell through" from "no swallow
+    happened at all". The signal's detail is registered only from
+    interaction_handoff's except clause and names the exception type that
+    fired, so checking it pins both facts.
 
     Mutation: reverting the default classification's reason back to
     `CreateConflict(reason="slot_taken")` turns this red."""
 
     from xagent.web.services import task_interaction_staging as staging_module
-    from xagent.web.services.task_interaction_staging import (
-        InteractionOriginUnknown,
-    )
 
     ctx = _system_call_ctx
     real_stage = staging_module.stage_interaction_request
+    forced_message = f"forced for test_unmapped_degraded_as ({unmapped_exc.__name__})"
 
     def _raise_unmapped(*args: Any, **kwargs: Any) -> Any:
-        raise InteractionOriginUnknown("forced for test_unmapped_degraded_as")
+        raise unmapped_exc(forced_message)
 
     with mock.patch.object(
         staging_module, "stage_interaction_request", side_effect=_raise_unmapped
@@ -5825,6 +5850,10 @@ def test_unmapped_degraded_as_maps_to_the_unclassified_outcome(
     assert outcome == svc.CreateConflict(reason="handoff_degraded_unclassified")
     assert real_stage is staging_module.stage_interaction_request
     assert _db.query(TaskInteractionRequest).count() == 0
+
+    detail = active_degradations()[INTERACTION_HANDOFF_DEGRADED]
+    assert unmapped_exc.__name__ in detail
+    assert forced_message in detail
 
 
 def test_swallowed_exception_types_are_mutually_unrelated() -> None:

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -227,15 +227,15 @@ def test_respond_outcome_union_has_exactly_the_eight_known_variants() -> None:
     }
 
 
-def test_create_outcome_reason_word_list_has_exactly_12_words() -> None:
-    assert len(svc.CREATE_OUTCOME_REASON_WORDS) == 12
+def test_create_outcome_reason_word_list_has_exactly_13_words() -> None:
+    assert len(svc.CREATE_OUTCOME_REASON_WORDS) == 13
 
 
-def test_create_outcome_producible_pairs_are_exactly_9() -> None:
+def test_create_outcome_producible_pairs_are_exactly_10() -> None:
     total = sum(
         len(reasons) for reasons in svc.CREATE_OUTCOME_PRODUCIBLE_REASONS.values()
     )
-    assert total == 9
+    assert total == 10
 
 
 def test_create_outcome_producible_reasons_are_a_subset_of_the_full_word_list() -> None:
@@ -5768,7 +5768,7 @@ def test_degraded_as_subclass_maps_to_the_parents_outcome(
     exact-type lookup's failure is visible in the outcome itself.
 
     Mutation: restoring `_DEGRADED_AS_OUTCOME.get(handoff.degraded_as)`
-    turns this red with CreateConflict(slot_taken)."""
+    turns this red with CreateConflict(handoff_degraded_unclassified)."""
 
     from xagent.web.services import task_interaction_staging as staging_module
     from xagent.web.services.task_interaction_staging import (
@@ -5790,6 +5790,39 @@ def test_degraded_as_subclass_maps_to_the_parents_outcome(
         outcome = _system_create(_db, ctx, request_idempotency_key="sys-key-subclass")
 
     assert outcome == svc.CreateStale(reason="anchor_run_mismatch")
+    assert real_stage is staging_module.stage_interaction_request
+    assert _db.query(TaskInteractionRequest).count() == 0
+
+
+def test_unmapped_degraded_as_maps_to_the_unclassified_outcome(
+    _db: Session, _system_call_ctx: dict[str, Any]
+) -> None:
+    """An unrecognized degradation gets its own reason word, not the
+    real-conflict one. InteractionOriginUnknown is one of the two swallowed
+    exceptions _DEGRADED_AS_OUTCOME does not map, so it exercises the
+    default classification, which now reports
+    handoff_degraded_unclassified rather than reusing slot_taken.
+
+    Mutation: reverting the default classification's reason back to
+    `CreateConflict(reason="slot_taken")` turns this red."""
+
+    from xagent.web.services import task_interaction_staging as staging_module
+    from xagent.web.services.task_interaction_staging import (
+        InteractionOriginUnknown,
+    )
+
+    ctx = _system_call_ctx
+    real_stage = staging_module.stage_interaction_request
+
+    def _raise_unmapped(*args: Any, **kwargs: Any) -> Any:
+        raise InteractionOriginUnknown("forced for test_unmapped_degraded_as")
+
+    with mock.patch.object(
+        staging_module, "stage_interaction_request", side_effect=_raise_unmapped
+    ):
+        outcome = _system_create(_db, ctx, request_idempotency_key="sys-key-unmapped")
+
+    assert outcome == svc.CreateConflict(reason="handoff_degraded_unclassified")
     assert real_stage is staging_module.stage_interaction_request
     assert _db.query(TaskInteractionRequest).count() == 0
 
@@ -5898,13 +5931,21 @@ def test_handoff_degraded_as_is_set_directly_on_a_slot_taken_swallow(
 ) -> None:
     """Unlike the outcome-level test above, this checks
     InteractionHandoff.degraded_as itself, at the staging primitive's own
-    layer -- discriminating power the outcome-level test lacks for this one
-    exception, since CreateConflict(slot_taken) is also this function's
-    fallback for an unset/unrecognized degraded_as, so an outcome-only
-    check cannot tell "correctly mapped" from "fell through to the
-    default". Deleting the `handoff.degraded_as = type(exc)` assignment in
-    interaction_handoff's except block turns this test red without
-    changing the outcome-level test's result at all."""
+    layer, pinning the `handoff.degraded_as = type(exc)` assignment
+    directly rather than through create()'s downstream mapping. Before the
+    default classification got its own reason word
+    (handoff_degraded_unclassified), CreateConflict(slot_taken) was also
+    this function's fallback for an unset/unrecognized degraded_as, so the
+    outcome alone could not tell "correctly mapped" from "fell through to
+    the default" for this one exception -- only this primitive-level check
+    could. That degeneracy is gone now that the default reports a
+    different word, so the outcome-level test above has the same
+    discriminating power for this exception today. Deleting the
+    `handoff.degraded_as = type(exc)` assignment in interaction_handoff's
+    except block turns both this test and the outcome-level test red
+    (verified; every other test that exercises a mapped swallowed
+    exception turns red too, since the same assignment backs all of
+    them)."""
 
     from xagent.web.services.task_interaction_staging import InteractionSlotTaken
 

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -181,10 +181,10 @@ def _clean_degradation_registry():
 # CreateOutcome's vocabulary guards (two pinned numbers, still plain dicts
 # in the source -- do not recompute them here):
 #
-#   - CreateOutcome reason word list: 12 words total (seam_not_wired was
+#   - CreateOutcome reason word list: 13 words total (seam_not_wired was
 #     deleted along with CreateNotWired once this seam's call body landed).
 #   - CreateOutcome pairs this function body has a code path that returns:
-#     9. Producible here means exactly that -- a code path exists in
+#     10. Producible here means exactly that -- a code path exists in
 #     create()'s own body -- not that the path is reachable from any wired
 #     production caller (see CREATE_OUTCOME_PRODUCIBLE_REASONS's own
 #     docstring for the two entries that stay in this set despite being

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -5767,7 +5767,8 @@ def test_degraded_as_subclass_maps_to_the_parents_outcome(
     _db: Session, _system_call_ctx: dict[str, Any]
 ) -> None:
     """A future subclass of a mapped swallowed type must classify as its
-    parent does, not fall through to the slot_taken default.
+    parent does, not fall through to the handoff_degraded_unclassified
+    default.
     InteractionRunPartitionMismatch is the discriminating choice: its
     outcome (CreateStale) is the one the default can never produce, so an
     exact-type lookup's failure is visible in the outcome itself.
@@ -5821,14 +5822,19 @@ def test_unmapped_degraded_as_maps_to_the_unclassified_outcome(
     from a wired caller (see _DEGRADED_AS_OUTCOME's own comment), so this
     test is the only statement of what create() reports for them.
 
-    The registered degradation is asserted, not just the outcome: an
-    unset degraded_as -- which is what a stage_interaction_request that
-    the patch below silently failed to intercept would leave behind --
-    reports the same reason word by design, so the outcome alone cannot
-    tell "the swallow happened and fell through" from "no swallow
-    happened at all". The signal's detail is registered only from
-    interaction_handoff's except clause and names the exception type that
-    fired, so checking it pins both facts.
+    The registered degradation is asserted on top of the outcome because
+    the two pin different facts. The detail assertions pin that the
+    swallow registered its degradation signal at all and that the signal
+    names the exception type that fired: deleting register_degradation
+    from interaction_handoff's except clause leaves the outcome assertion
+    green but makes the active_degradations() lookup below raise
+    KeyError. No assertion here pins the handoff.degraded_as assignment
+    itself; test_handoff_degraded_as_is_set_directly_on_a_slot_taken_swallow
+    covers that. A patch below that silently failed to intercept is
+    caught by the outcome and row-count assertions rather than by the
+    detail: the real stage_interaction_request would succeed, taking the
+    same path as test_system_principal_creates_a_fresh_row and yielding
+    CreateCreated plus one persisted row.
 
     Mutation: reverting the default classification's reason back to
     `CreateConflict(reason="slot_taken")` turns this red."""
@@ -5848,7 +5854,7 @@ def test_unmapped_degraded_as_maps_to_the_unclassified_outcome(
         outcome = _system_create(_db, ctx, request_idempotency_key="sys-key-unmapped")
 
     assert outcome == svc.CreateConflict(reason="handoff_degraded_unclassified")
-    assert real_stage is staging_module.stage_interaction_request
+    assert real_stage is staging_module.stage_interaction_request  # patch released
     assert _db.query(TaskInteractionRequest).count() == 0
 
     detail = active_degradations()[INTERACTION_HANDOFF_DEGRADED]


### PR DESCRIPTION
## What

`create()`'s default classification for an interaction_handoff
degradation it cannot identify now reports its own reason word,
`handoff_degraded_unclassified`, instead of reusing `slot_taken`.
`CREATE_OUTCOME_REASON_WORDS` grows from 12 to 13 words, and
`CREATE_OUTCOME_PRODUCIBLE_REASONS[CreateConflict]` gains the new word
(9 producible pairs become 10).

## Why

Today, an unidentified degradation -- either one of the two swallowed
exceptions `_DEGRADED_AS_OUTCOME` does not map, or an unset/unrecognized
`degraded_as` -- is reported as `CreateConflict(reason="slot_taken")`,
the exact same outcome a real conflict produces. An operator reading the
outcome cannot tell "something unrecognized happened here" from
"another requester already won the slot", and a future caller that
branches on the outcome's reason word would silently treat an
unidentified failure as an ordinary conflict. Giving the unclassified
case its own word makes it distinguishable on both counts.

## Verification

- `pytest tests/web/services/test_task_interaction_service.py -q`: 363
  passed (362 on the prior baseline, +1 for the new test).
- `pytest tests/web/services/ -q`: no failures (environment-gated tests
  skipped as before).
- `ruff check` and `ruff format --check` pass on both changed files.
- Mutation testing: reverting the default's reason back to
  `"slot_taken"` turns the new test red; reverting again turns it
  green. Removing `interaction_handoff`'s
  `handoff.degraded_as = type(exc)` assignment turns six existing tests
  red (every test that exercises a mapped swallowed exception), which
  is the evidence behind this change's updated test docstrings.
