### PR TITLE
ref(kb): make the store data plane concurrency-safe (#657)

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import threading
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
@@ -159,11 +160,8 @@ def _stale_version_count(table: Any, cutoff: datetime) -> int:
 class LanceDBMetadataStore(MetadataStore):
     """LanceDB implementation for control-plane metadata operations."""
 
-    def __init__(self) -> None:
-        self._conn: Optional[DBConnection] = None
-
     async def _get_connection(self) -> DBConnection:
-        """Open (and memoise) the connection without stalling the event loop.
+        """Reach the connection pool without stalling the event loop.
 
         Opening a LanceDB connection is blocking I/O, so it is dispatched to a
         worker thread. ``get_raw_connection`` is the synchronous equivalent for
@@ -626,15 +624,12 @@ class LanceDBMetadataStore(MetadataStore):
         """Get the underlying LanceDB connection.
 
         This method provides access to the raw connection for operations that
-        cannot be performed through the storage abstraction. It initializes
-        and caches the connection for consistency with async methods.
+        cannot be performed through the storage abstraction.
 
         Returns:
             DBConnection: The LanceDB connection object
         """
-        if self._conn is None:
-            self._conn = get_connection_from_env()
-        return self._conn
+        return get_connection_from_env()
 
 
 class LanceDBVectorIndexStore(VectorIndexStore):
@@ -648,47 +643,59 @@ class LanceDBVectorIndexStore(VectorIndexStore):
     _TABLE_CACHE_MAXSIZE = 64
 
     def __init__(self) -> None:
-        self._conn: Optional[DBConnection] = None
         self._async_conn: Optional[Any] = None  # AsyncConnection
         self._async_lock = asyncio.Lock()  # Protect async connection initialization
         self._table_cache: OrderedDict[str, Any] = OrderedDict()
+        # Guards _table_cache across the worker threads asyncio.to_thread
+        # dispatches handle storage calls to.
+        self._table_cache_lock = threading.Lock()
 
     def _get_connection(self) -> DBConnection:
-        if self._conn is None:
-            self._conn = get_connection_from_env()
-        return self._conn
+        return get_connection_from_env()
 
     def _get_table(self, table_name: str, *, use_cache: bool = True) -> Any:
         """Get a table handle, optionally reusing the per-process cache."""
         from ..LanceDB.schema_manager import _safe_close_table
 
         if use_cache:
-            cached = self._table_cache.get(table_name)
-            if cached is not None:
-                self._table_cache.move_to_end(table_name)
-                return cached
+            with self._table_cache_lock:
+                cached = self._table_cache.get(table_name)
+                if cached is not None:
+                    self._table_cache.move_to_end(table_name)
+                    return cached
+        # open_table is blocking I/O, so it stays outside the lock; a concurrent
+        # opener may win the insert below, in which case this handle is closed.
         table = self._get_connection().open_table(table_name)
-        if use_cache:
-            self._table_cache[table_name] = table
-            if len(self._table_cache) > self._TABLE_CACHE_MAXSIZE:
-                _evicted_name, _evicted_table = self._table_cache.popitem(last=False)
-                _safe_close_table(_evicted_table)
+        if not use_cache:
+            return table
+        discarded = None
+        with self._table_cache_lock:
+            existing = self._table_cache.get(table_name)
+            if existing is not None:
+                self._table_cache.move_to_end(table_name)
+                discarded, table = table, existing
+            else:
+                self._table_cache[table_name] = table
+                if len(self._table_cache) > self._TABLE_CACHE_MAXSIZE:
+                    _evicted_name, discarded = self._table_cache.popitem(last=False)
+        _safe_close_table(discarded)
         return table
 
     def invalidate_table_cache(self, table_name: str | None = None) -> None:
         """Clear table cache after drop/delete to avoid stale handles.
 
-        Cached handles are closed before removal so underlying file
-        descriptors are released promptly.
+        Handles are dropped from the cache under the lock and closed outside
+        it, so underlying file descriptors are released promptly.
         """
         from ..LanceDB.schema_manager import _safe_close_table
 
-        if table_name is None:
-            for _name, _table in list(self._table_cache.items()):
-                _safe_close_table(_table)
-            self._table_cache.clear()
-        else:
-            _table = self._table_cache.pop(table_name, None)
+        with self._table_cache_lock:
+            if table_name is None:
+                stale = list(self._table_cache.values())
+                self._table_cache.clear()
+            else:
+                stale = [self._table_cache.pop(table_name, None)]
+        for _table in stale:
             _safe_close_table(_table)
 
     async def _get_async_connection(self) -> Any:
@@ -3634,15 +3641,12 @@ class LanceDBIngestionStatusStore(IngestionStatusStore):
     """
 
     def __init__(self) -> None:
-        self._sync_conn: Optional[DBConnection] = None
         self._async_conn: Optional[Any] = None
         self._async_lock = asyncio.Lock()
 
     def _get_sync_connection(self) -> DBConnection:
         """Get sync LanceDB connection."""
-        if self._sync_conn is None:
-            self._sync_conn = get_connection_from_env()
-        return self._sync_conn
+        return get_connection_from_env()
 
     async def _get_async_connection(self) -> Any:
         """Get async LanceDB connection."""
@@ -3937,14 +3941,9 @@ class LanceDBPromptTemplateStore(PromptTemplateStore):
     Manages prompt_templates table for storing and retrieving prompt templates.
     """
 
-    def __init__(self) -> None:
-        self._sync_conn: Optional[DBConnection] = None
-
     def _get_sync_connection(self) -> DBConnection:
         """Get or create sync connection."""
-        if self._sync_conn is None:
-            self._sync_conn = get_connection_from_env()
-        return self._sync_conn
+        return get_connection_from_env()
 
     def _ensure_table(self) -> None:
         """Ensure prompt_templates table exists."""
@@ -4427,14 +4426,9 @@ class LanceDBMainPointerStore(MainPointerStore):
     multi-tenancy support.
     """
 
-    def __init__(self) -> None:
-        self._sync_conn: Optional[DBConnection] = None
-
     def _get_sync_connection(self) -> DBConnection:
         """Get or create sync connection."""
-        if self._sync_conn is None:
-            self._sync_conn = get_connection_from_env()
-        return self._sync_conn
+        return get_connection_from_env()
 
     def _ensure_table(self) -> None:
         """Ensure main_pointers table exists."""

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -669,6 +669,9 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         if not use_cache:
             return table
         discarded = None
+        # Unlocked, this read-modify-write is atomic only by grace of the GIL,
+        # so no test can trip it on CPython 3.12; the lock is what keeps it
+        # correct under free-threading.
         with self._table_cache_lock:
             existing = self._table_cache.get(table_name)
             if existing is not None:
@@ -684,8 +687,8 @@ class LanceDBVectorIndexStore(VectorIndexStore):
     def invalidate_table_cache(self, table_name: str | None = None) -> None:
         """Clear table cache after drop/delete to avoid stale handles.
 
-        Handles are dropped from the cache under the lock and closed outside
-        it, so underlying file descriptors are released promptly.
+        Handles are dropped from the cache under the lock, then closed outside
+        it so a blocking close never runs while the lock is held.
         """
         from ..LanceDB.schema_manager import _safe_close_table
 

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -669,9 +669,9 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         if not use_cache:
             return table
         discarded = None
-        # Unlocked, this read-modify-write is atomic only by grace of the GIL,
-        # so no test can trip it on CPython 3.12; the lock is what keeps it
-        # correct under free-threading.
+        # Unlocked, an insert landing inside invalidate_table_cache's own
+        # critical section is dropped by its clear() while absent from its
+        # stale snapshot, so that handle is never cached and never closed.
         with self._table_cache_lock:
             existing = self._table_cache.get(table_name)
             if existing is not None:

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -649,6 +649,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         # Guards _table_cache across the worker threads asyncio.to_thread
         # dispatches handle storage calls to.
         self._table_cache_lock = threading.Lock()
+        self._table_cache_epoch = 0
 
     def _get_connection(self) -> DBConnection:
         return get_connection_from_env()
@@ -657,32 +658,48 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         """Get a table handle, optionally reusing the per-process cache."""
         from ..LanceDB.schema_manager import _safe_close_table
 
-        if use_cache:
+        if not use_cache:
+            return self._get_connection().open_table(table_name)
+
+        # At most two passes. An invalidation landing while the unlocked open
+        # below is in flight means the table may have just been dropped, so
+        # that handle is thrown away and re-opened against the new epoch.
+        for last_pass in (False, True):
             with self._table_cache_lock:
                 cached = self._table_cache.get(table_name)
                 if cached is not None:
                     self._table_cache.move_to_end(table_name)
                     return cached
-        # open_table is blocking I/O, so it stays outside the lock; a concurrent
-        # opener may win the insert below, in which case this handle is closed.
-        table = self._get_connection().open_table(table_name)
-        if not use_cache:
-            return table
-        discarded = None
-        # Unlocked, an insert landing inside invalidate_table_cache's own
-        # critical section is dropped by its clear() while absent from its
-        # stale snapshot, so that handle is never cached and never closed.
-        with self._table_cache_lock:
-            existing = self._table_cache.get(table_name)
-            if existing is not None:
-                self._table_cache.move_to_end(table_name)
-                discarded, table = table, existing
-            else:
-                self._table_cache[table_name] = table
-                if len(self._table_cache) > self._TABLE_CACHE_MAXSIZE:
-                    _evicted_name, discarded = self._table_cache.popitem(last=False)
-        _safe_close_table(discarded)
-        return table
+                epoch = self._table_cache_epoch
+
+            # Blocking I/O, deliberately outside the lock: holding it across
+            # this would serialize every concurrent open.
+            table = self._get_connection().open_table(table_name)
+
+            discarded = None
+            with self._table_cache_lock:
+                if self._table_cache_epoch != epoch and not last_pass:
+                    discarded, table = table, None
+                else:
+                    # Unlocked, an insert landing inside
+                    # invalidate_table_cache's own critical section is dropped
+                    # by its clear() while absent from its stale snapshot, so
+                    # that handle would be neither cached nor closed.
+                    existing = self._table_cache.get(table_name)
+                    if existing is not None:
+                        self._table_cache.move_to_end(table_name)
+                        discarded, table = table, existing
+                    else:
+                        self._table_cache[table_name] = table
+                        if len(self._table_cache) > self._TABLE_CACHE_MAXSIZE:
+                            _evicted_name, discarded = self._table_cache.popitem(
+                                last=False
+                            )
+            _safe_close_table(discarded)
+            if table is not None:
+                return table
+
+        raise RuntimeError("unreachable: the second pass always returns")
 
     def invalidate_table_cache(self, table_name: str | None = None) -> None:
         """Clear table cache after drop/delete to avoid stale handles.
@@ -693,6 +710,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         from ..LanceDB.schema_manager import _safe_close_table
 
         with self._table_cache_lock:
+            self._table_cache_epoch += 1
             if table_name is None:
                 stale = list(self._table_cache.values())
                 self._table_cache.clear()
@@ -714,7 +732,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                 return self._async_conn
 
             # Get URI from sync connection for reuse
-            sync_conn = self._get_connection()
+            sync_conn = await asyncio.to_thread(self._get_connection)
             uri = getattr(sync_conn, "uri", None)
             if uri is None:
                 # Fallback: use LANCEDB_DIR env var
@@ -2531,7 +2549,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
 
         # Note: ensure_documents_table uses sync connection - may need async variant
         # For now, reuse sync connection for table creation
-        sync_conn = self._get_connection()
+        sync_conn = await asyncio.to_thread(self._get_connection)
         ensure_documents_table(sync_conn)
 
         from ..LanceDB.schema_manager import _safe_close_table
@@ -2560,7 +2578,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         async_conn = await self._get_async_connection()
 
         # Reuse sync connection for table creation
-        sync_conn = self._get_connection()
+        sync_conn = await asyncio.to_thread(self._get_connection)
         ensure_chunks_table(sync_conn)
 
         from ..LanceDB.schema_manager import _safe_close_table
@@ -2594,7 +2612,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             return
 
         async_conn = await self._get_async_connection()
-        sync_conn = self._get_connection()
+        sync_conn = await asyncio.to_thread(self._get_connection)
 
         table_name = f"embeddings_{to_model_tag(model_tag)}"
 

--- a/src/xagent/providers/vector_store/lancedb.py
+++ b/src/xagent/providers/vector_store/lancedb.py
@@ -205,7 +205,9 @@ class LanceDBConnectionManager:
             if env_var == "LANCEDB_DIR":
                 # Use default path only for the standard LANCEDB_DIR environment variable
                 db_dir = self.get_default_lancedb_dir()
-                logger.info(f"Using default LanceDB directory: {db_dir}")
+                # Reached on every connection request now that stores no
+                # longer memoise one, so this must not be INFO.
+                logger.debug(f"Using default LanceDB directory: {db_dir}")
             else:
                 # For other environment variables, raise KeyError as before
                 raise KeyError(f"Environment variable {env_var} is not set")

--- a/src/xagent/providers/vector_store/lancedb.py
+++ b/src/xagent/providers/vector_store/lancedb.py
@@ -205,9 +205,10 @@ class LanceDBConnectionManager:
             if env_var == "LANCEDB_DIR":
                 # Use default path only for the standard LANCEDB_DIR environment variable
                 db_dir = self.get_default_lancedb_dir()
-                # Reached on every connection request now that stores no
-                # longer memoise one, so this must not be INFO.
-                logger.debug(f"Using default LanceDB directory: {db_dir}")
+                # Reached on every connection request now that the KB stores
+                # no longer memoise one (LanceDBVectorStore still does), so
+                # this must be neither INFO nor an eager f-string.
+                logger.debug("Using default LanceDB directory: %s", db_dir)
             else:
                 # For other environment variables, raise KeyError as before
                 raise KeyError(f"Environment variable {env_var} is not set")

--- a/tests/core/tools/core/RAG_tools/kb/test_list_collections_event_loop.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_list_collections_event_loop.py
@@ -244,7 +244,7 @@ class _FakeConnection:
 
 def _store_with(connection: _FakeConnection) -> LanceDBMetadataStore:
     store = LanceDBMetadataStore()
-    store._conn = connection
+    store.get_raw_connection = lambda: connection  # type: ignore[method-assign]
     return store
 
 

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
@@ -31,6 +31,10 @@ from unittest.mock import Mock, patch
 import pytest
 
 from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+    LanceDBIngestionStatusStore,
+    LanceDBMainPointerStore,
+    LanceDBMetadataStore,
+    LanceDBPromptTemplateStore,
     LanceDBVectorIndexStore,
 )
 
@@ -187,20 +191,37 @@ async def test_concurrent_to_thread_handle_calls_share_no_mutable_connection() -
     _assert_every_handle_cached_or_closed(connection, store)
 
 
+@pytest.mark.parametrize(
+    ("store_class", "getter_name", "cache_attr"),
+    [
+        (LanceDBMetadataStore, "get_raw_connection", "_conn"),
+        (LanceDBVectorIndexStore, "_get_connection", "_conn"),
+        (LanceDBIngestionStatusStore, "_get_sync_connection", "_sync_conn"),
+        (LanceDBPromptTemplateStore, "_get_sync_connection", "_sync_conn"),
+        (LanceDBMainPointerStore, "_get_sync_connection", "_sync_conn"),
+    ],
+)
 @patch(
     "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
 )
-def test_connection_is_not_cached_on_the_instance(mock_get_connection: Mock) -> None:
+def test_connection_is_not_cached_on_the_instance(
+    mock_get_connection: Mock,
+    store_class: type,
+    getter_name: str,
+    cache_attr: str,
+) -> None:
     """Connections come from the process-wide pool, which holds its own lock.
 
     A per-instance cache would be unguarded shared state and would also outlive
-    both the pool's TTL and ``clear_connection_cache()``.
+    both the pool's TTL and ``clear_connection_cache()``. Every store that was
+    carrying one is covered, so re-adding a cache to any of them fails here.
     """
     conn: Any = Mock()
     mock_get_connection.return_value = conn
-    store = LanceDBVectorIndexStore()
+    store = store_class()
+    getter = getattr(store, getter_name)
 
-    assert not hasattr(store, "_conn")
-    assert store._get_connection() is conn
-    assert store._get_connection() is conn
+    assert not hasattr(store, cache_attr)
+    assert getter() is conn
+    assert getter() is conn
     assert mock_get_connection.call_count == 2

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
@@ -24,7 +24,9 @@ erased by its ``clear()`` without ever appearing in its stale snapshot.
 from __future__ import annotations
 
 import asyncio
+import sys
 import threading
+import time
 from typing import Any, List
 from unittest.mock import Mock, patch
 
@@ -39,17 +41,36 @@ from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _tight_switch_interval():
+    """Force frequent GIL handoffs so the narrow race windows get hit.
+
+    The insert-section window is a few bytecodes wide; at the default 5ms
+    interval a missing lock there slips through most runs.
+    """
+    original = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        yield
+    finally:
+        sys.setswitchinterval(original)
+
+
 class _FakeTable:
     def __init__(self, name: str, *, close_delay: float = 0.0) -> None:
         self.name = name
-        self.closed = False
+        self.close_count = 0
         self._close_delay = close_delay
+
+    @property
+    def closed(self) -> bool:
+        return self.close_count > 0
 
     def close(self) -> None:
         # A slow close widens the window an unguarded invalidate leaves open
         # between snapshotting the cache and clearing it.
-        threading.Event().wait(self._close_delay)
-        self.closed = True
+        time.sleep(self._close_delay)
+        self.close_count += 1
 
 
 class _RacyConnection:
@@ -63,7 +84,7 @@ class _RacyConnection:
 
     def open_table(self, name: str) -> _FakeTable:
         # The delay is what makes the interleaving reproducible rather than rare.
-        threading.Event().wait(self._delay)
+        time.sleep(self._delay)
         table = _FakeTable(name, close_delay=self._close_delay)
         with self._lock:
             self.opened.append(table)
@@ -89,6 +110,10 @@ def _assert_every_handle_cached_or_closed(
         f"{len(leaked)} of {len(connection.opened)} opened handles are neither "
         f"cached nor closed"
     )
+    twice = [table for table in connection.opened if table.close_count > 1]
+    assert not twice, f"{len(twice)} handles were closed more than once"
+    live = [table for table in connection.opened if id(table) in cached]
+    assert not [t for t in live if t.closed], "a cached handle was closed"
 
 
 def test_concurrent_open_of_one_table_leaks_no_handle() -> None:
@@ -120,10 +145,10 @@ def test_concurrent_get_and_invalidate_leaks_no_handle() -> None:
     """Interleaved cache fills and invalidations must stay consistent.
 
     Dropping ``invalidate_table_cache``'s lock fails this every run. Dropping
-    the insert-section lock fails it about one run in five: that window is only
-    a few bytecodes wide, and widening it further would mean a test hook inside
-    ``_get_table``. The table and invalidator counts below are tuned for those
-    odds -- raising the duration does not help, the window is what limits it.
+    the insert-section lock fails it most runs, but not all: that window is a
+    few bytecodes wide, and what makes it reachable at all is the autouse
+    ``sys.setswitchinterval`` fixture. Duration alone does nothing at the
+    default interval; paired with the tight one it does, hence 1.5s here.
     """
     connection = _RacyConnection(delay=0.001, close_delay=0.002)
     store = _store_on(connection)
@@ -150,12 +175,43 @@ def test_concurrent_get_and_invalidate_leaks_no_handle() -> None:
     threads += [threading.Thread(target=invalidator) for _ in range(4)]
     for thread in threads:
         thread.start()
-    threading.Event().wait(0.5)
+    time.sleep(1.5)
     stop.set()
     for thread in threads:
         thread.join(timeout=30)
 
     assert not errors, f"concurrent cache access raised: {errors}"
+    _assert_every_handle_cached_or_closed(connection, store)
+
+
+def test_invalidation_during_open_does_not_cache_a_stale_handle() -> None:
+    """A drop landing mid-open must not leave the dropped table cached.
+
+    Deterministic rather than timing-based: the connection invalidates the
+    cache from inside ``open_table``, which is exactly the interleaving a
+    concurrent drop produces -- the cache was empty when the invalidation ran,
+    so nothing there marks the in-flight handle as stale.
+    """
+    connection = _RacyConnection(delay=0.0)
+    store = _store_on(connection)
+    plain_open = connection.open_table
+    fired: List[bool] = []
+
+    def open_then_invalidate(name: str) -> _FakeTable:
+        table = plain_open(name)
+        if not fired:
+            fired.append(True)
+            store.invalidate_table_cache(name)
+        return table
+
+    connection.open_table = open_then_invalidate  # type: ignore[method-assign]
+
+    handle = store._get_table("documents")
+
+    assert len(connection.opened) == 2, "the raced handle must be re-opened"
+    assert connection.opened[0].closed, "the raced handle must not be leaked"
+    assert handle is connection.opened[1]
+    assert store._table_cache["documents"] is connection.opened[1]
     _assert_every_handle_cached_or_closed(connection, store)
 
 

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
@@ -1,0 +1,197 @@
+"""The store data plane must survive concurrent handle access.
+
+The coordinator offloads blocking handle calls with ``asyncio.to_thread``. Once
+those are awaited concurrently on a shared loop, several worker threads reach a
+single process-wide store instance at the same time. These tests pin the two
+pieces of shared state that made that unsafe: the table-handle cache, and the
+per-instance connection cache that no longer exists.
+
+The table-cache assertion is a conservation law rather than a race detector:
+every handle ``open_table`` returns must end up either in the cache or closed.
+An unguarded cache loses that -- two threads opening the same table overwrite
+one another, and the loser is neither cached nor closed, leaking its handle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, List
+from unittest.mock import Mock, patch
+
+import pytest
+
+from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+    LanceDBVectorIndexStore,
+)
+
+
+class _FakeTable:
+    def __init__(self, name: str, *, close_delay: float = 0.0) -> None:
+        self.name = name
+        self.closed = False
+        self._close_delay = close_delay
+
+    def close(self) -> None:
+        # A slow close widens the window an unguarded invalidate leaves open
+        # between snapshotting the cache and clearing it.
+        threading.Event().wait(self._close_delay)
+        self.closed = True
+
+
+class _RacyConnection:
+    """Hands out a distinct handle per ``open_table``, slowly enough to overlap."""
+
+    def __init__(self, *, delay: float = 0.005, close_delay: float = 0.0) -> None:
+        self._delay = delay
+        self._close_delay = close_delay
+        self._lock = threading.Lock()
+        self.opened: List[_FakeTable] = []
+
+    def open_table(self, name: str) -> _FakeTable:
+        # The delay is what makes the interleaving reproducible rather than rare.
+        threading.Event().wait(self._delay)
+        table = _FakeTable(name, close_delay=self._close_delay)
+        with self._lock:
+            self.opened.append(table)
+        return table
+
+
+def _store_on(connection: _RacyConnection) -> LanceDBVectorIndexStore:
+    store = LanceDBVectorIndexStore()
+    store._get_connection = lambda: connection  # type: ignore[method-assign]
+    return store
+
+
+def _assert_every_handle_cached_or_closed(
+    connection: _RacyConnection, store: LanceDBVectorIndexStore
+) -> None:
+    cached = set(id(table) for table in store._table_cache.values())
+    leaked = [
+        table
+        for table in connection.opened
+        if id(table) not in cached and not table.closed
+    ]
+    assert not leaked, (
+        f"{len(leaked)} of {len(connection.opened)} opened handles are neither "
+        f"cached nor closed"
+    )
+
+
+def test_concurrent_open_of_one_table_leaks_no_handle() -> None:
+    """Threads racing on the same table must not drop an opened handle."""
+    connection = _RacyConnection()
+    store = _store_on(connection)
+    barrier = threading.Barrier(8)
+    errors: List[BaseException] = []
+
+    def worker() -> None:
+        try:
+            barrier.wait(timeout=30)
+            store._get_table("documents")
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors, f"concurrent _get_table raised: {errors}"
+    assert len(store._table_cache) == 1
+    _assert_every_handle_cached_or_closed(connection, store)
+
+
+def test_concurrent_get_and_invalidate_leaks_no_handle() -> None:
+    """Interleaved cache fills and invalidations must stay consistent."""
+    connection = _RacyConnection(delay=0.001, close_delay=0.002)
+    store = _store_on(connection)
+    names = [f"table_{index}" for index in range(6)]
+    errors: List[BaseException] = []
+    stop = threading.Event()
+
+    def filler(name: str) -> None:
+        try:
+            while not stop.is_set():
+                store._get_table(name)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    def invalidator() -> None:
+        try:
+            while not stop.is_set():
+                store.invalidate_table_cache()
+                store.invalidate_table_cache("table_0")
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=filler, args=(name,)) for name in names]
+    threads += [threading.Thread(target=invalidator) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    threading.Event().wait(0.5)
+    stop.set()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors, f"concurrent cache access raised: {errors}"
+    _assert_every_handle_cached_or_closed(connection, store)
+
+
+def test_cache_never_exceeds_maxsize_under_concurrency() -> None:
+    """LRU eviction must hold when many threads fill the cache at once."""
+    connection = _RacyConnection(delay=0.0)
+    store = _store_on(connection)
+    over = store._TABLE_CACHE_MAXSIZE * 2
+    errors: List[BaseException] = []
+
+    def worker(index: int) -> None:
+        try:
+            store._get_table(f"table_{index}")
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(index,)) for index in range(over)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors, f"concurrent cache fill raised: {errors}"
+    assert len(store._table_cache) <= store._TABLE_CACHE_MAXSIZE
+    _assert_every_handle_cached_or_closed(connection, store)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_to_thread_handle_calls_share_no_mutable_connection() -> None:
+    """The shape #657 names: many to_thread storage calls on one shared loop."""
+    connection = _RacyConnection(delay=0.002)
+    store = _store_on(connection)
+
+    results = await asyncio.gather(
+        *(asyncio.to_thread(store._get_table, "documents") for _ in range(12))
+    )
+
+    assert all(table is results[0] for table in results)
+    assert len(store._table_cache) == 1
+    _assert_every_handle_cached_or_closed(connection, store)
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_connection_is_not_cached_on_the_instance(mock_get_connection: Mock) -> None:
+    """Connections come from the process-wide pool, which holds its own lock.
+
+    A per-instance cache would be unguarded shared state and would also outlive
+    both the pool's TTL and ``clear_connection_cache()``.
+    """
+    conn: Any = Mock()
+    mock_get_connection.return_value = conn
+    store = LanceDBVectorIndexStore()
+
+    assert not hasattr(store, "_conn")
+    assert store._get_connection() is conn
+    assert store._get_connection() is conn
+    assert mock_get_connection.call_count == 2

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
@@ -3,13 +3,22 @@
 The coordinator offloads blocking handle calls with ``asyncio.to_thread``. Once
 those are awaited concurrently on a shared loop, several worker threads reach a
 single process-wide store instance at the same time. These tests pin the two
-pieces of shared state that made that unsafe: the table-handle cache, and the
-per-instance connection cache that no longer exists.
+pieces of *synchronous* shared state that made that unsafe: the table-handle
+cache, and the per-instance sync connection cache that no longer exists.
+
+Async connection init is NOT covered here and is not safe yet: ``_async_conn``
+is still guarded by an ``asyncio.Lock`` that deadlocks when reached from more
+than one event loop. Tracked in #2200.
 
 The table-cache assertion is a conservation law rather than a race detector:
 every handle ``open_table`` returns must end up either in the cache or closed.
-An unguarded cache loses that -- two threads opening the same table overwrite
-one another, and the loser is neither cached nor closed, leaking its handle.
+What actually trips these tests on an unguarded cache is the crash -- a
+``move_to_end`` racing a concurrent ``clear``/``pop`` raises ``KeyError``.
+The conservation law is what catches a dropped ``_safe_close_table``.
+
+Note what is NOT reachable from a test: the cache-insert section's
+read-modify-write is atomic under the GIL, so removing its lock cannot be made
+to fail on CPython 3.12. That lock earns its place under free-threading only.
 """
 
 from __future__ import annotations

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
@@ -16,9 +16,9 @@ What actually trips these tests on an unguarded cache is the crash -- a
 ``move_to_end`` racing a concurrent ``clear``/``pop`` raises ``KeyError``.
 The conservation law is what catches a dropped ``_safe_close_table``.
 
-Note what is NOT reachable from a test: the cache-insert section's
-read-modify-write is atomic under the GIL, so removing its lock cannot be made
-to fail on CPython 3.12. That lock earns its place under free-threading only.
+Both locks are load-bearing: dropping either one loses the conservation law,
+because an unlocked insert can land inside the other's critical section and be
+erased by its ``clear()`` without ever appearing in its stale snapshot.
 """
 
 from __future__ import annotations
@@ -117,10 +117,17 @@ def test_concurrent_open_of_one_table_leaks_no_handle() -> None:
 
 
 def test_concurrent_get_and_invalidate_leaks_no_handle() -> None:
-    """Interleaved cache fills and invalidations must stay consistent."""
+    """Interleaved cache fills and invalidations must stay consistent.
+
+    Dropping ``invalidate_table_cache``'s lock fails this every run. Dropping
+    the insert-section lock fails it about one run in five: that window is only
+    a few bytecodes wide, and widening it further would mean a test hook inside
+    ``_get_table``. The table and invalidator counts below are tuned for those
+    odds -- raising the duration does not help, the window is what limits it.
+    """
     connection = _RacyConnection(delay=0.001, close_delay=0.002)
     store = _store_on(connection)
-    names = [f"table_{index}" for index in range(6)]
+    names = [f"table_{index}" for index in range(48)]
     errors: List[BaseException] = []
     stop = threading.Event()
 
@@ -140,7 +147,7 @@ def test_concurrent_get_and_invalidate_leaks_no_handle() -> None:
             errors.append(exc)
 
     threads = [threading.Thread(target=filler, args=(name,)) for name in names]
-    threads += [threading.Thread(target=invalidator) for _ in range(2)]
+    threads += [threading.Thread(target=invalidator) for _ in range(4)]
     for thread in threads:
         thread.start()
     threading.Event().wait(0.5)

--- a/tests/core/tools/core/RAG_tools/storage/test_vector_index_contract.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_vector_index_contract.py
@@ -68,7 +68,7 @@ def _store_on(db):
     )
 
     store = LanceDBVectorIndexStore()
-    store._conn = db
+    store._get_connection = lambda: db  # type: ignore[method-assign]
     return store
 
 


### PR DESCRIPTION
## Invariant

No unguarded mutable shared state remains where several worker threads reach one process-wide store instance at the same time.

## Background

The coordinator already offloads blocking handle calls with `asyncio.to_thread(handle.<method>, ...)`. The moment those are awaited concurrently on a shared event loop, several worker threads mutate the same store singleton. Today that is safe only because every collection-scoped operation lands on a single thread (`*_sync` wrappers drive a private single-coroutine loop, the parse path uses `asyncio.run`) and the coordinator has no `asyncio.gather`. This is the hardening that a real async-ingestion path needs first.

## Two pieces of shared state, handled differently

**1. The connection cache is deleted, not locked.** `LanceDBConnectionManager` (`providers/vector_store/lancedb.py:37-38,164-181`) is already a process-wide, `RLock`-guarded, TTL'd pool keyed by path. The five per-instance `_conn` / `_sync_conn` fields were caching something that was already cached thread-safely, so deleting them removes the whole class of race with no lock at all.

It also fixes a real bug: the pool closes a connection when `CONNECTION_TTL` expires (`lancedb.py:129-131`), but a store singleton held that exact object forever and never re-fetched, so the TTL was dead for every path going through a store.

**2. The table-handle cache does need a lock.** It caches table handles rather than connections, so the connection pool does not cover it, and the LRU + `_safe_close_table` eviction is deliberate fd management. `_get_table` now does a double-checked fill with `open_table` deliberately left *outside* the lock — holding it across that blocking I/O would serialize exactly the concurrency this issue exists to enable — and the handle that loses the insert race is closed. `invalidate_table_cache` drops entries under the lock and closes them outside it.

## Decision: threading lock, not native async

The issue leaves this open. Per #494's invariant (preserve existing sync/async shapes) and this issue's non-goal (do not change the public store contract shape), this takes the lock. Native async is left for the async-ingestion consumer that actually needs it.

## The invalidation/open race

`open_table` runs outside the lock on purpose — holding it there would serialize every concurrent open, which is the thing this PR exists to allow. That leaves a gap: an invalidation can run while an open is in flight, find an empty cache, and then the finishing open inserts a handle for a table that was just dropped. The cache is now epoch-stamped — `invalidate_table_cache` bumps it under the lock, `_get_table` snapshots it before the unlocked open — and a handle whose epoch moved is closed and re-opened once against the new one. `test_invalidation_during_open_does_not_cache_a_stale_handle` pins this deterministically by invalidating from inside `open_table` rather than racing threads.

## Note on how well each lock is pinned

Both cache locks are load-bearing, but they are not equally easy to catch. Dropping `invalidate_table_cache`'s lock fails the suite every run. Dropping the insert-section lock fails about half the runs.

The mechanism is worth recording, because I first got it wrong twice. The leak is not two openers overwriting each other — that interleaving really is unobservable under the GIL (37M unlocked insert attempts across 6 threads, zero overwrites). It is an unlocked insert landing *inside* `invalidate_table_cache`'s own critical section: absent from the stale snapshot it already took, then erased by its `clear()`. My second wrong call was claiming only a production hook could widen that window — an autouse `sys.setswitchinterval(1e-6)` fixture does it with nothing in production, taking detection from 1-in-5 to roughly half, and it is what makes the 1.5s duration matter (at the default interval, duration alone changed nothing).

## Not included

- No async-ingestion consumer is built here; this only makes the store safe for one.
- `_async_conn`'s `asyncio.Lock` (both stores) is untouched. It is awaited only on an event loop, so no thread crosses it — **but one `asyncio.Lock` reached from several event loops deadlocks, and these stores are process-wide singletons. That is a real pre-existing bug with a working reproduction, filed as #2200** rather than folded in here. The new test module's docstring says so explicitly, so nobody reads this PR as making the whole data plane safe.

## Change breakdown

Source `+63/-56` across two files, plus a 250-line concurrency test module. Two more lines re-point existing tests that injected fakes by assigning the private `store._conn`; they now override the connection getter instead.

## Validation

- Green: `RAG_tools` storage, kb, version_management, retrieval, management, LanceDB, plus `providers/vector_store/test_lancedb.py`.
- `pre-commit run --files` clean across every hook.
- The pool's default-directory log was INFO and is now DEBUG: with the per-instance caches gone it is reached on every connection request, and `LANCEDB_DIR` is set nowhere in the deploy config, so it would have logged once per storage operation. Measured 0 INFO records over 50 calls after the change.

### Mutation matrix

| Mutation | Detected |
|---|---|
| Drop the lock around the cache lookup | 5/5 — `KeyError`: `move_to_end` racing a concurrent `clear()`/`pop()`, a crash rather than the fd leak the issue describes |
| Drop the lock in `invalidate_table_cache` | 5/5 |
| Restore the per-instance connection cache | 5/5 |
| Drop `_safe_close_table(discarded)` | 3/3, three tests at once |
| Re-add a per-instance cache to any one of the five stores | 5/5, each store fails its own parametrized case |
| Drop the lock in the cache-insert section | 7/15 — see the note above |
| Skip the epoch check on a raced open | 5/5 |
| Stop bumping the epoch in `invalidate_table_cache` | 5/5 |
| Unmutated, 10 consecutive runs | 0 failures, not flaky |

Closes #657
