### PR TITLE
fix(mcp): drop the caller allow-list from unavailable MCP placeholder tools

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -963,7 +963,6 @@ class ToolFactory:
         *,
         server_name: object,
         server_id: object = None,
-        allow_users: object = None,
         reason: object = None,
         message: object = None,
         failure_code: object = None,
@@ -975,7 +974,6 @@ class ToolFactory:
         kwargs: dict[str, Any] = {
             "server_name": server_name if isinstance(server_name, str) else "",
             "server_id": server_id,
-            "allow_users": allow_users if isinstance(allow_users, list) else None,
             "failure_code": normalize_tool_failure_code(failure_code),
         }
         if isinstance(reason, str):
@@ -1008,7 +1006,6 @@ class ToolFactory:
                 cls._create_unavailable_mcp_tool(
                     server_name=failure.server_name,
                     server_id=server_id,
-                    allow_users=config.get("allow_users"),
                     reason=failure.phase.value,
                     message=mcp_load_failure_message(failure.phase),
                 )
@@ -1048,12 +1045,10 @@ class ToolFactory:
                 if isinstance(inner_config, dict) and inner_config.get("unavailable"):
                     try:
                         server_name = config.get("name")
-                        allow_users = config.get("allow_users")
                         unavailable_tools.append(
                             ToolFactory._create_unavailable_mcp_tool(
                                 server_name=server_name,
                                 server_id=inner_config.get("server_id"),
-                                allow_users=allow_users,
                                 reason=inner_config.get("reason"),
                                 message=inner_config.get("message"),
                                 failure_code=inner_config.get("failure_code"),
@@ -1087,7 +1082,6 @@ class ToolFactory:
                                 ToolFactory._create_unavailable_mcp_tool(
                                     server_name=config.get("name"),
                                     server_id=config.get("id"),
-                                    allow_users=config.get("allow_users"),
                                     reason="invalid_config",
                                     message="MCP server configuration is unavailable.",
                                 )
@@ -1099,7 +1093,6 @@ class ToolFactory:
                                 ToolFactory._create_unavailable_mcp_tool(
                                     server_name=server_name,
                                     server_id=config.get("id"),
-                                    allow_users=config.get("allow_users"),
                                     reason="invalid_config",
                                     message="MCP server configuration is unavailable.",
                                 )
@@ -1111,7 +1104,6 @@ class ToolFactory:
                                 ToolFactory._create_unavailable_mcp_tool(
                                     server_name=server_name,
                                     server_id=config.get("id"),
-                                    allow_users=config.get("allow_users"),
                                     reason="invalid_config",
                                     message="MCP server configuration is unavailable.",
                                 )
@@ -1176,7 +1168,6 @@ class ToolFactory:
                             ToolFactory._create_unavailable_mcp_tool(
                                 server_name=server_name,
                                 server_id=config.get("id"),
-                                allow_users=config.get("allow_users"),
                                 reason="loader_failed",
                                 message="MCP server tools could not be loaded.",
                             )
@@ -1262,7 +1253,6 @@ class ToolFactory:
                         cls._create_unavailable_mcp_tool(
                             server_name=getattr(server, "name", ""),
                             server_id=getattr(server, "id", None),
-                            allow_users=[str(user_id)] if user_id is not None else None,
                             reason="runtime_connection_failed",
                             message="MCP server configuration is unavailable.",
                         )
@@ -1274,7 +1264,6 @@ class ToolFactory:
                     configs_by_name[server_name] = {
                         "id": getattr(server, "id", None),
                         "name": server_name,
-                        "allow_users": [str(user_id)] if user_id is not None else None,
                     }
                     continue
                 diagnostic = build.diagnostic or {}
@@ -1287,7 +1276,6 @@ class ToolFactory:
                     cls._create_unavailable_mcp_tool(
                         server_name=getattr(server, "name", ""),
                         server_id=getattr(server, "id", None),
-                        allow_users=[str(user_id)] if user_id is not None else None,
                         reason=diagnostic.get("code", "runtime_connection_unavailable"),
                         message="MCP server configuration is unavailable.",
                     )
@@ -1313,7 +1301,6 @@ class ToolFactory:
                     cls._create_unavailable_mcp_tool(
                         server_name=server_name,
                         server_id=config.get("id"),
-                        allow_users=config.get("allow_users"),
                         reason="loader_failed",
                         message="MCP server tools could not be loaded.",
                     )

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1645,7 +1645,14 @@ class _UnavailableMCPToolResult(BaseModel):
 
 
 class UnavailableMCPTool(AbstractBaseTool):
-    """Server-level MCP tool returned when a selected server is unavailable."""
+    """Server-level MCP tool returned when a selected server is unavailable.
+
+    The tool exists to explain an outage, so it always reports that outage to
+    whoever invokes it: it carries no allow-list and performs no caller check.
+    Its result holds only a constant message plus an allowlisted ``reason`` and
+    ``failure_code``, and the server name it is built from is already exposed in
+    the tool listing, so there is nothing here to withhold from a caller.
+    """
 
     read_only = True
     concurrency_safe = True
@@ -1655,7 +1662,6 @@ class UnavailableMCPTool(AbstractBaseTool):
         *,
         server_name: str,
         server_id: Any | None,
-        allow_users: Optional[List[str]] = None,
         failure_code: str | None = None,
         reason: str | None = None,
         message: str = _DEFAULT_UNAVAILABLE_MCP_MESSAGE,
@@ -1666,7 +1672,6 @@ class UnavailableMCPTool(AbstractBaseTool):
 
         self._server_name = server_name
         self._server_id = server_id
-        self._allow_users = allow_users
         self._failure_code = normalize_tool_failure_code(failure_code)
         self._reason = reason
         self._message = message
@@ -1706,9 +1711,6 @@ class UnavailableMCPTool(AbstractBaseTool):
         return None
 
     def _run_unavailable(self) -> Dict[str, Any]:
-        current_user_id = _get_current_mcp_user_id()
-        if not _is_mcp_user_allowed(current_user_id, self._allow_users):
-            return _mcp_access_denied_result(current_user_id, self.name)
         content_message = self._message
         if self._message == _DEFAULT_UNAVAILABLE_MCP_MESSAGE:
             content_message = (

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1649,9 +1649,13 @@ class UnavailableMCPTool(AbstractBaseTool):
 
     The tool exists to explain an outage, so it always reports that outage to
     whoever invokes it: it carries no allow-list and performs no caller check.
-    Its result holds only a constant message plus an allowlisted ``reason`` and
-    ``failure_code``, and the server name it is built from is already exposed in
-    the tool listing, so there is nothing here to withhold from a caller.
+    Its result holds only a constant message plus a ``reason`` and a
+    ``failure_code``. ``failure_code`` is normalized against the public failure
+    allowlist here and dropped when it is not on it; ``reason`` is stored as
+    given, so an allowlisted value is a guarantee callers make, enforced where
+    the unavailable config is built. The server name it is built from is
+    already exposed in the tool listing, so there is nothing here to withhold
+    from a caller.
     """
 
     read_only = True

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3595,7 +3595,6 @@ class WebToolConfig(BaseToolConfig):
             "description": getattr(server, "description", None),
             "config": inner_config,
             "user_id": serialized_user_id,
-            "allow_users": [serialized_user_id],
         }
 
     def _build_oauth_mcp_stdio_transport_config(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -4433,9 +4433,7 @@ class WebToolConfig(BaseToolConfig):
         config["config"] = transport_config
 
         # Add user context for MCP tool isolation
-        serialized_user_id = self._serialize_mcp_user_id()
-        config["user_id"] = serialized_user_id
-        config["allow_users"] = [serialized_user_id]  # Only allow current user
+        config["user_id"] = self._serialize_mcp_user_id()
 
         logger.debug(f"Loaded MCP server config: {server.name} ({server.transport})")
         return config

--- a/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 import re
 from typing import Any
@@ -25,7 +26,6 @@ def _unavailable_tool(
     *,
     server_name: str = "Google Drive",
     server_id: int | None = 42,
-    allow_users: list[str] | None = None,
     failure_code: str | None = None,
     reason: str | None = None,
     message: str | None = None,
@@ -33,7 +33,6 @@ def _unavailable_tool(
     kwargs: dict[str, Any] = {
         "server_name": server_name,
         "server_id": server_id,
-        "allow_users": allow_users,
         "failure_code": failure_code,
     }
     if reason is not None:
@@ -49,7 +48,6 @@ def _unavailable_config(
     *,
     name: str | None = "Google Drive",
     server_id: int | None = 42,
-    allow_users: list[str] | None = None,
     failure_code: object | None = None,
 ) -> dict:
     config = {
@@ -62,7 +60,6 @@ def _unavailable_config(
             "message": "MCP server credentials are unavailable.",
             "server_id": server_id,
         },
-        "allow_users": allow_users,
     }
     if failure_code is not None:
         config["config"]["failure_code"] = failure_code
@@ -93,19 +90,20 @@ def test_unavailable_tool_empty_server_name_has_stable_fallback():
 
 
 def test_unavailable_tool_metadata_is_mcp_and_server_scoped():
-    tool = _unavailable_tool(allow_users=["7"])
+    tool = _unavailable_tool()
 
     assert tool.metadata.category == ToolCategory.MCP
     assert tool.metadata.source_server == "google_drive"
-    assert tool.metadata.allow_users == ["7"]
+    # The placeholder explains an outage to whoever calls it, so it carries no
+    # allow-list for the runtime to check the caller against.
+    assert tool.metadata.allow_users is None
     assert tool.metadata.read_only is True
     assert tool.metadata.concurrency_safe is True
 
 
 @pytest.mark.asyncio
-async def test_unavailable_tool_async_authorized_returns_clean_error(monkeypatch):
-    monkeypatch.setenv("XAGENT_USER_ID", "7")
-    tool = _unavailable_tool(allow_users=["7"])
+async def test_unavailable_tool_async_returns_clean_error():
+    tool = _unavailable_tool()
 
     result = await tool.run_json_async({})
 
@@ -118,9 +116,8 @@ async def test_unavailable_tool_async_authorized_returns_clean_error(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_unavailable_tool_authorized_returns_classified_failure(monkeypatch):
-    monkeypatch.setenv("XAGENT_USER_ID", "7")
-    tool = _unavailable_tool(allow_users=["7"], failure_code="oauth_token_required")
+async def test_unavailable_tool_returns_classified_failure():
+    tool = _unavailable_tool(failure_code="oauth_token_required")
 
     result = await tool.run_json_async({})
 
@@ -142,10 +139,8 @@ async def test_unavailable_tool_authorized_returns_classified_failure(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_unavailable_tool_accepts_public_runtime_reason_and_message(monkeypatch):
-    monkeypatch.setenv("XAGENT_USER_ID", "7")
+async def test_unavailable_tool_accepts_public_runtime_reason_and_message():
     tool = _unavailable_tool(
-        allow_users=["7"],
         reason="initialize",
         message="MCP server initialization failed.",
     )
@@ -181,9 +176,8 @@ def test_unavailable_tool_supports_public_load_phase_messages(reason, message):
     assert result["content"] == [{"text": message}]
 
 
-def test_unavailable_tool_sync_authorized_returns_clean_error(monkeypatch):
-    monkeypatch.setenv("XAGENT_USER_ID", "7")
-    tool = _unavailable_tool(allow_users=["7"])
+def test_unavailable_tool_sync_returns_clean_error():
+    tool = _unavailable_tool()
 
     result = tool.run_json_sync({})
 
@@ -191,67 +185,102 @@ def test_unavailable_tool_sync_authorized_returns_clean_error(monkeypatch):
     assert "MCP server credentials are unavailable" in result["content"][0]["text"]
 
 
+def test_unavailable_tool_takes_no_caller_allow_list():
+    """Neither the placeholder nor its factory accepts an allow-list.
+
+    Removing only the runtime check would leave the parameter in place, and a
+    construction site passing a list again is exactly how every caller came to
+    be denied; the parameter's absence is what keeps that from coming back.
+    """
+    assert (
+        "allow_users" not in inspect.signature(UnavailableMCPTool.__init__).parameters
+    )
+    assert (
+        "allow_users"
+        not in inspect.signature(ToolFactory._create_unavailable_mcp_tool).parameters
+    )
+    with pytest.raises(TypeError):
+        UnavailableMCPTool(
+            server_name="Google Drive",
+            server_id=42,
+            allow_users=["7"],
+        )
+
+
 @pytest.mark.asyncio
-async def test_unavailable_tool_async_unauthorized_uses_mcp_access_denied(
-    monkeypatch,
-):
+async def test_unavailable_tool_async_reports_the_outage_to_any_caller(monkeypatch):
+    """A caller identity that differs from the server owner changes nothing.
+
+    The placeholder used to check the caller against an allow-list and answer
+    "Access denied" instead of explaining the outage.
+    """
     monkeypatch.setenv("XAGENT_USER_ID", "8")
-    tool = _unavailable_tool(allow_users=["7"])
+    tool = _unavailable_tool()
 
     result = await tool.run_json_async({})
 
     assert result == {
+        "success": False,
+        "status": "error",
+        "is_error": True,
+        "error": "MCP server credentials are unavailable.",
         "content": [
             {
                 "text": (
-                    "Access denied: User 8 is not authorized to use tool "
-                    "mcp_google_drive_42_unavailable"
+                    "MCP server credentials are unavailable. Please reconnect "
+                    "the MCP server credentials and retry."
                 )
             }
         ],
-        "is_error": True,
     }
 
 
-def test_unavailable_tool_return_schema_accepts_access_denied_result(monkeypatch):
+def test_unavailable_tool_return_schema_accepts_the_outage_result(monkeypatch):
     monkeypatch.setenv("XAGENT_USER_ID", "8")
-    tool = _unavailable_tool(allow_users=["7"])
+    tool = _unavailable_tool()
 
     result = tool.run_json_sync({})
     parsed = tool.return_type().model_validate(result)
 
-    assert parsed.error is None
+    assert parsed.error == "MCP server credentials are unavailable."
     assert parsed.is_error is True
 
 
-def test_unavailable_tool_sync_unauthorized_uses_mcp_access_denied(monkeypatch):
+def test_unavailable_tool_sync_reports_the_outage_to_any_caller(monkeypatch):
     monkeypatch.setenv("XAGENT_USER_ID", "8")
-    tool = _unavailable_tool(allow_users=["7"])
+    tool = _unavailable_tool()
 
     result = tool.run_json_sync({})
 
     assert result["is_error"] is True
-    assert "Access denied" in result["content"][0]["text"]
+    assert "Access denied" not in result["content"][0]["text"]
+    assert "MCP server credentials are unavailable" in result["content"][0]["text"]
 
 
-def test_unavailable_tool_missing_user_permission_regression(monkeypatch):
-    monkeypatch.delenv("XAGENT_USER_ID", raising=False)
+@pytest.mark.parametrize(
+    "caller_user_id",
+    [None, "7", "8"],
+    ids=["no_caller_identity", "owning_user", "another_user"],
+)
+def test_unavailable_tool_reports_the_outage_for_every_caller_identity(
+    monkeypatch, caller_user_id
+):
+    """The reported outage does not depend on ``XAGENT_USER_ID``.
 
-    assert _unavailable_tool(allow_users=None).run_json_sync({})["is_error"] is True
-    assert (
-        "MCP server credentials"
-        in _unavailable_tool(allow_users=None).run_json_sync({})["content"][0]["text"]
-    )
-    assert (
-        "Access denied"
-        in _unavailable_tool(allow_users=["7"]).run_json_sync({})["content"][0]["text"]
-    )
-    assert (
-        "MCP server credentials"
-        in _unavailable_tool(allow_users=["system"]).run_json_sync({})["content"][0][
-            "text"
-        ]
-    )
+    A normal server process never writes that variable, so the identity is
+    absent in production; the owning-user and other-user cases only exist
+    because tests can set it.
+    """
+    if caller_user_id is None:
+        monkeypatch.delenv("XAGENT_USER_ID", raising=False)
+    else:
+        monkeypatch.setenv("XAGENT_USER_ID", caller_user_id)
+
+    result = _unavailable_tool().run_json_sync({})
+
+    assert result["is_error"] is True
+    assert "Access denied" not in result["content"][0]["text"]
+    assert "MCP server credentials" in result["content"][0]["text"]
 
 
 def test_mcp_tool_adapter_permission_helper_regression(monkeypatch):
@@ -322,12 +351,10 @@ async def test_factory_builds_unavailable_tools_without_normal_loader(monkeypatc
     ],
 )
 async def test_factory_revalidates_unavailable_failure_code(
-    monkeypatch,
     raw_failure_code,
     expected_failure_code,
 ):
-    monkeypatch.setenv("XAGENT_USER_ID", "7")
-    config = _unavailable_config(allow_users=["7"], failure_code=raw_failure_code)
+    config = _unavailable_config(failure_code=raw_failure_code)
     config["config"]["diagnostic"] = {
         "actor": "internal-actor",
         "resource": "internal-resource",
@@ -343,7 +370,7 @@ async def test_factory_revalidates_unavailable_failure_code(
 
 
 @pytest.mark.asyncio
-async def test_unavailable_config_failure_code_reaches_tool_failure_trace(monkeypatch):
+async def test_unavailable_config_failure_code_reaches_tool_failure_trace():
     class CapturingTracer:
         def __init__(self) -> None:
             self.events: list[dict[str, Any]] = []
@@ -356,8 +383,7 @@ async def test_unavailable_config_failure_code_reaches_tool_failure_trace(monkey
                 }
             )
 
-    monkeypatch.setenv("XAGENT_USER_ID", "7")
-    config = _unavailable_config(allow_users=["7"], failure_code="oauth_token_required")
+    config = _unavailable_config(failure_code="oauth_token_required")
     config["config"]["diagnostic"] = {
         "actor": "internal-actor",
         "resource": "internal-resource",
@@ -410,7 +436,6 @@ async def test_factory_normal_loader_failure_keeps_unavailable_tool(monkeypatch)
 async def test_factory_keeps_successful_tools_and_exposes_each_failed_server(
     monkeypatch,
 ):
-    monkeypatch.setenv("XAGENT_USER_ID", "7")
     healthy_tool = _unavailable_tool(server_name="Healthy result", server_id=99)
 
     async def loader(connections, **kwargs):
@@ -444,21 +469,18 @@ async def test_factory_keeps_successful_tools_and_exposes_each_failed_server(
                 "name": "healthy",
                 "transport": "stdio",
                 "config": {"command": "echo"},
-                "allow_users": ["7"],
             },
             {
                 "id": 12,
                 "name": "broken",
                 "transport": "stdio",
                 "config": {"command": "echo"},
-                "allow_users": ["7"],
             },
             {
                 "id": 13,
                 "name": "partial",
                 "transport": "stdio",
                 "config": {"command": "echo"},
-                "allow_users": ["7"],
             },
         ]
     )

--- a/tests/core/tools/test_mcp_database_integration.py
+++ b/tests/core/tools/test_mcp_database_integration.py
@@ -601,9 +601,15 @@ class TestToolFactoryMCPIntegration:
         assert "BearerSecretError" not in str(exc_info.value)
 
     @patch("xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools")
-    async def test_create_mcp_tools_scopes_loader_failure_to_requested_user(
+    async def test_create_mcp_tools_loader_failure_reports_the_outage_to_any_caller(
         self, mock_load_mcp, test_db, sample_stdio_config, monkeypatch
     ):
+        """A loader failure must surface as an outage, not as an access denial.
+
+        The database path used to build the placeholder with an allow-list of
+        the requesting user, so a caller identity that did not match answered
+        "Access denied" instead of naming the failure.
+        """
         manager = DatabaseMCPServerManager(test_db)
         manager.add_server(manager.create_config(**sample_stdio_config))
         server = (
@@ -624,7 +630,9 @@ class TestToolFactoryMCPIntegration:
 
         monkeypatch.setenv("XAGENT_USER_ID", "2")
         result = tools[0].run_json_sync({})
-        assert "Access denied" in result["content"][0]["text"]
+        assert "Access denied" not in result["content"][0]["text"]
+        assert result["reason"] == "loader_failed"
+        assert result["error"] == "MCP server tools could not be loaded."
 
     @patch("xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools")
     async def test_create_mcp_tools_no_connections(self, mock_load_mcp, test_db):

--- a/tests/web/tools/conftest.py
+++ b/tests/web/tools/conftest.py
@@ -1,0 +1,49 @@
+"""Stand-ins for the MCP server rows the ``WebToolConfig`` builders read.
+
+The builders only ever read plain attributes off a server row, so a namespace
+carrying exactly the attributes they touch is enough to drive them. Both
+builders are exercised from more than one module in this directory, so the two
+shapes live here rather than being rebuilt per module.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def unavailable_mcp_server() -> SimpleNamespace:
+    """A server whose config cannot be built, so no runtime connection is tried."""
+    return SimpleNamespace(
+        id=1,
+        name="Example",
+        description=None,
+        transport="unsupported-test-transport",
+        managed="external",
+        concurrency_safe=False,
+        concurrent_tools=[],
+    )
+
+
+@pytest.fixture
+def stdio_mcp_server() -> SimpleNamespace:
+    """A server whose config builds fine, so any failure happens at load time."""
+    return SimpleNamespace(
+        id=5,
+        name="Test Stdio Server",
+        transport="stdio",
+        description="",
+        command="python",
+        args=["-m", "xagent.web.tools.mcp.aws"],
+        env={"FOO": "bar"},
+        cwd=None,
+        managed="external",
+        docker_url=None,
+        docker_image=None,
+        docker_environment=None,
+        docker_working_dir=None,
+        volumes=None,
+        bind_ports=None,
+        restart_policy=None,
+        auto_start=None,
+    )

--- a/tests/web/tools/test_mcp_oauth_runtime.py
+++ b/tests/web/tools/test_mcp_oauth_runtime.py
@@ -167,7 +167,7 @@ def _assert_unavailable_runtime_config(
     assert config["config"]["diagnostic"] == diagnostic
     assert config["config"]["failure_code"] == "oauth_token_required"
     assert config["user_id"] == str(server.user_mcpservers[0].user_id)
-    assert config["allow_users"] == [str(server.user_mcpservers[0].user_id)]
+    assert "allow_users" not in config
     assert "runtime_input_schema" not in config
     assert "runtime_bindings" not in config
     assert "allow_delegated_authorization" not in config

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -288,7 +288,7 @@ def _assert_unavailable_mcp_config(
         assert "failure_code" not in config["config"]
     expected_user_id = str(server.user_mcpservers[0].user_id)
     assert config["user_id"] == expected_user_id
-    assert config["allow_users"] == [expected_user_id]
+    assert "allow_users" not in config
     assert "runtime_input_schema" not in config
     assert "runtime_bindings" not in config
     assert "allow_delegated_authorization" not in config
@@ -3090,7 +3090,7 @@ async def test_remote_hook_refresh_classification_reaches_tool_failure_trace(
             inputSchema={"type": "object", "properties": {}},
         ),
         connection=connection,
-        allow_users=configs[0]["allow_users"],
+        allow_users=None,
     )
     request = httpx.Request("POST", "https://mcp.example/api")
     response = httpx.Response(

--- a/tests/web/tools/test_unavailable_mcp_placeholder_pipeline.py
+++ b/tests/web/tools/test_unavailable_mcp_placeholder_pipeline.py
@@ -33,42 +33,6 @@ from xagent.web.tools.config import WebToolConfig
 OWNER_USER_ID = 42
 
 
-def _unavailable_server() -> SimpleNamespace:
-    """A server whose config cannot be built, matching the shape the builder reads."""
-    return SimpleNamespace(
-        id=1,
-        name="Example",
-        description=None,
-        transport="unsupported-test-transport",
-        managed="external",
-        concurrency_safe=False,
-        concurrent_tools=[],
-    )
-
-
-def _stdio_server() -> SimpleNamespace:
-    """A server whose config builds fine, so the failure happens at load time."""
-    return SimpleNamespace(
-        id=5,
-        name="Test Stdio Server",
-        transport="stdio",
-        description="",
-        command="python",
-        args=["-m", "xagent.web.tools.mcp.aws"],
-        env={"FOO": "bar"},
-        cwd=None,
-        managed="external",
-        docker_url=None,
-        docker_image=None,
-        docker_environment=None,
-        docker_working_dir=None,
-        volumes=None,
-        bind_ports=None,
-        restart_policy=None,
-        auto_start=None,
-    )
-
-
 def _assert_reports_outage(result: Any, *, expected_message: str) -> None:
     """The placeholder answered with its outage, not with a denial.
 
@@ -85,6 +49,7 @@ def _assert_reports_outage(result: Any, *, expected_message: str) -> None:
 @pytest.mark.asyncio
 async def test_config_load_failure_placeholder_reports_outage_without_a_caller_id(
     monkeypatch: pytest.MonkeyPatch,
+    unavailable_mcp_server: SimpleNamespace,
 ) -> None:
     """Real ``_build_unavailable_mcp_config`` output -> factory -> invocation.
 
@@ -95,7 +60,7 @@ async def test_config_load_failure_placeholder_reports_outage_without_a_caller_i
 
     cfg = WebToolConfig(db=None, request=None, user_id=OWNER_USER_ID)
     config = cfg._build_unavailable_mcp_config(
-        server=_unavailable_server(), reason="config_load_failed"
+        server=unavailable_mcp_server, reason="config_load_failed"
     )
 
     tools = await ToolFactory._create_mcp_tools_from_configs([config])
@@ -111,6 +76,7 @@ async def test_config_load_failure_placeholder_reports_outage_without_a_caller_i
 @pytest.mark.asyncio
 async def test_handshake_failure_placeholder_reports_outage_without_a_caller_id(
     monkeypatch: pytest.MonkeyPatch,
+    stdio_mcp_server: SimpleNamespace,
 ) -> None:
     """Real executable config -> failed handshake -> factory -> invocation.
 
@@ -126,7 +92,7 @@ async def test_handshake_failure_placeholder_reports_outage_without_a_caller_id(
 
     cfg = WebToolConfig(db=None, request=None, user_id=OWNER_USER_ID)
     config = await cfg._build_mcp_server_config(
-        server=_stdio_server(),
+        server=stdio_mcp_server,
         user_env_by_id={},
         shared_env_by_id={},
         env_source_by_id={},

--- a/tests/web/tools/test_unavailable_mcp_placeholder_pipeline.py
+++ b/tests/web/tools/test_unavailable_mcp_placeholder_pipeline.py
@@ -1,0 +1,163 @@
+"""End-to-end pins for the placeholder tool an unavailable MCP server yields.
+
+These tests run the whole production chain in one go: a config built by the
+real ``WebToolConfig`` builders, handed to the real ``ToolFactory`` entry point
+that assembles MCP tools, then the resulting placeholder tool actually invoked.
+``XAGENT_USER_ID`` is explicitly removed from the environment, because no
+server process writes it -- so the caller identity a placeholder would see in
+production is always absent. A placeholder that consults a caller identity here
+denies every caller and reports "Access denied" instead of the outage, which is
+the failure these tests exist to catch.
+
+The narrower unit tests elsewhere use hand-written config dictionaries; these
+start from the real builders so a change to what those builders emit cannot
+silently stop reaching the placeholder.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.factory import ToolFactory
+from xagent.core.tools.adapters.vibe.mcp_adapter import (
+    MCPFailurePhase,
+    MCPLoadResult,
+    MCPServerLoadFailure,
+    UnavailableMCPTool,
+)
+from xagent.web.tools.config import WebToolConfig
+
+OWNER_USER_ID = 42
+
+
+def _unavailable_server() -> SimpleNamespace:
+    """A server whose config cannot be built, matching the shape the builder reads."""
+    return SimpleNamespace(
+        id=1,
+        name="Example",
+        description=None,
+        transport="unsupported-test-transport",
+        managed="external",
+        concurrency_safe=False,
+        concurrent_tools=[],
+    )
+
+
+def _stdio_server() -> SimpleNamespace:
+    """A server whose config builds fine, so the failure happens at load time."""
+    return SimpleNamespace(
+        id=5,
+        name="Test Stdio Server",
+        transport="stdio",
+        description="",
+        command="python",
+        args=["-m", "xagent.web.tools.mcp.aws"],
+        env={"FOO": "bar"},
+        cwd=None,
+        managed="external",
+        docker_url=None,
+        docker_image=None,
+        docker_environment=None,
+        docker_working_dir=None,
+        volumes=None,
+        bind_ports=None,
+        restart_policy=None,
+        auto_start=None,
+    )
+
+
+def _assert_reports_outage(result: Any, *, expected_message: str) -> None:
+    """The placeholder answered with its outage, not with a denial.
+
+    The denial check comes first so that a regression fails on the thing this
+    test is about, rather than on a missing key of the outage result.
+    """
+    assert "Access denied" not in repr(result)
+    text = result["content"][0]["text"]
+    assert expected_message in text
+    assert result["is_error"] is True
+    assert result["error"] == expected_message
+
+
+@pytest.mark.asyncio
+async def test_config_load_failure_placeholder_reports_outage_without_a_caller_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real ``_build_unavailable_mcp_config`` output -> factory -> invocation.
+
+    This is the branch that runs when the config for a selected server cannot
+    be built at all (for example a transport the runtime cannot serve).
+    """
+    monkeypatch.delenv("XAGENT_USER_ID", raising=False)
+
+    cfg = WebToolConfig(db=None, request=None, user_id=OWNER_USER_ID)
+    config = cfg._build_unavailable_mcp_config(
+        server=_unavailable_server(), reason="config_load_failed"
+    )
+
+    tools = await ToolFactory._create_mcp_tools_from_configs([config])
+
+    assert [tool.name for tool in tools] == ["mcp_example_1_unavailable"]
+    placeholder = tools[0]
+    assert isinstance(placeholder, UnavailableMCPTool)
+    for result in (placeholder.run_json_sync({}), await placeholder.run_json_async({})):
+        _assert_reports_outage(result, expected_message="MCP server is unavailable.")
+        assert result["reason"] == "config_load_failed"
+
+
+@pytest.mark.asyncio
+async def test_handshake_failure_placeholder_reports_outage_without_a_caller_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real executable config -> failed handshake -> factory -> invocation.
+
+    The config here is the one ``_build_mcp_server_config`` emits for a server
+    that is configured correctly; the server itself fails to initialize. This
+    is the most common way a placeholder reaches a user. That this config
+    carries no caller allow-list for the factory to pass along is pinned
+    separately by ``test_executable_mcp_config_does_not_carry_allow_users`` in
+    ``test_webtoolconfig_identity.py``; here the assertion is on the outcome,
+    so a regression fails on the answer the caller gets.
+    """
+    monkeypatch.delenv("XAGENT_USER_ID", raising=False)
+
+    cfg = WebToolConfig(db=None, request=None, user_id=OWNER_USER_ID)
+    config = await cfg._build_mcp_server_config(
+        server=_stdio_server(),
+        user_env_by_id={},
+        shared_env_by_id={},
+        env_source_by_id={},
+    )
+
+    async def failing_loader(connections, **kwargs):
+        return MCPLoadResult(
+            tools=(),
+            loaded_servers=(),
+            failures=(
+                MCPServerLoadFailure(
+                    server_name="Test Stdio Server",
+                    phase=MCPFailurePhase.INITIALIZE,
+                    error_type="RuntimeError",
+                    attempts=3,
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools",
+        failing_loader,
+    )
+
+    tools = await ToolFactory._create_mcp_tools_from_configs([config])
+
+    assert [tool.name for tool in tools] == ["mcp_test_stdio_server_5_unavailable"]
+    placeholder = tools[0]
+    assert isinstance(placeholder, UnavailableMCPTool)
+    for result in (placeholder.run_json_sync({}), await placeholder.run_json_async({})):
+        _assert_reports_outage(
+            result, expected_message="MCP server initialization failed."
+        )
+        assert result["reason"] == "initialize"

--- a/tests/web/tools/test_webtoolconfig_identity.py
+++ b/tests/web/tools/test_webtoolconfig_identity.py
@@ -106,6 +106,31 @@ async def test_mcp_config_builders_require_an_explicit_user_identity(
             )
 
 
+def test_unavailable_mcp_config_does_not_scope_allow_users() -> None:
+    """The placeholder config for an unavailable server must not carry
+    ``allow_users``. The placeholder tool built from this config is meant to
+    explain the outage to whichever caller invokes it; scoping it to a single
+    user id caused the placeholder to deny its own caller in a normal server
+    process, where no per-request user id is bound to the environment."""
+    cfg = WebToolConfig(db=None, request=None, user_id=42)
+    server = SimpleNamespace(
+        id=1,
+        name="Example",
+        description=None,
+        transport="unsupported-test-transport",
+        managed="external",
+        concurrency_safe=False,
+        concurrent_tools=[],
+    )
+
+    config = cfg._build_unavailable_mcp_config(
+        server=server, reason="config_load_failed"
+    )
+
+    assert config["user_id"] == "42"
+    assert "allow_users" not in config
+
+
 @pytest.mark.asyncio
 async def test_identity_free_mcp_load_returns_before_cache_or_database(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/web/tools/test_webtoolconfig_identity.py
+++ b/tests/web/tools/test_webtoolconfig_identity.py
@@ -132,6 +132,47 @@ def test_unavailable_mcp_config_does_not_scope_allow_users() -> None:
 
 
 @pytest.mark.asyncio
+async def test_executable_mcp_config_does_not_carry_allow_users() -> None:
+    """The config for a server that loads must not carry ``allow_users`` either.
+
+    Nothing reads the key any more: the MCP tool adapter's allow-list is only
+    ever set through ``load_mcp_tools_as_agent_tools(allow_users=...)``, which
+    no caller passes, and the placeholder tool no longer has an allow-list at
+    all. The owning identity stays on the config as ``user_id``.
+    """
+    cfg = WebToolConfig(db=None, request=None, user_id=42)
+    server = SimpleNamespace(
+        id=5,
+        name="Test Stdio Server",
+        transport="stdio",
+        description="",
+        command="python",
+        args=["-m", "xagent.web.tools.mcp.aws"],
+        env={"FOO": "bar"},
+        cwd=None,
+        managed="external",
+        docker_url=None,
+        docker_image=None,
+        docker_environment=None,
+        docker_working_dir=None,
+        volumes=None,
+        bind_ports=None,
+        restart_policy=None,
+        auto_start=None,
+    )
+
+    config = await cfg._build_mcp_server_config(
+        server=server,
+        user_env_by_id={},
+        shared_env_by_id={},
+        env_source_by_id={},
+    )
+
+    assert config["user_id"] == "42"
+    assert "allow_users" not in config
+
+
+@pytest.mark.asyncio
 async def test_identity_free_mcp_load_returns_before_cache_or_database(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/web/tools/test_webtoolconfig_identity.py
+++ b/tests/web/tools/test_webtoolconfig_identity.py
@@ -80,17 +80,10 @@ def test_identity_free_config_ignores_request_authentication(monkeypatch) -> Non
 @pytest.mark.parametrize("builder", ["unavailable", "executable"])
 async def test_mcp_config_builders_require_an_explicit_user_identity(
     builder: str,
+    unavailable_mcp_server: SimpleNamespace,
 ) -> None:
     cfg = WebToolConfig(db=None, request=None, user_id=None)
-    server = SimpleNamespace(
-        id=1,
-        name="Example",
-        description=None,
-        transport="unsupported-test-transport",
-        managed="external",
-        concurrency_safe=False,
-        concurrent_tools=[],
-    )
+    server = unavailable_mcp_server
 
     with pytest.raises(RuntimeError, match="require a user identity"):
         if builder == "unavailable":
@@ -106,25 +99,18 @@ async def test_mcp_config_builders_require_an_explicit_user_identity(
             )
 
 
-def test_unavailable_mcp_config_does_not_scope_allow_users() -> None:
+def test_unavailable_mcp_config_does_not_scope_allow_users(
+    unavailable_mcp_server: SimpleNamespace,
+) -> None:
     """The placeholder config for an unavailable server must not carry
     ``allow_users``. The placeholder tool built from this config is meant to
     explain the outage to whichever caller invokes it; scoping it to a single
     user id caused the placeholder to deny its own caller in a normal server
     process, where no per-request user id is bound to the environment."""
     cfg = WebToolConfig(db=None, request=None, user_id=42)
-    server = SimpleNamespace(
-        id=1,
-        name="Example",
-        description=None,
-        transport="unsupported-test-transport",
-        managed="external",
-        concurrency_safe=False,
-        concurrent_tools=[],
-    )
 
     config = cfg._build_unavailable_mcp_config(
-        server=server, reason="config_load_failed"
+        server=unavailable_mcp_server, reason="config_load_failed"
     )
 
     assert config["user_id"] == "42"
@@ -132,7 +118,9 @@ def test_unavailable_mcp_config_does_not_scope_allow_users() -> None:
 
 
 @pytest.mark.asyncio
-async def test_executable_mcp_config_does_not_carry_allow_users() -> None:
+async def test_executable_mcp_config_does_not_carry_allow_users(
+    stdio_mcp_server: SimpleNamespace,
+) -> None:
     """The config for a server that loads must not carry ``allow_users`` either.
 
     Nothing reads the key any more: the MCP tool adapter's allow-list is only
@@ -141,28 +129,9 @@ async def test_executable_mcp_config_does_not_carry_allow_users() -> None:
     all. The owning identity stays on the config as ``user_id``.
     """
     cfg = WebToolConfig(db=None, request=None, user_id=42)
-    server = SimpleNamespace(
-        id=5,
-        name="Test Stdio Server",
-        transport="stdio",
-        description="",
-        command="python",
-        args=["-m", "xagent.web.tools.mcp.aws"],
-        env={"FOO": "bar"},
-        cwd=None,
-        managed="external",
-        docker_url=None,
-        docker_image=None,
-        docker_environment=None,
-        docker_working_dir=None,
-        volumes=None,
-        bind_ports=None,
-        restart_policy=None,
-        auto_start=None,
-    )
 
     config = await cfg._build_mcp_server_config(
-        server=server,
+        server=stdio_mcp_server,
         user_env_by_id={},
         shared_env_by_id={},
         env_source_by_id={},


### PR DESCRIPTION
## What

When an MCP server cannot be loaded, the tool factory keeps a placeholder tool in the
tool list (`UnavailableMCPTool`, named `mcp_<server>_<id>_unavailable`) so the model is
told why the server is missing instead of silently losing it. Calling that placeholder
returned an authorization error rather than the outage message:

```
Access denied: User None is not authorized to use tool mcp_google_calendar_17_unavailable
```

This removes the caller allow-list from the placeholder entirely:

- `UnavailableMCPTool.__init__` no longer takes `allow_users` and no longer stores
  `self._allow_users`; `_run_unavailable` no longer resolves a caller or checks one.
- `ToolFactory._create_unavailable_mcp_tool` drops the `allow_users` parameter and its
  `kwargs` entry; all nine call sites in `factory.py` drop the argument, together with the
  local `allow_users` binding in `_create_mcp_tools_from_configs` and the `"allow_users"`
  key written into `configs_by_name` in `create_mcp_tools`.
- Both `allow_users` writers in `web/tools/config.py` are deleted: the placeholder one in
  `_build_unavailable_mcp_config` (already removed by this branch's first commit, kept)
  and the executable-tool one in `_build_mcp_server_config`. Each config keeps `user_id`.

`git grep -n allow_users -- src/xagent/core/tools/adapters/vibe/factory.py` and
`git grep -n allow_users -- src/xagent/web/tools/config.py` both return nothing after the
change.

The PR title changes from `fix(web)` to `fix(mcp)`: the fix no longer lives in the web
config layer but in the core MCP adapter that owns the placeholder tool.

## Why

**The trigger is any MCP server outage, not one config path.** A remote server that is
down, a tool listing that times out, a config field of the wrong type, a loader
exception -- every one of those produces a placeholder. Ten construction sites build
placeholders; nine of them used to pass an allow-list.

**The root cause is the check, not the config.** `_run_unavailable` resolved the caller
through `_get_current_mcp_user_id()`, which reads `XAGENT_USER_ID` from the process
environment. Nothing in a normal server process writes that variable. Its only writer is
`UserContext.set_context` in `web/user_context.py`, and its only caller is
`MCPToolAdapter.run_json_async`, which constructs `UserContext(current_user_id)` from the
value the same reader just returned:

```
os.environ["XAGENT_USER_ID"]
     | read                          ^ write
     v                               |
_get_current_mcp_user_id()  ----->  UserContext(user_id).set_context()
       returns None                 if self.user_id:   <- None is falsy, never runs
```

Real request paths bind the user through `contextvars` (`web/user_isolated_memory.py`),
which never reaches the environment. So the caller identity is always `None`, and
`_is_mcp_user_allowed` denies by default when the identity is missing and an allow-list is
present. "Has a list" therefore meant "denies everyone".

**Why this layer.** The placeholder is an error message, not a resource. Its result holds
only a constant string plus an allowlisted `reason` and a normalized `failure_code`; the
server name it is built from is already in the tool listing handed to the model before any
call; and the tool object is built per assembly for a single user's `WebToolConfig`, so
one user's placeholder never reaches another. It has nothing to withhold. Fixing this on
the producer side would mean nine separate edits, and a tenth construction site added
later would bring the bug back. Making the class refuse the concept keeps the invariant in
one place: **an unavailable-MCP placeholder always reports its unavailability.**

**Real MCP tools are unchanged.** `MCPToolAdapter` keeps its own allow-list check
(`run_json_async` and `_is_user_allowed`), and `_is_mcp_user_allowed` /
`_mcp_access_denied_result` remain in `mcp_adapter.py` for it. The removal is strictly
scoped to the placeholder.

**Why the config writers go too.** After the placeholder loses its allow-list, nothing
reads `config["allow_users"]` anywhere in `src`. The adapter's allow-list can only be set
through `load_mcp_tools_as_agent_tools(allow_users=...)`, and none of its four call sites
passes it, so it is always `None` there. Leaving two writers for a key with no readers
would leave the next reader of this code to re-investigate whether it matters.

The `allow_users` parameter still carried by `MCPToolAdapter` and
`load_mcp_tools_as_agent_tools`, and the `XAGENT_USER_ID` mechanism behind it, are out of
scope for this PR.

## How

| File | Change |
|---|---|
| `src/xagent/core/tools/adapters/vibe/mcp_adapter.py` | `UnavailableMCPTool` drops the `allow_users` parameter and attribute; `_run_unavailable` drops the caller check; class docstring states the invariant |
| `src/xagent/core/tools/adapters/vibe/factory.py` | `_create_unavailable_mcp_tool` drops the parameter and `kwargs` entry; 9 call sites drop the argument; the local binding and the `configs_by_name` key are removed |
| `src/xagent/web/tools/config.py` | `_build_mcp_server_config` no longer writes `allow_users` (the placeholder writer in `_build_unavailable_mcp_config` was removed in the first commit and stays removed) |

`ToolMetadata.allow_users` is populated in `base.py` with
`getattr(self, "_allow_users", None)`, so the placeholder's metadata now reports `None`
without any change to the shared metadata contract or to other tools.

## Tests

Six tests asserted the removed behavior. Each called `monkeypatch.setenv("XAGENT_USER_ID", ...)`
itself, creating a condition that does not occur in a server process; what they pinned was
"if the variable is set, the list is enforced", not anything production depends on. They
are replaced, not deleted:

| Was | Now |
|---|---|
| `test_unavailable_tool_async_unauthorized_uses_mcp_access_denied` | `test_unavailable_tool_async_reports_the_outage_to_any_caller` -- with `XAGENT_USER_ID` set to a different user, the full outage payload is returned |
| `test_unavailable_tool_sync_unauthorized_uses_mcp_access_denied` | `test_unavailable_tool_sync_reports_the_outage_to_any_caller` |
| `test_unavailable_tool_return_schema_accepts_access_denied_result` | `test_unavailable_tool_return_schema_accepts_the_outage_result` -- the parsed result now carries the outage `error` |
| `test_unavailable_tool_missing_user_permission_regression` | `test_unavailable_tool_reports_the_outage_for_every_caller_identity`, parametrized over no identity / the owning user / another user |
| `test_unavailable_tool_metadata_is_mcp_and_server_scoped` (asserted `metadata.allow_users == ["7"]`) | same test, now asserting `metadata.allow_users is None` |
| `test_create_mcp_tools_scopes_loader_failure_to_requested_user` | `test_create_mcp_tools_loader_failure_reports_the_outage_to_any_caller` -- the database path's loader failure surfaces `reason == "loader_failed"`, not an access denial |

Added:

- `test_unavailable_tool_takes_no_caller_allow_list` -- neither `UnavailableMCPTool.__init__`
  nor `ToolFactory._create_unavailable_mcp_tool` accepts `allow_users`. Without this,
  re-wiring a producer would not be caught by the tool's own tests, because no test can
  produce a list any more.
- `test_executable_mcp_config_does_not_carry_allow_users` -- the executable-tool config
  keeps `user_id` and carries no `allow_users`, alongside the existing
  `test_unavailable_mcp_config_does_not_scope_allow_users` for the placeholder config.
- `tests/web/tools/test_unavailable_mcp_placeholder_pipeline.py` -- a new module that runs
  the whole production chain end to end, with `XAGENT_USER_ID` explicitly removed from the
  environment (`monkeypatch.delenv`), since no server process writes it. Both tests start
  from a config the real `WebToolConfig` builders emit, hand it to the real
  `ToolFactory._create_mcp_tools_from_configs`, and invoke the resulting placeholder
  through both `run_json_sync({})` and `run_json_async({})`; the shared helper
  `_assert_reports_outage` checks that the answer contains the outage message, contains no
  `Access denied` anywhere, and has `is_error is True`.

  | Test | Chain it covers |
  |---|---|
  | `test_config_load_failure_placeholder_reports_outage_without_a_caller_id` | `WebToolConfig._build_unavailable_mcp_config` -> factory -> placeholder, `reason == "config_load_failed"` |
  | `test_handshake_failure_placeholder_reports_outage_without_a_caller_id` | `WebToolConfig._build_mcp_server_config` (an executable stdio config) -> a server that fails to initialize -> factory -> placeholder, `reason == "initialize"` |

  The existing factory-level tests build their configs from a fixture written in the test
  file, so nothing pinned the real builders to the placeholder. These do, which is what
  makes them fail on the pre-fix tree rather than only on a hand-written config.

The two shared assertion helpers `_assert_unavailable_mcp_config`
(`tests/web/tools/test_oauth_token_resolver_hook.py`) and `_assert_unavailable_runtime_config`
(`tests/web/tools/test_mcp_oauth_runtime.py`) already assert `"allow_users" not in config`
from the first commit and pass unchanged.

Runs:

```
pytest tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py \
       tests/core/tools/test_mcp_database_integration.py \
       tests/web/tools/test_webtoolconfig_identity.py \
       tests/web/tools/test_mcp_oauth_runtime.py \
       tests/web/tools/test_oauth_token_resolver_hook.py \
       tests/core/tools/adapters/vibe/test_mcp_adapter.py \
       tests/web/tools/test_unavailable_mcp_placeholder_pipeline.py
453 passed

pytest tests/core/tools tests/web/tools
6184 passed, 18 failed
```

The 18 failures are pre-existing and unrelated: `test_pptx_tool.py` and
`test_command_executor.py` need a working Node.js / python subprocess in the sandbox, plus
one path check in `test_document_ingestion.py`. The same 18 fail on the unmodified tree.

Mutation checks (each reverted afterwards):

- Re-adding an effective caller check in `_run_unavailable`: 16 of 38 tests in
  `test_mcp_unavailable_tool.py` fail.
- Re-adding the placeholder allow-list wiring (constructor parameter, factory parameter,
  the handshake/loader-failure call sites, the `configs_by_name` key) plus the
  `config.py` writer: `test_unavailable_tool_takes_no_caller_allow_list`,
  `test_create_mcp_tools_loader_failure_reports_the_outage_to_any_caller` and
  `test_executable_mcp_config_does_not_carry_allow_users` fail.
- Re-adding only the `config.py` executable-tool writer:
  `test_executable_mcp_config_does_not_carry_allow_users` fails.
- Restoring the three source files to their pre-fix state (`mcp_adapter.py`, `factory.py`,
  `config.py`) while keeping the new tests: both tests in
  `test_unavailable_mcp_placeholder_pipeline.py` fail, on
  `Access denied: User None is not authorized to use tool mcp_example_1_unavailable` and
  `... mcp_test_stdio_server_5_unavailable` respectively -- the reported bug, reproduced
  end to end from the real config builders. Re-adding the caller check to
  `_run_unavailable` alone does not fail them, because with no producer writing an
  allow-list `_is_mcp_user_allowed(None, None)` still allows: what these tests pin is the
  answer the caller gets, not the presence of a check.
