### PR TITLE
test(web): pin the answer fence write point's re-verified term set

### DIFF
--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -2571,14 +2571,28 @@ def test_answer_fence_predicate_guest_branch_adds_a_json_lookup_term() -> None:
 # entity binding, or the channel binding -- none of which the write point
 # re-checks -- and the answer still lands.
 #
-# Why accepted rather than closed: closing it means folding the guest's
-# JSON-lookup terms into the write point's WHERE clause, and the two
-# backends read a JSON key differently there (PostgreSQL's `->>` versus
-# SQLite's `json_extract`, per the same production docstring), so closing
-# it costs either an extra read or an extra Python re-check. The
-# production docstring leaves that policy decision to whichever change
-# wires the first production caller of `respond()`; this pair of tests is
-# where accepting the window, for now, is recorded.
+# Why accepted rather than closed: it is not the JSON lookup itself that
+# resists being folded into the write point's WHERE clause. The guest's
+# own `guest_id` term is already in that clause, written backend-neutrally
+# as `Task.agent_config["guest_id"].as_string() == ...` and costing
+# neither an extra read nor a Python re-check. What resists is the Python
+# control flow around the other terms. Which entity-binding key needs
+# comparing at all is decided by a four-way dispatch on whichever single
+# principal field is populated (`task_is_owned_by_public_principal`, the
+# `if direction == "widget_agent"` chain), and three of those four
+# branches compare through `_json_entity_binding_matches`, which rejects
+# `bool` outright and treats any value that will not convert to `int` as
+# "does not match" rather than letting the conversion raise. One SQL
+# conjunction has neither the branch selection nor that tolerant
+# coercion, so closing the window means either re-deriving the direction
+# in SQL or keeping a Python re-check beside the UPDATE. The channel
+# binding is not a JSON lookup at all -- it is the row-level
+# `Task.channel_id IS NULL` -- and could be folded in on its own; it
+# stays out because the window is accepted as a whole, not because
+# anything blocks that one term. The production docstring leaves that
+# policy decision to whichever change wires the first production caller
+# of `respond()`; this pair of tests is where accepting the window, for
+# now, is recorded.
 #
 # Why unreachable today: `respond()` has zero production callers,
 # enforced by `test_no_production_module_calls_create_or_respond` in
@@ -2593,10 +2607,10 @@ def test_answer_fence_predicate_guest_branch_adds_a_json_lookup_term() -> None:
 
 
 def test_answer_fence_write_point_reasserts_exactly_three_terms() -> None:
-    """The predicate the write point compiles into its WHERE clause
-    carries all three re-verified terms: task status, task ownership, and
-    (for a guest) the ``guest_id`` match. Uses a guest principal because
-    only the guest branch carries all three terms at once.
+    """The WHERE clause the write point actually compiles carries all
+    three re-verified terms: task status, task ownership, and (for a
+    guest) the ``guest_id`` match. Uses a guest principal because only the
+    guest branch carries all three terms at once.
 
     Also asserts the term counts directly (three for a guest, two for a
     plain user): the existing relative assertion in
@@ -2615,17 +2629,28 @@ def test_answer_fence_write_point_reasserts_exactly_three_terms() -> None:
     assert len(terms) == 3
     assert len(svc._answer_fence_task_predicate(_owning_principal(1))) == 2
 
-    stmt = sa.select(TaskInteractionRequest).where(
-        TaskInteractionRequest.id == 1,
-        TaskInteractionRequest.task_id == 1,
-        Task.id == 1,
-        *svc._active_native_row_criteria(),
-        *terms,
+    stmt = svc._answer_fence_stmt(
+        interaction_id=1,
+        task_id=1,
+        principal=guest_principal,
+        response_payload={"ok": True},
+        now=datetime.now(timezone.utc),
+        responder_user_id=None,
+        responder_identity="guest:guest-1",
     )
     import sqlalchemy.dialects.sqlite
 
+    # Compiled from the statement ``_answer_fence_stmt`` returns, not from
+    # a ``sa.select(...)`` this test assembles out of the same terms. Only
+    # the former asserts the wiring: a hand-assembled copy of the write
+    # point's WHERE clause carries these three terms whether or not
+    # ``_answer_fence_stmt`` still splices in
+    # ``_answer_fence_task_predicate``, so it stays green with that call
+    # deleted from production. ``.whereclause`` alone rather than the
+    # whole statement, for the ``literal_binds`` reason the next test's
+    # comment spells out.
     compiled = str(
-        stmt.compile(
+        stmt.whereclause.compile(
             dialect=sqlalchemy.dialects.sqlite.dialect(),
             compile_kwargs={"literal_binds": True},
         )
@@ -2638,13 +2663,14 @@ def test_answer_fence_write_point_reasserts_exactly_three_terms() -> None:
 def test_answer_fence_write_point_omits_the_read_time_only_terms() -> None:
     """The write point's full UPDATE statement -- not just the predicate
     helper -- never carries ``auth_mode``, any of the four entity-binding
-    keys, or the channel binding. It compiles the WHERE clause of the
-    statement built by ``_answer_fence_stmt`` (rather than only
-    ``_answer_fence_task_predicate``'s output, as the previous test does):
-    a future change could add one of these terms directly to
-    ``_answer_fence_stmt``'s own ``where(...)`` without ever touching the
-    predicate helper, and only a check against the full statement's WHERE
-    clause would catch that.
+    keys, or the channel binding. Like the previous test it compiles the
+    WHERE clause of the statement ``_answer_fence_stmt`` builds, rather
+    than only ``_answer_fence_task_predicate``'s output: a future change
+    could add one of these terms directly to ``_answer_fence_stmt``'s own
+    ``where(...)`` without ever touching the predicate helper, and only a
+    check against the statement's own WHERE clause would catch that.
+    Where the previous test pins the terms that must be present, this one
+    pins the terms that must be absent.
 
     This does not assert these three terms go unchecked anywhere -- they
     are evaluated once in Python at the read point
@@ -2679,22 +2705,37 @@ def test_answer_fence_write_point_omits_the_read_time_only_terms() -> None:
     # ``_answer_fence_stmt``'s own ``where(...)`` rather than through the
     # predicate helper. With literal binds, a JSON path lookup renders its
     # key inline (``JSON_EXTRACT(tasks.agent_config, '$."auth_mode"')``)
-    # instead of hiding it in a bind parameter. The two bindings that
-    # compare a row-level column instead of a JSON key are matched by
-    # that column's own name: the widget-agent direction compares
-    # ``Task.agent_id``, so ``tasks.agent_id`` is this loop's marker.
+    # instead of hiding it in a bind parameter.
+    #
+    # The widget-agent direction compares a row-level column today
+    # (``Task.agent_id``), but its marker below is the bare key name
+    # ``agent_id`` rather than ``tasks.agent_id``. The bare name matches
+    # both renderings -- the row-level ``tasks.agent_id`` and the JSON
+    # path ``JSON_EXTRACT(tasks.agent_config, '$."agent_id"')`` -- so the
+    # loop keeps catching this direction if the binding ever moves into
+    # ``agent_config`` (#1304), which ``tasks.agent_id`` would not. It
+    # cannot fire on the clause this statement compiles today: the only
+    # other ``agent``-prefixed name there is ``tasks.agent_config``. The
+    # channel binding has no JSON form at all, so ``tasks.channel_id``
+    # stays a column-name marker.
     compiled = str(
         stmt.whereclause.compile(
             dialect=sqlalchemy.dialects.sqlite.dialect(),
             compile_kwargs={"literal_binds": True},
         )
     )
+    # A positive canary ahead of the negative loop: were ``compiled`` ever
+    # to come back empty or truncated, every ``not in`` below would pass
+    # and this test would assert nothing. ``tasks.user_id`` is one of the
+    # three terms the write point does re-verify, so it is present
+    # whenever this statement compiled at all.
+    assert "tasks.user_id" in compiled
     for marker in (
         "auth_mode",
         "widget_workforce_id",
         "share_agent_id",
         "share_workforce_id",
-        "tasks.agent_id",
+        "agent_id",
         "tasks.channel_id",
     ):
         assert marker not in compiled

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -2554,6 +2554,153 @@ def test_answer_fence_predicate_guest_branch_adds_a_json_lookup_term() -> None:
 
 
 # ---------------------------------------------------------------------------
+# The write point re-verifies three of the six ownership terms the read
+# point checks; the other three are read-point-only. The next two tests
+# pin that split so it cannot drift silently, either by widening (someone
+# assuming all six are re-verified at write time) or narrowing (someone
+# quietly dropping one of the three that already are).
+#
+# The fact, stated by `_answer_fence_task_predicate`'s own docstring: "A
+# successful answer therefore proves the three terms above held at write
+# time and that the other three held at read time, not that all six held
+# at write time."
+#
+# The window this leaves open: a guest passes all six checks at the read
+# point (`task_is_owned_by_public_principal`); between the read and the
+# write, an administrator tightens the agent's `auth_mode`, or changes the
+# entity binding, or the channel binding -- none of which the write point
+# re-checks -- and the answer still lands.
+#
+# Why accepted rather than closed: closing it means folding the guest's
+# JSON-lookup terms into the write point's WHERE clause, and the two
+# backends read a JSON key differently there (PostgreSQL's `->>` versus
+# SQLite's `json_extract`, per the same production docstring), so closing
+# it costs either an extra read or an extra Python re-check. The
+# production docstring leaves that policy decision to whichever change
+# wires the first production caller of `respond()`; this pair of tests is
+# where accepting the window, for now, is recorded.
+#
+# Why unreachable today: `respond()` has zero production callers,
+# enforced by `test_no_production_module_calls_create_or_respond` in
+# `test_task_interaction_service_create_gate.py`.
+#
+# What the next two tests catch and do not catch: they catch the write
+# point's WHERE clause silently gaining one of the three read-point-only
+# terms, or silently losing one of the three it already re-verifies. They
+# do not narrow the window itself -- a grant already revoked between the
+# read and the write still lets an answer land through this path.
+# ---------------------------------------------------------------------------
+
+
+def test_answer_fence_write_point_reasserts_exactly_three_terms() -> None:
+    """The predicate the write point compiles into its WHERE clause
+    carries all three re-verified terms: task status, task ownership, and
+    (for a guest) the ``guest_id`` match. Uses a guest principal because
+    only the guest branch carries all three terms at once.
+
+    Also asserts the term counts directly (three for a guest, two for a
+    plain user): the existing relative assertion in
+    ``test_answer_fence_predicate_guest_branch_adds_a_json_lookup_term``
+    only checks "guest has one more term than a plain user", which stays
+    green even if both counts were quietly reduced by one together.
+    """
+    guest_principal = svc.InteractionPrincipal(
+        kind="guest",
+        user_id=1,
+        is_admin=False,
+        auth_mode="widget",
+        guest_id="guest-1",
+    )
+    terms = svc._answer_fence_task_predicate(guest_principal)
+    assert len(terms) == 3
+    assert len(svc._answer_fence_task_predicate(_owning_principal(1))) == 2
+
+    stmt = sa.select(TaskInteractionRequest).where(
+        TaskInteractionRequest.id == 1,
+        TaskInteractionRequest.task_id == 1,
+        Task.id == 1,
+        *svc._active_native_row_criteria(),
+        *terms,
+    )
+    import sqlalchemy.dialects.sqlite
+
+    compiled = str(
+        stmt.compile(
+            dialect=sqlalchemy.dialects.sqlite.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+    assert "WAITING_FOR_USER" in compiled
+    assert "tasks.user_id" in compiled
+    assert "guest_id" in compiled
+
+
+def test_answer_fence_write_point_omits_the_read_time_only_terms() -> None:
+    """The write point's full UPDATE statement -- not just the predicate
+    helper -- never carries ``auth_mode``, any of the four entity-binding
+    keys, or the channel binding. It compiles the WHERE clause of the
+    statement built by ``_answer_fence_stmt`` (rather than only
+    ``_answer_fence_task_predicate``'s output, as the previous test does):
+    a future change could add one of these terms directly to
+    ``_answer_fence_stmt``'s own ``where(...)`` without ever touching the
+    predicate helper, and only a check against the full statement's WHERE
+    clause would catch that.
+
+    This does not assert these three terms go unchecked anywhere -- they
+    are evaluated once in Python at the read point
+    (``task_is_owned_by_public_principal``) before ``respond()`` reaches
+    this statement. It asserts only that they are absent here.
+    """
+    guest_principal = svc.InteractionPrincipal(
+        kind="guest",
+        user_id=1,
+        is_admin=False,
+        auth_mode="widget",
+        guest_id="guest-1",
+    )
+    stmt = svc._answer_fence_stmt(
+        interaction_id=1,
+        task_id=1,
+        principal=guest_principal,
+        response_payload={"ok": True},
+        now=datetime.now(timezone.utc),
+        responder_user_id=None,
+        responder_identity="guest:guest-1",
+    )
+    import sqlalchemy.dialects.sqlite
+
+    # ``literal_binds=True`` cannot compile the whole statement: its
+    # ``VALUES`` clause carries ``response_payload``, a JSON column, and
+    # SQLAlchemy's JSON type has no ``literal_processor`` on any dialect,
+    # so that raises ``sqlalchemy.exc.CompileError: No literal value
+    # renderer is available ... with datatype JSON``. Compiling the WHERE
+    # clause alone avoids the VALUES clause while still covering every
+    # term the statement carries, including one added directly to
+    # ``_answer_fence_stmt``'s own ``where(...)`` rather than through the
+    # predicate helper. With literal binds, a JSON path lookup renders its
+    # key inline (``JSON_EXTRACT(tasks.agent_config, '$."auth_mode"')``)
+    # instead of hiding it in a bind parameter. The two bindings that
+    # compare a row-level column instead of a JSON key are matched by
+    # that column's own name: the widget-agent direction compares
+    # ``Task.agent_id``, so ``tasks.agent_id`` is this loop's marker.
+    compiled = str(
+        stmt.whereclause.compile(
+            dialect=sqlalchemy.dialects.sqlite.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+    for marker in (
+        "auth_mode",
+        "widget_workforce_id",
+        "share_agent_id",
+        "share_workforce_id",
+        "tasks.agent_id",
+        "tasks.channel_id",
+    ):
+        assert marker not in compiled
+
+
+# ---------------------------------------------------------------------------
 # Structural guards: raw SQL.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Two new tests on `_answer_fence_task_predicate` / `_answer_fence_stmt`
(the compare-and-swap statement `respond()` uses to write an answer):

- `test_answer_fence_write_point_reasserts_exactly_three_terms` compiles
  the predicate to SQLite SQL with literal binds and asserts the three
  re-verified terms are present, plus asserts the term counts directly
  (three for a guest, two for a plain user).
- `test_answer_fence_write_point_omits_the_read_time_only_terms` takes
  the full UPDATE statement built by `_answer_fence_stmt`, compiles that
  statement's WHERE clause with literal binds, and asserts the three
  read-point-only terms are absent from it -- checked through six string
  markers, because the entity-binding term covers four separate
  directions.

A guiding comment above both tests states the fact these tests pin, the
window it leaves open, why that window is accepted rather than closed
here, why it is unreachable today, and what the two tests do and do not
catch.

## Why

`_answer_fence_task_predicate`'s own docstring already states that a
successful answer only proves three of six ownership terms held at write
time; the other three are checked once at the read point and never
re-verified when the write actually happens. That is an accepted,
documented gap, not something this change closes -- closing it means
folding the guest's JSON-lookup terms into the write point's WHERE
clause, and the two backends read a JSON key differently there
(`->>` on PostgreSQL, `json_extract` on SQLite), so closing it costs
either an extra read or an extra Python re-check. That policy decision
is left to whichever change wires the first production caller of
`respond()` (it has none today, enforced by a separate static gate).

Without a test pinning the current split, a later change could silently
widen it (assuming all six terms are re-verified at the write point) or
narrow it (quietly dropping one of the three that already are), and
nothing would catch either.

The second test compiles the statement's WHERE clause rather than the
whole statement, and does so with `literal_binds=True`. The whole
statement cannot take literal binds: its `VALUES` clause carries the
JSON-typed `response_payload` column, and SQLAlchemy's JSON type has no
literal renderer on any dialect, so compiling it that way raises
`CompileError`. The WHERE clause carries no JSON column, so it compiles
cleanly -- and with literal binds a JSON path lookup renders its key
inline (`JSON_EXTRACT(tasks.agent_config, '$."auth_mode"')`) instead of
hiding it in a bind parameter. The two terms that compare a row-level
column rather than a JSON key are matched by that column's own name
instead: `tasks.agent_id` for the widget-agent direction of the entity
binding, and `tasks.channel_id` for the channel binding. All six markers
in the assertion loop therefore catch a term added directly to
`_answer_fence_stmt`'s own `where(...)`, bypassing the predicate helper.

## Verification

- `pytest tests/web/services/test_task_interaction_service.py -q`:
  364 collected (362 on the base commit), all passing.
- `pytest tests/web/services/test_task_interaction_service.py -k
  answer_fence -q`: 4 passed (2 pre-existing, 2 new).
- `pytest tests/web/services/test_task_interaction_service_postgresql.py
  -q`: all 20 skipped -- no PostgreSQL client and no
  `XAGENT_TEST_POSTGRES_URL` on the machine this was verified on; not
  independently verified against PostgreSQL. The JSON-key-compilation
  difference between the two backends is already covered by that
  existing file for the production predicate itself; the two new tests
  here compile against SQLite only.
- `ruff check` and `ruff format --check`: clean.
- No production code under `src/` is touched; the diff is confined to
  the one test file.
- Mutation testing, applied directly against `src/` and reverted after
  each check (never committed): removing one of the three re-verified
  terms turns the first test red while the existing relative assertion
  ("a guest has one more term than a plain user") stays green; adding a
  fourth term to the predicate turns both tests red. Then, one at a
  time, each of the six markers' corresponding terms was added directly
  to the full statement's `where(...)`, bypassing the predicate helper:
  all six turn the second test red, confirming it covers the whole
  statement's WHERE clause rather than only the predicate's output.
