### PR TITLE
refactor(web): report the active interaction read as three states

### DIFF
--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from time import monotonic
-from typing import Any, Mapping
+from typing import Any, Mapping, assert_never
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
@@ -523,8 +523,7 @@ async def _resume_input_required_a2a_task(
             active_interaction_id = active_interaction_read.interaction_id
         elif isinstance(active_interaction_read, ActiveInteractionAbsent):
             active_interaction_id = None
-        else:
-            assert isinstance(active_interaction_read, ActiveInteractionUnavailable)
+        elif isinstance(active_interaction_read, ActiveInteractionUnavailable):
             active_interaction_id = None
             logger.info(
                 "active interaction read unavailable (reason=%s) for "
@@ -532,6 +531,8 @@ async def _resume_input_required_a2a_task(
                 active_interaction_read.reason,
                 task_id,
             )
+        else:
+            assert_never(active_interaction_read)
 
         async def inject_user_message() -> tuple[Any, UserMessageInjectionOutcome]:
             from .chat import get_agent_manager

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -65,6 +65,9 @@ from ..services.task_execution_controller import (
     task_execution_controller,
 )
 from ..services.task_interaction_close import (
+    ActiveInteractionAbsent,
+    ActiveInteractionFound,
+    ActiveInteractionUnavailable,
     active_interaction_id_sync,
     clear_interaction_marker_if_unpaired,
     close_legacy_resume_interaction,
@@ -502,9 +505,33 @@ async def _resume_input_required_a2a_task(
         # _update_a2a_resume_input_sync reads that report to decide whether
         # to skip its close call -- see the guard inside that function for
         # why a replay must skip it.
-        active_interaction_id = await run_db_io_cancellation_safe(
+        active_interaction_read = await run_db_io_cancellation_safe(
             lambda: active_interaction_id_sync(task_id)
         )
+        # Translate the three-state read into the `int | None` this site's
+        # close call takes. Absent and Unavailable both become `None` here
+        # -- but that is not folding Unavailable into Absent, it is this
+        # call's own contract: `None` means "bind the close to no primary
+        # key, so it matches zero rows and the active row and marker both
+        # survive" (see active_interaction_id_sync's docstring), which is
+        # the safe outcome for a read that could not be made, not a claim
+        # that nothing was ever active. Written as three branches, not
+        # `interaction_id if isinstance(..., ActiveInteractionFound) else
+        # None`, so a reader (and mypy) sees Unavailable handled on its own
+        # line rather than merged into Absent's.
+        if isinstance(active_interaction_read, ActiveInteractionFound):
+            active_interaction_id = active_interaction_read.interaction_id
+        elif isinstance(active_interaction_read, ActiveInteractionAbsent):
+            active_interaction_id = None
+        else:
+            assert isinstance(active_interaction_read, ActiveInteractionUnavailable)
+            active_interaction_id = None
+            logger.info(
+                "active interaction read unavailable (reason=%s) for "
+                "task_id=%s; the legacy resume close will match no row",
+                active_interaction_read.reason,
+                task_id,
+            )
 
         async def inject_user_message() -> tuple[Any, UserMessageInjectionOutcome]:
             from .chat import get_agent_manager

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -512,10 +512,13 @@ async def _resume_input_required_a2a_task(
         # close call takes. Absent and Unavailable both become `None` here
         # -- but that is not folding Unavailable into Absent, it is this
         # call's own contract: `None` means "bind the close to no primary
-        # key, so it matches zero rows and the active row and marker both
-        # survive" (see active_interaction_id_sync's docstring), which is
-        # the safe outcome for a read that could not be made, not a claim
-        # that nothing was ever active. Written as three branches, not
+        # key", so it matches zero rows and retires no question either
+        # way, which is the safe outcome for a read that could not be
+        # made, not a claim that nothing was ever active. What then
+        # happens to the task's marker differs between the two, and this
+        # value is not what decides it -- the clear beside the close runs
+        # its own check (see active_interaction_id_sync's docstring).
+        # Written as three branches, not
         # `interaction_id if isinstance(..., ActiveInteractionFound) else
         # None`, so a reader (and mypy) sees Unavailable handled on its own
         # line rather than merged into Absent's.

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -61,6 +61,9 @@ from ...services.db_runtime import (
 from ...services.llm_utils import AutoModelUnavailableError
 from ...services.task_execution_controller import TaskControlState
 from ...services.task_interaction_close import (
+    ActiveInteractionAbsent,
+    ActiveInteractionFound,
+    ActiveInteractionUnavailable,
     active_interaction_id_sync,
     clear_interaction_marker_if_unpaired,
     close_legacy_resume_interaction,
@@ -523,9 +526,33 @@ async def reply_to_task(
         # Read before the injection below, not inside
         # _update_reply_input_sync, whose session opens only afterwards.
         # See task_interaction_close's module docstring for why.
-        active_interaction_id = await run_db_io_cancellation_safe(
+        active_interaction_read = await run_db_io_cancellation_safe(
             lambda: active_interaction_id_sync(task_id)
         )
+        # Translate the three-state read into the `int | None` this site's
+        # close call takes. Absent and Unavailable both become `None` here
+        # -- but that is not folding Unavailable into Absent, it is this
+        # call's own contract: `None` means "bind the close to no primary
+        # key, so it matches zero rows and the active row and marker both
+        # survive" (see active_interaction_id_sync's docstring), which is
+        # the safe outcome for a read that could not be made, not a claim
+        # that nothing was ever active. Written as three branches, not
+        # `interaction_id if isinstance(..., ActiveInteractionFound) else
+        # None`, so a reader (and mypy) sees Unavailable handled on its own
+        # line rather than merged into Absent's.
+        if isinstance(active_interaction_read, ActiveInteractionFound):
+            active_interaction_id = active_interaction_read.interaction_id
+        elif isinstance(active_interaction_read, ActiveInteractionAbsent):
+            active_interaction_id = None
+        else:
+            assert isinstance(active_interaction_read, ActiveInteractionUnavailable)
+            active_interaction_id = None
+            logger.info(
+                "active interaction read unavailable (reason=%s) for "
+                "task_id=%s; the legacy resume close will match no row",
+                active_interaction_read.reason,
+                task_id,
+            )
 
         async def inject_user_message() -> tuple[Any, bool]:
             from .. import chat

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -533,10 +533,13 @@ async def reply_to_task(
         # close call takes. Absent and Unavailable both become `None` here
         # -- but that is not folding Unavailable into Absent, it is this
         # call's own contract: `None` means "bind the close to no primary
-        # key, so it matches zero rows and the active row and marker both
-        # survive" (see active_interaction_id_sync's docstring), which is
-        # the safe outcome for a read that could not be made, not a claim
-        # that nothing was ever active. Written as three branches, not
+        # key", so it matches zero rows and retires no question either
+        # way, which is the safe outcome for a read that could not be
+        # made, not a claim that nothing was ever active. What then
+        # happens to the task's marker differs between the two, and this
+        # value is not what decides it -- the clear beside the close runs
+        # its own check (see active_interaction_id_sync's docstring).
+        # Written as three branches, not
         # `interaction_id if isinstance(..., ActiveInteractionFound) else
         # None`, so a reader (and mypy) sees Unavailable handled on its own
         # line rather than merged into Absent's.

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -40,7 +40,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, assert_never
 from uuid import uuid4
 
 from sqlalchemy import func
@@ -544,8 +544,7 @@ async def reply_to_task(
             active_interaction_id = active_interaction_read.interaction_id
         elif isinstance(active_interaction_read, ActiveInteractionAbsent):
             active_interaction_id = None
-        else:
-            assert isinstance(active_interaction_read, ActiveInteractionUnavailable)
+        elif isinstance(active_interaction_read, ActiveInteractionUnavailable):
             active_interaction_id = None
             logger.info(
                 "active interaction read unavailable (reason=%s) for "
@@ -553,6 +552,8 @@ async def reply_to_task(
                 active_interaction_read.reason,
                 task_id,
             )
+        else:
+            assert_never(active_interaction_read)
 
         async def inject_user_message() -> tuple[Any, bool]:
             from .. import chat

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -6783,11 +6783,15 @@ async def _handle_chat_message_unserialized(
                     # apart from a fresh Absent). Absent and Unavailable both
                     # become `None` for the same reason as the other two
                     # close sites: `None` binds the close to no primary key,
-                    # which matches zero rows and leaves the active row and
-                    # marker both in place -- the safe outcome for a read
-                    # that could not be made, not a claim that nothing was
-                    # ever active. Three branches, not a two-way isinstance
-                    # fold, so Unavailable stays visible on its own line.
+                    # which matches zero rows and retires no question
+                    # either way -- the safe outcome for a read that could
+                    # not be made, not a claim that nothing was ever
+                    # active. What then happens to the task's marker
+                    # differs between the two, and this value is not what
+                    # decides it: the clear beside the close runs its own
+                    # check (see active_interaction_id_sync's docstring).
+                    # Three branches, not a two-way isinstance fold, so
+                    # Unavailable stays visible on its own line.
                     if isinstance(active_interaction_read, ActiveInteractionFound):
                         active_interaction_id = active_interaction_read.interaction_id
                     elif isinstance(active_interaction_read, ActiveInteractionAbsent):

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -23,6 +23,7 @@ from typing import (
     Literal,
     Optional,
     Union,
+    assert_never,
     cast,
     overload,
 )
@@ -6791,10 +6792,9 @@ async def _handle_chat_message_unserialized(
                         active_interaction_id = active_interaction_read.interaction_id
                     elif isinstance(active_interaction_read, ActiveInteractionAbsent):
                         active_interaction_id = None
-                    else:
-                        assert isinstance(
-                            active_interaction_read, ActiveInteractionUnavailable
-                        )
+                    elif isinstance(
+                        active_interaction_read, ActiveInteractionUnavailable
+                    ):
                         active_interaction_id = None
                         logger.info(
                             "active interaction read unavailable (reason=%s) "
@@ -6803,6 +6803,8 @@ async def _handle_chat_message_unserialized(
                             active_interaction_read.reason,
                             task_id,
                         )
+                    else:
+                        assert_never(active_interaction_read)
 
                     posted = UserMessageInjectionOutcome.NOT_POSTED
                     if live_task_lease is not None:
@@ -9122,8 +9124,12 @@ async def _handle_resume_task_unserialized(
                 task_id,
                 task_fields.run_id,
             )
+        elif isinstance(active_interaction_read, ActiveInteractionAbsent):
+            # Nothing to do: no native interaction row is waiting on an
+            # answer, so this gate lets the resume through.
+            pass
         else:
-            assert isinstance(active_interaction_read, ActiveInteractionAbsent)
+            assert_never(active_interaction_read)
 
         attempt_count = message_data.get("_durable_attempt_count")
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -199,6 +199,9 @@ from ..services.task_execution_controller import (
     task_execution_controller,
 )
 from ..services.task_interaction_close import (
+    ActiveInteractionAbsent,
+    ActiveInteractionFound,
+    ActiveInteractionUnavailable,
     active_interaction_id_sync,
     clear_interaction_marker_if_unpaired,
     close_legacy_resume_interaction_sync,
@@ -6764,9 +6767,42 @@ async def _handle_chat_message_unserialized(
                     # local, posted false hands the same value to
                     # execute_resume_background through pending_user_message,
                     # so one observation only ever serves one close.
-                    active_interaction_id = await run_db_io_cancellation_safe(
+                    active_interaction_read = await run_db_io_cancellation_safe(
                         lambda: active_interaction_id_sync(task_id)
                     )
+                    # Translated here, on the read side, for both branches at
+                    # once: the deferred path (posted false) does not re-read
+                    # -- it carries whatever this site puts in
+                    # pending_user_message["interaction_id"] and is pinned by
+                    # tests/web/api/test_websocket_owner_actor.py not to call
+                    # active_interaction_id_sync itself -- so translating the
+                    # three-state read anywhere past this point would leave
+                    # that path with a three-state value it has no way to
+                    # judge (it never re-reads, so it cannot tell Unavailable
+                    # apart from a fresh Absent). Absent and Unavailable both
+                    # become `None` for the same reason as the other two
+                    # close sites: `None` binds the close to no primary key,
+                    # which matches zero rows and leaves the active row and
+                    # marker both in place -- the safe outcome for a read
+                    # that could not be made, not a claim that nothing was
+                    # ever active. Three branches, not a two-way isinstance
+                    # fold, so Unavailable stays visible on its own line.
+                    if isinstance(active_interaction_read, ActiveInteractionFound):
+                        active_interaction_id = active_interaction_read.interaction_id
+                    elif isinstance(active_interaction_read, ActiveInteractionAbsent):
+                        active_interaction_id = None
+                    else:
+                        assert isinstance(
+                            active_interaction_read, ActiveInteractionUnavailable
+                        )
+                        active_interaction_id = None
+                        logger.info(
+                            "active interaction read unavailable (reason=%s) "
+                            "for task_id=%s; the legacy resume close will "
+                            "match no row",
+                            active_interaction_read.reason,
+                            task_id,
+                        )
 
                     posted = UserMessageInjectionOutcome.NOT_POSTED
                     if live_task_lease is not None:
@@ -8989,10 +9025,10 @@ async def _handle_resume_task_unserialized(
         # append to or replan around an unanswered question. This runs
         # before agent_service is built (below) so a refused request never
         # pays for constructing one. Gated on tasks.interaction_protocol_
-        # version first, though: under a NULL marker the read below returns
-        # None regardless of whether an active row exists, so this refusal
-        # never fires for that state -- deliberately, matching what the
-        # read surface would show for the same task (see
+        # version first, though: under a NULL marker the read below reports
+        # ActiveInteractionAbsent regardless of whether an active row
+        # exists, so this refusal never fires for that state -- deliberately,
+        # matching what the read surface would show for the same task (see
         # active_interaction_id_sync's own docstring).
         #
         # Residual window, named here rather than closed here: this lookup
@@ -9005,10 +9041,11 @@ async def _handle_resume_task_unserialized(
         # The read itself is task_interaction_close.active_interaction_id_sync
         # -- the same reader the three legacy-resume injection sites use, so
         # this gate and the close cannot disagree about which row is live.
-        active_interaction_id = await run_db_io_cancellation_safe(
+        active_interaction_read = await run_db_io_cancellation_safe(
             lambda: active_interaction_id_sync(task_id)
         )
-        if active_interaction_id is not None:
+        if isinstance(active_interaction_read, ActiveInteractionFound):
+            active_interaction_id = active_interaction_read.interaction_id
             receipt_interaction_id = message_data.get("interaction_id")
             receipt_responder_identity = message_data.get("responder_identity")
             # isinstance before comparing, the same shape the cancel
@@ -9060,6 +9097,33 @@ async def _handle_resume_task_unserialized(
                     reason,
                     reason_code="interaction_pending",
                 )
+        elif isinstance(active_interaction_read, ActiveInteractionUnavailable):
+            # Same action as the ActiveInteractionAbsent branch below -- the
+            # resume proceeds -- but deliberately its own branch rather than
+            # a shared one. This is the arm that turns into a refusal, and
+            # refusing here is wired by the change that first writes
+            # tasks.interaction_protocol_version = 1. Until that marker can
+            # be 1, nothing in src/ having written it to anything but NULL,
+            # a read that could not be made cannot be hiding a live native
+            # interaction row: refusing today would cost a refused resume on
+            # every waiting task, including the ones that provably carry no
+            # question at all. Keeping the branch separate is what lets that
+            # later change edit one branch's action and touch neither of the
+            # other two.
+            #
+            # Logged at info, not warning: the read itself already logs one
+            # warning for this same incident (see
+            # active_interaction_id_sync), and a second warning-level line
+            # would double-count one read failure.
+            logger.info(
+                "the active interaction read was unavailable (reason=%s) for "
+                "task_id=%s run_id=%s; the resume proceeds",
+                active_interaction_read.reason,
+                task_id,
+                task_fields.run_id,
+            )
+        else:
+            assert isinstance(active_interaction_read, ActiveInteractionAbsent)
 
         attempt_count = message_data.get("_durable_attempt_count")
 

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -248,24 +248,32 @@ class ActiveInteractionFound:
 
 @dataclass(frozen=True)
 class ActiveInteractionAbsent:
-    """No live native interaction row exists for this task, confirmed: no
-    database configured, a NULL protocol marker, no interaction table yet,
-    or an empty row lookup. Every one of those means the same thing as an
-    empty lookup, not a failure -- there is nothing to close and nothing
-    being hidden by a failed read.
+    """No live native interaction row exists for this task. Reached from
+    four situations: no database configured, a NULL protocol marker, no
+    interaction table yet, or an empty row lookup. The first two answer
+    without querying the interaction table at all -- they are not a
+    lookup that came back empty, they are a state in which no row can be
+    staged -- and the last two are that lookup coming back empty. All
+    four mean the same thing to a caller, and none of them is a failed
+    read: there is nothing to close and nothing being hidden.
     """
 
 
 @dataclass(frozen=True)
 class ActiveInteractionUnavailable:
-    """The read could not be made at all -- a closed set of reasons, in
-    ``ACTIVE_INTERACTION_UNAVAILABLE_REASONS``. This is not
-    ``ActiveInteractionAbsent``: the row may or may not exist, the read
-    just could not tell. Kept distinct from ``ActiveInteractionAbsent`` at
-    the type level even where a caller's action for the two is the same
-    today: collapsing them into one member, or into one branch, is what
-    makes the distinction unrecoverable for the caller that has to act on
-    it differently later.
+    """The read could not be made at all. ``reason`` carries which of the
+    two words in ``ACTIVE_INTERACTION_UNAVAILABLE_REASONS`` applies --
+    provisionally two, because ``"lookup_failed"`` currently covers both a
+    transient query failure and the structural case of a deployment whose
+    ``tasks`` table has no ``interaction_protocol_version`` column yet
+    (#1314). Splitting that word belongs with the change that gives a
+    caller a reason to act on the two differently, not with this one.
+    This is not ``ActiveInteractionAbsent``: the row may or may not
+    exist, the read just could not tell. Kept distinct from
+    ``ActiveInteractionAbsent`` at the type level even where a caller's
+    action for the two is the same today: collapsing them into one
+    member, or into one branch, is what makes the distinction
+    unrecoverable for the caller that has to act on it differently later.
     """
 
     reason: str
@@ -277,29 +285,35 @@ class ActiveInteractionUnavailable:
 # shapes lets a caller collapse ActiveInteractionUnavailable into
 # ActiveInteractionAbsent with one truthy check on the id (`if
 # x.interaction_id is not None`), and mypy would have nothing to say about
-# it. Only a tagged union of distinct types makes every caller's `match`
-# (or isinstance chain) exhaustive under mypy -- the read-direction anchor
-# resolver in task_interaction_service.py (_AnchorUnresolved) uses the
-# same frozen-dataclass-with-a-reason shape for the same kind of "this
-# failed, here is why" result.
+# it. A tagged union of distinct types is what makes an exhaustiveness
+# check possible at all, but it does not by itself produce one: mypy only
+# reports a missing arm when the branch chain ends in `assert_never`, so
+# every caller in this repo ends its chain that way and the union is the
+# thing that makes those calls type-check. ClarificationResolution in
+# task_clarification_draft.py has the same shape: a union of frozen
+# dataclasses, one member per outcome, with a reason word on the members
+# that need to say why.
 ActiveInteractionRead = (
     ActiveInteractionFound | ActiveInteractionAbsent | ActiveInteractionUnavailable
 )
 
-# The closed set of ActiveInteractionUnavailable.reason values. Each
-# corresponds to one of the two logger.warning call sites inside
-# active_interaction_id_sync below, which already carry distinct message
-# text -- this constant is what keeps a future change from quietly
-# merging the two log messages (and the two reasons they describe) into
-# one.
+# Every ActiveInteractionUnavailable.reason value this module produces
+# today. Each corresponds to one of the two logger.warning call sites
+# inside active_interaction_id_sync below, which already carry distinct
+# message text -- this constant is what keeps a future change from
+# quietly merging the two log messages (and the two reasons they
+# describe) into one. It is also what the tests parametrize and assert
+# over, so a word added here gains its coverage cells without anyone
+# remembering to add them; that is the reason it is a runtime constant
+# and not only a type.
 ACTIVE_INTERACTION_UNAVAILABLE_REASONS: frozenset[str] = frozenset(
     {"session_unavailable", "lookup_failed"}
 )
 
 
 def active_interaction_id_sync(task_id: int) -> ActiveInteractionRead:
-    """This task's active native interaction row: found, confirmed absent,
-    or unavailable (the read itself could not be made).
+    """This task's active native interaction row: found, absent, or
+    unavailable (the read itself could not be made).
 
     Read this *before* injecting the user message, and translate the
     result before passing it to ``close_legacy_resume_interaction`` -- see
@@ -329,16 +343,24 @@ def active_interaction_id_sync(task_id: int) -> ActiveInteractionRead:
     at all -- no session, a failing query -- and ``ActiveInteractionAbsent``
     when the read completes but finds nothing to close -- no table yet, a
     NULL marker, no active row. At the three legacy-resume close sites,
-    both translate to "close nothing": the close statement matches zero
-    rows and the active row survives -- and so does the marker, because
-    the clear beside the close is conditioned on no active row remaining
-    for this ``(task_id, run_id)`` pair (see
-    ``close_legacy_resume_interaction``). A reader keeps seeing the live
-    native question the read could not see, instead of falling back to
-    the legacy transcript question. The alternative -- closing on the old
-    unbound predicate when the read fails -- is the retire-the-wrong-row
-    bug this function exists to prevent, so an unreadable id must never
-    widen what the close matches.
+    both translate to "close nothing": the close statement is bound to no
+    primary key, so it matches zero rows and retires no question in
+    either case.
+
+    What happens to the task's marker is where the two part ways, and no
+    caller decides it: the clear beside the close is conditioned on no
+    active row remaining for this ``(task_id, run_id)`` pair (see
+    ``close_legacy_resume_interaction``). Under
+    ``ActiveInteractionAbsent`` nothing is there to hold that condition
+    back, so the marker clears. Under ``ActiveInteractionUnavailable``
+    the condition is evaluated against whatever is really in the table,
+    which is the case this state exists for: a live row the read could
+    not see holds the clear back, so the marker survives with the row and
+    a reader keeps seeing that live native question instead of falling
+    back to the legacy transcript question. The alternative -- closing on
+    the old unbound predicate when the read fails -- is the
+    retire-the-wrong-row bug this function exists to prevent, so an
+    unreadable id must never widen what the close matches.
 
     At the resume command seam's refusal gate (``websocket.py``), all three
     states are handled on their own branch, and today

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -139,6 +139,7 @@ schema corruption after the fact.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 import sqlalchemy as sa
@@ -233,12 +234,76 @@ def _classify_close_rowcount(
         )
 
 
-def active_interaction_id_sync(task_id: int) -> int | None:
-    """The id of this task's active native interaction row, or ``None``.
+@dataclass(frozen=True)
+class ActiveInteractionFound:
+    """A live native interaction row exists for this task, keyed by its
+    primary key. Callers pass ``interaction_id`` straight to
+    ``close_legacy_resume_interaction`` / ``close_legacy_resume_interaction_sync``
+    and, at the resume command seam, compare it against the client's
+    receipt.
+    """
 
-    Read this *before* injecting the user message, and pass what it
-    returns to ``close_legacy_resume_interaction`` -- see this module's
-    docstring for why that ordering is the whole point.
+    interaction_id: int
+
+
+@dataclass(frozen=True)
+class ActiveInteractionAbsent:
+    """No live native interaction row exists for this task, confirmed: no
+    database configured, a NULL protocol marker, no interaction table yet,
+    or an empty row lookup. Every one of those means the same thing as an
+    empty lookup, not a failure -- there is nothing to close and nothing
+    being hidden by a failed read.
+    """
+
+
+@dataclass(frozen=True)
+class ActiveInteractionUnavailable:
+    """The read could not be made at all -- a closed set of reasons, in
+    ``ACTIVE_INTERACTION_UNAVAILABLE_REASONS``. This is not
+    ``ActiveInteractionAbsent``: the row may or may not exist, the read
+    just could not tell. Kept distinct from ``ActiveInteractionAbsent`` at
+    the type level even where a caller's action for the two is the same
+    today: collapsing them into one member, or into one branch, is what
+    makes the distinction unrecoverable for the caller that has to act on
+    it differently later.
+    """
+
+    reason: str
+
+
+# The three-state result of reading a task's active native interaction
+# row. A union of three frozen dataclasses, not an enum with an optional
+# id and not a single dataclass with two optional fields: either of those
+# shapes lets a caller collapse ActiveInteractionUnavailable into
+# ActiveInteractionAbsent with one truthy check on the id (`if
+# x.interaction_id is not None`), and mypy would have nothing to say about
+# it. Only a tagged union of distinct types makes every caller's `match`
+# (or isinstance chain) exhaustive under mypy -- the read-direction anchor
+# resolver in task_interaction_service.py (_AnchorUnresolved) uses the
+# same frozen-dataclass-with-a-reason shape for the same kind of "this
+# failed, here is why" result.
+ActiveInteractionRead = (
+    ActiveInteractionFound | ActiveInteractionAbsent | ActiveInteractionUnavailable
+)
+
+# The closed set of ActiveInteractionUnavailable.reason values. Each
+# corresponds to one of the two logger.warning call sites inside
+# active_interaction_id_sync below, which already carry distinct message
+# text -- this constant is what keeps a future change from quietly
+# merging the two log messages (and the two reasons they describe) into
+# one.
+ACTIVE_INTERACTION_UNAVAILABLE_REASONS: frozenset[str] = frozenset(
+    {"session_unavailable", "lookup_failed"}
+)
+
+
+def active_interaction_id_sync(task_id: int) -> ActiveInteractionRead:
+    """This task's active native interaction row: found, confirmed absent,
+    or unavailable (the read itself could not be made).
+
+    Read this *before* injecting the user message, and translate the
+    result before passing it to ``close_legacy_resume_interaction`` -- see
+    this module's docstring for why that ordering is the whole point.
 
     Opens and closes its own short session. Three legacy-resume injection
     paths call it from a point where they hold no session of their own: the
@@ -260,11 +325,14 @@ def active_interaction_id_sync(task_id: int) -> int | None:
     predicate of its own -- the close this feeds and the readers that show
     the question must not disagree about which row is live.
 
-    Returns ``None`` when the read cannot be made at all -- no table yet,
-    no session, a failing query. ``None`` closes nothing: the close
-    statement matches zero rows and the active row survives -- and so
-    does the marker, because the clear beside the close is conditioned on
-    no active row remaining for this ``(task_id, run_id)`` pair (see
+    Returns ``ActiveInteractionUnavailable`` when the read cannot be made
+    at all -- no session, a failing query -- and ``ActiveInteractionAbsent``
+    when the read completes but finds nothing to close -- no table yet, a
+    NULL marker, no active row. At the three legacy-resume close sites,
+    both translate to "close nothing": the close statement matches zero
+    rows and the active row survives -- and so does the marker, because
+    the clear beside the close is conditioned on no active row remaining
+    for this ``(task_id, run_id)`` pair (see
     ``close_legacy_resume_interaction``). A reader keeps seeing the live
     native question the read could not see, instead of falling back to
     the legacy transcript question. The alternative -- closing on the old
@@ -272,12 +340,26 @@ def active_interaction_id_sync(task_id: int) -> int | None:
     bug this function exists to prevent, so an unreadable id must never
     widen what the close matches.
 
-    Two branches decide "no id" before the row lookup runs, and both mean
-    the same thing as an empty lookup, not a failure:
-    ``get_optional_session_local()`` returning ``None`` (no database
-    configured in this process -- expected in tests, never in production),
-    and ``tasks.interaction_protocol_version`` being ``NULL``. The marker
-    gate is the write side of the same first step
+    At the resume command seam's refusal gate (``websocket.py``), all three
+    states are handled on their own branch, and today
+    ``ActiveInteractionUnavailable`` takes the same action as
+    ``ActiveInteractionAbsent``: the resume proceeds. That is not the two
+    being interchangeable -- it is what the marker gate makes true right
+    now. Nothing in ``src/`` writes ``tasks.interaction_protocol_version``
+    to anything but ``NULL``, so a read that could not be made cannot be
+    hiding a live native interaction row, and refusing on it would cost a
+    refused resume on tasks that provably carry no question. The change
+    that first writes that marker to ``1`` is the one that turns this
+    gate's ``ActiveInteractionUnavailable`` branch into a refusal; the
+    branch is already separate so that change edits one branch's action
+    and touches neither of the other two.
+
+    Two branches resolve to ``ActiveInteractionAbsent`` before the row
+    lookup ever runs, and both mean the same thing as an empty lookup, not
+    a failure: ``get_optional_session_local()`` returning ``None`` (no
+    database configured in this process -- expected in tests, never in
+    production), and ``tasks.interaction_protocol_version`` being ``NULL``.
+    The marker gate is the write side of the same first step
     ``get_pending_interaction_question`` (``task_interaction_read.py``)
     takes on the read side: a NULL marker means no native row was ever
     staged for this task's current wait, so the interaction table goes
@@ -291,7 +373,7 @@ def active_interaction_id_sync(task_id: int) -> int | None:
     That gate decides every call today: the only statements in ``src/``
     that write the column are this module's two clears, and both of them
     write ``NULL``, so the marker is NULL for every task and this branch
-    returns ``None`` before anything below it runs.
+    returns ``ActiveInteractionAbsent()`` before anything below it runs.
 
     This is also the resume command seam's reader (``websocket.py``'s
     refusal gate for a resume whose payload cannot prove it answered the
@@ -304,7 +386,7 @@ def active_interaction_id_sync(task_id: int) -> int | None:
 
     SessionLocal = get_optional_session_local()
     if SessionLocal is None:
-        return None
+        return ActiveInteractionAbsent()
     try:
         db = SessionLocal()
     except Exception:
@@ -314,7 +396,7 @@ def active_interaction_id_sync(task_id: int) -> int | None:
             task_id,
             exc_info=True,
         )
-        return None
+        return ActiveInteractionUnavailable("session_unavailable")
     try:
         marker = (
             db.query(Task.interaction_protocol_version)
@@ -322,9 +404,9 @@ def active_interaction_id_sync(task_id: int) -> int | None:
             .scalar()
         )
         if marker is None:
-            return None
+            return ActiveInteractionAbsent()
         if not interaction_requests_table_exists(db):
-            return None
+            return ActiveInteractionAbsent()
         row = (
             db.query(TaskInteractionRequest.id)
             .join(Task, Task.id == TaskInteractionRequest.task_id)
@@ -334,7 +416,9 @@ def active_interaction_id_sync(task_id: int) -> int | None:
             )
             .first()
         )
-        return int(row[0]) if row is not None else None
+        if row is None:
+            return ActiveInteractionAbsent()
+        return ActiveInteractionFound(int(row[0]))
     except Exception:
         logger.warning(
             "the active interaction row lookup failed for task_id=%s; "
@@ -342,7 +426,7 @@ def active_interaction_id_sync(task_id: int) -> int | None:
             task_id,
             exc_info=True,
         )
-        return None
+        return ActiveInteractionUnavailable("lookup_failed")
     finally:
         db.close()
 

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import json
+import logging
 import sqlite3
 from datetime import UTC, datetime, timedelta
 from threading import Event, get_ident
@@ -18,7 +19,7 @@ from tests.web.pool_contention_shared import (
     gated_pool_checkout,
     wait_for_ticks,
 )
-from tests.web.services.active_interaction_read_shared import _PRE_CHANGE_EQUIVALENT
+from tests.web.services.active_interaction_read_shared import PRE_CHANGE_EQUIVALENT
 from xagent.core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
@@ -49,7 +50,10 @@ from xagent.web.services.task_command_transport import (
     max_command_defers,
 )
 from xagent.web.services.task_execution_controller import TaskControlState
-from xagent.web.services.task_interaction_close import ActiveInteractionRead
+from xagent.web.services.task_interaction_close import (
+    ActiveInteractionRead,
+    ActiveInteractionUnavailable,
+)
 from xagent.web.services.task_lease_service import TaskLease, current_task_lease
 from xagent.web.services.task_orchestrator import (
     TaskTurnError,
@@ -1051,20 +1055,13 @@ def test_message_send_skips_the_close_on_a_replayed_injection() -> None:
     close_mock.assert_not_called()
 
 
-# A fabricated id, not the seeded row's -- test_message_send_reads_the_
-# interaction_row_before_injecting hands this to the close instead of the
-# real row id, so a site that re-read the row at close time would hand the
-# close the real id and fail there instead. Matches the Found row in
-# _PRE_CHANGE_EQUIVALENT (test_task_interaction_close.py), which this test
-# parametrizes over.
-_OBSERVED_INTERACTION_ID = 4321
-
-
 @pytest.mark.parametrize(
-    "active_interaction_read,expected_interaction_id", _PRE_CHANGE_EQUIVALENT
+    "active_interaction_read,expected_interaction_id", PRE_CHANGE_EQUIVALENT
 )
 def test_message_send_reads_the_interaction_row_before_injecting(
-    active_interaction_read: ActiveInteractionRead, expected_interaction_id: int | None
+    active_interaction_read: ActiveInteractionRead,
+    expected_interaction_id: int | None,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The close is keyed on the row observed *before* the injection,
     and only the ordering makes that true -- see task_interaction_close's
@@ -1074,12 +1071,18 @@ def test_message_send_reads_the_interaction_row_before_injecting(
     seeded row's, so a site that re-read the row at close time would hand
     the close the real id and fail here.
 
-    Parametrized over every state _PRE_CHANGE_EQUIVALENT enumerates
+    Parametrized over every state PRE_CHANGE_EQUIVALENT enumerates
     (Found, Absent, and both Unavailable reasons): this site's translation
     to the ``int | None`` the close call takes must produce the same
     result for all three states that it did before this became a
     three-state read, regardless of which reason an unavailable read
     carries.
+
+    That equivalence alone would also hold for a two-way ``Found``
+    versus everything-else fold, so the cells also assert the log line
+    this site emits on -- and only on -- the ``ActiveInteractionUnavailable``
+    branch, carrying that state's own reason word. A fold that dropped
+    the third branch leaves both unavailable cells without their line.
     """
 
     agent_id, full_key = _create_published_agent_with_key()
@@ -1102,10 +1105,10 @@ def test_message_send_reads_the_interaction_row_before_injecting(
         db.commit()
         db.refresh(task)
         task_id = int(task.id)
-        # Kept real and distinct from _OBSERVED_INTERACTION_ID: a site that
-        # re-read the row at close time (instead of using the id observed
-        # before injection) would hand the close this real id and fail the
-        # assertion below.
+        # Kept real and distinct from the fabricated id the Found row in
+        # PRE_CHANGE_EQUIVALENT carries: a site that re-read the row at
+        # close time (instead of using the id observed before injection)
+        # would hand the close this real id and fail the assertion below.
         _seed_active_interaction_row(
             db,
             task_id=task_id,
@@ -1142,6 +1145,7 @@ def test_message_send_reads_the_interaction_row_before_injecting(
         patch(
             "xagent.web.api.a2a.close_legacy_resume_interaction", return_value=1
         ) as close_mock,
+        caplog.at_level(logging.INFO, logger="xagent.web.api.a2a"),
     ):
         response = client.post(
             f"/api/a2a/agents/{agent_id}/message:send",
@@ -1163,6 +1167,20 @@ def test_message_send_reads_the_interaction_row_before_injecting(
     assert close_mock.call_args.kwargs["task_id"] == task_id
     assert close_mock.call_args.kwargs["run_id"] == "run-close-order"
     assert close_mock.call_args.kwargs["interaction_id"] == expected_interaction_id
+
+    unavailable_lines = [
+        record.getMessage()
+        for record in caplog.records
+        if "active interaction read unavailable" in record.getMessage()
+    ]
+    if isinstance(active_interaction_read, ActiveInteractionUnavailable):
+        assert unavailable_lines == [
+            "active interaction read unavailable "
+            f"(reason={active_interaction_read.reason}) for task_id={task_id}; "
+            "the legacy resume close will match no row"
+        ]
+    else:
+        assert unavailable_lines == []
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -48,6 +48,7 @@ from xagent.web.services.task_command_transport import (
     max_command_defers,
 )
 from xagent.web.services.task_execution_controller import TaskControlState
+from xagent.web.services.task_interaction_close import ActiveInteractionFound
 from xagent.web.services.task_lease_service import TaskLease, current_task_lease
 from xagent.web.services.task_orchestrator import (
     TaskTurnError,
@@ -1100,9 +1101,9 @@ def test_message_send_reads_the_interaction_row_before_injecting() -> None:
 
     order: list[str] = []
 
-    def record_read(_task_id: int) -> int:
+    def record_read(_task_id: int) -> ActiveInteractionFound:
         order.append("read")
-        return _OBSERVED_INTERACTION_ID
+        return ActiveInteractionFound(_OBSERVED_INTERACTION_ID)
 
     async def record_injection(
         *_args: object, **_kwargs: object

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -18,7 +18,7 @@ from tests.web.pool_contention_shared import (
     gated_pool_checkout,
     wait_for_ticks,
 )
-from tests.web.services.test_task_interaction_close import _PRE_CHANGE_EQUIVALENT
+from tests.web.services.active_interaction_read_shared import _PRE_CHANGE_EQUIVALENT
 from xagent.core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -18,6 +18,7 @@ from tests.web.pool_contention_shared import (
     gated_pool_checkout,
     wait_for_ticks,
 )
+from tests.web.services.test_task_interaction_close import _PRE_CHANGE_EQUIVALENT
 from xagent.core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
@@ -48,7 +49,7 @@ from xagent.web.services.task_command_transport import (
     max_command_defers,
 )
 from xagent.web.services.task_execution_controller import TaskControlState
-from xagent.web.services.task_interaction_close import ActiveInteractionFound
+from xagent.web.services.task_interaction_close import ActiveInteractionRead
 from xagent.web.services.task_lease_service import TaskLease, current_task_lease
 from xagent.web.services.task_orchestrator import (
     TaskTurnError,
@@ -1053,18 +1054,33 @@ def test_message_send_skips_the_close_on_a_replayed_injection() -> None:
 # A fabricated id, not the seeded row's -- test_message_send_reads_the_
 # interaction_row_before_injecting hands this to the close instead of the
 # real row id, so a site that re-read the row at close time would hand the
-# close the real id and fail there instead.
+# close the real id and fail there instead. Matches the Found row in
+# _PRE_CHANGE_EQUIVALENT (test_task_interaction_close.py), which this test
+# parametrizes over.
 _OBSERVED_INTERACTION_ID = 4321
 
 
-def test_message_send_reads_the_interaction_row_before_injecting() -> None:
+@pytest.mark.parametrize(
+    "active_interaction_read,expected_interaction_id", _PRE_CHANGE_EQUIVALENT
+)
+def test_message_send_reads_the_interaction_row_before_injecting(
+    active_interaction_read: ActiveInteractionRead, expected_interaction_id: int | None
+) -> None:
     """The close is keyed on the row observed *before* the injection,
     and only the ordering makes that true -- see task_interaction_close's
     module docstring. Moving the read after the injection leaves the whole
     change doing nothing while the row-level assertions in the test above
-    stay green. The observed value is a fabricated id, not the seeded row's,
-    so a site that re-read the row at close time would hand the close the
-    real id and fail here."""
+    stay green. The Found case's observed value is a fabricated id, not the
+    seeded row's, so a site that re-read the row at close time would hand
+    the close the real id and fail here.
+
+    Parametrized over every state _PRE_CHANGE_EQUIVALENT enumerates
+    (Found, Absent, and both Unavailable reasons): this site's translation
+    to the ``int | None`` the close call takes must produce the same
+    result for all three states that it did before this became a
+    three-state read, regardless of which reason an unavailable read
+    carries.
+    """
 
     agent_id, full_key = _create_published_agent_with_key()
     db = _direct_db_session()
@@ -1101,9 +1117,9 @@ def test_message_send_reads_the_interaction_row_before_injecting() -> None:
 
     order: list[str] = []
 
-    def record_read(_task_id: int) -> ActiveInteractionFound:
+    def record_read(_task_id: int) -> ActiveInteractionRead:
         order.append("read")
-        return ActiveInteractionFound(_OBSERVED_INTERACTION_ID)
+        return active_interaction_read
 
     async def record_injection(
         *_args: object, **_kwargs: object
@@ -1146,7 +1162,7 @@ def test_message_send_reads_the_interaction_row_before_injecting() -> None:
     close_mock.assert_called_once()
     assert close_mock.call_args.kwargs["task_id"] == task_id
     assert close_mock.call_args.kwargs["run_id"] == "run-close-order"
-    assert close_mock.call_args.kwargs["interaction_id"] == _OBSERVED_INTERACTION_ID
+    assert close_mock.call_args.kwargs["interaction_id"] == expected_interaction_id
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_resume_interaction_seam.py
+++ b/tests/web/api/test_resume_interaction_seam.py
@@ -42,6 +42,7 @@ from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import ops_signals
+from xagent.web.services.task_interaction_close import ActiveInteractionUnavailable
 from xagent.web.services.task_lease_service import TASK_RUN_ID_TRACE_FIELD
 from xagent.web.services.task_setup_snapshot import (
     RuntimeUserFields,
@@ -785,12 +786,130 @@ async def test_stale_run_active_row_does_not_trip_the_seam(
     assert resume_scheduled.is_set()
 
 
-# active_interaction_id_sync's own four fail-open branches (no database
-# configured yet, a session that fails to open, the interaction table not
-# existing yet, the row lookup itself raising) used to be pinned here,
-# against websocket.py's own _active_native_interaction_id_sync. That
-# function is gone -- the seam now reads through the same
-# task_interaction_close.active_interaction_id_sync the four legacy-resume
-# injection sites use -- and its four fail-open branches are pinned in
-# tests/web/services/test_task_interaction_close.py instead, alongside the
+@pytest.mark.asyncio
+async def test_legacy_resume_is_not_refused_when_the_active_interaction_read_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch, _seeded_task: int
+) -> None:
+    """``ActiveInteractionUnavailable`` takes its own branch at this gate,
+    distinct from ``ActiveInteractionAbsent``, but today's action on that
+    branch is the same as ``ActiveInteractionAbsent``'s: the resume
+    proceeds. Nothing in ``src/`` writes
+    ``tasks.interaction_protocol_version`` to anything but ``NULL``, so a
+    read that could not be made cannot be hiding a live native interaction
+    row -- refusing here would only cost a refused resume on tasks that
+    provably carry no question. Turning this branch into a refusal is the
+    job of the change that first writes that marker to ``1``; that change
+    edits this one branch's action, and this test is what will need to
+    flip when it does.
+
+    Patches ``active_interaction_id_sync`` directly rather than seeding a
+    real row and breaking the database under it: the production code path
+    this exercises is entirely on the caller's side of that function (the
+    three-way branch and what each arm does), not inside the function
+    itself -- its own failure branches are pinned in
+    tests/web/services/test_task_interaction_close.py.
+    """
+
+    monkeypatch.setattr(
+        websocket_api,
+        "active_interaction_id_sync",
+        lambda task_id: ActiveInteractionUnavailable("lookup_failed"),
+    )
+
+    snapshot = _snapshot(task_id=_seeded_task)
+    connection_manager = _connection_manager()
+    background_manager = MagicMock()
+    background_manager.running_tasks = {}
+    background_manager.resume_admission_state.return_value = None
+    background_manager.try_reserve_resume.return_value = (
+        websocket_api.ResumeReservationOutcome.RESERVED
+    )
+    transition = AsyncMock(
+        return_value=SimpleNamespace(run_id=RUN_ID, status=TaskStatus.WAITING_FOR_USER)
+    )
+    agent_service = MagicMock()
+    agent_service.supports_live_control = MagicMock(return_value=True)
+
+    resume_scheduled = asyncio.Event()
+
+    async def _stub_execute_resume_background(**kwargs: object) -> None:
+        resume_scheduled.set()
+
+    from xagent.web.services import task_setup_snapshot as snapshot_module
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(
+                snapshot_module, "load_task_setup_snapshot_sync", return_value=snapshot
+            )
+        )
+        stack.enter_context(patch.object(websocket_api, "manager", connection_manager))
+        stack.enter_context(
+            patch.object(
+                websocket_api.task_execution_controller, "transition", new=transition
+            )
+        )
+        stack.enter_context(
+            patch.object(websocket_api, "background_task_manager", background_manager)
+        )
+        # The handler asks the DB whether another process still holds a live
+        # lease before it schedules; these suites drive the handler without a
+        # task row, so answer "no foreign owner" explicitly.
+        stack.enter_context(
+            patch.object(
+                websocket_api, "task_has_live_foreign_runner", return_value=False
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                websocket_api,
+                "execute_resume_background",
+                side_effect=_stub_execute_resume_background,
+            )
+        )
+        agent_manager = MagicMock()
+        agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+        stack.enter_context(
+            patch.object(chat_api, "get_agent_manager", lambda: agent_manager)
+        )
+
+        result = await websocket_api._handle_resume_task_unserialized(
+            MagicMock(),
+            _seeded_task,
+            {"user": SimpleNamespace(id=OWNER_ID, is_admin=False)},
+        )
+
+        agent_manager.get_agent_for_task.assert_awaited()
+        await asyncio.wait_for(resume_scheduled.wait(), timeout=1)
+
+    assert resume_scheduled.is_set()
+    transition.assert_awaited()
+    errors = [
+        call.args[0]
+        for call in connection_manager.send_personal_message.await_args_list
+        if isinstance(call.args[0], dict) and call.args[0].get("type") == "error"
+    ]
+    assert errors == []
+    assert (
+        ops_signals.INTERACTION_LEGACY_RESUME_SHIM
+        not in ops_signals.active_degradations()
+    )
+    assert result.outcome is not websocket_api.ResumeCommandOutcome.REJECTED
+
+
+# active_interaction_id_sync's own four branches (no database configured
+# yet, a session that fails to open, the interaction table not existing
+# yet, the row lookup itself raising) used to be pinned here, against
+# websocket.py's own _active_native_interaction_id_sync, back when all
+# four were fail-open. That function is gone -- the seam now reads through
+# the same task_interaction_close.active_interaction_id_sync the four
+# legacy-resume injection sites use, and the fail-open behavior of all four
+# branches is unchanged: what changed is only that the reader now reports
+# them as one of three states instead of collapsing all of them into the
+# same None, and this gate handles each state on its own branch (see
+# test_legacy_resume_is_not_refused_when_the_active_interaction_read_is_
+# unavailable above for the ActiveInteractionUnavailable branch, and
+# test_legacy_resume_is_not_refused_when_the_task_marker_is_null above for
+# ActiveInteractionAbsent). All four branches of the read itself are pinned
+# in tests/web/services/test_task_interaction_close.py, alongside the
 # marker gate that reader adds ahead of them.

--- a/tests/web/api/test_resume_interaction_seam.py
+++ b/tests/web/api/test_resume_interaction_seam.py
@@ -21,6 +21,7 @@ has real data to answer against.
 from __future__ import annotations
 
 import asyncio
+import logging
 from contextlib import ExitStack
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -42,7 +43,10 @@ from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import ops_signals
-from xagent.web.services.task_interaction_close import ActiveInteractionUnavailable
+from xagent.web.services.task_interaction_close import (
+    ACTIVE_INTERACTION_UNAVAILABLE_REASONS,
+    ActiveInteractionUnavailable,
+)
 from xagent.web.services.task_lease_service import TASK_RUN_ID_TRACE_FIELD
 from xagent.web.services.task_setup_snapshot import (
     RuntimeUserFields,
@@ -787,8 +791,12 @@ async def test_stale_run_active_row_does_not_trip_the_seam(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("reason", sorted(ACTIVE_INTERACTION_UNAVAILABLE_REASONS))
 async def test_legacy_resume_is_not_refused_when_the_active_interaction_read_is_unavailable(
-    monkeypatch: pytest.MonkeyPatch, _seeded_task: int
+    monkeypatch: pytest.MonkeyPatch,
+    _seeded_task: int,
+    reason: str,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """``ActiveInteractionUnavailable`` takes its own branch at this gate,
     distinct from ``ActiveInteractionAbsent``, but today's action on that
@@ -808,12 +816,20 @@ async def test_legacy_resume_is_not_refused_when_the_active_interaction_read_is_
     three-way branch and what each arm does), not inside the function
     itself -- its own failure branches are pinned in
     tests/web/services/test_task_interaction_close.py.
+
+    Parametrized over the whole reason vocabulary
+    (``ACTIVE_INTERACTION_UNAVAILABLE_REASONS``) rather than one word:
+    this gate must not start keying on which reason an unavailable read
+    carries, and a reason word added later gains its cell here without
+    anyone remembering to add one. The log line this branch emits is
+    asserted too -- it is the only trace this arm leaves, since the gate's
+    action here is to do nothing.
     """
 
     monkeypatch.setattr(
         websocket_api,
         "active_interaction_id_sync",
-        lambda task_id: ActiveInteractionUnavailable("lookup_failed"),
+        lambda task_id: ActiveInteractionUnavailable(reason),
     )
 
     snapshot = _snapshot(task_id=_seeded_task)
@@ -872,6 +888,9 @@ async def test_legacy_resume_is_not_refused_when_the_active_interaction_read_is_
         stack.enter_context(
             patch.object(chat_api, "get_agent_manager", lambda: agent_manager)
         )
+        stack.enter_context(
+            caplog.at_level(logging.INFO, logger="xagent.web.api.websocket")
+        )
 
         result = await websocket_api._handle_resume_task_unserialized(
             MagicMock(),
@@ -895,6 +914,14 @@ async def test_legacy_resume_is_not_refused_when_the_active_interaction_read_is_
         not in ops_signals.active_degradations()
     )
     assert result.outcome is not websocket_api.ResumeCommandOutcome.REJECTED
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if "the active interaction read was unavailable" in record.getMessage()
+    ] == [
+        f"the active interaction read was unavailable (reason={reason}) for "
+        f"task_id={_seeded_task} run_id={RUN_ID}; the resume proceeds"
+    ]
 
 
 # active_interaction_id_sync's own four branches (no database configured

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -74,6 +74,7 @@ from xagent.web.services.task_command_transport import (
     TaskCommandRejected,
 )
 from xagent.web.services.task_execution_controller import StaleTaskRunError
+from xagent.web.services.task_interaction_close import ActiveInteractionFound
 from xagent.web.services.task_lease_service import (
     TaskLease,
     current_task_lease,
@@ -2064,9 +2065,9 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
 
     order: list[str] = []
 
-    def record_read(_task_id: int) -> int:
+    def record_read(_task_id: int) -> ActiveInteractionFound:
         order.append("read")
-        return 4321
+        return ActiveInteractionFound(4321)
 
     async def record_injection(
         *_args: object, **_kwargs: object

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -28,6 +28,7 @@ from tests.shared.execution_scope import register_scope_resolver
 from tests.web.services.task_lease_shared import (
     live_task_lease as live_task_lease_fixture,
 )
+from tests.web.services.test_task_interaction_close import _PRE_CHANGE_EQUIVALENT
 from xagent.core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
@@ -74,7 +75,7 @@ from xagent.web.services.task_command_transport import (
     TaskCommandRejected,
 )
 from xagent.web.services.task_execution_controller import StaleTaskRunError
-from xagent.web.services.task_interaction_close import ActiveInteractionFound
+from xagent.web.services.task_interaction_close import ActiveInteractionRead
 from xagent.web.services.task_lease_service import (
     TaskLease,
     current_task_lease,
@@ -2043,15 +2044,27 @@ async def test_live_marker_failure_after_registered_handoff_is_still_accepted(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "active_interaction_read,expected_interaction_id", _PRE_CHANGE_EQUIVALENT
+)
 async def test_live_resume_reads_the_interaction_row_before_injecting(
     live_task_lease,
     db_session,
+    active_interaction_read: ActiveInteractionRead,
+    expected_interaction_id: int | None,
 ) -> None:
     """The close is keyed on the row observed *before* the injection, and
     only the ordering makes that true -- see task_interaction_close's
     module docstring. The read also sits before the ``posted`` fork, so the
     deferred branch carries the same observation instead of taking one of
-    its own even later."""
+    its own even later.
+
+    Parametrized over every state _PRE_CHANGE_EQUIVALENT enumerates (Found,
+    Absent, and both Unavailable reasons): this site's translation to the
+    ``int | None`` the close call takes must produce the same result for
+    all three states that it did before this became a three-state read,
+    regardless of which reason an unavailable read carries.
+    """
 
     owner = _user(db_session, "close-order-owner")
     task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
@@ -2065,9 +2078,9 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
 
     order: list[str] = []
 
-    def record_read(_task_id: int) -> ActiveInteractionFound:
+    def record_read(_task_id: int) -> ActiveInteractionRead:
         order.append("read")
-        return ActiveInteractionFound(4321)
+        return active_interaction_read
 
     async def record_injection(
         *_args: object, **_kwargs: object
@@ -2114,7 +2127,9 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
 
     assert order == ["read", "inject"]
     close_mock.assert_called_once_with(
-        task_id=int(task.id), run_id="close-order-run", interaction_id=4321
+        task_id=int(task.id),
+        run_id="close-order-run",
+        interaction_id=expected_interaction_id,
     )
 
 

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -25,10 +25,10 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from tests.shared.execution_scope import register_scope_resolver
+from tests.web.services.active_interaction_read_shared import _PRE_CHANGE_EQUIVALENT
 from tests.web.services.task_lease_shared import (
     live_task_lease as live_task_lease_fixture,
 )
-from tests.web.services.test_task_interaction_close import _PRE_CHANGE_EQUIVALENT
 from xagent.core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -10,6 +10,7 @@ isolation; here we exercise the handlers end to end).
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
@@ -25,7 +26,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from tests.shared.execution_scope import register_scope_resolver
-from tests.web.services.active_interaction_read_shared import _PRE_CHANGE_EQUIVALENT
+from tests.web.services.active_interaction_read_shared import PRE_CHANGE_EQUIVALENT
 from tests.web.services.task_lease_shared import (
     live_task_lease as live_task_lease_fixture,
 )
@@ -75,7 +76,10 @@ from xagent.web.services.task_command_transport import (
     TaskCommandRejected,
 )
 from xagent.web.services.task_execution_controller import StaleTaskRunError
-from xagent.web.services.task_interaction_close import ActiveInteractionRead
+from xagent.web.services.task_interaction_close import (
+    ActiveInteractionRead,
+    ActiveInteractionUnavailable,
+)
 from xagent.web.services.task_lease_service import (
     TaskLease,
     current_task_lease,
@@ -2045,13 +2049,14 @@ async def test_live_marker_failure_after_registered_handoff_is_still_accepted(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "active_interaction_read,expected_interaction_id", _PRE_CHANGE_EQUIVALENT
+    "active_interaction_read,expected_interaction_id", PRE_CHANGE_EQUIVALENT
 )
 async def test_live_resume_reads_the_interaction_row_before_injecting(
     live_task_lease,
     db_session,
     active_interaction_read: ActiveInteractionRead,
     expected_interaction_id: int | None,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The close is keyed on the row observed *before* the injection, and
     only the ordering makes that true -- see task_interaction_close's
@@ -2059,11 +2064,17 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
     deferred branch carries the same observation instead of taking one of
     its own even later.
 
-    Parametrized over every state _PRE_CHANGE_EQUIVALENT enumerates (Found,
+    Parametrized over every state PRE_CHANGE_EQUIVALENT enumerates (Found,
     Absent, and both Unavailable reasons): this site's translation to the
     ``int | None`` the close call takes must produce the same result for
     all three states that it did before this became a three-state read,
     regardless of which reason an unavailable read carries.
+
+    That equivalence alone would also hold for a two-way ``Found`` versus
+    everything-else fold, so the cells also assert the log line this site
+    emits on -- and only on -- the ``ActiveInteractionUnavailable``
+    branch, carrying that state's own reason word. A fold that dropped the
+    third branch leaves both unavailable cells without their line.
     """
 
     owner = _user(db_session, "close-order-owner")
@@ -2113,6 +2124,7 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
             "xagent.web.api.websocket.close_legacy_resume_interaction_sync",
             return_value=1,
         ) as close_mock,
+        caplog.at_level(logging.INFO, logger="xagent.web.api.websocket"),
     ):
         await _handle_chat_message_unserialized(
             MagicMock(),
@@ -2131,6 +2143,20 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
         run_id="close-order-run",
         interaction_id=expected_interaction_id,
     )
+
+    unavailable_lines = [
+        record.getMessage()
+        for record in caplog.records
+        if "active interaction read unavailable" in record.getMessage()
+    ]
+    if isinstance(active_interaction_read, ActiveInteractionUnavailable):
+        assert unavailable_lines == [
+            "active interaction read unavailable "
+            f"(reason={active_interaction_read.reason}) for task_id={int(task.id)}; "
+            "the legacy resume close will match no row"
+        ]
+    else:
+        assert unavailable_lines == []
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -30,6 +30,7 @@ from xagent.web.schemas.v1 import ReplyRequest
 from xagent.web.services.client_error_messages import CLIENT_SAFE_AUTO_MODEL_UNAVAILABLE
 from xagent.web.services.llm_utils import AutoModelUnavailableError
 from xagent.web.services.task_execution_controller import TaskControlState
+from xagent.web.services.task_interaction_close import ActiveInteractionFound
 from xagent.web.services.task_lease_service import TaskLease, current_task_lease
 
 from ..conftest import _admin_headers, _direct_db_session, client
@@ -640,9 +641,9 @@ def test_reply_reads_the_interaction_row_before_injecting(mock_start_task):
 
     order: list[str] = []
 
-    def record_read(_task_id: int) -> int:
+    def record_read(_task_id: int) -> ActiveInteractionFound:
         order.append("read")
-        return _OBSERVED_INTERACTION_ID
+        return ActiveInteractionFound(_OBSERVED_INTERACTION_ID)
 
     async def record_injection(
         *_args: object, **_kwargs: object

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.web.services.test_task_interaction_close import _PRE_CHANGE_EQUIVALENT
 from xagent.core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
@@ -30,7 +31,7 @@ from xagent.web.schemas.v1 import ReplyRequest
 from xagent.web.services.client_error_messages import CLIENT_SAFE_AUTO_MODEL_UNAVAILABLE
 from xagent.web.services.llm_utils import AutoModelUnavailableError
 from xagent.web.services.task_execution_controller import TaskControlState
-from xagent.web.services.task_interaction_close import ActiveInteractionFound
+from xagent.web.services.task_interaction_close import ActiveInteractionRead
 from xagent.web.services.task_lease_service import TaskLease, current_task_lease
 
 from ..conftest import _admin_headers, _direct_db_session, client
@@ -616,18 +617,35 @@ def test_reply_closes_the_legacy_resume_interaction_row_on_successful_injection(
 # A fabricated id, not the seeded row's -- test_reply_reads_the_interaction_
 # row_before_injecting hands this to the close instead of the real row id,
 # so a site that re-read the row at close time would hand the close the
-# real id and fail there instead.
+# real id and fail there instead. Matches the Found row in
+# _PRE_CHANGE_EQUIVALENT (test_task_interaction_close.py), which this test
+# parametrizes over.
 _OBSERVED_INTERACTION_ID = 4321
 
 
-def test_reply_reads_the_interaction_row_before_injecting(mock_start_task):
+@pytest.mark.parametrize(
+    "active_interaction_read,expected_interaction_id", _PRE_CHANGE_EQUIVALENT
+)
+def test_reply_reads_the_interaction_row_before_injecting(
+    mock_start_task,
+    active_interaction_read: ActiveInteractionRead,
+    expected_interaction_id: int | None,
+):
     """The close is keyed on the row observed *before* the injection,
     and only the ordering makes that true -- see task_interaction_close's
     module docstring. Moving the read after the injection leaves the whole
     change doing nothing while the row-level assertions in the test above
-    stay green. The observed value is a fabricated id, not the seeded row's,
-    so a site that re-read the row at close time would hand the close the
-    real id and fail here."""
+    stay green. The Found case's observed value is a fabricated id, not the
+    seeded row's, so a site that re-read the row at close time would hand
+    the close the real id and fail here.
+
+    Parametrized over every state _PRE_CHANGE_EQUIVALENT enumerates
+    (Found, Absent, and both Unavailable reasons): this site's translation
+    to the ``int | None`` the close call takes must produce the same
+    result for all three states that it did before this became a
+    three-state read, regardless of which reason an unavailable read
+    carries.
+    """
 
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_waiting_task(full_key, agent_id, run_id="run-close-order")
@@ -641,9 +659,9 @@ def test_reply_reads_the_interaction_row_before_injecting(mock_start_task):
 
     order: list[str] = []
 
-    def record_read(_task_id: int) -> ActiveInteractionFound:
+    def record_read(_task_id: int) -> ActiveInteractionRead:
         order.append("read")
-        return ActiveInteractionFound(_OBSERVED_INTERACTION_ID)
+        return active_interaction_read
 
     async def record_injection(
         *_args: object, **_kwargs: object
@@ -680,7 +698,7 @@ def test_reply_reads_the_interaction_row_before_injecting(mock_start_task):
     close_mock.assert_called_once()
     assert close_mock.call_args.kwargs["task_id"] == task_id
     assert close_mock.call_args.kwargs["run_id"] == "run-close-order"
-    assert close_mock.call_args.kwargs["interaction_id"] == _OBSERVED_INTERACTION_ID
+    assert close_mock.call_args.kwargs["interaction_id"] == expected_interaction_id
 
 
 def test_update_reply_input_rolls_back_the_interaction_close_with_the_fence() -> None:

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tests.web.services.test_task_interaction_close import _PRE_CHANGE_EQUIVALENT
+from tests.web.services.active_interaction_read_shared import _PRE_CHANGE_EQUIVALENT
 from xagent.core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -9,12 +9,13 @@ up a real background execution, these tests patch the analogous
 """
 
 import asyncio
+import logging
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tests.web.services.active_interaction_read_shared import _PRE_CHANGE_EQUIVALENT
+from tests.web.services.active_interaction_read_shared import PRE_CHANGE_EQUIVALENT
 from xagent.core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
@@ -31,7 +32,10 @@ from xagent.web.schemas.v1 import ReplyRequest
 from xagent.web.services.client_error_messages import CLIENT_SAFE_AUTO_MODEL_UNAVAILABLE
 from xagent.web.services.llm_utils import AutoModelUnavailableError
 from xagent.web.services.task_execution_controller import TaskControlState
-from xagent.web.services.task_interaction_close import ActiveInteractionRead
+from xagent.web.services.task_interaction_close import (
+    ActiveInteractionRead,
+    ActiveInteractionUnavailable,
+)
 from xagent.web.services.task_lease_service import TaskLease, current_task_lease
 
 from ..conftest import _admin_headers, _direct_db_session, client
@@ -614,22 +618,14 @@ def test_reply_closes_the_legacy_resume_interaction_row_on_successful_injection(
         db.close()
 
 
-# A fabricated id, not the seeded row's -- test_reply_reads_the_interaction_
-# row_before_injecting hands this to the close instead of the real row id,
-# so a site that re-read the row at close time would hand the close the
-# real id and fail there instead. Matches the Found row in
-# _PRE_CHANGE_EQUIVALENT (test_task_interaction_close.py), which this test
-# parametrizes over.
-_OBSERVED_INTERACTION_ID = 4321
-
-
 @pytest.mark.parametrize(
-    "active_interaction_read,expected_interaction_id", _PRE_CHANGE_EQUIVALENT
+    "active_interaction_read,expected_interaction_id", PRE_CHANGE_EQUIVALENT
 )
 def test_reply_reads_the_interaction_row_before_injecting(
     mock_start_task,
     active_interaction_read: ActiveInteractionRead,
     expected_interaction_id: int | None,
+    caplog: pytest.LogCaptureFixture,
 ):
     """The close is keyed on the row observed *before* the injection,
     and only the ordering makes that true -- see task_interaction_close's
@@ -639,20 +635,26 @@ def test_reply_reads_the_interaction_row_before_injecting(
     seeded row's, so a site that re-read the row at close time would hand
     the close the real id and fail here.
 
-    Parametrized over every state _PRE_CHANGE_EQUIVALENT enumerates
+    Parametrized over every state PRE_CHANGE_EQUIVALENT enumerates
     (Found, Absent, and both Unavailable reasons): this site's translation
     to the ``int | None`` the close call takes must produce the same
     result for all three states that it did before this became a
     three-state read, regardless of which reason an unavailable read
     carries.
+
+    That equivalence alone would also hold for a two-way ``Found`` versus
+    everything-else fold, so the cells also assert the log line this site
+    emits on -- and only on -- the ``ActiveInteractionUnavailable``
+    branch, carrying that state's own reason word. A fold that dropped the
+    third branch leaves both unavailable cells without their line.
     """
 
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_waiting_task(full_key, agent_id, run_id="run-close-order")
-    # Kept real and distinct from _OBSERVED_INTERACTION_ID: a site that
-    # re-read the row at close time (instead of using the id observed before
-    # injection) would hand the close this real id and fail the assertion
-    # below.
+    # Kept real and distinct from the fabricated id the Found row in
+    # PRE_CHANGE_EQUIVALENT carries: a site that re-read the row at close
+    # time (instead of using the id observed before injection) would hand
+    # the close this real id and fail the assertion below.
     _seed_active_interaction_row(
         task_id, run_id="run-close-order", idempotency_key="reply-close-order-q1"
     )
@@ -686,6 +688,7 @@ def test_reply_reads_the_interaction_row_before_injecting(
             "xagent.web.api.v1.task_reply.close_legacy_resume_interaction",
             return_value=1,
         ) as close_mock,
+        caplog.at_level(logging.INFO, logger="xagent.web.api.v1.task_reply"),
     ):
         resp = client.post(
             f"/v1/chat/tasks/{task_id}/reply",
@@ -699,6 +702,20 @@ def test_reply_reads_the_interaction_row_before_injecting(
     assert close_mock.call_args.kwargs["task_id"] == task_id
     assert close_mock.call_args.kwargs["run_id"] == "run-close-order"
     assert close_mock.call_args.kwargs["interaction_id"] == expected_interaction_id
+
+    unavailable_lines = [
+        record.getMessage()
+        for record in caplog.records
+        if "active interaction read unavailable" in record.getMessage()
+    ]
+    if isinstance(active_interaction_read, ActiveInteractionUnavailable):
+        assert unavailable_lines == [
+            "active interaction read unavailable "
+            f"(reason={active_interaction_read.reason}) for task_id={task_id}; "
+            "the legacy resume close will match no row"
+        ]
+    else:
+        assert unavailable_lines == []
 
 
 def test_update_reply_input_rolls_back_the_interaction_close_with_the_fence() -> None:

--- a/tests/web/services/active_interaction_read_shared.py
+++ b/tests/web/services/active_interaction_read_shared.py
@@ -26,10 +26,17 @@ from __future__ import annotations
 from xagent.web.services.task_interaction_close import (
     ActiveInteractionAbsent,
     ActiveInteractionFound,
+    ActiveInteractionRead,
     ActiveInteractionUnavailable,
 )
 
-_PRE_CHANGE_EQUIVALENT: list[tuple[object, int | None]] = [
+# Annotated with the union itself rather than ``object``: a row carrying
+# something that is not an ``ActiveInteractionRead`` is a type error at the
+# table, not a mystery failure in whichever call site's parameterized test
+# reads it. ``tests/`` is outside this repo's mypy scope, so the annotation
+# only pays off for a reader and for an editor's checker -- which is still
+# more than ``object`` offers either.
+PRE_CHANGE_EQUIVALENT: list[tuple[ActiveInteractionRead, int | None]] = [
     (ActiveInteractionFound(4321), 4321),
     (ActiveInteractionAbsent(), None),
     (ActiveInteractionUnavailable("session_unavailable"), None),

--- a/tests/web/services/active_interaction_read_shared.py
+++ b/tests/web/services/active_interaction_read_shared.py
@@ -1,0 +1,37 @@
+"""The pre-change equivalence table for the three-state active interaction read.
+
+Each row pairs one ``ActiveInteractionRead`` state with the ``int | None``
+value ``active_interaction_id_sync`` returned for that same situation
+before it became three-state. Every production call site's translation of
+the three states back into that value is checked against these rows: the
+parameterized order tests in tests/web/api/test_a2a_api.py,
+tests/web/api/v1/test_task_reply.py and
+tests/web/api/test_websocket_owner_actor.py (the three legacy-resume close
+sites) all read the table from here.
+
+Written in its own module rather than in test_task_interaction_close.py so
+that those three files do not have to import a name out of another suite's
+test module -- the same split task_interaction_schema_shared.py and
+task_status_storage_shared.py use for the row builders and constants their
+suites share.
+
+The table's own exhaustiveness (a state or an unavailable-reason word
+added later must gain a row here) is pinned by
+test_task_interaction_close.py::test_the_pre_change_equivalent_table_covers_every_state,
+which lives with the rest of that reader's per-situation tests.
+"""
+
+from __future__ import annotations
+
+from xagent.web.services.task_interaction_close import (
+    ActiveInteractionAbsent,
+    ActiveInteractionFound,
+    ActiveInteractionUnavailable,
+)
+
+_PRE_CHANGE_EQUIVALENT: list[tuple[object, int | None]] = [
+    (ActiveInteractionFound(4321), 4321),
+    (ActiveInteractionAbsent(), None),
+    (ActiveInteractionUnavailable("session_unavailable"), None),
+    (ActiveInteractionUnavailable("lookup_failed"), None),
+]

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -16,10 +16,12 @@ tests/web/api/test_a2a_api.py.
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy import Select, event
 
 from tests.web.services.task_interaction_schema_shared import (
     make_row,
@@ -45,6 +47,10 @@ from xagent.web.models.task import Task
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import ops_signals
 from xagent.web.services.task_interaction_close import (
+    ACTIVE_INTERACTION_UNAVAILABLE_REASONS,
+    ActiveInteractionAbsent,
+    ActiveInteractionFound,
+    ActiveInteractionUnavailable,
     _classify_close_rowcount,
     active_interaction_id_sync,
     clear_interaction_marker_if_unpaired,
@@ -468,7 +474,7 @@ def test_clear_marker_if_unpaired_no_ops_when_the_interaction_table_does_not_exi
 # active_interaction_id_sync -- the pre-injection read whose result the close
 # binds to. Every caller reaches it through a patched name, so the body is
 # exercised here: the id it returns for a live row, and the two shapes that
-# must degrade to None rather than to a wrong id.
+# must resolve to ActiveInteractionAbsent rather than to a wrong id.
 # --------------------------------------------------------------------------
 
 
@@ -476,10 +482,10 @@ def test_active_interaction_id_sync_returns_the_live_rows_id(db) -> None:
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
 
-    assert active_interaction_id_sync(task_id) == row_id
+    assert active_interaction_id_sync(task_id) == ActiveInteractionFound(row_id)
 
 
-def test_active_interaction_id_sync_returns_none_without_the_interaction_table(
+def test_active_interaction_id_sync_reports_absence_without_the_interaction_table(
     db_without_interaction_table,
 ) -> None:
     db = db_without_interaction_table
@@ -490,10 +496,10 @@ def test_active_interaction_id_sync_returns_none_without_the_interaction_table(
     )
     db.commit()
 
-    assert active_interaction_id_sync(task_id) is None
+    assert active_interaction_id_sync(task_id) == ActiveInteractionAbsent()
 
 
-def test_active_interaction_id_sync_returns_none_when_the_task_marker_is_null(
+def test_active_interaction_id_sync_reports_absence_when_the_task_marker_is_null(
     db, caplog: pytest.LogCaptureFixture
 ) -> None:
     """``tasks.interaction_protocol_version`` being ``NULL`` means no native
@@ -508,17 +514,17 @@ def test_active_interaction_id_sync_returns_none_when_the_task_marker_is_null(
     with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
         result = active_interaction_id_sync(task_id)
 
-    assert result is None
+    assert result == ActiveInteractionAbsent()
     assert caplog.records == []
 
 
-def test_active_interaction_id_sync_returns_none_for_an_absent_task(
+def test_active_interaction_id_sync_reports_absence_for_an_absent_task(
     db, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
         result = active_interaction_id_sync(999_999_999)
 
-    assert result is None
+    assert result == ActiveInteractionAbsent()
     assert caplog.records == []
 
 
@@ -528,12 +534,20 @@ def test_active_interaction_id_sync_returns_none_for_an_absent_task(
 # live as websocket.py's own _active_native_interaction_id_sync: no database
 # configured yet, a session that fails to open, the interaction table not
 # existing yet, and the row lookup itself raising. The module docstring
-# argues at length for why each one resolves to "assume no active row"
+# argues at length for why each one resolves to "no active row to close"
 # instead of propagating -- these pin that argument down to actual
 # behavior, and distinguish the two branches that are expected in normal
-# operation (no session factory yet, table not migrated yet -- no warning)
-# from the two that represent a genuine failure worth a log line (session
-# open failure, lookup failure).
+# operation (no session factory yet, table not migrated yet -- no warning,
+# ActiveInteractionAbsent) from the two that represent a genuine failure
+# worth a log line (session open failure, lookup failure --
+# ActiveInteractionUnavailable). "Fail-open" here describes the close
+# sites, not this function's own return value any more: the two genuine
+# failures now report ActiveInteractionUnavailable, distinct from
+# ActiveInteractionAbsent, so that a caller can tell them apart even though
+# every caller today takes the same action for both -- the type-level
+# split is the seam a later change edits to make one particular caller
+# (the resume command seam's refusal gate) act on the two differently,
+# without having to first separate what this change already kept separate.
 #
 # The last of the four is reached by two different schema states, and both
 # are covered: a lookup that raises because the shared predicate raises
@@ -543,41 +557,44 @@ def test_active_interaction_id_sync_returns_none_for_an_absent_task(
 # --------------------------------------------------------------------------
 
 
-def test_active_interaction_id_sync_returns_none_without_a_session_factory(
+def test_active_interaction_id_sync_reports_absence_without_a_session_factory(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """``get_optional_session_local() is None`` -- no database configured yet
-    for this process -- is the cheap, expected-in-tests case: it must return
-    ``None`` without ever calling the (nonexistent) session factory, and
-    without logging a warning. A caller that removed this branch would fall
-    through to ``SessionLocal()`` with ``SessionLocal is None``, which raises
-    ``TypeError`` and is instead caught by the *next* branch below -- still
-    returning ``None``, but only after logging a warning this branch is
-    specifically here to avoid."""
+    for this process -- is the cheap, expected-in-tests case: it must report
+    ``ActiveInteractionAbsent()`` without ever calling the (nonexistent)
+    session factory, and without logging a warning. A caller that removed
+    this branch would fall through to ``SessionLocal()`` with
+    ``SessionLocal is None``, which raises ``TypeError`` and is instead
+    caught by the *next* branch below -- still resolving to "no active
+    row", but as ``ActiveInteractionUnavailable`` and only after logging a
+    warning this branch is specifically here to avoid."""
 
     monkeypatch.setattr(database_module, "get_optional_session_local", lambda: None)
 
     with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
         result = active_interaction_id_sync(1)
 
-    assert result is None
+    assert result == ActiveInteractionAbsent()
     assert caplog.records == []
 
 
-def test_active_interaction_id_sync_returns_none_when_opening_a_session_fails(
+def test_active_interaction_id_sync_reports_unavailable_when_opening_a_session_fails(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A session factory that is installed but raises when called -- e.g. a
     prior test left a factory pointed at a since-removed temporary database
-    file -- must also resolve to "no active row", but unlike the branch
-    above this is a genuine failure and must be logged.
+    file -- must resolve to ``ActiveInteractionUnavailable("session_unavailable")``,
+    and unlike the branch above this is a genuine failure and must be
+    logged.
 
-    What "closes nothing" costs is pinned separately, by
+    What the three legacy-resume close sites do with this outcome is
+    pinned separately, by
     test_close_keeps_the_marker_when_the_pre_injection_read_failed below:
-    the close matches no row and the marker stays, so the live question the
-    read could not see keeps its reader.
+    translated to ``None``, the close matches no row and the marker stays,
+    so the live question the read could not see keeps its reader.
     """
 
     def _broken_session_local() -> None:
@@ -590,12 +607,12 @@ def test_active_interaction_id_sync_returns_none_when_opening_a_session_fails(
     with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
         result = active_interaction_id_sync(1)
 
-    assert result is None
+    assert result == ActiveInteractionUnavailable("session_unavailable")
     assert len(caplog.records) == 1
     assert "could not open a session" in caplog.records[0].message
 
 
-def test_active_interaction_id_sync_returns_none_when_the_table_gate_reports_missing(
+def test_active_interaction_id_sync_reports_absence_when_the_table_gate_reports_missing(
     db,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -604,16 +621,16 @@ def test_active_interaction_id_sync_returns_none_when_the_table_gate_reports_mis
     table does exist: ``interaction_requests_table_exists`` is stubbed to
     ``False`` while a real active row sits in a real table. What that
     isolates is the gate itself -- a caller that removed it would find the
-    row and return its id, so ``None`` here can only have come from the
-    gate, never from an empty table.
+    row and return ``ActiveInteractionFound``, so ``ActiveInteractionAbsent``
+    here can only have come from the gate, never from an empty table.
 
     The gate returning ``False`` for the reason it exists for -- a
     deployment that has not yet run the migration creating
     ``task_interaction_requests`` -- is covered without any stub by
-    test_active_interaction_id_sync_returns_none_without_the_interaction_table
+    test_active_interaction_id_sync_reports_absence_without_the_interaction_table
     above, which builds that schema shape for real. Both must resolve to
-    ``None`` without a warning: a known deployment window is not a
-    failure."""
+    ``ActiveInteractionAbsent()`` without a warning: a known deployment
+    window is not a failure."""
 
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     seed_active_row(db, task_id=task_id, run_id="run-a")
@@ -626,20 +643,20 @@ def test_active_interaction_id_sync_returns_none_when_the_table_gate_reports_mis
     with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
         result = active_interaction_id_sync(task_id)
 
-    assert result is None
+    assert result == ActiveInteractionAbsent()
     assert caplog.records == []
 
 
-def test_active_interaction_id_sync_returns_none_when_the_lookup_raises(
+def test_active_interaction_id_sync_reports_unavailable_when_the_lookup_raises(
     db,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A failure inside the row lookup itself -- reproduced here by making
     the shared active-row predicate raise, the same seam
-    ``_answer_fence_stmt`` reuses -- must resolve to "no active row" and log
-    a warning naming the lookup, not the session-open failure above's
-    message."""
+    ``_answer_fence_stmt`` reuses -- must resolve to
+    ``ActiveInteractionUnavailable("lookup_failed")`` and log a warning
+    naming the lookup, not the session-open failure above's message."""
 
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     seed_active_row(db, task_id=task_id, run_id="run-a")
@@ -655,7 +672,7 @@ def test_active_interaction_id_sync_returns_none_when_the_lookup_raises(
     with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
         result = active_interaction_id_sync(task_id)
 
-    assert result is None
+    assert result == ActiveInteractionUnavailable("lookup_failed")
     assert len(caplog.records) == 1
     assert "the active interaction row lookup failed" in caplog.records[0].message
 
@@ -744,19 +761,19 @@ def _seed_task_without_the_marker_column(db, *, run_id: str) -> int:
     return int(result.inserted_primary_key[0])
 
 
-def test_active_interaction_id_sync_returns_none_when_the_marker_column_is_missing(
+def test_active_interaction_id_sync_reports_unavailable_when_the_marker_column_is_missing(
     db_without_the_protocol_version_column,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The marker read is the first statement this function issues, and on
     a deployment missing that column it does not come back empty -- it
     raises OperationalError before any gate has run. The catch-all around
-    the lookup is what turns that into "assume no active row": the function
-    returns None, logs one warning, and lets the caller's close match
-    nothing, instead of failing a resume injection over a schema state the
-    next migration fixes.
+    the lookup is what turns that into ``ActiveInteractionUnavailable``:
+    the function reports the lookup failure, logs one warning, and lets
+    the caller's close match nothing, instead of failing a resume
+    injection over a schema state the next migration fixes.
 
-    A real active row is seeded to keep the None honest: the table is
+    A real active row is seeded to keep the result honest: the table is
     present and populated here, so nothing but the failing marker read can
     be producing it.
     """
@@ -767,7 +784,7 @@ def test_active_interaction_id_sync_returns_none_when_the_marker_column_is_missi
     with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
         result = active_interaction_id_sync(task_id)
 
-    assert result is None
+    assert result == ActiveInteractionUnavailable("lookup_failed")
     assert len(caplog.records) == 1
     assert "the active interaction row lookup failed" in caplog.records[0].message
 
@@ -775,11 +792,23 @@ def test_active_interaction_id_sync_returns_none_when_the_marker_column_is_missi
 def test_close_keeps_the_marker_when_the_pre_injection_read_failed(
     db, monkeypatch
 ) -> None:
-    """The two halves composed: the pre-injection read fails, so the close
-    is handed ``None`` and matches nothing -- and the marker survives,
-    because the question the read could not see is still active and still
-    unanswered. Clearing it there would point every reader at the legacy
-    transcript question while the native row it named waits for an answer.
+    """The two halves composed: the pre-injection read comes back
+    ``ActiveInteractionUnavailable``, the call site translates that to
+    ``None`` (the same translation every legacy-resume close site performs
+    -- see task_interaction_close.py's callers), and the close is handed
+    ``None`` and matches nothing -- and the marker survives, because the
+    question the read could not see is still active and still unanswered.
+    Clearing it there would point every reader at the legacy transcript
+    question while the native row it named waits for an answer.
+
+    This is also this repo's behavioral pin for a translated
+    ``ActiveInteractionUnavailable`` reaching one of the three
+    legacy-resume close sites: the static gate in
+    test_every_call_site_of_active_interaction_id_sync_names_unavailable
+    below only checks that ``ActiveInteractionUnavailable`` is named in
+    each caller's module, not that the translation is correct, so this is
+    the one place asserting the translated value actually leaves the row
+    untouched.
 
     The failure is injected only for the read: the close below opens its
     own session through the same factory and has to reach a working
@@ -796,9 +825,18 @@ def test_close_keeps_the_marker_when_the_pre_injection_read_failed(
         failing_read.setattr(
             database_module, "get_optional_session_local", lambda: _broken_session_local
         )
-        observed_id = active_interaction_id_sync(task_id)
+        active_interaction_read = active_interaction_id_sync(task_id)
 
-    assert observed_id is None
+    assert active_interaction_read == ActiveInteractionUnavailable(
+        "session_unavailable"
+    )
+
+    # The same three-branch translation every production call site performs
+    # (see e.g. a2a.py's): Found -> its id, Absent or Unavailable -> None.
+    if isinstance(active_interaction_read, ActiveInteractionFound):
+        observed_id = active_interaction_read.interaction_id
+    else:
+        observed_id = None
 
     rowcount = close_legacy_resume_interaction_sync(
         task_id=task_id, run_id="run-a", interaction_id=observed_id
@@ -807,6 +845,164 @@ def test_close_keeps_the_marker_when_the_pre_injection_read_failed(
     assert rowcount == 0
     assert row_state(db, row_id).status == "active"
     assert task_marker(db, task_id) == 1
+
+
+# --------------------------------------------------------------------------
+# ACTIVE_INTERACTION_UNAVAILABLE_REASONS -- the closed two-word vocabulary
+# the two logger.warning call sites above are keyed to. A future change
+# that merges those two log messages back into one would, if it also
+# collapsed the reason vocabulary, slip past every assertion above (each
+# only checks one reason string at a time); this pins the vocabulary's
+# size directly.
+# --------------------------------------------------------------------------
+
+
+def test_active_interaction_unavailable_reasons_is_exactly_two_words() -> None:
+    assert ACTIVE_INTERACTION_UNAVAILABLE_REASONS == {
+        "session_unavailable",
+        "lookup_failed",
+    }
+
+
+# --------------------------------------------------------------------------
+# Statement-count pin for the marker gate: on every deployment today (the
+# protocol marker is NULL for every task -- see active_interaction_id_sync's
+# own docstring), the marker gate short-circuits before the row lookup, so
+# this reader issues exactly one statement and returns ActiveInteractionAbsent
+# rather than paying for the uncached catalog inspection plus the two-table
+# join below it. This test covers only that success path: the marker read
+# itself can raise (see
+# test_active_interaction_id_sync_reports_unavailable_when_the_marker_column_
+# is_missing above), and when it does this function returns
+# ActiveInteractionUnavailable instead, which this test's own assertion on
+# the return value would catch, not paper over. The broader claim that this
+# change leaves every caller's user-visible outcome unchanged is carried by
+# test_the_pre_change_equivalent_table_covers_every_state and the
+# parameterized order tests it feeds, not by this test alone.
+# --------------------------------------------------------------------------
+
+
+@contextmanager
+def _counted_selects(bind):
+    """Record every ``SELECT`` issued on ``bind`` while the context is
+    open. Copied from
+    tests/web/services/test_task_interaction_read.py::test_m3_marker_null_
+    issues_no_statement_the_reader_would_not, which pins the analogous claim
+    for the read surface this function's marker gate mirrors.
+    """
+
+    seen: list[object] = []
+
+    def _record(conn, clauseelement, multiparams, params, execution_options):
+        if isinstance(clauseelement, Select):
+            seen.append(clauseelement)
+
+    event.listen(bind, "before_execute", _record)
+    try:
+        yield seen
+    finally:
+        event.remove(bind, "before_execute", _record)
+
+
+def test_active_interaction_id_sync_issues_only_the_marker_read_under_a_null_marker(
+    db,
+) -> None:
+    """Under a NULL marker -- today's state for every task in every
+    deployment, since the only writers of this column are this module's own
+    two clears and both write NULL -- this function must return
+    ``ActiveInteractionAbsent()`` after issuing exactly the one statement
+    that reads the marker itself, and nothing more. A real active row is
+    seeded so the assertion is not vacuous: if the marker gate were ever
+    removed (or if ``ActiveInteractionUnavailable("lookup_failed")`` were
+    ever produced from this branch instead), the row lookup below the gate
+    would run and this would fail either on the statement count or on the
+    returned value.
+
+    This pins the marker gate's short-circuit and the cost it saves (one
+    primary-key lookup instead of an uncached catalog inspection plus a
+    two-table join). It covers only the success path -- the marker read can
+    itself raise, which is a different situation pinned separately (see
+    test_active_interaction_id_sync_reports_unavailable_when_the_marker_
+    column_is_missing above) -- so it is not, on its own, the pin for "no
+    user-visible behavior changed" across every caller; that claim is
+    carried by test_the_pre_change_equivalent_table_covers_every_state and
+    the parameterized order tests it feeds.
+
+    Mutation: delete the ``if marker is None: return
+    ActiveInteractionAbsent()`` short-circuit inside
+    ``active_interaction_id_sync`` and this goes red, because the row
+    lookup it guards would then issue a second statement this test asserts
+    never happens.
+    """
+    task_id = seed_task_with_run(db, run_id="run-a", marker=None)
+    seed_active_row(db, task_id=task_id, run_id="run-a")
+    bind = db.get_bind()
+
+    with _counted_selects(bind) as statements:
+        result = active_interaction_id_sync(task_id)
+
+    assert result == ActiveInteractionAbsent()
+    assert len(statements) == 1
+
+
+# --------------------------------------------------------------------------
+# No user-visible behavior change: the claim in this change's description
+# is not carried by any single test above, and cannot be, because it spans
+# every production call site. It is instead a three-layer claim, each layer
+# pinned separately:
+#
+#   1. Which state each situation produces -- pinned one test per situation
+#      above (the seven tests from
+#      test_active_interaction_id_sync_returns_the_live_rows_id through
+#      test_active_interaction_id_sync_reports_unavailable_when_the_marker_
+#      column_is_missing).
+#   2. Which int | None value each state corresponds to in the shape this
+#      reader returned before it became three-state -- pinned once, here,
+#      by _PRE_CHANGE_EQUIVALENT and the test below.
+#   3. That every call site really applies that same projection -- pinned
+#      by the parameterized order tests in tests/web/api/test_a2a_api.py,
+#      tests/web/api/v1/test_task_reply.py and
+#      tests/web/api/test_websocket_owner_actor.py (the three legacy-resume
+#      close sites), and by the refusal-gate cells in
+#      tests/web/api/test_resume_interaction_seam.py (the fourth call site,
+#      which does not close anything but must still let Absent and
+#      Unavailable both through unchanged).
+#
+# All three layers have to hold for the claim to hold; this section is only
+# layer 2.
+# --------------------------------------------------------------------------
+
+_PRE_CHANGE_EQUIVALENT: list[tuple[object, int | None]] = [
+    (ActiveInteractionFound(4321), 4321),
+    (ActiveInteractionAbsent(), None),
+    (ActiveInteractionUnavailable("session_unavailable"), None),
+    (ActiveInteractionUnavailable("lookup_failed"), None),
+]
+
+
+def test_the_pre_change_equivalent_table_covers_every_state() -> None:
+    """``_PRE_CHANGE_EQUIVALENT`` is what every production call site's
+    translation is checked against (imported directly by the parameterized
+    order tests in the three close sites' own test files); this pins the
+    table itself as exhaustive, so a state or a reason word added later
+    without a corresponding row here fails loudly instead of silently
+    narrowing what those other tests cover.
+
+    Mutation: add a fourth member to ``ActiveInteractionRead`` without
+    adding a row for it here, or add a third word to
+    ``ACTIVE_INTERACTION_UNAVAILABLE_REASONS`` without adding a row for it
+    here, and one of the two assertions below goes red.
+    """
+    assert {type(state) for state, _ in _PRE_CHANGE_EQUIVALENT} == {
+        ActiveInteractionFound,
+        ActiveInteractionAbsent,
+        ActiveInteractionUnavailable,
+    }
+    assert {
+        state.reason
+        for state, _ in _PRE_CHANGE_EQUIVALENT
+        if isinstance(state, ActiveInteractionUnavailable)
+    } == ACTIVE_INTERACTION_UNAVAILABLE_REASONS
 
 
 # --------------------------------------------------------------------------

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -19,12 +19,13 @@ import ast
 import logging
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
+from typing import get_args
 
 import pytest
 import sqlalchemy as sa
 from sqlalchemy import Select, event
 
-from tests.web.services.active_interaction_read_shared import _PRE_CHANGE_EQUIVALENT
+from tests.web.services.active_interaction_read_shared import PRE_CHANGE_EQUIVALENT
 from tests.web.services.interaction_static_scan_shared import _scan_root
 from tests.web.services.task_interaction_schema_shared import (
     make_row,
@@ -53,6 +54,7 @@ from xagent.web.services.task_interaction_close import (
     ACTIVE_INTERACTION_UNAVAILABLE_REASONS,
     ActiveInteractionAbsent,
     ActiveInteractionFound,
+    ActiveInteractionRead,
     ActiveInteractionUnavailable,
     _classify_close_rowcount,
     active_interaction_id_sync,
@@ -834,8 +836,14 @@ def test_close_keeps_the_marker_when_the_pre_injection_read_failed(
         "session_unavailable"
     )
 
-    # The same three-branch translation every production call site performs
-    # (see e.g. a2a.py's): Found -> its id, Absent or Unavailable -> None.
+    # The value every production call site's translation produces for this
+    # state, reached here by a two-branch stand-in rather than a copy of
+    # the three branches themselves: what this test is about is the close
+    # being handed `None`, not the shape of the translation. Whether each
+    # site really keeps Unavailable on its own branch -- and logs it -- is
+    # pinned at the sites, in the parameterized order tests in
+    # tests/web/api/test_a2a_api.py, tests/web/api/v1/test_task_reply.py
+    # and tests/web/api/test_websocket_owner_actor.py.
     if isinstance(active_interaction_read, ActiveInteractionFound):
         observed_id = active_interaction_read.interaction_id
     else:
@@ -851,8 +859,9 @@ def test_close_keeps_the_marker_when_the_pre_injection_read_failed(
 
 
 # --------------------------------------------------------------------------
-# ACTIVE_INTERACTION_UNAVAILABLE_REASONS -- the closed two-word vocabulary
-# the two logger.warning call sites above are keyed to. A future change
+# ACTIVE_INTERACTION_UNAVAILABLE_REASONS -- the two-word reason
+# vocabulary the two logger.warning call sites above are keyed to, and
+# the table every caller-side test parametrizes over. A future change
 # that merges those two log messages back into one would, if it also
 # collapsed the reason vocabulary, slip past every assertion above (each
 # only checks one reason string at a time); this pins the vocabulary's
@@ -1030,7 +1039,7 @@ def test_active_interaction_id_sync_issues_only_the_marker_read_under_a_null_mar
 #      column_is_missing).
 #   2. Which int | None value each state corresponds to in the shape this
 #      reader returned before it became three-state -- pinned once by
-#      _PRE_CHANGE_EQUIVALENT, written in
+#      PRE_CHANGE_EQUIVALENT, written in
 #      tests/web/services/active_interaction_read_shared.py because the
 #      layer-3 tests read it too, and by the test below.
 #   3. That every call site really applies that same projection -- pinned
@@ -1048,7 +1057,7 @@ def test_active_interaction_id_sync_issues_only_the_marker_read_under_a_null_mar
 
 
 def test_the_pre_change_equivalent_table_covers_every_state() -> None:
-    """``_PRE_CHANGE_EQUIVALENT`` is what every production call site's
+    """``PRE_CHANGE_EQUIVALENT`` is what every production call site's
     translation is checked against (the parameterized order tests in the
     three close sites' own test files read the same table out of
     active_interaction_read_shared.py); this pins the table itself as
@@ -1060,15 +1069,19 @@ def test_the_pre_change_equivalent_table_covers_every_state() -> None:
     adding a row for it here, or add a third word to
     ``ACTIVE_INTERACTION_UNAVAILABLE_REASONS`` without adding a row for it
     here, and one of the two assertions below goes red.
+
+    The first assertion reads the union's members out of the union itself
+    (``typing.get_args``) rather than repeating the three class names: a
+    hand-written literal set would have to be edited by the same change
+    that adds a fourth member, so it would go green again on exactly the
+    change this test exists to catch.
     """
-    assert {type(state) for state, _ in _PRE_CHANGE_EQUIVALENT} == {
-        ActiveInteractionFound,
-        ActiveInteractionAbsent,
-        ActiveInteractionUnavailable,
-    }
+    assert {type(state) for state, _ in PRE_CHANGE_EQUIVALENT} == set(
+        get_args(ActiveInteractionRead)
+    )
     assert {
         state.reason
-        for state, _ in _PRE_CHANGE_EQUIVALENT
+        for state, _ in PRE_CHANGE_EQUIVALENT
         if isinstance(state, ActiveInteractionUnavailable)
     } == ACTIVE_INTERACTION_UNAVAILABLE_REASONS
 

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -15,6 +15,7 @@ tests/web/api/test_a2a_api.py.
 
 from __future__ import annotations
 
+import ast
 import logging
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
@@ -23,6 +24,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy import Select, event
 
+from tests.web.services.interaction_static_scan_shared import _scan_root
 from tests.web.services.task_interaction_schema_shared import (
     make_row,
     make_task,
@@ -862,6 +864,75 @@ def test_active_interaction_unavailable_reasons_is_exactly_two_words() -> None:
         "session_unavailable",
         "lookup_failed",
     }
+
+
+# --------------------------------------------------------------------------
+# Static gate: every production module that calls active_interaction_id_sync
+# must also name ActiveInteractionUnavailable. This does not check that a
+# caller's Unavailable branch does anything sensible -- a branch reduced to
+# `pass` still satisfies it -- only that the three-state return cannot be
+# quietly narrowed back to a two-state one by a caller that pattern-matches
+# on ActiveInteractionFound and treats everything else as absent. AST-based
+# rather than a substring grep, following the same shape as this package's
+# other zero-caller / production-use gates
+# (test_task_interaction_service_create_gate.py,
+# test_interaction_handoff_production_surface.py,
+# test_task_interaction_anchor.py's _anchor_production_uses): a plain-text
+# search would also match the name inside a docstring or comment, which
+# proves nothing about whether the module's code actually handles the
+# third state.
+# --------------------------------------------------------------------------
+
+_READER_NAME = "active_interaction_id_sync"
+_UNAVAILABLE_NAME = "ActiveInteractionUnavailable"
+_CLOSE_MODULE_STEM = "task_interaction_close"
+
+
+def _references_name(tree: ast.AST, name: str) -> bool:
+    """Whether ``name`` appears as a real reference in ``tree`` -- an
+    import, a bare identifier, or an attribute access -- as opposed to
+    merely appearing inside a string (a docstring or comment mentioning the
+    name proves nothing about whether the module's code handles it)."""
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if any(alias.name == name for alias in node.names):
+                return True
+        elif isinstance(node, ast.Name) and node.id == name:
+            return True
+        elif isinstance(node, ast.Attribute) and node.attr == name:
+            return True
+    return False
+
+
+def test_every_call_site_of_active_interaction_id_sync_names_unavailable() -> None:
+    """Every production module that calls ``active_interaction_id_sync``
+    must also reference ``ActiveInteractionUnavailable`` somewhere in the
+    same module. ``task_interaction_close.py`` itself is excluded from the
+    scan: it defines both names but is not one of this function's callers.
+
+    What this does not catch, by design: a caller that imports
+    ``ActiveInteractionUnavailable`` and then does nothing with it (e.g. an
+    ``isinstance`` branch reduced to ``pass``) still passes. That is a
+    known, disclosed gap -- the behavioral pin for what the ``Unavailable``
+    branch must actually do lives in test_resume_interaction_seam.py (the
+    refusal gate) and in test_close_keeps_the_marker_when_the_pre_injection_
+    read_failed above (the close sites). This gate only catches the most
+    common regression shape: a fifth call site added later that pattern-
+    matches on ``ActiveInteractionFound`` and folds everything else into
+    "absent" without ever mentioning ``ActiveInteractionUnavailable`` at
+    all.
+    """
+
+    offenders: list[str] = []
+    for path in _scan_root(_CLOSE_MODULE_STEM):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        if _references_name(tree, _READER_NAME) and not _references_name(
+            tree, _UNAVAILABLE_NAME
+        ):
+            offenders.append(str(path))
+    assert offenders == []
 
 
 # --------------------------------------------------------------------------

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -24,6 +24,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy import Select, event
 
+from tests.web.services.active_interaction_read_shared import _PRE_CHANGE_EQUIVALENT
 from tests.web.services.interaction_static_scan_shared import _scan_root
 from tests.web.services.task_interaction_schema_shared import (
     make_row,
@@ -1028,8 +1029,10 @@ def test_active_interaction_id_sync_issues_only_the_marker_read_under_a_null_mar
 #      test_active_interaction_id_sync_reports_unavailable_when_the_marker_
 #      column_is_missing).
 #   2. Which int | None value each state corresponds to in the shape this
-#      reader returned before it became three-state -- pinned once, here,
-#      by _PRE_CHANGE_EQUIVALENT and the test below.
+#      reader returned before it became three-state -- pinned once by
+#      _PRE_CHANGE_EQUIVALENT, written in
+#      tests/web/services/active_interaction_read_shared.py because the
+#      layer-3 tests read it too, and by the test below.
 #   3. That every call site really applies that same projection -- pinned
 #      by the parameterized order tests in tests/web/api/test_a2a_api.py,
 #      tests/web/api/v1/test_task_reply.py and
@@ -1043,21 +1046,15 @@ def test_active_interaction_id_sync_issues_only_the_marker_read_under_a_null_mar
 # layer 2.
 # --------------------------------------------------------------------------
 
-_PRE_CHANGE_EQUIVALENT: list[tuple[object, int | None]] = [
-    (ActiveInteractionFound(4321), 4321),
-    (ActiveInteractionAbsent(), None),
-    (ActiveInteractionUnavailable("session_unavailable"), None),
-    (ActiveInteractionUnavailable("lookup_failed"), None),
-]
-
 
 def test_the_pre_change_equivalent_table_covers_every_state() -> None:
     """``_PRE_CHANGE_EQUIVALENT`` is what every production call site's
-    translation is checked against (imported directly by the parameterized
-    order tests in the three close sites' own test files); this pins the
-    table itself as exhaustive, so a state or a reason word added later
-    without a corresponding row here fails loudly instead of silently
-    narrowing what those other tests cover.
+    translation is checked against (the parameterized order tests in the
+    three close sites' own test files read the same table out of
+    active_interaction_read_shared.py); this pins the table itself as
+    exhaustive, so a state or a reason word added later without a
+    corresponding row here fails loudly instead of silently narrowing what
+    those other tests cover.
 
     Mutation: add a fourth member to ``ActiveInteractionRead`` without
     adding a row for it here, or add a third word to


### PR DESCRIPTION
## What

`active_interaction_id_sync` in `task_interaction_close.py` returned
`int | None`, and six different situations all produced the same `None`:
no database configured in this process, a session that fails to open, a
NULL `tasks.interaction_protocol_version`, no interaction table yet, an
empty row lookup, and the lookup itself raising. It now returns one of
three states -- `ActiveInteractionFound(interaction_id)`,
`ActiveInteractionAbsent()`, or `ActiveInteractionUnavailable(reason)`
over a closed two-word reason vocabulary -- so a caller can tell "there
is no live interaction row" apart from "this read could not tell".

All four production call sites take the same action they take today, on
their own branch per state:

- the three legacy-resume close sites (`a2a.py`, `v1/task_reply.py`, and
  the online chat injection site in `websocket.py`) translate the result
  to the `int | None` their close call takes: the id for `Found`, `None`
  for both `Absent` and `Unavailable`. `None` binds the close to no
  primary key, so it matches zero rows and both the active row and the
  marker survive -- which is the safe outcome for a read that could not
  be made, not a claim that nothing was ever active;
- the resume command seam's refusal gate in `websocket.py` acts on
  `Found` exactly as before (compare the client's receipt against the
  primary key, refuse if it does not match) and lets both `Absent` and
  `Unavailable` through, exactly as it does today for a bare `None`.

`Absent` and `Unavailable` stay on their own branch at every call site
even where the action is identical, because the branch is the seam: the
change that first writes `tasks.interaction_protocol_version = 1` turns
the gate's `Unavailable` branch into a refusal by editing one branch's
action and nothing else.

No user-visible behavior changes. No new `reason_code`, no new
client-facing message, no new refusal path, no new degradation signal.

## Why

The gate's test was `if active_interaction_id is not None:`, so every one
of those six situations let a resume through. Two of them are read
failures rather than confirmed absence -- a session that fails to open,
and the row lookup raising -- and both are reachable today: the marker
read is the first statement this function issues, and this repository
already pins one schema state where it raises rather than coming back
empty (see
`test_active_interaction_id_sync_reports_unavailable_when_the_marker_column_is_missing`,
which predates this change). Collapsing those two into the same `None`
as "confirmed absent" is what makes a transient read failure
indistinguishable from an answered question at the gate.

This change makes the distinction available to callers without acting on
it yet, and that split is deliberate:

- the gate cannot usefully refuse yet. Nothing in `src/` writes
  `tasks.interaction_protocol_version` to anything but `NULL`, so a read
  that could not be made cannot be hiding a live native interaction row.
  Refusing on it today would turn a connection-pool hiccup into a refused
  resume for every waiting task, the large majority of which carry no
  native interaction row at all -- the cost `#1314`'s third item names
  for exactly this kind of reversal. The change that first writes that
  marker to `1` is the one that both makes an unavailable read meaningful
  and turns this branch into a refusal;
- the close sites should not refuse at all, now or later. By the time
  they run, the user's answer is already injected; refusing there saves
  nothing and would only strand the resume. "Could not read, so close
  nothing" is already the safe direction, and the close's own contract
  makes `None` mean exactly that.

### Why the test diff is larger than the production diff

The diff is 234 production insertions against 520 test insertions. That
ratio is a consequence of what this change claims rather than of the
change's own size. The type change itself is small: one union of three
frozen dataclasses in the reader, and a three-branch translation at each
of the four call sites. The claim it carries -- that no caller's
user-visible outcome changed -- cannot be asserted in a sentence and be
worth anything, so it is instead pinned as a three-layer matrix, and the
matrix is where most of the test growth is:

1. which state each situation produces -- one test per situation, seven
   in total;
2. which `int | None` value each state corresponded to before this
   reader became three-state -- one table, `_PRE_CHANGE_EQUIVALENT`,
   plus a test pinning that table as exhaustive over both the states and
   the reason words;
3. that every call site really applies that same projection -- the three
   close sites' existing read-before-injection order tests, now
   parameterized over all four rows of that table, plus two refusal-gate
   cells for the fourth call site, which closes nothing but must still
   let `Absent` and `Unavailable` both through.

Layers 2 and 3 are new, and they are what a reviewer should read first:
without them the "no behavior change" line in this description is an
assertion, and with them it is a matrix that fails loudly when it stops
being true.

## Verification

- `pytest tests/web/services/test_task_interaction_close.py` (40 passed),
  `tests/web/api/test_resume_interaction_seam.py` (12 passed),
  `tests/web/api/test_a2a_api.py` (73 passed),
  `tests/web/api/test_websocket_owner_actor.py` (95 passed),
  `tests/web/api/v1/test_task_reply.py` (32 passed),
  `tests/web/api/test_durable_message_resume_contention.py` (10 passed),
  plus `tests/web/services/` in full (2569 passed, 283 skipped) and
  `tests/web/api/` in full (2867 passed, 63 skipped).
- Of those skips: all 63 in `tests/web/api/` are
  `XAGENT_TEST_POSTGRES_URL is not set`. In `tests/web/services/`, 279 of
  the 283 are that same reason and the remaining 4, all in
  `test_gmail_provisioning_pubsub_emulator.py`, need a Pub/Sub emulator
  (`PUBSUB_EMULATOR_HOST`); those 4 are unrelated to this change and skip
  identically on the base commit. Nothing errored.
- `ruff check` and `ruff format --check` pass over all nine changed
  files. `mypy --package xagent` reports nothing on any of them; mypy
  over the package is what forces all four call sites to handle the third
  state rather than pattern-matching on `ActiveInteractionFound` and
  treating the rest as absent.
- "No user-visible behavior change" is pinned as a matrix, not asserted
  as a claim: one test per situation for which state it produces; one
  test that the table of pre-change equivalents covers every state and
  every reason word; the three close-site order tests parameterized over
  all four table rows (`Found`, `Absent`, and both `Unavailable` reasons),
  asserting the `interaction_id` handed to the close; and refusal-gate
  cells asserting the resume proceeds under both `Absent` and
  `Unavailable`.
- Mutation-tested, five ways: making the gate refuse on
  `ActiveInteractionUnavailable` turns
  `test_legacy_resume_is_not_refused_when_the_active_interaction_read_is_unavailable`
  red; narrowing a close site's translation to two branches (dropping the
  `ActiveInteractionUnavailable` reference) turns the static call-site
  gate red; translating `Unavailable` to a real id instead of `None` at a
  close site turns that site's parameterized order test red on exactly
  the `Unavailable` cases; reporting the NULL-marker branch as
  `Unavailable` instead of `Absent` turns the marker-gate statement-count
  pin red; adding a third reason word turns both the vocabulary assertion
  and the pre-change equivalents table red. All five reverted cleanly.
- **Not verified on PostgreSQL**: this environment has no PostgreSQL
  client and no `XAGENT_TEST_POSTGRES_URL`, so
  `test_task_interaction_close_postgresql.py` skipped (8 tests) rather
  than ran.


