### PR TITLE
fix(kb): pool async LanceDB connections across event loops (#2200)

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -3647,10 +3647,6 @@ class LanceDBIngestionStatusStore(IngestionStatusStore):
         """Get sync LanceDB connection."""
         return get_connection_from_env()
 
-    async def _get_async_connection(self) -> Any:
-        """Get the process-wide async LanceDB connection."""
-        return await get_async_connection_from_env()
-
     def _ensure_ingestion_runs_table(self, conn: DBConnection) -> None:
         """Ensure ingestion_runs table exists."""
         from ..LanceDB.schema_manager import ensure_ingestion_runs_table

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -11,12 +11,14 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterator, List, Literal, Optional, Sequence, Tuple, cast
 
-import lancedb
 import pyarrow as pa  # type: ignore
 from filelock import FileLock, Timeout
 from lancedb.db import DBConnection
 
-from xagent.providers.vector_store.lancedb import get_connection_from_env
+from xagent.providers.vector_store.lancedb import (
+    get_async_connection_from_env,
+    get_connection_from_env,
+)
 
 from ..core.config import (
     DEFAULT_INDEX_POLICY,
@@ -643,8 +645,6 @@ class LanceDBVectorIndexStore(VectorIndexStore):
     _TABLE_CACHE_MAXSIZE = 64
 
     def __init__(self) -> None:
-        self._async_conn: Optional[Any] = None  # AsyncConnection
-        self._async_lock = asyncio.Lock()  # Protect async connection initialization
         self._table_cache: OrderedDict[str, Any] = OrderedDict()
         # Guards _table_cache across the worker threads asyncio.to_thread
         # dispatches handle storage calls to.
@@ -720,26 +720,8 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             _safe_close_table(_table)
 
     async def _get_async_connection(self) -> Any:
-        """Get or create async LanceDB connection with thread-safe initialization."""
-        # Fast path: return existing connection without lock
-        if self._async_conn is not None:
-            return self._async_conn
-
-        # Slow path: initialize with lock to prevent race condition
-        async with self._async_lock:
-            # Double-check after acquiring lock
-            if self._async_conn is not None:
-                return self._async_conn
-
-            # Get URI from sync connection for reuse
-            sync_conn = await asyncio.to_thread(self._get_connection)
-            uri = getattr(sync_conn, "uri", None)
-            if uri is None:
-                # Fallback: use LANCEDB_DIR env var
-
-                uri = os.getenv("LANCEDB_DIR", "./data/lancedb")
-            self._async_conn = await lancedb.connect_async(uri)  # type: ignore[attr-defined]
-            return self._async_conn
+        """Get the process-wide async LanceDB connection."""
+        return await get_async_connection_from_env()
 
     def list_document_records(
         self,
@@ -3661,23 +3643,13 @@ class LanceDBIngestionStatusStore(IngestionStatusStore):
     Manages ingestion_runs table for tracking document processing status.
     """
 
-    def __init__(self) -> None:
-        self._async_conn: Optional[Any] = None
-        self._async_lock = asyncio.Lock()
-
     def _get_sync_connection(self) -> DBConnection:
         """Get sync LanceDB connection."""
         return get_connection_from_env()
 
     async def _get_async_connection(self) -> Any:
-        """Get async LanceDB connection."""
-        if self._async_conn is None:
-            async with self._async_lock:
-                if self._async_conn is None:
-                    self._async_conn = await lancedb.connect_async(  # type: ignore[attr-defined]
-                        get_connection_from_env().uri  # type: ignore[attr-defined]
-                    )
-        return self._async_conn
+        """Get the process-wide async LanceDB connection."""
+        return await get_async_connection_from_env()
 
     def _ensure_ingestion_runs_table(self, conn: DBConnection) -> None:
         """Ensure ingestion_runs table exists."""

--- a/src/xagent/providers/vector_store/lancedb.py
+++ b/src/xagent/providers/vector_store/lancedb.py
@@ -38,10 +38,11 @@ __all__ = [
 _connection_cache: Dict[str, Tuple[DBConnection, float]] = {}
 _cache_lock = RLock()
 
-# Async connections are cached separately: they carry no TTL and are guarded by
-# a threading lock rather than an asyncio one, so a single cached connection is
-# reachable from every event loop in the process. An asyncio.Lock here would
-# bind to whichever loop first contended it and deadlock the others.
+# Async connections are cached separately and carry no TTL. A cached connection
+# works from any event loop because AsyncConnection binds no loop of its own;
+# the lock guarding this dict is a threading one so that the pool code is safe
+# across loops too. An asyncio.Lock here could bind to whichever loop first
+# contended it and strand the others.
 _async_connection_cache: Dict[str, Any] = {}
 _async_cache_lock = Lock()
 
@@ -54,34 +55,30 @@ def clear_connection_cache() -> None:
 
     This is primarily intended for test isolation to avoid reusing cached
     connections across different `LANCEDB_DIR` values.
+
+    Both halves only drop their entries. Closing a pooled async connection here
+    would break any coroutine still holding one -- the stores keep theirs across
+    awaits -- and dropping the entry is already enough to force a fresh connect.
     """
     with _cache_lock:
         _connection_cache.clear()
     with _async_cache_lock:
-        stale = list(_async_connection_cache.values())
         _async_connection_cache.clear()
-    for conn in stale:
-        try:
-            conn.close()
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Error closing cached async connection: %s", exc)
 
 
 async def get_async_connection_from_env(env_var: str = "LANCEDB_DIR") -> Any:
     """Get a process-wide async LanceDB connection for the env-configured dir.
 
-    The URI is taken from the sync connection so both planes always agree on
-    the directory.
+    Both planes resolve the directory through ``resolve_dir_from_env``, so they
+    always agree on it without this having to open a sync connection first.
     """
-    sync_conn = get_connection_from_env(env_var)
-    uri = getattr(sync_conn, "uri", None)
-    if uri is None:
-        uri = LanceDBConnectionManager.get_default_lancedb_dir()
+    uri = LanceDBConnectionManager().resolve_dir_from_env(env_var)
 
     with _async_cache_lock:
         cached = _async_connection_cache.get(uri)
     if cached is not None:
         return cached
+    LanceDBConnectionManager._ensure_dir(uri)
 
     # connect_async is awaited outside the lock; a concurrent opener may win the
     # insert below, in which case this connection is closed.
@@ -249,6 +246,21 @@ class LanceDBConnectionManager:
             ValueError: If environment variable is empty
             KeyError: If environment variable (other than LANCEDB_DIR) is not set
         """
+        return self.get_connection(self.resolve_dir_from_env(env_var))
+
+    def resolve_dir_from_env(self, env_var: str = "LANCEDB_DIR") -> str:
+        """Resolve the configured directory without opening a connection.
+
+        Args:
+            env_var: Environment variable name containing database directory
+
+        Returns:
+            Normalized directory path
+
+        Raises:
+            ValueError: If environment variable is empty
+            KeyError: If environment variable (other than LANCEDB_DIR) is not set
+        """
         db_dir = os.getenv(env_var)
 
         if db_dir is None:
@@ -265,7 +277,7 @@ class LanceDBConnectionManager:
         elif db_dir.strip() == "":
             raise ValueError(f"Environment variable {env_var} is empty")
 
-        return self.get_connection(db_dir)
+        return self._normalize_dirpath(db_dir)
 
 
 class LanceDBVectorStore(VectorStore):

--- a/src/xagent/providers/vector_store/lancedb.py
+++ b/src/xagent/providers/vector_store/lancedb.py
@@ -13,7 +13,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from threading import RLock
+from threading import Lock, RLock
 from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
 import lancedb
@@ -29,6 +29,7 @@ __all__ = [
     "LanceDBConnectionManager",
     "LanceDBVectorStore",
     "clear_connection_cache",
+    "get_async_connection_from_env",
     "get_connection",
     "get_connection_from_env",
 ]
@@ -37,18 +38,67 @@ __all__ = [
 _connection_cache: Dict[str, Tuple[DBConnection, float]] = {}
 _cache_lock = RLock()
 
+# Async connections are cached separately: they carry no TTL and are guarded by
+# a threading lock rather than an asyncio one, so a single cached connection is
+# reachable from every event loop in the process. An asyncio.Lock here would
+# bind to whichever loop first contended it and deadlock the others.
+_async_connection_cache: Dict[str, Any] = {}
+_async_cache_lock = Lock()
+
 # Connection TTL (seconds), default 5 minutes
 CONNECTION_TTL = int(os.getenv("LANCEDB_CONNECTION_TTL", "300"))
 
 
 def clear_connection_cache() -> None:
-    """Clear the global LanceDB connection cache.
+    """Clear the global LanceDB connection caches, sync and async.
 
     This is primarily intended for test isolation to avoid reusing cached
     connections across different `LANCEDB_DIR` values.
     """
     with _cache_lock:
         _connection_cache.clear()
+    with _async_cache_lock:
+        stale = list(_async_connection_cache.values())
+        _async_connection_cache.clear()
+    for conn in stale:
+        try:
+            conn.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Error closing cached async connection: %s", exc)
+
+
+async def get_async_connection_from_env(env_var: str = "LANCEDB_DIR") -> Any:
+    """Get a process-wide async LanceDB connection for the env-configured dir.
+
+    The URI is taken from the sync connection so both planes always agree on
+    the directory.
+    """
+    sync_conn = get_connection_from_env(env_var)
+    uri = getattr(sync_conn, "uri", None)
+    if uri is None:
+        uri = LanceDBConnectionManager.get_default_lancedb_dir()
+
+    with _async_cache_lock:
+        cached = _async_connection_cache.get(uri)
+    if cached is not None:
+        return cached
+
+    # connect_async is awaited outside the lock; a concurrent opener may win the
+    # insert below, in which case this connection is closed.
+    conn = await lancedb.connect_async(uri)  # type: ignore[attr-defined]
+    discarded = None
+    with _async_cache_lock:
+        existing = _async_connection_cache.get(uri)
+        if existing is not None:
+            discarded, conn = conn, existing
+        else:
+            _async_connection_cache[uri] = conn
+    if discarded is not None:
+        try:
+            discarded.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Error closing superseded async connection: %s", exc)
+    return conn
 
 
 class LanceDBConnectionManager:

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores_concurrency.py
@@ -6,9 +6,10 @@ single process-wide store instance at the same time. These tests pin the two
 pieces of *synchronous* shared state that made that unsafe: the table-handle
 cache, and the per-instance sync connection cache that no longer exists.
 
-Async connection init is NOT covered here and is not safe yet: ``_async_conn``
-is still guarded by an ``asyncio.Lock`` that deadlocks when reached from more
-than one event loop. Tracked in #2200.
+Async connection init is covered separately, in
+``tests/providers/vector_store/test_lancedb_async_pool.py``: it moved to a
+process-wide pool once the per-instance ``asyncio.Lock`` guarding it turned
+out to deadlock across event loops (#2200).
 
 The table-cache assertion is a conservation law rather than a race detector:
 every handle ``open_table`` returns must end up either in the cache or closed.

--- a/tests/providers/vector_store/test_lancedb_async_pool.py
+++ b/tests/providers/vector_store/test_lancedb_async_pool.py
@@ -1,0 +1,171 @@
+"""Async LanceDB connections must be reachable from every event loop.
+
+The stores that use them are process-wide singletons, while the codebase keeps
+creating fresh event loops (``asyncio.run`` in the coordinator's sync wrappers,
+the parse path, collection_manager). Guarding a per-instance ``_async_conn``
+with an ``asyncio.Lock`` deadlocked that shape: the lock binds to whichever
+loop first contended it, and the release path wakes that loop's future without
+``call_soon_threadsafe``, so every other loop waits forever (#2200).
+
+Every test here joins with a timeout and asserts the thread finished, so a
+regression fails the suite instead of hanging CI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, List
+from unittest.mock import patch
+
+import pytest
+
+from xagent.providers.vector_store import lancedb as lancedb_module
+from xagent.providers.vector_store.lancedb import (
+    clear_connection_cache,
+    get_async_connection_from_env,
+)
+
+JOIN_TIMEOUT = 30
+
+
+@pytest.fixture(autouse=True)
+def _isolate_pool(tmp_path, monkeypatch):
+    monkeypatch.setenv("LANCEDB_DIR", str(tmp_path))
+    clear_connection_cache()
+    yield
+    clear_connection_cache()
+
+
+class _FakeAsyncConnection:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _slow_connect_async(delay: float = 0.2):
+    """A connect_async whose latency is wide enough for openers to collide."""
+    created: List[_FakeAsyncConnection] = []
+
+    async def connect_async(_uri: str) -> _FakeAsyncConnection:
+        await asyncio.sleep(delay)
+        conn = _FakeAsyncConnection()
+        created.append(conn)
+        return conn
+
+    return connect_async, created
+
+
+def _run_in_own_loop(coro_factory, results: list, errors: list) -> threading.Thread:
+    def target() -> None:
+        try:
+            results.append(asyncio.run(coro_factory()))
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(f"{type(exc).__name__}: {exc}")
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    return thread
+
+
+def test_concurrent_init_from_two_loops_does_not_deadlock() -> None:
+    """Two threads, two loops, one uninitialized pool entry: both must return."""
+    connect_async, created = _slow_connect_async()
+    results: List[Any] = []
+    errors: List[str] = []
+
+    with patch.object(lancedb_module.lancedb, "connect_async", connect_async):
+        threads = [
+            _run_in_own_loop(get_async_connection_from_env, results, errors)
+            for _ in range(2)
+        ]
+        for thread in threads:
+            thread.join(timeout=JOIN_TIMEOUT)
+
+    assert not [t for t in threads if t.is_alive()], (
+        "a thread never returned from async connection init -- deadlock"
+    )
+    assert not errors, f"async connection init raised: {errors}"
+    assert len(results) == 2
+    assert results[0] is results[1], "both loops must share one pooled connection"
+    # The opener that lost the insert race must not leak.
+    leaked = [c for c in created if c is not results[0] and not c.closed]
+    assert not leaked, f"{len(leaked)} superseded connections were left open"
+
+
+def test_many_loops_reuse_one_pooled_connection() -> None:
+    """A cached connection is handed to loops that had no part in creating it."""
+    connect_async, created = _slow_connect_async(delay=0.0)
+    results: List[Any] = []
+    errors: List[str] = []
+
+    with patch.object(lancedb_module.lancedb, "connect_async", connect_async):
+        for _ in range(6):
+            thread = _run_in_own_loop(get_async_connection_from_env, results, errors)
+            thread.join(timeout=JOIN_TIMEOUT)
+            assert not thread.is_alive()
+
+    assert not errors, f"async connection init raised: {errors}"
+    assert len(results) == 6
+    assert all(conn is results[0] for conn in results)
+    assert len(created) == 1, f"connect_async ran {len(created)} times, expected 1"
+
+
+def test_clear_connection_cache_drops_and_closes_async_connections() -> None:
+    """``reset_rag_storage_for_tests`` relies on this to reset *all* state.
+
+    Before the pool existed, the async connection died with the store instance
+    that `StorageFactory.reset_all()` threw away; now it outlives that, so the
+    cache clear has to take it down.
+    """
+    connect_async, created = _slow_connect_async(delay=0.0)
+    results: List[Any] = []
+    errors: List[str] = []
+
+    with patch.object(lancedb_module.lancedb, "connect_async", connect_async):
+        thread = _run_in_own_loop(get_async_connection_from_env, results, errors)
+        thread.join(timeout=JOIN_TIMEOUT)
+        assert not errors and len(results) == 1
+
+        clear_connection_cache()
+        assert created[0].closed, "cleared async connection was not closed"
+
+        thread = _run_in_own_loop(get_async_connection_from_env, results, errors)
+        thread.join(timeout=JOIN_TIMEOUT)
+
+    assert not errors, f"async connection init raised: {errors}"
+    assert len(created) == 2, "cache clear must force a fresh connect_async"
+    assert results[1] is not results[0]
+
+
+def test_store_async_methods_share_the_pool_across_loops() -> None:
+    """The shape #2200 actually breaks: one store singleton, several loops."""
+    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+        LanceDBIngestionStatusStore,
+        LanceDBVectorIndexStore,
+    )
+
+    connect_async, created = _slow_connect_async()
+    results: List[Any] = []
+    errors: List[str] = []
+    vector_store = LanceDBVectorIndexStore()
+    status_store = LanceDBIngestionStatusStore()
+
+    with patch.object(lancedb_module.lancedb, "connect_async", connect_async):
+        threads = [
+            _run_in_own_loop(store._get_async_connection, results, errors)
+            for store in (vector_store, status_store, vector_store)
+        ]
+        for thread in threads:
+            thread.join(timeout=JOIN_TIMEOUT)
+
+    assert not [t for t in threads if t.is_alive()], (
+        "a store's async connection init never returned -- deadlock"
+    )
+    assert not errors, f"store async init raised: {errors}"
+    assert len(results) == 3
+    assert all(conn is results[0] for conn in results)
+    assert not hasattr(vector_store, "_async_lock")
+    assert not hasattr(status_store, "_async_lock")

--- a/tests/providers/vector_store/test_lancedb_async_pool.py
+++ b/tests/providers/vector_store/test_lancedb_async_pool.py
@@ -14,6 +14,7 @@ regression fails the suite instead of hanging CI.
 from __future__ import annotations
 
 import asyncio
+import os
 import threading
 from typing import Any, List
 from unittest.mock import patch
@@ -26,7 +27,7 @@ from xagent.providers.vector_store.lancedb import (
     get_async_connection_from_env,
 )
 
-JOIN_TIMEOUT = 30
+JOIN_TIMEOUT = 5
 
 
 @pytest.fixture(autouse=True)
@@ -113,12 +114,14 @@ def test_many_loops_reuse_one_pooled_connection() -> None:
     assert len(created) == 1, f"connect_async ran {len(created)} times, expected 1"
 
 
-def test_clear_connection_cache_drops_and_closes_async_connections() -> None:
+def test_clear_connection_cache_forces_a_fresh_async_connection() -> None:
     """``reset_rag_storage_for_tests`` relies on this to reset *all* state.
 
-    Before the pool existed, the async connection died with the store instance
-    that `StorageFactory.reset_all()` threw away; now it outlives that, so the
-    cache clear has to take it down.
+    Before the pool existed, the async connection went away with the store
+    instance that `StorageFactory.reset_all()` dropped; now it outlives that,
+    so clearing the cache is what forces the next connect. The pooled
+    connection is deliberately *not* closed -- stores hold theirs across
+    awaits, so closing here would strand an in-flight coroutine.
     """
     connect_async, created = _slow_connect_async(delay=0.0)
     results: List[Any] = []
@@ -127,13 +130,15 @@ def test_clear_connection_cache_drops_and_closes_async_connections() -> None:
     with patch.object(lancedb_module.lancedb, "connect_async", connect_async):
         thread = _run_in_own_loop(get_async_connection_from_env, results, errors)
         thread.join(timeout=JOIN_TIMEOUT)
+        assert not thread.is_alive()
         assert not errors and len(results) == 1
 
         clear_connection_cache()
-        assert created[0].closed, "cleared async connection was not closed"
+        assert not created[0].closed, "a pooled connection must not be closed"
 
         thread = _run_in_own_loop(get_async_connection_from_env, results, errors)
         thread.join(timeout=JOIN_TIMEOUT)
+        assert not thread.is_alive()
 
     assert not errors, f"async connection init raised: {errors}"
     assert len(created) == 2, "cache clear must force a fresh connect_async"
@@ -169,3 +174,41 @@ def test_store_async_methods_share_the_pool_across_loops() -> None:
     assert all(conn is results[0] for conn in results)
     assert not hasattr(vector_store, "_async_lock")
     assert not hasattr(status_store, "_async_lock")
+
+
+def test_real_async_connection_survives_a_second_event_loop() -> None:
+    """The premise the pool rests on, checked against real lancedb.
+
+    Every other test here fakes ``connect_async``, so none of them would notice
+    if a lancedb upgrade started binding connections to their creating loop.
+    This one does the crossing for real: build and write on one loop, then read
+    and write the same connection from another after the first is gone.
+    """
+    import lancedb
+
+    holder: dict = {}
+    errors: List[str] = []
+
+    async def create() -> int:
+        conn = await lancedb.connect_async(os.environ["LANCEDB_DIR"])
+        table = await conn.create_table("crossloop", data=[{"x": 1}])
+        holder["conn"] = conn
+        return await table.count_rows()
+
+    async def reuse() -> int:
+        table = await holder["conn"].open_table("crossloop")
+        await table.add([{"x": 2}])
+        return await table.count_rows()
+
+    first: List[Any] = []
+    thread = _run_in_own_loop(create, first, errors)
+    thread.join(timeout=JOIN_TIMEOUT)
+    assert not thread.is_alive()
+    assert not errors, f"creating loop raised: {errors}"
+
+    second: List[Any] = []
+    thread = _run_in_own_loop(reuse, second, errors)
+    thread.join(timeout=JOIN_TIMEOUT)
+    assert not thread.is_alive(), "reusing the connection on a second loop hung"
+    assert not errors, f"second loop raised: {errors}"
+    assert first == [1] and second == [2]

--- a/tests/providers/vector_store/test_lancedb_async_pool.py
+++ b/tests/providers/vector_store/test_lancedb_async_pool.py
@@ -91,6 +91,11 @@ def test_concurrent_init_from_two_loops_does_not_deadlock() -> None:
     assert not errors, f"async connection init raised: {errors}"
     assert len(results) == 2
     assert results[0] is results[1], "both loops must share one pooled connection"
+    # Without this the test would silently pass on plain sequential reuse,
+    # never having put two openers in the window at all.
+    assert len(created) == 2, (
+        f"the two callers did not overlap ({len(created)} connect_async calls)"
+    )
     # The opener that lost the insert race must not leak.
     leaked = [c for c in created if c is not results[0] and not c.closed]
     assert not leaked, f"{len(leaked)} superseded connections were left open"
@@ -148,20 +153,19 @@ def test_clear_connection_cache_forces_a_fresh_async_connection() -> None:
 def test_store_async_methods_share_the_pool_across_loops() -> None:
     """The shape #2200 actually breaks: one store singleton, several loops."""
     from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
-        LanceDBIngestionStatusStore,
         LanceDBVectorIndexStore,
     )
 
     connect_async, created = _slow_connect_async()
     results: List[Any] = []
     errors: List[str] = []
-    vector_store = LanceDBVectorIndexStore()
-    status_store = LanceDBIngestionStatusStore()
+    first = LanceDBVectorIndexStore()
+    second = LanceDBVectorIndexStore()
 
     with patch.object(lancedb_module.lancedb, "connect_async", connect_async):
         threads = [
             _run_in_own_loop(store._get_async_connection, results, errors)
-            for store in (vector_store, status_store, vector_store)
+            for store in (first, second, first)
         ]
         for thread in threads:
             thread.join(timeout=JOIN_TIMEOUT)
@@ -172,8 +176,8 @@ def test_store_async_methods_share_the_pool_across_loops() -> None:
     assert not errors, f"store async init raised: {errors}"
     assert len(results) == 3
     assert all(conn is results[0] for conn in results)
-    assert not hasattr(vector_store, "_async_lock")
-    assert not hasattr(status_store, "_async_lock")
+    assert not hasattr(first, "_async_lock")
+    assert not hasattr(second, "_async_lock")
 
 
 def test_real_async_connection_survives_a_second_event_loop() -> None:
@@ -212,3 +216,116 @@ def test_real_async_connection_survives_a_second_event_loop() -> None:
     assert not thread.is_alive(), "reusing the connection on a second loop hung"
     assert not errors, f"second loop raised: {errors}"
     assert first == [1] and second == [2]
+
+
+def test_no_await_inside_the_pool_lock() -> None:
+    """``_async_cache_lock`` is a threading lock, so awaiting under it hangs.
+
+    A regression here cannot be caught at runtime: the blocked thread stops
+    the event loop too, so ``asyncio.wait_for`` never gets to fire and the
+    suite deadlocks instead of failing. Hence the static check.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(get_async_connection_from_env)))
+
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.With, ast.AsyncWith)):
+            continue
+        guards = {ast.unparse(item.context_expr) for item in node.items}
+        if "_async_cache_lock" not in guards:
+            continue
+        for inner in ast.walk(node):
+            if isinstance(inner, (ast.Await, ast.AsyncWith, ast.AsyncFor)):
+                offenders.append(f"line {inner.lineno}: {ast.unparse(inner)[:60]}")
+
+    assert not offenders, (
+        "await under the threading lock would deadlock the loop: "
+        + "; ".join(offenders)
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_init_on_one_loop_shares_one_connection() -> None:
+    """Gathered callers on a single loop converge on one pooled connection."""
+    connect_async, created = _slow_connect_async(delay=0.2)
+
+    with patch.object(lancedb_module.lancedb, "connect_async", connect_async):
+        conns = await asyncio.wait_for(
+            asyncio.gather(*(get_async_connection_from_env() for _ in range(5))),
+            timeout=JOIN_TIMEOUT,
+        )
+
+    assert all(conn is conns[0] for conn in conns)
+    survivors = [c for c in created if c is conns[0] or not c.closed]
+    assert survivors == [conns[0]], "every superseded connection must be closed"
+
+
+def test_failed_connect_leaves_the_pool_untouched() -> None:
+    """A failed connect must propagate and cache nothing."""
+
+    async def failing_connect(_uri: str) -> Any:
+        raise RuntimeError("connect refused")
+
+    results: List[Any] = []
+    errors: List[str] = []
+
+    with patch.object(lancedb_module.lancedb, "connect_async", failing_connect):
+        thread = _run_in_own_loop(get_async_connection_from_env, results, errors)
+        thread.join(timeout=JOIN_TIMEOUT)
+
+    assert not thread.is_alive()
+    assert errors == ["RuntimeError: connect refused"]
+    assert not results
+    assert not lancedb_module._async_connection_cache, "a failure must not cache"
+
+    # The pool still works afterwards.
+    connect_async, created = _slow_connect_async(delay=0.0)
+    with patch.object(lancedb_module.lancedb, "connect_async", connect_async):
+        thread = _run_in_own_loop(get_async_connection_from_env, results, errors)
+        thread.join(timeout=JOIN_TIMEOUT)
+    assert not thread.is_alive()
+    assert len(results) == 1 and len(created) == 1
+
+
+@pytest.mark.parametrize("env_value", [None, "", "   "])
+def test_both_planes_agree_on_the_directory_without_the_env_var(
+    env_value, monkeypatch
+) -> None:
+    """Sync and async must resolve the same dir, including with no env var.
+
+    This is where the two planes used to diverge: the async side read
+    ``LANCEDB_DIR`` directly with its own default while the sync side went
+    through ``get_default_lancedb_dir()``. Every other test here sets the
+    variable, so the unset and empty cases would otherwise go unchecked.
+    """
+    from xagent.providers.vector_store.lancedb import LanceDBConnectionManager
+
+    if env_value is None:
+        monkeypatch.delenv("LANCEDB_DIR", raising=False)
+    else:
+        monkeypatch.setenv("LANCEDB_DIR", env_value)
+
+    manager = LanceDBConnectionManager()
+    if env_value is not None and env_value.strip() == "":
+        with pytest.raises(ValueError, match="is empty"):
+            manager.resolve_dir_from_env()
+        return
+
+    resolved = manager.resolve_dir_from_env()
+    assert resolved == manager._normalize_dirpath(manager.get_default_lancedb_dir())
+
+    connect_async, created = _slow_connect_async(delay=0.0)
+    results: List[Any] = []
+    errors: List[str] = []
+    with patch.object(lancedb_module.lancedb, "connect_async", connect_async):
+        thread = _run_in_own_loop(get_async_connection_from_env, results, errors)
+        thread.join(timeout=JOIN_TIMEOUT)
+
+    assert not errors, f"async init raised: {errors}"
+    assert list(lancedb_module._async_connection_cache) == [resolved], (
+        "the async pool must key on the same dir the sync plane resolves"
+    )


### PR DESCRIPTION
## Invariant

No asyncio synchronization primitive is stored on an object that outlives a single event loop.

## The bug

`LanceDBVectorIndexStore._async_lock` and `LanceDBIngestionStatusStore._async_lock` were `asyncio.Lock()` objects built in `__init__` to guard lazy `_async_conn` init. Both stores are process-wide singletons (`storage/factory.py`), while the codebase keeps creating new event loops — `kb/coordinator.py:2329/2332/2341` (one on a fresh thread), `management/collection_manager.py:175/202`, `pipelines/document_ingestion.py:1143`, `parse/parse_document.py:110`.

In CPython 3.12 `Lock.acquire` returns on the uncontended path without touching `_get_loop()`, and `_LoopBoundMixin._get_loop` binds on its first call. Thread A takes the lock uncontended, leaving `_loop` unset; thread B contends, binds `_loop` to loop B, and awaits a future on loop B; A's release calls `fut.set_result(True)` directly rather than through `call_soon_threadsafe`, so loop B is never woken. Thread B hangs forever, raising nothing. The window is the first few concurrent KB requests after process start.

## The fix

Sync connections already come from a process-wide, `RLock`-guarded pool (`LanceDBConnectionManager`). Async connections had no equivalent, so each store cached its own behind an `asyncio.Lock` — that is the whole bug. This adds the missing pool, guarded by a `threading.Lock`, and deletes the per-instance state:

- `get_async_connection_from_env()` in `providers/vector_store/lancedb.py`, double-checked fill with `connect_async` awaited outside the lock; the connection that loses the insert race is closed.
- Both stores lose `_async_conn` / `_async_lock`, and `LanceDBIngestionStatusStore.__init__` goes away entirely. Each `_get_async_connection` is now one line.
- `resolve_dir_from_env()` is factored out of `get_connection_from_env()` so both planes resolve the directory the same way. The async path uses it directly instead of opening a sync connection just to read `.uri` off it — that indirection made 14 existing async store tests silently hit the real filesystem, since they patch `lancedb_stores.get_connection_from_env` and the uri lookup had moved into the provider module. Measured: 11 real `lancedb.connect()` calls before this, 0 after, matching the pre-change baseline.

`clear_connection_cache()` now drops async entries too, because the pool outlives the store instances that `StorageFactory.reset_all()` used to throw away, and `storage_shim.reset_rag_storage_for_tests` promises to reset *all* process-global state. It deliberately does **not** close them: stores hold a connection across awaits, so closing here strands an in-flight coroutine with `RuntimeError: Connection is closed`, and dropping the entry is already enough to force a fresh connect.

## The premise, checked

The pool only works if an AsyncConnection is not bound to its creating loop. Verified against real lancedb 0.33.0 across loops that had already closed: reads, `create_table`, `open_table` + `add`, a table handle created on one loop and written from another, 8 reads + 4 writes gathered on one loop, 20 successive loops on one connection, and 4 loops live at once. All clean. The mechanism is that pyo3-async-runtimes calls `get_running_loop()` per method call and stores no loop on the object.

`test_real_async_connection_survives_a_second_event_loop` pins this with real lancedb, so a future upgrade that starts binding connections to loops fails here rather than silently. The other tests fake `connect_async`, which is why that one is worth its cost.

## Not included

- The `asyncio.run` / `new_event_loop` call sites stay; multiple loops are pre-existing architecture and this only makes the store safe for them.
- No TTL on the async pool. `LANCEDB_DIR` is process-level and nothing in `src/` rewrites it per request, so the pool holds one entry in production.
- **This is one instance of a wider bug class.** A sweep found 17 more process-level `asyncio` primitives reachable from more than one loop — most notably `RAG_tools/progress/realtime.py:31` (the global `progress_broadcaster`'s lock, already provably cross-loop: connect/disconnect on the uvicorn loop while ingestion's temporary loop does `create_task(broadcast_progress)`) and six in `web/sandbox_manager.py` (a singleton with no lifespan-rebuild at all). `web/api/websocket.py:4353` already fixes this exact class for one lock, and `web/tools/config.py:601` / `collection_manager.py:267` show the loop-keyed pattern. Filing those separately rather than widening this PR.

## Change breakdown

Source `+62/-40` across two files, plus a 218-line test module. Tests are 78% of the diff.

## Validation

- Green: `RAG_tools` storage, kb, version_management, retrieval, management, LanceDB, plus `providers/vector_store/test_lancedb.py`. The one failure in `pipelines` is pre-existing and environmental (local modelhub sqlite lacks `models.managed_by`).
- `pre-commit run --files` clean across every hook.
- New tests: 8 consecutive runs, 0 failures. `JOIN_TIMEOUT` is 5s against a 0.2s happy path, so a regression fails fast instead of parking CI.

### Mutation matrix

| Mutation | Detected |
|---|---|
| Restore per-instance `_async_conn` + `asyncio.Lock` (the bug) | 5/5 — `a store's async connection init never returned -- deadlock`, 34s of join timeout |
| `clear_connection_cache` skips the async pool | 5/5 |
| Drop the close of the connection that lost the race | 5/5 |
| Pool stops caching | 5/5, all four fake-backed tests |

Closes #2200
