### PR TITLE
docs(web): correct stale premises in checkpoint recovery and staging comments

### DIFF
--- a/src/xagent/core/agent/checkpoint.py
+++ b/src/xagent/core/agent/checkpoint.py
@@ -58,10 +58,16 @@ class CheckpointReadError(RuntimeError):
 class CheckpointUnavailableError(CheckpointReadError):
     """Raised when a checkpoint read could not be completed.
 
-    Covers infrastructure failures only: session checkout, query
+    Two kinds of cause, both retryable, which is why they share this
+    class. The first is infrastructure failure: session checkout, query
     execution, and generic per-row decode errors such as a failed blob
-    prefetch. Rows that decode as permanently unreadable are classified
-    by the corrupt error once the matching set is exhausted.
+    prefetch. The second is not a failure at all -- a read whose partition
+    decision was invalidated between resolving that partition and
+    producing a result declines to hand back an answer it can no longer
+    vouch for, and reports it here (see the root-checkpoint read path's
+    re-probe at its own boundary). Rows that decode as permanently
+    unreadable are classified by the corrupt error instead, once the
+    matching set is exhausted.
     """
 
 

--- a/src/xagent/core/agent/checkpoint.py
+++ b/src/xagent/core/agent/checkpoint.py
@@ -56,15 +56,13 @@ class CheckpointReadError(RuntimeError):
 
 
 class CheckpointUnavailableError(CheckpointReadError):
-    """Raised when a checkpoint read could not be completed.
+    """Raised when a checkpoint read did not produce an answer the reader
+    can vouch for.
 
-    Two kinds of cause, both retryable, which is why they share this
-    class. The first is infrastructure failure: session checkout, query
-    execution, and generic per-row decode errors such as a failed blob
-    prefetch. The second is not a failure at all -- a read whose partition
-    decision was invalidated between resolving that partition and
-    producing a result declines to hand back an answer it can no longer
-    vouch for, and reports it here (see the root-checkpoint read path's
+    Covers causes including infrastructure failure (session checkout,
+    query execution, and generic per-row decode errors such as a failed
+    blob prefetch) and a read whose partition decision was invalidated
+    before it produced a result (see the root-checkpoint read path's
     re-probe at its own boundary). Rows that decode as permanently
     unreadable are classified by the corrupt error instead, once the
     matching set is exhausted.

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -245,9 +245,21 @@ def _acquire_reply_prelease_sync(
         # last_checkpoint_trace_event_id) as part of the same UPDATE. If
         # this reply later fails closed, releasing the lease back to
         # waiting_for_user does not restore those two columns -- they stay
-        # cleared. This is not a behavior change worth guarding against:
-        # a row with no run_id never had a run-fenced checkpoint to
-        # recover in the first place, so nothing resumable is lost.
+        # cleared. The premise that used to justify this as costless -- "a
+        # row with no run_id never had a run-fenced checkpoint to recover in
+        # the first place" -- no longer holds: the root-checkpoint read path
+        # can resolve an untagged partition and read a checkpoint row
+        # written before the run-partition field existed, so such a row can
+        # have something resumable to lose. What survives of the original
+        # reasoning is narrower and is about where the resume looks rather
+        # than whether anything is there: with both pointer columns
+        # cleared, that read path's by-primary-key anchor has nothing to
+        # anchor on and falls back to its own legacy scan, which is keyed
+        # on task/checkpoint-type/execution-id and partition rather than on
+        # either cleared column, so it can still find the row the pointer
+        # used to name. Whether to keep clearing unconditionally has not
+        # been re-decided under the corrected premise; this comment records
+        # the premise correctly rather than standing on the retired one.
         task_lease = acquire_task_lease_no_commit(
             db,
             task_id,

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -256,10 +256,15 @@ def _acquire_reply_prelease_sync(
         # cleared, that read path's by-primary-key anchor has nothing to
         # anchor on and falls back to its own legacy scan, which is keyed
         # on task/checkpoint-type/execution-id and partition rather than on
-        # either cleared column, so it can still find the row the pointer
-        # used to name. Whether to keep clearing unconditionally has not
-        # been re-decided under the corrected premise; this comment records
-        # the premise correctly rather than standing on the retired one.
+        # either cleared column. That scan reaches the row the pointer used
+        # to name only when the row carries an execution identity of its
+        # own: the scan filters on one, while the pointer path names a row
+        # unconditionally and is deliberately the more permissive of the
+        # two (see ``_load_pk_anchored_checkpoint``'s own docstring). For a
+        # row predating that field, the cleared pointer was the only way to
+        # reach it. Whether to keep clearing unconditionally has not been
+        # re-decided under the corrected premise; this comment records the
+        # premise correctly rather than standing on the retired one.
         task_lease = acquire_task_lease_no_commit(
             db,
             task_id,

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -263,8 +263,9 @@ def _acquire_reply_prelease_sync(
         # two (see ``_load_pk_anchored_checkpoint``'s own docstring). For a
         # row predating that field, the cleared pointer was the only way to
         # reach it. Whether to keep clearing unconditionally has not been
-        # re-decided under the corrected premise; this comment records the
-        # premise correctly rather than standing on the retired one.
+        # re-decided under the corrected premise (see #2024); this comment
+        # records the premise correctly rather than standing on the retired
+        # one.
         task_lease = acquire_task_lease_no_commit(
             db,
             task_id,

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -60,10 +60,19 @@ Caller obligations, because none of them happen here:
   the two a direct caller can still see after the reclaim UPDATE has
   already committed in this transaction.
 
-Zero production callers as of this module's introduction: a static test
-(``tests/web/services/test_interaction_staging_production_gate.py``) asserts
-that no production module imports or calls either entry point. See that
-test's docstring for the removal condition.
+One production caller today: ``task_interaction_service.create`` enters
+``interaction_handoff`` and calls ``stage()`` on the system principal's
+write path. The all-or-nothing zero-caller gate that used to guard these
+two entry points was retired together with the change that filled that
+call body; three static guards
+(``tests/web/services/test_interaction_handoff_production_surface.py``)
+took its place and assert the shape of that one caller instead of the
+absence of every caller: the production use points of
+``interaction_handoff`` are exactly ``{task_interaction_service}``,
+validation always runs before the handoff is entered, and the set of
+modules importing anything from this module is exactly the three that
+need to. See that file's own docstring for what each guard covers and
+why the replacement is not a weakening.
 
 Every rejection the database's 23 CHECK constraints could raise on the
 INSERT is rejected in plain Python first, inside

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -61,18 +61,15 @@ Caller obligations, because none of them happen here:
   already committed in this transaction.
 
 One production caller today: ``task_interaction_service.create`` enters
-``interaction_handoff`` and calls ``stage()`` on the system principal's
-write path. The all-or-nothing zero-caller gate that used to guard these
-two entry points was retired together with the change that filled that
-call body; three static guards
+``interaction_handoff`` and calls ``stage()``. ``create()`` itself still
+has zero production callers, held there by a live gate
+(``tests/web/services/test_task_interaction_service_create_gate.py``), so
+the chain is not reachable in production yet. The old zero-caller gate on
+this module's two entry points was replaced by three static guards
 (``tests/web/services/test_interaction_handoff_production_surface.py``)
-took its place and assert the shape of that one caller instead of the
-absence of every caller: the production use points of
-``interaction_handoff`` are exactly ``{task_interaction_service}``,
-validation always runs before the handoff is entered, and the set of
-modules importing anything from this module is exactly the three that
-need to. See that file's own docstring for what each guard covers and
-why the replacement is not a weakening.
+asserting: the only production use of ``interaction_handoff`` is
+``task_interaction_service``, validation always runs before it is
+entered, and only the three modules that need it import from this one.
 
 Every rejection the database's 23 CHECK constraints could raise on the
 INSERT is rejected in plain Python first, inside

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -355,10 +355,17 @@ def _checkpoint_row_matches_candidate(
     (``resolve_checkpoint_recovery``) rather than here, because only the
     exact-pointer path has a second candidate set to defer to.
 
-    The vocabularies still differ -- this path calls the outcome a mismatch
-    and the reader calls it corrupt (``CheckpointCorruptError``) -- and that
-    difference is still deliberate, because each names the outcome for its
-    own caller. What is no longer true is that the two could drift on *what*
+    The vocabularies still differ -- this path calls the outcome a
+    mismatch, and the by-primary-key read raises
+    ``CheckpointCorruptError`` for it -- and that difference is still
+    deliberate, because each names the outcome for its own caller. One
+    qualification the older wording lacked: what that read's *caller*
+    ultimately sees is not always corrupt either. A read performed under
+    the widened (untagged) partition has its verdict re-probed at the
+    read's boundary and reclassified as a retryable
+    ``CheckpointUnavailableError`` when a run-tagged checkpoint has since
+    appeared (see ``_load_pk_anchored_checkpoint``'s own docstring). What
+    is no longer true, separately, is that the two could drift on *what*
     they judge.
     """
 
@@ -506,10 +513,20 @@ def resolve_checkpoint_recovery(
             # the same predicate, so a RECOVERABLE verdict still requires a
             # real run-partition match. The by-primary-key *read*
             # (``_load_pk_anchored_checkpoint``, ``trace_handlers.py``) does
-            # not reach this verdict for the same row shape -- it still
-            # raises ``CheckpointCorruptError``, unchanged from before this
-            # predicate existed. That divergence is deliberate; see
-            # task_interaction_anchor.py's module docstring and #2023.
+            # not reach this verdict for the same row shape: it still raises
+            # ``CheckpointCorruptError`` there, unchanged. What that raise
+            # then means to a caller is no longer unconditional, though --
+            # when the read resolved the widened (untagged) partition, the
+            # read's own boundary (``_sync_load_latest_checkpoint``)
+            # re-probes and replaces the corrupt verdict with a retryable
+            # ``CheckpointUnavailableError`` if a run-tagged checkpoint has
+            # since appeared. A non-widened read still surfaces the corrupt
+            # verdict as-is. So the divergence from this function is about
+            # the terminal-versus-deferred *verdict*, not about a fixed
+            # error class on the other side; it remains deliberate. See
+            # ``_load_pk_anchored_checkpoint``'s own docstring for the
+            # boundary, task_interaction_anchor.py's module docstring for
+            # the write direction, and #2023 for the convergence.
             logger.info(
                 "Task %s's checkpoint pointer %s is missing its "
                 "run-partition field; deferring to the legacy event_id scan "

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -355,18 +355,16 @@ def _checkpoint_row_matches_candidate(
     (``resolve_checkpoint_recovery``) rather than here, because only the
     exact-pointer path has a second candidate set to defer to.
 
-    The vocabularies still differ -- this path calls the outcome a
-    mismatch, and the by-primary-key read raises
-    ``CheckpointCorruptError`` for it -- and that difference is still
-    deliberate, because each names the outcome for its own caller. One
+    The vocabularies still differ deliberately -- this path calls the
+    outcome a mismatch, the by-primary-key read raises
+    ``CheckpointCorruptError`` for it, and each names the outcome for its
+    own caller -- but they can no longer drift on *what* they judge. One
     qualification the older wording lacked: what that read's *caller*
     ultimately sees is not always corrupt either. A read performed under
     the widened (untagged) partition has its verdict re-probed at the
     read's boundary and reclassified as a retryable
     ``CheckpointUnavailableError`` when a run-tagged checkpoint has since
-    appeared (see ``_load_pk_anchored_checkpoint``'s own docstring). What
-    is no longer true, separately, is that the two could drift on *what*
-    they judge.
+    appeared (see ``_load_pk_anchored_checkpoint``'s own docstring).
     """
 
     if candidate.run_id is None:
@@ -513,17 +511,16 @@ def resolve_checkpoint_recovery(
             # the same predicate, so a RECOVERABLE verdict still requires a
             # real run-partition match. The by-primary-key *read*
             # (``_load_pk_anchored_checkpoint``, ``trace_handlers.py``) does
-            # not reach this verdict for the same row shape: it still raises
-            # ``CheckpointCorruptError`` there, unchanged. What that raise
-            # then means to a caller is no longer unconditional, though --
-            # when the read resolved the widened (untagged) partition, the
-            # read's own boundary (``_sync_load_latest_checkpoint``)
-            # re-probes and replaces the corrupt verdict with a retryable
-            # ``CheckpointUnavailableError`` if a run-tagged checkpoint has
-            # since appeared. A non-widened read still surfaces the corrupt
-            # verdict as-is. So the divergence from this function is about
-            # the terminal-versus-deferred *verdict*, not about a fixed
-            # error class on the other side; it remains deliberate. See
+            # not reach this verdict for the same row shape, and which way
+            # it goes there is decided by the partition that read resolved.
+            # A read bound to a run raises ``CheckpointCorruptError`` for
+            # the row, unchanged. A widened (untagged) read finds the same
+            # row's absent run field a partition match instead and hands
+            # the checkpoint back, so it never reaches a corrupt verdict
+            # for this shape. Only the run-bound read is the comparison
+            # here -- a candidate without a ``run_id`` already returned
+            # above, and a widened read is never run-bound -- and that
+            # divergence remains deliberate. See
             # ``_load_pk_anchored_checkpoint``'s own docstring for the
             # boundary, task_interaction_anchor.py's module docstring for
             # the write direction, and #2023 for the convergence.


### PR DESCRIPTION
## What

- `src/xagent/web/services/task_interaction_staging.py`: the module
  docstring claimed zero production callers guarded by a static gate.
  `task_interaction_service.create()` has been the production caller of
  `stage()`/`interaction_handoff` since #1954, and the retired gate was
  replaced by three static guards in
  `test_interaction_handoff_production_surface.py`. The docstring now
  names the real caller and the real guards, and keeps the fact the old
  text carried: `create()` itself still has no production callers of its
  own, held there by `test_task_interaction_service_create_gate.py`, so
  the chain is not reachable in production yet.
- `src/xagent/web/services/task_lease_service.py`: two docstrings/comments
  (`resolve_checkpoint_recovery` and `_checkpoint_row_matches_candidate`)
  said the by-primary-key read always raises `CheckpointCorruptError` for
  a row missing its run-partition field, unconditionally. That is true
  only of a read bound to a run. A widened (untagged) read resolves the
  same row's absent run field as a partition match and hands the
  checkpoint back, so it never reaches a corrupt verdict for that row
  shape, and `_ResolvedReadPartition` enforces that a widened read is
  never run-bound. Both spots now state the outcome by the partition the
  read resolved rather than as an unconditional raise. Only the run-bound
  read is the comparison lease recovery makes, because a candidate with no
  `run_id` fails closed before reaching that branch.
- `src/xagent/web/api/v1/task_reply.py`: the comment justifying clearing
  both checkpoint pointer columns at lease-mint time argued nothing
  resumable is lost for a legacy row with no `run_id`. The root-checkpoint
  read path's widened-partition scan can read such a row, so something can
  in fact be lost. What survives of the original reasoning is narrower and
  conditional: that scan is keyed on task/checkpoint-type/execution-id and
  partition rather than on either cleared column, so it reaches the row the
  pointer used to name only when the row carries an execution identity of
  its own -- its predicate drops any row without one from the candidate
  set. For a row written before that field existed, which is the shape the
  pointer anchors, the cleared pointer was the only way to reach it. The
  comment now states that condition instead of asserting the scan always
  finds the row, and cites #2024 for the open design question.
- `src/xagent/core/agent/checkpoint.py`: `CheckpointUnavailableError`'s
  class docstring said it covers infrastructure failures only. It is also
  raised when a read's partition decision is invalidated between resolving
  that partition and producing a result, which is not an infrastructure
  failure. The docstring now lists both without presenting the pair as the
  complete set or as uniformly retryable: the scan-page cap and the
  missing-task-row raise fit neither kind, and a deleted task row does not
  come back on retry. Its one-line summary no longer says the read could
  not be completed, which contradicted the body describing a read that did
  complete but could not be vouched for. No `web` layer symbol is named,
  keeping the dependency direction between core and web intact.

A fifth spot was in scope when this branch was written: the `TA11`
docstring in `tests/web/services/test_task_interaction_anchor.py`
compared itself to a since-deleted gate file
(`test_interaction_staging_production_gate.py`). #2198 corrected that
same sentence on `main` first, so this branch no longer touches that
file.

## Why

Each of these comments stated a premise that an earlier, already-merged
behavior change disproved. Two are the pair `#2127` asked for; the others
are the same drift showing up again, in files `#2127` did not enumerate.
A reader trusting any of these comments as written would draw the wrong
conclusion about what the current code does.

This change is documentation only. Whether to keep clearing the
checkpoint pointer unconditionally at lease-mint time is a separate
design question that this change does not resolve -- it only makes sure
the reasoning recorded next to that code is accurate.

## Verification

- `pytest tests/web/services/test_task_interaction_anchor.py -q`:
  31 passed, 0 failed.
- `pytest tests/web/services/test_interaction_handoff_production_surface.py -q`:
  12 passed, 0 failed.
- `python -m compileall` on all four changed files: no errors.
- `ruff check` and `ruff format --check` on all four changed files: clean.
- Every changed line is either a `#`-prefixed comment or text inside a
  docstring's triple-quoted body; no executable code changed.

Closes #2127

The design question about clearing the checkpoint pointer at lease-mint time is tracked in #2024.
