### PR TITLE
fix(mcp): log the underlying error when an MCP tool call or binding fails

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -28,6 +28,7 @@ from typing import (
     Union,
     cast,
 )
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 from mcp.types import Tool as MCPTool
@@ -228,6 +229,18 @@ logger = logging.getLogger(__name__)
 _RUNTIME_CONNECTION_REFRESH_KEY = "_connector_runtime_refresh"
 _OAUTH_TOKEN_RESOLVER_REFRESH_KEY = "_oauth_token_resolver_refresh"
 _RESOLVER_HTTP_401_NODE_LIMIT = 64
+# Caps the exception message logged when an MCP tool call fails, so a server
+# that echoes a large payload back in its error (or an SDK that dumps a full
+# request) can't blow up log volume. This bound applies to everything this
+# module emits about the failure -- no traceback is attached alongside it,
+# so this cap is what actually reaches the log. The message returned to the
+# caller ("Error executing MCP tool.") never carries it.
+_MCP_TOOL_ERROR_LOG_MAX_CHARS = 500
+# Caps how many related exceptions of a failed call get their own log line:
+# the leaves of a (possibly nested) BaseExceptionGroup and the exceptions on
+# their __cause__/__context__ chains. A fan-out call (e.g. concurrent
+# sub-requests) can otherwise raise a group with dozens of members.
+_MCP_TOOL_ERROR_LOG_MAX_SUB_EXCEPTIONS = 5
 _HTTP_401_TEXT_RE = re.compile(
     r"\b(?:http(?:\s+status)?|status(?:\s+code)?|response|code)\s*[:=]?\s*401\b|"
     r"\b401\s+unauthorized\b",
@@ -642,6 +655,54 @@ def _bounded_exception_nodes(
         if isinstance(current.__context__, BaseException):
             linked.append(current.__context__)
         pending.extend((node, False) for node in reversed(linked))
+
+
+_URL_TOKEN_RE = re.compile(r"https?://[^\s'\"<>]+", re.IGNORECASE)
+
+
+def _redact_urls_in_text(text: str) -> str:
+    """Return ``text`` with every ``scheme://...`` URL replaced by a copy
+    that has its query string and userinfo stripped.
+
+    Exception messages that legitimately need to name the server sometimes
+    embed the full request URL -- e.g. ``httpx.HTTPStatusError``'s message
+    is "... for url '<url>'" and an unfollowed redirect's message names the
+    ``Location`` response header. Connector URLs commonly carry secrets
+    (API keys, tokens) in the query string or in ``user:pass@host``
+    userinfo, so those parts are dropped before the message is logged, and
+    so is the fragment (it never reaches a server and carries no diagnostic
+    value). The scheme, host, port, and path are kept so the log line still
+    says which server failed. A token that fails to parse as a URL is
+    replaced wholesale with ``<url redacted>`` rather than risking a partial
+    leak.
+    """
+
+    def _redact(match: "re.Match[str]") -> str:
+        token = match.group(0)
+        try:
+            parts = urlsplit(token)
+            # Keep the authority verbatim minus userinfo: re-assembling it
+            # from ``hostname``/``port`` would drop IPv6 brackets and lower
+            # the case, and reading ``port`` raises on out-of-range values.
+            netloc = parts.netloc.rsplit("@", 1)[-1]
+            return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+        except (ValueError, UnicodeError):
+            return "<url redacted>"
+
+    return _URL_TOKEN_RE.sub(_redact, text)
+
+
+def _truncated_error_message(exc: BaseException) -> str:
+    """Return ``str(exc)`` with any embedded URLs stripped of their query
+    string and userinfo, bounded to ``_MCP_TOOL_ERROR_LOG_MAX_CHARS`` for
+    logging. It is otherwise just the exception's own message (e.g. a
+    JSON-RPC error string or an HTTP status line) -- it must never be
+    additionally handed tool_args, tool_meta, or connection headers, none of
+    which are exception messages to begin with."""
+    text = _redact_urls_in_text(str(exc))
+    if len(text) <= _MCP_TOOL_ERROR_LOG_MAX_CHARS:
+        return text
+    return text[: _MCP_TOOL_ERROR_LOG_MAX_CHARS - 1].rstrip() + "…"
 
 
 def _strict_http_401_responses(
@@ -1416,10 +1477,24 @@ class MCPToolAdapter(AbstractBaseTool):
 
         except BaseExceptionGroup as e:
             logger.error(
-                "MCP tool %s execution failed with exception group %s",
+                "MCP tool %s execution failed with exception group %s: %s",
                 self.mcp_tool.name,
                 type(e).__name__,
+                _truncated_error_message(e),
             )
+            leaf_count = 0
+            for node in _bounded_exception_nodes(e):
+                if node is e or isinstance(node, BaseExceptionGroup):
+                    continue
+                if leaf_count >= _MCP_TOOL_ERROR_LOG_MAX_SUB_EXCEPTIONS:
+                    break
+                leaf_count += 1
+                logger.error(
+                    "MCP tool %s execution failed with related exception %s: %s",
+                    self.mcp_tool.name,
+                    type(node).__name__,
+                    _truncated_error_message(node),
+                )
             return {
                 "content": [{"text": "Error executing MCP tool."}],
                 "is_error": True,
@@ -1427,9 +1502,10 @@ class MCPToolAdapter(AbstractBaseTool):
 
         except Exception as e:
             logger.error(
-                "MCP tool %s execution failed with %s",
+                "MCP tool %s execution failed with %s: %s",
                 self.mcp_tool.name,
                 type(e).__name__,
+                _truncated_error_message(e),
             )
             return {
                 "content": [{"text": "Error executing MCP tool."}],
@@ -1623,7 +1699,16 @@ class MCPToolAdapter(AbstractBaseTool):
             if target.get("target_type") != TARGET_TOOL_ARGUMENTS:
                 continue
             target_key = target.get("key")
-            if not isinstance(target_key, str) or target_key not in properties:
+            if not isinstance(target_key, str):
+                continue
+            if target_key not in properties:
+                logger.warning(
+                    "Skipping runtime MCP tool argument binding for %s on "
+                    "tool %s: the tool's input schema does not declare "
+                    "this argument",
+                    target_key,
+                    self.mcp_tool.name,
+                )
                 continue
             value = binding_source_value(
                 binding,

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -660,7 +660,7 @@ def _bounded_exception_nodes(
 _URL_TOKEN_RE = re.compile(r"https?://[^\s'\"<>]+", re.IGNORECASE)
 
 
-def _redact_urls_in_text(text: str) -> str:
+def redact_urls_in_text(text: str) -> str:
     """Return ``text`` with every ``scheme://...`` URL replaced by a copy
     that has its query string and userinfo stripped.
 
@@ -699,7 +699,7 @@ def _truncated_error_message(exc: BaseException) -> str:
     JSON-RPC error string or an HTTP status line) -- it must never be
     additionally handed tool_args, tool_meta, or connection headers, none of
     which are exception messages to begin with."""
-    text = _redact_urls_in_text(str(exc))
+    text = redact_urls_in_text(str(exc))
     if len(text) <= _MCP_TOOL_ERROR_LOG_MAX_CHARS:
         return text
     return text[: _MCP_TOOL_ERROR_LOG_MAX_CHARS - 1].rstrip() + "…"

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -234,12 +234,13 @@ _OAUTH_TOKEN_RESOLVER_REFRESH_KEY = "_oauth_token_resolver_refresh"
 # Two consumers read it: _bounded_exception_nodes (the 401 resolver's
 # challenge lookup) and _level_order_exception_nodes (failure logging).
 _EXCEPTION_WALK_NODE_LIMIT = 64
-# Caps the exception message logged when an MCP tool call fails, so a server
+# Caps each exception message logged when an MCP tool call fails, so a server
 # that echoes a large payload back in its error (or an SDK that dumps a full
-# request) can't blow up log volume. This bound applies to everything this
-# module emits about the failure -- no traceback is attached alongside it,
-# so this cap is what actually reaches the log. The message returned to the
-# caller ("Error executing MCP tool.") never carries it.
+# request) can't blow up log volume. The cap is per line, not per failure: a
+# plain failure logs one capped line, and an exception-group failure logs one
+# for the group plus up to _MCP_TOOL_ERROR_LOG_MAX_SUB_EXCEPTIONS more, each
+# capped on its own. No traceback is attached to any of them. The message
+# returned to the caller ("Error executing MCP tool.") never carries it.
 _MCP_TOOL_ERROR_LOG_MAX_CHARS = 500
 # Caps how many related exceptions of a failed call get their own log line:
 # the leaves of a (possibly nested) BaseExceptionGroup and the exceptions on
@@ -764,9 +765,9 @@ def _truncated_error_message(exc: BaseException) -> str:
     otherwise just the exception's own message (e.g. a JSON-RPC error
     string or an HTTP status line) -- it must never be additionally handed
     tool_args, tool_meta, or connection headers, none of which are
-    exception messages to begin with. One shape is recognised by neither
-    helper -- a secret sitting in a URL path segment (#2272) -- and for that
-    the cap is what bounds the exposure.
+    exception messages to begin with. Some shapes are recognised by neither
+    helper -- a secret in a URL path segment (#2272) and the others listed in
+    #2356 -- and for those the cap is what bounds the exposure.
     """
     try:
         text = redact_sensitive_text(redact_urls_in_text(str(exc)))
@@ -1552,6 +1553,14 @@ class MCPToolAdapter(AbstractBaseTool):
                         return retry_result
                     raise
 
+        # The tool-loading handlers (_load_direct_mcp_tools,
+        # load_mcp_tools_as_agent_tools) log only the class name above DEBUG
+        # and keep the raw traceback (exc_info) for DEBUG, because a traceback
+        # is unredacted and unbounded. These two handlers log at ERROR, but
+        # only _truncated_error_message() output -- passed through
+        # redact_urls_in_text and redact_sensitive_text and capped per line --
+        # and never a traceback, so do not add exc_info here. Shapes neither
+        # helper recognises: #2272, #2356.
         except BaseExceptionGroup as e:
             logger.error(
                 "MCP tool %s execution failed with exception group %s: %s",

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -242,6 +242,15 @@ _EXCEPTION_WALK_NODE_LIMIT = 64
 # capped on its own. No traceback is attached to any of them. The message
 # returned to the caller ("Error executing MCP tool.") never carries it.
 _MCP_TOOL_ERROR_LOG_MAX_CHARS = 500
+# Caps str(exc) before either redaction pass in _truncated_error_message runs.
+# str(exc) comes from a remote MCP server (or an SDK relaying its response)
+# and has no length limit of its own, while both redaction passes cost time
+# proportional to their input, so an unbounded message is a CPU-cost lever a
+# hostile or compromised server can pull regardless of how cheap either pass
+# is made per character. This bound only needs to keep the redaction passes
+# themselves cheap -- _MCP_TOOL_ERROR_LOG_MAX_CHARS is still what bounds the
+# final logged size.
+_MCP_TOOL_ERROR_RAW_MAX_CHARS = 4096
 # Caps how many related exceptions of a failed call get their own log line:
 # the leaves of a (possibly nested) BaseExceptionGroup and the exceptions on
 # their __cause__/__context__ chains. A fan-out call (e.g. concurrent
@@ -706,6 +715,51 @@ _URL_TRAILING_PUNCTUATION = ",.;:"
 _URL_TRAILING_BRACKETS = {")": "(", "]": "[", "}": "{"}
 
 
+def _split_url_token(token: str) -> tuple[str, str]:
+    """Split a matched URL token into ``(clean, trailing)``.
+
+    ``trailing`` is sentence punctuation immediately following the URL (a
+    closing paren, a period, ...) that should survive redaction even
+    though the URL itself does not; ``clean`` is the token with that
+    punctuation removed, ready to hand to ``urlsplit``.
+
+    The boundary between the two is found by scanning backward from the
+    end of the *scheme+authority+path* portion of the token only -- never
+    past the first ``?`` or ``#`` -- dropping characters that are either
+    in ``_URL_TRAILING_PUNCTUATION`` or a closing bracket with no
+    matching opener earlier in that same portion, until neither applies.
+    Stopping at the query/fragment boundary is deliberate: those parts are
+    dropped wholesale by the caller, so a credential value ending in one
+    of these characters (``...api_key=S)))``) must not have that tail
+    split off, survive the drop, and be reattached to the redacted URL as
+    if it were sentence punctuation -- nothing at or after the boundary is
+    ever part of either return value. Bracket counts for the scanned
+    portion are computed once up front and decremented as brackets are
+    consumed, rather than re-scanned on every character, so the scan is
+    linear in the token length instead of quadratic.
+    """
+    boundary = len(token)
+    for sep in ("?", "#"):
+        idx = token.find(sep)
+        if idx != -1 and idx < boundary:
+            boundary = idx
+    scanned = token[:boundary]
+    remaining = {c: scanned.count(c) for c in _URL_TRAILING_BRACKETS}
+    openers = {c: scanned.count(o) for c, o in _URL_TRAILING_BRACKETS.items()}
+    end = boundary
+    while end > 0:
+        last = token[end - 1]
+        if last in _URL_TRAILING_PUNCTUATION:
+            end -= 1
+            continue
+        if last in _URL_TRAILING_BRACKETS and openers[last] < remaining[last]:
+            remaining[last] -= 1
+            end -= 1
+            continue
+        break
+    return token[:end], token[end:boundary]
+
+
 def redact_urls_in_text(text: str) -> str:
     """Return ``text`` with every ``scheme://...`` URL replaced by a copy
     that has its query string and userinfo stripped.
@@ -726,32 +780,28 @@ def redact_urls_in_text(text: str) -> str:
     Sentence punctuation that trails the token (a closing paren, a period,
     ...) is split off before parsing and re-appended to the result
     afterwards, so redaction does not eat the punctuation that follows a
-    URL. Text separated from the URL only by a character that is legal
-    inside a query string (a comma, say) is still part of the token and
-    is dropped with the query; see the ``comma-inside-query`` test case.
+    URL -- but only punctuation trailing the scheme/authority/path:
+    nothing at or after the first ``?``/``#`` is ever treated as trailing,
+    since that is where the query string / fragment begins and both are
+    dropped wholesale (see ``_split_url_token``). Text separated from the
+    URL only by a character that is legal inside a query string (a comma,
+    say) is still part of the token and is dropped with the query; see
+    the ``comma-inside-query`` test case.
     """
 
     def _redact(match: "re.Match[str]") -> str:
         token = match.group(0)
-        trailing = ""
-        while token:
-            last = token[-1]
-            if last in _URL_TRAILING_PUNCTUATION or (
-                last in _URL_TRAILING_BRACKETS
-                and token.count(_URL_TRAILING_BRACKETS[last]) < token.count(last)
-            ):
-                trailing = last + trailing
-                token = token[:-1]
-                continue
-            break
+        clean, trailing = _split_url_token(token)
         try:
-            parts = urlsplit(token)
+            parts = urlsplit(clean)
             # Keep the authority verbatim minus userinfo: re-assembling it
             # from ``hostname``/``port`` would drop IPv6 brackets and lower
             # the case, and reading ``port`` raises on out-of-range values.
             netloc = parts.netloc.rsplit("@", 1)[-1]
             return urlunsplit((parts.scheme, netloc, parts.path, "", "")) + trailing
-        except (ValueError, UnicodeError):
+        except ValueError:
+            # UnicodeError is a ValueError subclass, so this also covers a
+            # token that fails to decode as IDNA.
             return "<url redacted>" + trailing
 
     return _URL_TOKEN_RE.sub(_redact, text)
@@ -768,9 +818,15 @@ def _truncated_error_message(exc: BaseException) -> str:
     exception messages to begin with. Some shapes are recognised by neither
     helper -- a secret in a URL path segment (#2272) and some of the shapes
     listed in #2356 -- and for those the cap is what bounds the exposure.
+    ``str(exc)`` is also bounded to ``_MCP_TOOL_ERROR_RAW_MAX_CHARS`` before
+    either redaction pass runs, since it is remote-controlled and unbounded
+    while both passes cost time proportional to their input.
     """
     try:
-        text = redact_sensitive_text(redact_urls_in_text(str(exc)))
+        raw = str(exc)
+        if len(raw) > _MCP_TOOL_ERROR_RAW_MAX_CHARS:
+            raw = raw[:_MCP_TOOL_ERROR_RAW_MAX_CHARS]
+        text = redact_sensitive_text(redact_urls_in_text(raw))
     except BaseException:
         # Every caller is an ``except`` handler whose contract is to return
         # a result dict, so a custom ``__str__`` that raises must not escape

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -764,10 +764,9 @@ def _truncated_error_message(exc: BaseException) -> str:
     otherwise just the exception's own message (e.g. a JSON-RPC error
     string or an HTTP status line) -- it must never be additionally handed
     tool_args, tool_meta, or connection headers, none of which are
-    exception messages to begin with. Two shapes are recognised by neither
-    helper -- a secret sitting in a URL path segment (#2272), and an
-    assignment whose key carries a prefix such as ``MCP_API_KEY=`` (#2304)
-    -- and for those the cap is what bounds the exposure.
+    exception messages to begin with. One shape is recognised by neither
+    helper -- a secret sitting in a URL path segment (#2272) -- and for that
+    the cap is what bounds the exposure.
     """
     try:
         text = redact_sensitive_text(redact_urls_in_text(str(exc)))

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -765,9 +765,9 @@ def _truncated_error_message(exc: BaseException) -> str:
     string or an HTTP status line) -- it must never be additionally handed
     tool_args, tool_meta, or connection headers, none of which are
     exception messages to begin with. Two shapes are recognised by neither
-    helper -- a secret sitting in a URL path segment, and an assignment
-    whose key carries a prefix such as ``MCP_API_KEY=`` -- and for those
-    the cap is what bounds the exposure.
+    helper -- a secret sitting in a URL path segment (#2272), and an
+    assignment whose key carries a prefix such as ``MCP_API_KEY=`` (#2304)
+    -- and for those the cap is what bounds the exposure.
     """
     try:
         text = redact_sensitive_text(redact_urls_in_text(str(exc)))

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -766,8 +766,8 @@ def _truncated_error_message(exc: BaseException) -> str:
     string or an HTTP status line) -- it must never be additionally handed
     tool_args, tool_meta, or connection headers, none of which are
     exception messages to begin with. Some shapes are recognised by neither
-    helper -- a secret in a URL path segment (#2272) and the others listed in
-    #2356 -- and for those the cap is what bounds the exposure.
+    helper -- a secret in a URL path segment (#2272) and some of the shapes
+    listed in #2356 -- and for those the cap is what bounds the exposure.
     """
     try:
         text = redact_sensitive_text(redact_urls_in_text(str(exc)))
@@ -1560,7 +1560,7 @@ class MCPToolAdapter(AbstractBaseTool):
         # only _truncated_error_message() output -- passed through
         # redact_urls_in_text and redact_sensitive_text and capped per line --
         # and never a traceback, so do not add exc_info here. Shapes neither
-        # helper recognises: #2272, #2356.
+        # helper recognises: #2272 and some of those listed in #2356.
         except BaseExceptionGroup as e:
             logger.error(
                 "MCP tool %s execution failed with exception group %s: %s",

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -36,6 +36,7 @@ from pydantic import BaseModel, Field, create_model
 
 from ..... import config as _root_config
 from .....sandbox.base import Sandbox
+from ....utils.security import redact_sensitive_text
 from ...core.mcp.sessions import Connection, create_session
 from ...core.mcp.tools import load_mcp_tools, raw_annotations_for
 from .base import AbstractBaseTool, ToolVisibility
@@ -228,7 +229,11 @@ class EmptyArgsModel(BaseModel):
 logger = logging.getLogger(__name__)
 _RUNTIME_CONNECTION_REFRESH_KEY = "_connector_runtime_refresh"
 _OAUTH_TOKEN_RESOLVER_REFRESH_KEY = "_oauth_token_resolver_refresh"
-_RESOLVER_HTTP_401_NODE_LIMIT = 64
+# Hard ceiling on how many exception nodes either walk over a failed call
+# visits, so a wide or cyclic __cause__/__context__ graph cannot spin.
+# Two consumers read it: _bounded_exception_nodes (the 401 resolver's
+# challenge lookup) and _level_order_exception_nodes (failure logging).
+_EXCEPTION_WALK_NODE_LIMIT = 64
 # Caps the exception message logged when an MCP tool call fails, so a server
 # that echoes a large payload back in its error (or an SDK that dumps a full
 # request) can't blow up log volume. This bound applies to everything this
@@ -240,6 +245,9 @@ _MCP_TOOL_ERROR_LOG_MAX_CHARS = 500
 # the leaves of a (possibly nested) BaseExceptionGroup and the exceptions on
 # their __cause__/__context__ chains. A fan-out call (e.g. concurrent
 # sub-requests) can otherwise raise a group with dozens of members.
+# Members at the same nesting depth are visited before any of their own
+# chains, so a fan-out failure logs one line per leg before spending
+# budget on a leg's causes.
 _MCP_TOOL_ERROR_LOG_MAX_SUB_EXCEPTIONS = 5
 _HTTP_401_TEXT_RE = re.compile(
     r"\b(?:http(?:\s+status)?|status(?:\s+code)?|response|code)\s*[:=]?\s*401\b|"
@@ -634,7 +642,7 @@ def _bounded_exception_nodes(
     pending = [(exc, True)]
     visited: set[int] = set()
     visited_count = 0
-    while pending and visited_count < _RESOLVER_HTTP_401_NODE_LIMIT:
+    while pending and visited_count < _EXCEPTION_WALK_NODE_LIMIT:
         current, is_root = pending.pop()
         current_id = id(current)
         if current_id in visited or (
@@ -657,7 +665,44 @@ def _bounded_exception_nodes(
         pending.extend((node, False) for node in reversed(linked))
 
 
-_URL_TOKEN_RE = re.compile(r"https?://[^\s'\"<>]+", re.IGNORECASE)
+def _level_order_exception_nodes(exc: BaseException) -> Iterator[BaseException]:
+    """Yield ``exc`` and the exceptions linked to it in level order: the
+    members of an exception group at one nesting depth are reached before
+    any of those members' own ``__cause__``/``__context__`` chains.
+
+    ``_bounded_exception_nodes`` walks the same edges depth-first, which is
+    what the 401 resolver wants -- it only needs one matching response from
+    anywhere in the graph. A capped log wants the opposite: a fan-out call
+    fails as a group with one member per failed leg, and depth-first order
+    lets the first leg's own cause chain spend the whole per-call budget,
+    so the other legs never get a line at all.
+    """
+    pending: list[BaseException] = [exc]
+    visited: set[int] = set()
+    index = 0
+    while index < len(pending) and len(visited) < _EXCEPTION_WALK_NODE_LIMIT:
+        current = pending[index]
+        index += 1
+        current_id = id(current)
+        if current_id in visited:
+            continue
+        visited.add(current_id)
+        yield current
+
+        if isinstance(current, BaseExceptionGroup):
+            pending.extend(current.exceptions)
+        if isinstance(current.__cause__, BaseException):
+            pending.append(current.__cause__)
+        if isinstance(current.__context__, BaseException):
+            pending.append(current.__context__)
+
+
+_URL_TOKEN_RE = re.compile(r"(?:https?|wss?)://[^\s'\"<>]+", re.IGNORECASE)
+# Punctuation that ends the sentence rather than the URL. Closing brackets
+# are only dropped when the token holds no matching opener, so an IPv6
+# authority ("https://[::1]") and a parenthesised path segment survive.
+_URL_TRAILING_PUNCTUATION = ",.;:"
+_URL_TRAILING_BRACKETS = {")": "(", "]": "[", "}": "{"}
 
 
 def redact_urls_in_text(text: str) -> str:
@@ -674,32 +719,65 @@ def redact_urls_in_text(text: str) -> str:
     value). The scheme, host, port, and path are kept so the log line still
     says which server failed. A token that fails to parse as a URL is
     replaced wholesale with ``<url redacted>`` rather than risking a partial
-    leak.
+    leak. ``ws://``/``wss://`` tokens are covered the same way as
+    ``http``/``https``, because a websocket transport cannot send headers,
+    so a websocket connector has nowhere but the URL to put its credential.
+    Sentence punctuation that trails the token (a closing paren, a period,
+    ...) is split off before parsing and re-appended to the result
+    afterwards, so redaction does not eat the punctuation that follows a
+    URL. Text separated from the URL only by a character that is legal
+    inside a query string (a comma, say) is still part of the token and
+    is dropped with the query; see the ``comma-inside-query`` test case.
     """
 
     def _redact(match: "re.Match[str]") -> str:
         token = match.group(0)
+        trailing = ""
+        while token:
+            last = token[-1]
+            if last in _URL_TRAILING_PUNCTUATION or (
+                last in _URL_TRAILING_BRACKETS
+                and token.count(_URL_TRAILING_BRACKETS[last]) < token.count(last)
+            ):
+                trailing = last + trailing
+                token = token[:-1]
+                continue
+            break
         try:
             parts = urlsplit(token)
             # Keep the authority verbatim minus userinfo: re-assembling it
             # from ``hostname``/``port`` would drop IPv6 brackets and lower
             # the case, and reading ``port`` raises on out-of-range values.
             netloc = parts.netloc.rsplit("@", 1)[-1]
-            return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+            return urlunsplit((parts.scheme, netloc, parts.path, "", "")) + trailing
         except (ValueError, UnicodeError):
-            return "<url redacted>"
+            return "<url redacted>" + trailing
 
     return _URL_TOKEN_RE.sub(_redact, text)
 
 
 def _truncated_error_message(exc: BaseException) -> str:
-    """Return ``str(exc)`` with any embedded URLs stripped of their query
-    string and userinfo, bounded to ``_MCP_TOOL_ERROR_LOG_MAX_CHARS`` for
-    logging. It is otherwise just the exception's own message (e.g. a
-    JSON-RPC error string or an HTTP status line) -- it must never be
-    additionally handed tool_args, tool_meta, or connection headers, none of
-    which are exception messages to begin with."""
-    text = redact_urls_in_text(str(exc))
+    """Return ``str(exc)`` made safe to log: URLs lose their query string,
+    userinfo and fragment (``redact_urls_in_text``), header- and
+    assignment-shaped secrets are masked (``redact_sensitive_text``), and
+    the result is bounded to ``_MCP_TOOL_ERROR_LOG_MAX_CHARS``. It is
+    otherwise just the exception's own message (e.g. a JSON-RPC error
+    string or an HTTP status line) -- it must never be additionally handed
+    tool_args, tool_meta, or connection headers, none of which are
+    exception messages to begin with. Two shapes are recognised by neither
+    helper -- a secret sitting in a URL path segment, and an assignment
+    whose key carries a prefix such as ``MCP_API_KEY=`` -- and for those
+    the cap is what bounds the exposure.
+    """
+    try:
+        text = redact_sensitive_text(redact_urls_in_text(str(exc)))
+    except BaseException:
+        # Every caller is an ``except`` handler whose contract is to return
+        # a result dict, so a custom ``__str__`` that raises must not escape
+        # here. ``BaseException`` is deliberate: nothing in the guarded block
+        # awaits, so no cancellation can originate in it, and a ``__str__``
+        # is free to raise a BaseException subclass.
+        return type(exc).__name__
     if len(text) <= _MCP_TOOL_ERROR_LOG_MAX_CHARS:
         return text
     return text[: _MCP_TOOL_ERROR_LOG_MAX_CHARS - 1].rstrip() + "…"
@@ -1483,7 +1561,7 @@ class MCPToolAdapter(AbstractBaseTool):
                 _truncated_error_message(e),
             )
             leaf_count = 0
-            for node in _bounded_exception_nodes(e):
+            for node in _level_order_exception_nodes(e):
                 if node is e or isinstance(node, BaseExceptionGroup):
                     continue
                 if leaf_count >= _MCP_TOOL_ERROR_LOG_MAX_SUB_EXCEPTIONS:

--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -41,10 +41,10 @@ ASSIGNMENT_PATTERN = re.compile(r"(?<![A-Za-z0-9_-])([A-Za-z0-9_-]+)=([^&\s]+)")
 # ends in one of these words and the word is the whole key or is joined to
 # the prefix by ``_``/``-``. ``key`` itself is included: ``SECRET_KEY=``,
 # ``AWS_SECRET_ACCESS_KEY=``, ``STRIPE_KEY=`` and ``PRIVATE_KEY=`` are all
-# credentials, and an unknown ``*_key`` is treated as one (fail closed). Only
-# the qualifiers below name ordinary fields (``primary_key=``, ``sort_key=``,
-# ``PUBLIC_KEY=``); those stay readable because this text also reaches user-
-# and model-facing error messages.
+# credentials, and an unknown ``*_key`` or ``*_token`` is treated as one (fail
+# closed). Only the per-suffix qualifiers below name ordinary fields
+# (``primary_key=``, ``PUBLIC_KEY=``, ``next_token=``); those stay readable
+# because this text also reaches user- and model-facing error messages.
 _CREDENTIAL_KEY_SUFFIXES = (
     "api_key",
     "api-key",
@@ -77,6 +77,24 @@ _NON_CREDENTIAL_KEY_QUALIFIERS = frozenset(
         "s3",
     }
 )
+# ``*_token`` names that mark a position or a request, not access: paging
+# cursors (``next_token``, ``page_token``, ``continuation_token``, ...) and a
+# client-chosen de-duplication id (``idempotency_token``). Kept apart from
+# the ``key`` list: ``public_token`` is exchanged for an access token, and
+# ``s3_token`` / ``cache_token`` may be credentials.
+# ``page_token`` is ambiguous: some code also names a Facebook Page access
+# token that way. The name alone cannot tell them apart (#2356).
+_NON_CREDENTIAL_TOKEN_QUALIFIERS = frozenset(
+    {"idempotency", "next", "page", "continuation", "cursor", "sync", "pagination"}
+)
+# The qualifier is the ``_``/``-`` segment just before the suffix
+# (``next_page_token`` -> ``page``). Every other suffix (``api_key``,
+# ``access_token``, ``password``, ``secret`` and their spellings) has no
+# exemption, so ``page_access_token=`` stays masked.
+_NON_CREDENTIAL_QUALIFIERS_BY_SUFFIX = {
+    "key": _NON_CREDENTIAL_KEY_QUALIFIERS,
+    "token": _NON_CREDENTIAL_TOKEN_QUALIFIERS,
+}
 
 
 def _is_credential_key(key: str) -> bool:
@@ -92,9 +110,10 @@ def _is_credential_key(key: str) -> bool:
             # ``monkey=`` / ``hotkey=`` / ``tokens=``: the credential word is
             # not a separate segment of the identifier.
             continue
-        if suffix == "key":
+        exempt = _NON_CREDENTIAL_QUALIFIERS_BY_SUFFIX.get(suffix)
+        if exempt is not None:
             qualifier = re.split(r"[_-]", prefix.rstrip("_-"))[-1]
-            if qualifier in _NON_CREDENTIAL_KEY_QUALIFIERS:
+            if qualifier in exempt:
                 return False
         return True
     return False
@@ -406,7 +425,15 @@ def redact_url_credentials_for_logging(url: str) -> str:
 
 
 def redact_sensitive_text(text: str) -> str:
-    """Redact common key/token patterns from arbitrary text."""
+    """Redact common key/token patterns from arbitrary text.
+
+    Recognition is by keyword and shape, so it is not exhaustive: it covers
+    ``http(s)://`` URLs (``redact_url_credentials_for_logging``),
+    ``identifier=value`` assignments whose identifier ``_is_credential_key``
+    accepts, and the header shapes in ``AUTH_HEADER_PATTERN`` and
+    ``HEADER_KEY_PATTERNS``. Shapes it is known to miss are listed in
+    #2356; add a pattern here when a new one turns up.
+    """
     if not text:
         return text
 

--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -29,17 +29,52 @@ SENSITIVE_QUERY_KEYS = {
 }
 
 URL_PATTERN = re.compile(r"https?://[^\s\"'>]+")
-# A credential key may carry an identifier prefix (``MCP_API_KEY=``,
-# ``SERVICE_ACCESS_TOKEN=``, ``DB_PASSWORD=``), so the key is matched from a
-# non-identifier boundary and allowed any ``_``/``-``-joined prefix in front
-# of a credential word. A bare ``key`` is only masked without a prefix:
-# ``primary_key=`` / ``sort_key=`` / ``PUBLIC_KEY=`` name ordinary fields, not
-# secrets, and this text also reaches user- and model-facing error messages.
-ASSIGNMENT_SECRET_PATTERN = re.compile(
-    r"(?i)(?<![A-Za-z0-9])"
-    r"((?:[A-Za-z0-9]+[_-])*(?:api[_-]?key|access[_-]?token|token|password|secret)"
-    r"|(?<![_-])key)=([^&\s]+)"
+# Every ``identifier=value`` assignment in the text; ``_is_credential_key``
+# decides which of them carry a secret. The regex itself stays linear: a
+# single identifier run followed by ``=``, anchored on a non-identifier
+# boundary, so a long run of ``a_a_a_...`` without ``=`` fails once per run
+# instead of re-trying every segment split (a nested ``(prefix_)*word``
+# quantifier did that and took seconds on a 20 kB hostile message).
+ASSIGNMENT_PATTERN = re.compile(r"(?<![A-Za-z0-9_-])([A-Za-z0-9_-]+)=([^&\s]+)")
+# A credential word may sit behind an identifier prefix (``MCP_API_KEY=``,
+# ``SERVICE_ACCESS_TOKEN=``, ``DB_PASSWORD=``), so a key is a credential when it
+# ends in one of these words and the word is the whole key or is joined to
+# the prefix by ``_``/``-``. A bare ``key`` (or ``--key``) is a credential,
+# but ``primary_key=`` / ``sort_key=`` / ``PUBLIC_KEY=`` name ordinary fields,
+# and this text also reaches user- and model-facing error messages, so a
+# prefixed ``*_key`` is left readable.
+_CREDENTIAL_KEY_SUFFIXES = (
+    "api_key",
+    "api-key",
+    "apikey",
+    "access_token",
+    "access-token",
+    "accesstoken",
+    "token",
+    "password",
+    "secret",
 )
+
+
+def _is_credential_key(key: str) -> bool:
+    lowered = key.lower()
+    if lowered.endswith("key") and lowered[:-3].strip("-") == "":
+        return True
+    for suffix in _CREDENTIAL_KEY_SUFFIXES:
+        if lowered.endswith(suffix):
+            prefix = lowered[: -len(suffix)]
+            if prefix == "" or prefix[-1] in "_-":
+                return True
+    return False
+
+
+def _redact_assignment(match: "re.Match[str]") -> str:
+    key, value = match.group(1), match.group(2)
+    if not _is_credential_key(key):
+        return match.group(0)
+    return f"{key}={_mask_secret(value)}"
+
+
 AUTH_HEADER_PATTERN = re.compile(
     r"(?i)(authorization\s*[:=]\s*(?:bearer|basic)\s+)([^\s,;]+)"
 )
@@ -347,10 +382,7 @@ def redact_sensitive_text(text: str) -> str:
         lambda match: redact_url_credentials_for_logging(match.group(0)),
         text,
     )
-    redacted = ASSIGNMENT_SECRET_PATTERN.sub(
-        lambda match: f"{match.group(1)}={_mask_secret(match.group(2))}",
-        redacted,
-    )
+    redacted = ASSIGNMENT_PATTERN.sub(_redact_assignment, redacted)
     redacted = AUTH_HEADER_PATTERN.sub(
         lambda match: f"{match.group(1)}{_mask_secret(match.group(2))}",
         redacted,

--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -29,13 +29,18 @@ SENSITIVE_QUERY_KEYS = {
 }
 
 URL_PATTERN = re.compile(r"https?://[^\s\"'>]+")
-# Every ``identifier=value`` assignment in the text; ``_is_credential_key``
-# decides which of them carry a secret. The regex itself stays linear: a
-# single identifier run followed by ``=``, anchored on a non-identifier
-# boundary, so a long run of ``a_a_a_...`` without ``=`` fails once per run
-# instead of re-trying every segment split (a nested ``(prefix_)*word``
-# quantifier did that and took seconds on a 20 kB hostile message).
-ASSIGNMENT_PATTERN = re.compile(r"(?<![A-Za-z0-9_-])([A-Za-z0-9_-]+)=([^&\s]+)")
+# Every ``identifier=`` in the text; ``_is_credential_key`` decides which
+# identifiers name a secret. Only a credential's value is consumed
+# (``_ASSIGNMENT_VALUE_PATTERN``: up to ``&`` or whitespace). After any other
+# identifier the scan resumes right behind its ``=``, so a credential that
+# follows it without a space (``host=db;password=...``) is still judged on
+# its own. The regex itself stays linear: a single identifier run followed
+# by ``=``, anchored on a non-identifier boundary, so a long run of
+# ``a_a_a_...`` without ``=`` fails once per run instead of re-trying every
+# segment split (a nested ``(prefix_)*word`` quantifier did that and took
+# seconds on a 20 kB hostile message).
+ASSIGNMENT_PATTERN = re.compile(r"(?<![A-Za-z0-9_-])([A-Za-z0-9_-]+)=")
+_ASSIGNMENT_VALUE_PATTERN = re.compile(r"[^&\s]+")
 # A credential word may sit behind an identifier prefix (``MCP_API_KEY=``,
 # ``SERVICE_ACCESS_TOKEN=``, ``DB_PASSWORD=``), so a key is a credential when it
 # ends in one of these words and the word is the whole key or is joined to
@@ -107,7 +112,7 @@ def _is_credential_key(key: str) -> bool:
             # Bare word, or a CLI-style flag such as ``--api-key=``.
             return True
         if prefix[-1] not in "_-":
-            # ``monkey=`` / ``hotkey=`` / ``tokens=``: the credential word is
+            # ``monkey=`` / ``hotkey=`` / ``mytoken=``: the credential word is
             # not a separate segment of the identifier.
             continue
         exempt = _NON_CREDENTIAL_QUALIFIERS_BY_SUFFIX.get(suffix)
@@ -119,11 +124,25 @@ def _is_credential_key(key: str) -> bool:
     return False
 
 
-def _redact_assignment(match: "re.Match[str]") -> str:
-    key, value = match.group(1), match.group(2)
-    if not _is_credential_key(key):
-        return match.group(0)
-    return f"{key}={_mask_secret(value)}"
+def _redact_assignments(text: str) -> str:
+    # Values are read only for credentials and never overlap, and finditer
+    # tries each position once, so every character is examined a constant
+    # number of times however many ``identifier=`` runs the text holds.
+    parts: list[str] = []
+    copied = 0
+    for match in ASSIGNMENT_PATTERN.finditer(text):
+        if match.start() < copied or not _is_credential_key(match.group(1)):
+            # Inside a value already masked, or not a credential: leave the
+            # text as it is and keep scanning right after this ``=``.
+            continue
+        value = _ASSIGNMENT_VALUE_PATTERN.match(text, match.end())
+        if value is None:
+            continue
+        parts.append(text[copied : match.end()])
+        parts.append(_mask_secret(value.group(0)))
+        copied = value.end()
+    parts.append(text[copied:])
+    return "".join(parts)
 
 
 AUTH_HEADER_PATTERN = re.compile(
@@ -432,7 +451,8 @@ def redact_sensitive_text(text: str) -> str:
     ``identifier=value`` assignments whose identifier ``_is_credential_key``
     accepts, and the header shapes in ``AUTH_HEADER_PATTERN`` and
     ``HEADER_KEY_PATTERNS``. Shapes it is known to miss are listed in
-    #2356; add a pattern here when a new one turns up.
+    #2356, and secrets in URL path segments in #2272; add a pattern here
+    when a new one turns up.
     """
     if not text:
         return text
@@ -441,7 +461,7 @@ def redact_sensitive_text(text: str) -> str:
         lambda match: redact_url_credentials_for_logging(match.group(0)),
         text,
     )
-    redacted = ASSIGNMENT_PATTERN.sub(_redact_assignment, redacted)
+    redacted = _redact_assignments(redacted)
     redacted = AUTH_HEADER_PATTERN.sub(
         lambda match: f"{match.group(1)}{_mask_secret(match.group(2))}",
         redacted,

--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -95,7 +95,10 @@ _NON_CREDENTIAL_TOKEN_QUALIFIERS = frozenset(
 # The qualifier is the ``_``/``-`` segment just before the suffix
 # (``next_page_token`` -> ``page``). Every other suffix (``api_key``,
 # ``access_token``, ``password``, ``secret`` and their spellings) has no
-# exemption, so ``page_access_token=`` stays masked.
+# exemption, so ``page_access_token=`` stays masked. The exemption below
+# only applies when that segment is joined to the suffix with ``_``; a
+# hyphen join (``next-token=``, ``cache-key=``) is treated as a credential
+# and masked.
 _NON_CREDENTIAL_QUALIFIERS_BY_SUFFIX = {
     "key": _NON_CREDENTIAL_KEY_QUALIFIERS,
     "token": _NON_CREDENTIAL_TOKEN_QUALIFIERS,
@@ -115,8 +118,13 @@ def _is_credential_key(key: str) -> bool:
             # ``monkey=`` / ``hotkey=`` / ``mytoken=``: the credential word is
             # not a separate segment of the identifier.
             continue
+        # The exemption only reads as a deliberate structural-field name
+        # when the qualifier is joined to the suffix by ``_``
+        # (``primary_key=``, ``next_token=``). A hyphen join is treated as
+        # a credential name: ``cache-key=`` / ``next-token=`` are masked;
+        # only the underscore-joined spelling is exempt.
         exempt = _NON_CREDENTIAL_QUALIFIERS_BY_SUFFIX.get(suffix)
-        if exempt is not None:
+        if exempt is not None and prefix[-1] == "_":
             qualifier = re.split(r"[_-]", prefix.rstrip("_-"))[-1]
             if qualifier in exempt:
                 return False

--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -39,10 +39,12 @@ ASSIGNMENT_PATTERN = re.compile(r"(?<![A-Za-z0-9_-])([A-Za-z0-9_-]+)=([^&\s]+)")
 # A credential word may sit behind an identifier prefix (``MCP_API_KEY=``,
 # ``SERVICE_ACCESS_TOKEN=``, ``DB_PASSWORD=``), so a key is a credential when it
 # ends in one of these words and the word is the whole key or is joined to
-# the prefix by ``_``/``-``. A bare ``key`` (or ``--key``) is a credential,
-# but ``primary_key=`` / ``sort_key=`` / ``PUBLIC_KEY=`` name ordinary fields,
-# and this text also reaches user- and model-facing error messages, so a
-# prefixed ``*_key`` is left readable.
+# the prefix by ``_``/``-``. ``key`` itself is included: ``SECRET_KEY=``,
+# ``AWS_SECRET_ACCESS_KEY=``, ``STRIPE_KEY=`` and ``PRIVATE_KEY=`` are all
+# credentials, and an unknown ``*_key`` is treated as one (fail closed). Only
+# the qualifiers below name ordinary fields (``primary_key=``, ``sort_key=``,
+# ``PUBLIC_KEY=``); those stay readable because this text also reaches user-
+# and model-facing error messages.
 _CREDENTIAL_KEY_SUFFIXES = (
     "api_key",
     "api-key",
@@ -53,18 +55,48 @@ _CREDENTIAL_KEY_SUFFIXES = (
     "token",
     "password",
     "secret",
+    "key",
+)
+_NON_CREDENTIAL_KEY_QUALIFIERS = frozenset(
+    {
+        "primary",
+        "foreign",
+        "unique",
+        "composite",
+        "index",
+        "sort",
+        "partition",
+        "range",
+        "hash",
+        "lookup",
+        "cache",
+        "routing",
+        "idempotency",
+        "public",
+        "object",
+        "s3",
+    }
 )
 
 
 def _is_credential_key(key: str) -> bool:
     lowered = key.lower()
-    if lowered.endswith("key") and lowered[:-3].strip("-") == "":
-        return True
     for suffix in _CREDENTIAL_KEY_SUFFIXES:
-        if lowered.endswith(suffix):
-            prefix = lowered[: -len(suffix)]
-            if prefix == "" or prefix[-1] in "_-":
-                return True
+        if not lowered.endswith(suffix):
+            continue
+        prefix = lowered[: -len(suffix)]
+        if prefix.strip("-") == "":
+            # Bare word, or a CLI-style flag such as ``--api-key=``.
+            return True
+        if prefix[-1] not in "_-":
+            # ``monkey=`` / ``hotkey=`` / ``tokens=``: the credential word is
+            # not a separate segment of the identifier.
+            continue
+        if suffix == "key":
+            qualifier = re.split(r"[_-]", prefix.rstrip("_-"))[-1]
+            if qualifier in _NON_CREDENTIAL_KEY_QUALIFIERS:
+                return False
+        return True
     return False
 
 

--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -29,8 +29,16 @@ SENSITIVE_QUERY_KEYS = {
 }
 
 URL_PATTERN = re.compile(r"https?://[^\s\"'>]+")
+# A credential key may carry an identifier prefix (``MCP_API_KEY=``,
+# ``SERVICE_ACCESS_TOKEN=``, ``DB_PASSWORD=``), so the key is matched from a
+# non-identifier boundary and allowed any ``_``/``-``-joined prefix in front
+# of a credential word. A bare ``key`` is only masked without a prefix:
+# ``primary_key=`` / ``sort_key=`` / ``PUBLIC_KEY=`` name ordinary fields, not
+# secrets, and this text also reaches user- and model-facing error messages.
 ASSIGNMENT_SECRET_PATTERN = re.compile(
-    r"(?i)\b(api[_-]?key|access[_-]?token|token|password|secret|key)=([^&\s]+)"
+    r"(?i)(?<![A-Za-z0-9])"
+    r"((?:[A-Za-z0-9]+[_-])*(?:api[_-]?key|access[_-]?token|token|password|secret)"
+    r"|(?<![_-])key)=([^&\s]+)"
 )
 AUTH_HEADER_PATTERN = re.compile(
     r"(?i)(authorization\s*[:=]\s*(?:bearer|basic)\s+)([^\s,;]+)"

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -478,6 +478,21 @@ def _bounded_oauth_metadata(value: Any, *, max_length: int = 128) -> str:
     return f"{text[: max_length - 3]}..."
 
 
+def _redacted_bounded_resource(resource: str | None) -> str | None:
+    """Redact and bound an OAuth resource URL for a diagnostic, or ``None``
+    if there is none. Every producer of ``resource`` (``mcp_runtime.py``'s
+    ``effective_mcp_oauth_resource`` and this module's
+    ``_oauth_token_configured_resource``) excludes the empty string, so a
+    truthy guard and an ``is not None`` guard are equivalent in practice;
+    this uses the truthy form so ``""`` -- if a producer's contract ever
+    changes -- is treated the same as ``None`` rather than redacted and
+    bounded into a diagnostic-empty string.
+    """
+    if not resource:
+        return None
+    return _bounded_oauth_metadata(redact_urls_in_text(resource))
+
+
 def _extract_oauth_token_resolver_diagnostic_actor_id(exc: Exception) -> str | None:
     try:
         raw_actor_id = getattr(exc, "oauth_token_resolver_diagnostic_actor_id", None)
@@ -3604,9 +3619,7 @@ class WebToolConfig(BaseToolConfig):
             server,
             code=OAUTH_TOKEN_RESOLVER_FAILURE_CODE,
             message=OAUTH_TOKEN_RESOLVER_FAILURE_MESSAGE,
-            resource=_bounded_oauth_metadata(redact_urls_in_text(error.resource))
-            if error.resource is not None
-            else None,
+            resource=_redacted_bounded_resource(error.resource),
         )
         diagnostic["providers"] = [
             _bounded_oauth_metadata(provider) for provider in error.providers[:2]
@@ -3634,9 +3647,7 @@ class WebToolConfig(BaseToolConfig):
             getattr(server, "name", "<unknown>"),
             error.exception_type,
             error.failure_code,
-            _bounded_oauth_metadata(redact_urls_in_text(error.resource))
-            if error.resource
-            else None,
+            _redacted_bounded_resource(error.resource),
         )
         return self._build_unavailable_mcp_config(
             server=server,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -63,6 +63,7 @@ from ...core.tools.adapters.vibe.connector_runtime import (
     runtime_bindings_from_config,
 )
 from ...core.tools.adapters.vibe.db_session import tool_session_scope
+from ...core.tools.adapters.vibe.mcp_adapter import redact_urls_in_text
 from ..services.actor_mcp_runtime import (
     ActorMCPStdioSessionIdentity,
     resolve_actor_mcp_stdio_configs,
@@ -3633,7 +3634,9 @@ class WebToolConfig(BaseToolConfig):
             getattr(server, "name", "<unknown>"),
             error.exception_type,
             error.failure_code,
-            error.resource,
+            _bounded_oauth_metadata(redact_urls_in_text(error.resource))
+            if error.resource
+            else None,
         )
         return self._build_unavailable_mcp_config(
             server=server,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3604,7 +3604,7 @@ class WebToolConfig(BaseToolConfig):
             server,
             code=OAUTH_TOKEN_RESOLVER_FAILURE_CODE,
             message=OAUTH_TOKEN_RESOLVER_FAILURE_MESSAGE,
-            resource=_bounded_oauth_metadata(error.resource)
+            resource=_bounded_oauth_metadata(redact_urls_in_text(error.resource))
             if error.resource is not None
             else None,
         )

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3628,9 +3628,12 @@ class WebToolConfig(BaseToolConfig):
         )
         self._mcp_oauth_diagnostics.append(diagnostic)
         logger.warning(
-            "OAuth token resolver failed for MCP server '%s' with %s",
+            "OAuth token resolver failed for MCP server '%s' with %s "
+            "(failure_code=%s, resource=%s)",
             getattr(server, "name", "<unknown>"),
             error.exception_type,
+            error.failure_code,
+            error.resource,
         )
         return self._build_unavailable_mcp_config(
             server=server,

--- a/tests/core/model/test_security.py
+++ b/tests/core/model/test_security.py
@@ -333,11 +333,46 @@ def test_redact_sensitive_text_masks_prefixed_assignment_keys() -> None:
     )
 
 
+def test_redact_sensitive_text_masks_prefixed_secret_key_names() -> None:
+    # An unknown ``*_key`` is treated as a credential (fail closed): the
+    # common secret names below end in ``key`` without any other credential
+    # word in front of it.
+    text = (
+        "AWS_SECRET_ACCESS_KEY=AKIA-secret-1 "
+        "SECRET_KEY=django-secret-1 "
+        "STRIPE_KEY=sk_live_1234567 "
+        "PRIVATE_KEY=pem-private-1 "
+        "x-client-key=ck-000111"
+    )
+    redacted = redact_sensitive_text(text)
+
+    for raw in (
+        "AKIA-secret-1",
+        "django-secret-1",
+        "sk_live_1234567",
+        "pem-private-1",
+        "ck-000111",
+    ):
+        assert raw not in redacted
+    assert redacted == (
+        "AWS_SECRET_ACCESS_KEY=***et-1 "
+        "SECRET_KEY=***et-1 "
+        "STRIPE_KEY=***4567 "
+        "PRIVATE_KEY=***te-1 "
+        "x-client-key=***0111"
+    )
+
+
 def test_redact_sensitive_text_leaves_non_credential_key_suffixes() -> None:
-    # ``key`` alone is a credential word only when it stands by itself: a
-    # prefixed ``*_key`` names an ordinary field, and this text reaches
-    # user- and model-facing error messages, so it must stay readable.
-    text = "primary_key=42 sort_key=created_at PUBLIC_KEY=pem-body cache_key=user:42"
+    # Only a ``*_key`` whose qualifier names a structural field is left
+    # alone; this text reaches user- and model-facing error messages, so
+    # these must stay readable. ``hotkey=`` / ``monkey=`` have no separate
+    # ``key`` segment and are not assignments of a credential either.
+    text = (
+        "primary_key=42 sort_key=created_at partition_key=tenant "
+        "PUBLIC_KEY=pem-body cache_key=user:42 idempotency_key=uuid-1 "
+        "s3_key=path/to/obj routing_key=orders.new hotkey=ctrl-k monkey=1"
+    )
 
     assert redact_sensitive_text(text) == text
 

--- a/tests/core/model/test_security.py
+++ b/tests/core/model/test_security.py
@@ -454,3 +454,71 @@ def test_redact_sensitive_text_is_linear_on_hostile_identifier_runs() -> None:
     started = time.perf_counter()
     assert redact_sensitive_text(hostile) == hostile
     assert time.perf_counter() - started < 1.0
+
+
+# Assignments that are not credentials, and characters that can sit between
+# one of them and a credential right behind it: first the ones that do not
+# end a value, then the three that do. The non-credential assignment must
+# not take its value with it, or the credential is never looked at.
+_NON_CREDENTIAL_ASSIGNMENTS = (
+    "host=example.com",
+    "Username=app",
+    "error=invalid_request",
+    "code=400",
+    "primary_key=42",
+    "next_token=CUR",
+    "page_token=p1",
+)
+_ASSIGNMENT_SEPARATORS = tuple(";,|\"':/)]}=") + ("\t", "&", " ")
+_TRAILING_CREDENTIAL_KEYS = (
+    "api_key",
+    "access_token",
+    "Password",
+    "token",
+    "MCP_API_KEY",
+)
+
+
+@pytest.mark.parametrize("separator", _ASSIGNMENT_SEPARATORS, ids=repr)
+def test_redact_sensitive_text_masks_a_credential_after_a_non_credential_one(
+    separator: str,
+) -> None:
+    for prefix in _NON_CREDENTIAL_ASSIGNMENTS:
+        for key in _TRAILING_CREDENTIAL_KEYS:
+            text = f"{prefix}{separator}{key}=SECRET-abc123"
+
+            assert redact_sensitive_text(text) == (
+                f"{prefix}{separator}{key}=***c123"
+            ), text
+
+
+def test_redact_sensitive_text_masks_a_credential_value_as_one_piece() -> None:
+    # A credential's value runs to the next ``&`` or whitespace, so it can
+    # take a following field with it (#2356); a credential inside that value
+    # is covered by the same mask and is not masked a second time.
+    assert (
+        redact_sensitive_text("Host=db;Username=app;Password=SECRET-pw;Database=x")
+        == "Host=db;Username=app;Password=***se=x"
+    )
+    assert (
+        redact_sensitive_text("api_key=SECRET-abc123;token=SECRET-def456 rest")
+        == "api_key=***f456 rest"
+    )
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["a=" * 50_000, "a=b;" * 25_000, "x_" * 50_000 + "=v", "api_key=" * 12_500],
+    ids=["bare-assignments", "semicolon-assignments", "one-long-key", "credentials"],
+)
+def test_redact_sensitive_text_is_linear_on_hostile_assignment_runs(
+    hostile: str,
+) -> None:
+    # 100 kB of back-to-back ``identifier=`` from a remote service. The scan
+    # resumes right after a non-credential's ``=`` and reads a value only for
+    # a credential, so this takes milliseconds; re-reading each value to the
+    # end of the text after every identifier takes seconds here. The budget
+    # is loose so a slow CI worker cannot trip it.
+    started = time.perf_counter()
+    redact_sensitive_text(hostile)
+    assert time.perf_counter() - started < 1.0

--- a/tests/core/model/test_security.py
+++ b/tests/core/model/test_security.py
@@ -380,21 +380,78 @@ def test_redact_sensitive_text_leaves_non_credential_key_suffixes() -> None:
     assert redact_sensitive_text(text) == text
 
 
+# Each hyphen-joined structural qualifier paired with its underscore-joined
+# counterpart. The exemption requires an underscore join, so these
+# hyphen-joined names are masked; their underscore counterparts stay
+# exempt.
+_HYPHEN_QUALIFIER_REGRESSION_PAIRS = [
+    ("primary-key", "primary_key"),
+    ("foreign-key", "foreign_key"),
+    ("unique-key", "unique_key"),
+    ("composite-key", "composite_key"),
+    ("index-key", "index_key"),
+    ("sort-key", "sort_key"),
+    ("partition-key", "partition_key"),
+    ("range-key", "range_key"),
+    ("hash-key", "hash_key"),
+    ("lookup-key", "lookup_key"),
+    ("cache-key", "cache_key"),
+    ("routing-key", "routing_key"),
+    ("idempotency-key", "idempotency_key"),
+    ("public-key", "public_key"),
+    ("object-key", "object_key"),
+    ("s3-key", "s3_key"),
+    ("idempotency-token", "idempotency_token"),
+    ("next-token", "next_token"),
+    ("page-token", "page_token"),
+    ("continuation-token", "continuation_token"),
+    ("cursor-token", "cursor_token"),
+    ("sync-token", "sync_token"),
+    ("pagination-token", "pagination_token"),
+]
+
+
+@pytest.mark.parametrize(
+    ("hyphen_key", "underscore_key"), _HYPHEN_QUALIFIER_REGRESSION_PAIRS
+)
+def test_redact_sensitive_text_masks_hyphenated_structural_qualifiers(
+    hyphen_key: str, underscore_key: str
+) -> None:
+    hyphen_text = f"{hyphen_key}=SECRET-abc123"
+    underscore_text = f"{underscore_key}=SECRET-abc123"
+
+    assert redact_sensitive_text(hyphen_text) == f"{hyphen_key}=***c123"
+    assert redact_sensitive_text(underscore_text) == underscore_text
+
+
+def test_redact_sensitive_text_still_masks_prefixed_key_despite_hyphen_gate() -> None:
+    # The hyphen-vs-underscore gate above only governs the non-credential
+    # qualifier exemption; it must not weaken the fail-closed prefixed-key
+    # masking (#2304), which has no exemption at all.
+    assert redact_sensitive_text("MCP_API_KEY=SECRET-abc123") == "MCP_API_KEY=***c123"
+
+
 # ``*_token`` names that locate a page or de-duplicate a request; they are not
 # credentials, and this text reaches user- and model-facing error messages.
+# The exemption only fires when the qualifier is joined to ``token`` by
+# ``_`` (see ``_is_credential_key``); a hyphen join is masked, so
+# hyphenated names like ``x-idempotency-token`` and ``--page-token`` are
+# not listed here even though their qualifier is the same word.
 _POSITION_MARKER_TOKEN_KEYS = (
     "idempotency_token next_token page_token continuation_token cursor_token "
-    "sync_token pagination_token next_page_token X_IDEMPOTENCY_TOKEN "
-    "x-idempotency-token --page-token"
+    "sync_token pagination_token next_page_token X_IDEMPOTENCY_TOKEN"
 ).split()
 # Credential ``*_token`` names (``page_access_token`` puts a position word in
-# front of ``access_token``), the ``*_key`` family that must keep masking, and
-# every ``*_key`` qualifier that is not also a ``*_token`` one (``public_token``).
+# front of ``access_token``), the ``*_key`` family that must keep masking,
+# every ``*_key`` qualifier that is not also a ``*_token`` one (``public_token``),
+# and hyphen-joined position-marker names -- the exemption above only exempts
+# an underscore join, so these are masked.
 _CREDENTIAL_TOKEN_KEYS = (
     "token access_token refresh_token id_token session_token auth_token "
     "api_token bearer_token csrf_token oauth_token github_token "
     "MCP_ACCESS_TOKEN page_access_token client_token "
-    "AWS_SECRET_ACCESS_KEY MCP_API_KEY api_key"
+    "AWS_SECRET_ACCESS_KEY MCP_API_KEY api_key "
+    "x-idempotency-token --page-token"
 ).split() + [
     f"{qualifier}_token"
     for qualifier in sorted(

--- a/tests/core/model/test_security.py
+++ b/tests/core/model/test_security.py
@@ -8,6 +8,9 @@ import httpx
 import pytest
 
 from xagent.core.utils.security import (
+    _NON_CREDENTIAL_KEY_QUALIFIERS,
+    _NON_CREDENTIAL_QUALIFIERS_BY_SUFFIX,
+    _NON_CREDENTIAL_TOKEN_QUALIFIERS,
     PrivateNetworkHostError,
     fetch_public_http_bytes,
     redact_sensitive_text,
@@ -375,6 +378,62 @@ def test_redact_sensitive_text_leaves_non_credential_key_suffixes() -> None:
     )
 
     assert redact_sensitive_text(text) == text
+
+
+# ``*_token`` names that locate a page or de-duplicate a request; they are not
+# credentials, and this text reaches user- and model-facing error messages.
+_POSITION_MARKER_TOKEN_KEYS = (
+    "idempotency_token next_token page_token continuation_token cursor_token "
+    "sync_token pagination_token next_page_token X_IDEMPOTENCY_TOKEN "
+    "x-idempotency-token --page-token"
+).split()
+# Credential ``*_token`` names (``page_access_token`` puts a position word in
+# front of ``access_token``), the ``*_key`` family that must keep masking, and
+# every ``*_key`` qualifier that is not also a ``*_token`` one (``public_token``).
+_CREDENTIAL_TOKEN_KEYS = (
+    "token access_token refresh_token id_token session_token auth_token "
+    "api_token bearer_token csrf_token oauth_token github_token "
+    "MCP_ACCESS_TOKEN page_access_token client_token "
+    "AWS_SECRET_ACCESS_KEY MCP_API_KEY api_key"
+).split() + [
+    f"{qualifier}_token"
+    for qualifier in sorted(
+        _NON_CREDENTIAL_KEY_QUALIFIERS - _NON_CREDENTIAL_TOKEN_QUALIFIERS
+    )
+]
+
+
+@pytest.mark.parametrize("key", _POSITION_MARKER_TOKEN_KEYS)
+def test_redact_sensitive_text_leaves_position_marker_tokens(key: str) -> None:
+    text = f"{key}=opaque-cursor-123 rejected"
+
+    assert redact_sensitive_text(text) == text
+
+
+@pytest.mark.parametrize("key", _CREDENTIAL_TOKEN_KEYS)
+def test_redact_sensitive_text_masks_credential_tokens(key: str) -> None:
+    text = f"{key}=SECRET-abc123 rejected"
+
+    assert redact_sensitive_text(text) == f"{key}=***c123 rejected"
+
+
+def test_non_credential_qualifiers_are_listed_per_suffix() -> None:
+    # Each word here leaves ``<word>_token=`` unmasked. Before adding one, add
+    # ``<word>_token`` to _POSITION_MARKER_TOKEN_KEYS and check that no
+    # service uses that name for a credential.
+    assert set(_NON_CREDENTIAL_QUALIFIERS_BY_SUFFIX) == {"key", "token"}
+    assert _NON_CREDENTIAL_TOKEN_QUALIFIERS == {
+        "idempotency",
+        "next",
+        "page",
+        "continuation",
+        "cursor",
+        "sync",
+        "pagination",
+    }
+    assert {f"{q}_token" for q in _NON_CREDENTIAL_TOKEN_QUALIFIERS} <= set(
+        _POSITION_MARKER_TOKEN_KEYS
+    )
 
 
 def test_redact_sensitive_text_still_masks_bare_and_cli_style_keys() -> None:

--- a/tests/core/model/test_security.py
+++ b/tests/core/model/test_security.py
@@ -522,3 +522,17 @@ def test_redact_sensitive_text_is_linear_on_hostile_assignment_runs(
     started = time.perf_counter()
     redact_sensitive_text(hostile)
     assert time.perf_counter() - started < 1.0
+
+
+def test_redact_sensitive_text_leaves_a_credential_without_a_value() -> None:
+    # A credential name followed directly by ``&``, whitespace or the end of
+    # the text has no value to mask; the text after it is still scanned.
+    assert (
+        redact_sensitive_text("api_key=&token=SECRET-abc123")
+        == "api_key=&token=***c123"
+    )
+    assert (
+        redact_sensitive_text("missing api_key= in request")
+        == "missing api_key= in request"
+    )
+    assert redact_sensitive_text("host=db;api_key=") == "host=db;api_key="

--- a/tests/core/model/test_security.py
+++ b/tests/core/model/test_security.py
@@ -309,3 +309,39 @@ def test_redact_sensitive_text_masks_assignment_style_secrets() -> None:
     assert "sk-super-secret" not in redacted
     assert "api_key=***" in redacted
     assert "timeout=30" in redacted
+
+
+def test_redact_sensitive_text_masks_prefixed_assignment_keys() -> None:
+    text = (
+        "MCP_API_KEY=SECRET-abc123 rejected; "
+        "SERVICE_ACCESS_TOKEN=tok-987654 expired; "
+        "DB_PASSWORD=pw-secret-1 refused; "
+        "x-client-secret=cs-000111 invalid"
+    )
+    redacted = redact_sensitive_text(text)
+
+    assert "SECRET-abc123" not in redacted
+    assert "tok-987654" not in redacted
+    assert "pw-secret-1" not in redacted
+    assert "cs-000111" not in redacted
+    assert redacted == (
+        "MCP_API_KEY=***c123 rejected; "
+        "SERVICE_ACCESS_TOKEN=***7654 expired; "
+        "DB_PASSWORD=***et-1 refused; "
+        "x-client-secret=***0111 invalid"
+    )
+
+
+def test_redact_sensitive_text_leaves_non_credential_key_suffixes() -> None:
+    # ``key`` alone is a credential word only when it stands by itself: a
+    # prefixed ``*_key`` names an ordinary field, and this text reaches
+    # user- and model-facing error messages, so it must stay readable.
+    text = "primary_key=42 sort_key=created_at PUBLIC_KEY=pem-body cache_key=user:42"
+
+    assert redact_sensitive_text(text) == text
+
+
+def test_redact_sensitive_text_still_masks_bare_and_cli_style_keys() -> None:
+    redacted = redact_sensitive_text("key=SECRET-bare --api-key=sk-cli-secret")
+
+    assert redacted == "key=***bare --api-key=***cret"

--- a/tests/core/model/test_security.py
+++ b/tests/core/model/test_security.py
@@ -1,6 +1,7 @@
 """Tests for shared security helpers."""
 
 import socket
+import time
 from unittest.mock import patch
 
 import httpx
@@ -345,3 +346,17 @@ def test_redact_sensitive_text_still_masks_bare_and_cli_style_keys() -> None:
     redacted = redact_sensitive_text("key=SECRET-bare --api-key=sk-cli-secret")
 
     assert redacted == "key=***bare --api-key=***cret"
+
+
+def test_redact_sensitive_text_is_linear_on_hostile_identifier_runs() -> None:
+    # A remote service controls this text. A long run of ``_``-joined
+    # identifier segments with no ``=`` must fail once per run, not once per
+    # segment split: a nested ``(prefix_)*word`` quantifier took seconds on
+    # 20 kB of this input; the current pattern takes well under a
+    # millisecond. The budget is loose on purpose so a slow CI worker cannot
+    # trip it, while a quadratic regression (tens of seconds here) still does.
+    hostile = "a_" * 50_000
+
+    started = time.perf_counter()
+    assert redact_sensitive_text(hostile) == hostile
+    assert time.perf_counter() - started < 1.0

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -3659,6 +3659,6 @@ def test_only_read_only_is_a_safe_reading():
     ],
 )
 def test_redact_urls_in_text_edge_shapes(text, expected):
-    from xagent.core.tools.adapters.vibe.mcp_adapter import _redact_urls_in_text
+    from xagent.core.tools.adapters.vibe.mcp_adapter import redact_urls_in_text
 
-    assert _redact_urls_in_text(text) == expected
+    assert redact_urls_in_text(text) == expected

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -1255,6 +1255,118 @@ def test_mcp_runtime_tool_argument_missing_source_warns(caplog):
     assert "list_clients" in caplog.text
 
 
+def test_mcp_runtime_tool_argument_undeclared_target_warns_and_is_skipped(caplog):
+    """A runtime binding can name a tool argument the connector author
+    thinks exists. If the tool's actual input schema (from tools/list)
+    doesn't declare that argument, the binding must be dropped loudly, not
+    silently -- the previous silent `continue` gave no signal that the
+    connector's runtime_bindings and the tool's real schema had drifted
+    apart."""
+    mcp_tool = SimpleNamespace(
+        name="list_clients",
+        description="List clients",
+        inputSchema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+        },
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={
+            "transport": "stdio",
+            "command": "python",
+            "args": [],
+            "runtime_bindings": [
+                {
+                    "source": {"input_type": "context", "key": "account_id"},
+                    "target": {
+                        "target_type": "tool_arguments",
+                        "key": "account_id",
+                    },
+                },
+            ],
+            "connector_runtime": {
+                "context": {"account_id": "6185"},
+                "secrets": {},
+                "auth_selector": {},
+            },
+        },
+    )
+
+    caplog.set_level("WARNING")
+    assert adapter._runtime_tool_arguments() == {}
+    assert (
+        "does not declare this argument" in caplog.text
+        or "input schema does not declare" in caplog.text
+    )
+    assert "account_id" in caplog.text
+    assert "list_clients" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_call_proceeds_when_runtime_binding_target_is_undeclared(
+    monkeypatch,
+):
+    """Even though the runtime binding above can't be applied, the tool call
+    itself must still go through -- an undeclared binding target degrades to
+    'this one argument isn't injected', not 'the tool call fails'."""
+    mcp_tool = SimpleNamespace(
+        name="list_clients",
+        description="List clients",
+        inputSchema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+        },
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={
+            "transport": "stdio",
+            "command": "python",
+            "args": [],
+            "runtime_bindings": [
+                {
+                    "source": {"input_type": "context", "key": "account_id"},
+                    "target": {
+                        "target_type": "tool_arguments",
+                        "key": "account_id",
+                    },
+                },
+            ],
+            "connector_runtime": {
+                "context": {"account_id": "6185"},
+                "secrets": {},
+                "auth_selector": {},
+            },
+        },
+    )
+
+    captured: dict[str, Any] = {}
+
+    class _FakeSession:
+        async def initialize(self):
+            return None
+
+        async def call_tool(self, name, arguments, **kwargs):
+            captured["name"] = name
+            captured["arguments"] = arguments
+            return CallToolResult(content=[], isError=False)
+
+    @asynccontextmanager
+    async def _fake_create_session(_connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.create_session",
+        _fake_create_session,
+    )
+
+    result = await adapter.run_json_async({"query": "active"})
+
+    assert result["is_error"] is False
+    assert captured["arguments"] == {"query": "active"}
+
+
 def _resolver_retry_adapter(connection):
     return MCPToolAdapter(
         mcp_tool=SimpleNamespace(
@@ -2208,6 +2320,201 @@ async def test_mcp_tool_execution_error_does_not_echo_raw_exception(monkeypatch)
     assert result["is_error"] is True
     assert result["content"][0]["text"] == "Error executing MCP tool."
     assert "runtime-token" not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_execution_error_logs_truncated_message(monkeypatch, caplog):
+    """The generic-exception handler must log the server's actual error
+    message (bounded), not just the exception's class name, so an on-call
+    engineer reading the log can see what the server actually said."""
+    mcp_tool = SimpleNamespace(
+        name="list_clients",
+        description="List clients",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+    overlong_detail = "server-said-this-and-nothing-else-" + "z" * 600
+
+    class _FakeSession:
+        async def initialize(self):
+            raise RuntimeError(overlong_detail)
+
+    @asynccontextmanager
+    async def _fake_create_session(connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.create_session",
+        _fake_create_session,
+    )
+    caplog.set_level("ERROR")
+
+    result = await adapter.run_json_async({})
+
+    assert result == {
+        "content": [{"text": "Error executing MCP tool."}],
+        "is_error": True,
+    }
+    # No traceback is attached to this log record: attaching one would print
+    # the exception's raw, unbounded message a second time (Python's own
+    # traceback formatting bypasses the truncation below), defeating the
+    # bound. So the untruncated payload must not appear anywhere in the
+    # emitted log, not just outside the formatted message field.
+    assert "RuntimeError" in caplog.text
+    assert "server-said-this-and-nothing-else-" in caplog.text
+    assert overlong_detail not in caplog.text
+    assert caplog.records[-1].exc_info is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_execution_error_redacts_url_query_and_userinfo(
+    monkeypatch, caplog
+):
+    """httpx.HTTPStatusError formats its own message as "... for url
+    '<url>'". Connector URLs commonly carry secrets (API keys, tokens) in
+    the query string, so the logged message must have the query string
+    dropped while still naming the host and status so the log stays
+    useful."""
+    mcp_tool = SimpleNamespace(
+        name="list_clients",
+        description="List clients",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+    request = httpx.Request(
+        "POST",
+        "https://mcp.example.test/mcp?api_key=SECRET-abc123&tenant=acme",
+    )
+    response = httpx.Response(403, request=request)
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        response.raise_for_status()
+    status_error = exc_info.value
+
+    class _FakeSession:
+        async def initialize(self):
+            raise status_error
+
+    @asynccontextmanager
+    async def _fake_create_session(connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.create_session",
+        _fake_create_session,
+    )
+    caplog.set_level("ERROR")
+
+    result = await adapter.run_json_async({})
+
+    assert result == {
+        "content": [{"text": "Error executing MCP tool."}],
+        "is_error": True,
+    }
+    assert "SECRET-abc123" not in caplog.text
+    assert "tenant=acme" not in caplog.text
+    assert "403" in caplog.text
+    assert "mcp.example.test" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_execution_error_redacts_url_userinfo(monkeypatch, caplog):
+    """A message that embeds a URL with userinfo (``user:pass@host``) must
+    have both the credentials and the query string stripped before
+    logging."""
+    mcp_tool = SimpleNamespace(
+        name="list_clients",
+        description="List clients",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+
+    class _FakeSession:
+        async def initialize(self):
+            raise RuntimeError(
+                "upstream refused connection to https://user:pw@host/path?x=1"
+            )
+
+    @asynccontextmanager
+    async def _fake_create_session(connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.create_session",
+        _fake_create_session,
+    )
+    caplog.set_level("ERROR")
+
+    result = await adapter.run_json_async({})
+
+    assert result == {
+        "content": [{"text": "Error executing MCP tool."}],
+        "is_error": True,
+    }
+    assert "pw" not in caplog.text
+    assert "x=1" not in caplog.text
+    assert "host" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_execution_error_group_logs_each_sub_exception(
+    monkeypatch, caplog
+):
+    """The exception-group handler must log each leaf exception's own class
+    and message (bounded), not just the group's class name -- a fan-out MCP
+    call raises one group per failed leg (and the MCP client's own two
+    nested task groups can wrap that again), and a group itself carries no
+    detail about which leg failed or why. Nested groups must be expanded to
+    their leaves rather than logged as an opaque inner ExceptionGroup."""
+    mcp_tool = SimpleNamespace(
+        name="list_clients",
+        description="List clients",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+
+    class _FakeSession:
+        async def initialize(self):
+            raise BaseExceptionGroup(
+                "outer",
+                [
+                    BaseExceptionGroup("inner", [RuntimeError("first-leg-failed")]),
+                    ValueError("second-leg"),
+                ],
+            )
+
+    @asynccontextmanager
+    async def _fake_create_session(connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.create_session",
+        _fake_create_session,
+    )
+    caplog.set_level("ERROR")
+
+    result = await adapter.run_json_async({})
+
+    assert result == {
+        "content": [{"text": "Error executing MCP tool."}],
+        "is_error": True,
+    }
+    assert "RuntimeError" in caplog.text
+    assert "first-leg-failed" in caplog.text
+    assert "ValueError" in caplog.text
+    assert "second-leg" in caplog.text
+    assert "related exception ExceptionGroup" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -3332,3 +3639,26 @@ def test_only_read_only_is_a_safe_reading():
         MCPWriteHint.DESTRUCTIVE,
         MCPWriteHint.UNDECLARED,
     }
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("HTTPS://H.EXAMPLE/P?K=SECRET", "https://H.EXAMPLE/P"),
+        ("https://cb.example/done#access_token=TOKEN&t=b", "https://cb.example/done"),
+        ("https://[::1]:8080/x?y=1 done", "https://[::1]:8080/x done"),
+        ("https://user:pw@Host.Example:8443/p?x=1", "https://Host.Example:8443/p"),
+        ("https://[::1/x?y=1 done", "<url redacted> done"),
+    ],
+    ids=[
+        "uppercase-scheme",
+        "fragment-dropped",
+        "ipv6-brackets-kept",
+        "userinfo-and-case",
+        "unparsable",
+    ],
+)
+def test_redact_urls_in_text_edge_shapes(text, expected):
+    from xagent.core.tools.adapters.vibe.mcp_adapter import _redact_urls_in_text
+
+    assert _redact_urls_in_text(text) == expected

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -2375,6 +2375,54 @@ async def test_mcp_tool_execution_error_logs_truncated_message(monkeypatch, capl
 
 
 @pytest.mark.asyncio
+async def test_mcp_tool_execution_error_redacts_prefixed_credential_assignments(
+    monkeypatch, caplog
+):
+    """A server error that echoes a prefixed credential assignment such as
+    ``MCP_API_KEY=...`` must not leave the raw value in any emitted log
+    record: the shared sanitizer masks the value while keeping the key name
+    so the log still says which setting the server complained about."""
+    mcp_tool = SimpleNamespace(
+        name="list_clients",
+        description="List clients",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+
+    class _FakeSession:
+        async def initialize(self):
+            raise RuntimeError(
+                "MCP_API_KEY=SECRET-abc123 rejected; "
+                "SERVICE_ACCESS_TOKEN=tok-987654 expired"
+            )
+
+    @asynccontextmanager
+    async def _fake_create_session(connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.create_session",
+        _fake_create_session,
+    )
+    caplog.set_level("ERROR")
+
+    result = await adapter.run_json_async({})
+
+    assert result == {
+        "content": [{"text": "Error executing MCP tool."}],
+        "is_error": True,
+    }
+    assert "SECRET-abc123" not in caplog.text
+    assert "tok-987654" not in caplog.text
+    assert "MCP_API_KEY=***c123 rejected" in caplog.text
+    assert "SERVICE_ACCESS_TOKEN=***7654 expired" in caplog.text
+    assert caplog.records[-1].exc_info is None
+
+
+@pytest.mark.asyncio
 async def test_mcp_tool_execution_error_redacts_url_query_and_userinfo(
     monkeypatch, caplog
 ):
@@ -3758,6 +3806,14 @@ def test_only_read_only_is_a_safe_reading():
         (
             "config error: api_key=SECRET-abc123",
             "config error: api_key=***c123",
+        ),
+        (
+            "MCP_API_KEY=SECRET-abc123 rejected",
+            "MCP_API_KEY=***c123 rejected",
+        ),
+        (
+            "SERVICE_ACCESS_TOKEN=tok-987654 expired",
+            "SERVICE_ACCESS_TOKEN=***7654 expired",
         ),
     ],
 )

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -2407,7 +2407,9 @@ async def test_mcp_tool_execution_error_redacts_prefixed_credential_assignments(
         "xagent.core.tools.adapters.vibe.mcp_adapter.create_session",
         _fake_create_session,
     )
-    caplog.set_level("ERROR")
+    # Capture every level, not just ERROR: the guarantee is that the raw
+    # value is absent from every record this call emits.
+    caplog.set_level("DEBUG")
 
     result = await adapter.run_json_async({})
 

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -1297,12 +1297,44 @@ def test_mcp_runtime_tool_argument_undeclared_target_warns_and_is_skipped(caplog
 
     caplog.set_level("WARNING")
     assert adapter._runtime_tool_arguments() == {}
-    assert (
-        "does not declare this argument" in caplog.text
-        or "input schema does not declare" in caplog.text
+    assert [(record.levelname, record.getMessage()) for record in caplog.records] == [
+        (
+            "WARNING",
+            "Skipping runtime MCP tool argument binding for account_id on tool "
+            "list_clients: the tool's input schema does not declare this argument",
+        )
+    ]
+
+
+@pytest.mark.parametrize("target_key", [123, None])
+def test_mcp_runtime_tool_argument_non_string_target_key_is_skipped_silently(
+    caplog, target_key
+):
+    """A binding whose target key is not a string is dropped without any log
+    line, unlike a string key the tool's schema does not declare, which warns."""
+    adapter = MCPToolAdapter(
+        mcp_tool=_mcp_tool("list_clients"),
+        connection={
+            "transport": "stdio",
+            "command": "python",
+            "args": [],
+            "runtime_bindings": [
+                {
+                    "source": {"input_type": "context", "key": "account_id"},
+                    "target": {"target_type": "tool_arguments", "key": target_key},
+                },
+            ],
+            "connector_runtime": {
+                "context": {"account_id": "6185"},
+                "secrets": {},
+                "auth_selector": {},
+            },
+        },
     )
-    assert "account_id" in caplog.text
-    assert "list_clients" in caplog.text
+
+    caplog.set_level("DEBUG")
+    assert adapter._runtime_tool_arguments() == {}
+    assert caplog.records == []
 
 
 @pytest.mark.asyncio
@@ -2570,6 +2602,7 @@ async def test_mcp_tool_execution_error_group_logs_each_sub_exception(
     assert "ValueError" in caplog.text
     assert "second-leg" in caplog.text
     assert "related exception ExceptionGroup" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
 
 
 async def _run_json_with_failure(monkeypatch, exc: BaseException) -> dict[str, Any]:

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -19,6 +19,7 @@ from xagent.core.model.chat.basic.claude import _fix_pydantic_schema_for_claude
 from xagent.core.tools.adapters.vibe import mcp_adapter as mcp_adapter_module
 from xagent.core.tools.adapters.vibe.mcp_adapter import (
     _FIELD_TEXT_MAX_CHARS,
+    _MCP_TOOL_ERROR_LOG_MAX_CHARS,
     EmptyArgsModel,
     MCPFailurePhase,
     MCPServerLoadFailure,
@@ -28,6 +29,7 @@ from xagent.core.tools.adapters.vibe.mcp_adapter import (
     _compact_json,
     _exception_indicates_http_401,
     _mcp_return_value_as_string,
+    _truncated_error_message,
     classify_non_idempotent_write,
     classify_write_hint,
     load_mcp_tools_as_agent_tools,
@@ -509,7 +511,7 @@ def test_resolver_challenge_traversal_stops_at_named_node_budget():
     current: BaseException = _http_status_error(
         authenticate=['Bearer error="invalid_token"']
     )
-    for index in range(mcp_adapter_module._RESOLVER_HTTP_401_NODE_LIMIT):
+    for index in range(mcp_adapter_module._EXCEPTION_WALK_NODE_LIMIT):
         wrapper = RuntimeError(f"wrapper-{index}")
         wrapper.__cause__ = current
         current = wrapper
@@ -1981,7 +1983,7 @@ async def test_resolver_retry_prunes_over_budget_initial_exception_subtree(
     deep_original: BaseException = _http_status_error(
         authenticate=['Bearer error="invalid_token"']
     )
-    for index in range(mcp_adapter_module._RESOLVER_HTTP_401_NODE_LIMIT + 1):
+    for index in range(mcp_adapter_module._EXCEPTION_WALK_NODE_LIMIT + 1):
         wrapper = RuntimeError(f"initial-wrapper-{index}")
         wrapper.__cause__ = deep_original
         deep_original = wrapper
@@ -2367,6 +2369,9 @@ async def test_mcp_tool_execution_error_logs_truncated_message(monkeypatch, capl
     assert "server-said-this-and-nothing-else-" in caplog.text
     assert overlong_detail not in caplog.text
     assert caplog.records[-1].exc_info is None
+    truncated = caplog.records[-1].args[-1]
+    assert len(truncated) == _MCP_TOOL_ERROR_LOG_MAX_CHARS
+    assert truncated.endswith("…")
 
 
 @pytest.mark.asyncio
@@ -2459,9 +2464,9 @@ async def test_mcp_tool_execution_error_redacts_url_userinfo(monkeypatch, caplog
         "content": [{"text": "Error executing MCP tool."}],
         "is_error": True,
     }
-    assert "pw" not in caplog.text
-    assert "x=1" not in caplog.text
-    assert "host" in caplog.text
+    assert caplog.records[-1].args[-1] == (
+        "upstream refused connection to https://host/path"
+    )
 
 
 @pytest.mark.asyncio
@@ -2515,6 +2520,84 @@ async def test_mcp_tool_execution_error_group_logs_each_sub_exception(
     assert "ValueError" in caplog.text
     assert "second-leg" in caplog.text
     assert "related exception ExceptionGroup" not in caplog.text
+
+
+async def _run_json_with_failure(monkeypatch, exc: BaseException) -> dict[str, Any]:
+    """Run an adapter whose session raises ``exc`` and return its result."""
+    adapter = MCPToolAdapter(
+        mcp_tool=_mcp_tool("list_clients"),
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+
+    class _FakeSession:
+        async def initialize(self):
+            raise exc
+
+    @asynccontextmanager
+    async def _fake_create_session(_connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(mcp_adapter_module, "create_session", _fake_create_session)
+    return await adapter.run_json_async({})
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_execution_error_group_logs_every_member_before_chains(
+    monkeypatch, caplog
+):
+    """A fan-out call raises one group member per failed leg. If one leg's
+    own __cause__/__context__ chain runs deep, a depth-first walk spends the
+    whole per-call log budget on that one leg's chain and the other legs
+    never get a line. Every member must get a line before any single
+    member's chain is followed further."""
+    member_a: BaseException = RuntimeError("member-a-root")
+    for level in range(1, 8):
+        wrapper = RuntimeError(f"member-a-chain-{level}")
+        wrapper.__context__ = member_a
+        member_a = wrapper
+
+    exc_group = BaseExceptionGroup(
+        "fan-out",
+        [member_a, ValueError("second-leg"), ValueError("third-leg")],
+    )
+    caplog.set_level("ERROR")
+
+    result = await _run_json_with_failure(monkeypatch, exc_group)
+
+    assert result == {
+        "content": [{"text": "Error executing MCP tool."}],
+        "is_error": True,
+    }
+    assert "second-leg" in caplog.text
+    assert "third-leg" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_execution_error_group_survives_exploding_context_str(
+    monkeypatch, caplog
+):
+    """A group member's __context__ can itself be an exception whose
+    __str__ raises. ``_exception_indicates_http_401`` only recurses into a
+    group's own members, not its __cause__/__context__ chain, so that
+    incidental protection does not cover this shape: the logging path
+    itself must not let a misbehaving __str__ escape ``run_json_async``."""
+
+    class _ExplodingStr(Exception):
+        def __str__(self):
+            raise ValueError("__str__ exploded")
+
+    member = RuntimeError("member-ok")
+    member.__context__ = _ExplodingStr()
+    exc_group = BaseExceptionGroup("fan-out", [member])
+    caplog.set_level("ERROR")
+
+    result = await _run_json_with_failure(monkeypatch, exc_group)
+
+    assert result == {
+        "content": [{"text": "Error executing MCP tool."}],
+        "is_error": True,
+    }
+    assert "_ExplodingStr" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -3411,6 +3494,25 @@ def test_description_length_boundary(length, truncated):
         assert description == raw
 
 
+@pytest.mark.parametrize(
+    "length,truncated",
+    [
+        (_MCP_TOOL_ERROR_LOG_MAX_CHARS - 1, False),
+        (_MCP_TOOL_ERROR_LOG_MAX_CHARS, False),
+        (_MCP_TOOL_ERROR_LOG_MAX_CHARS + 1, True),
+    ],
+)
+def test_truncated_error_message_length_boundary(length, truncated):
+    """The cap is inclusive: exactly the cap is kept, one over is shortened."""
+    message = _truncated_error_message(RuntimeError("a" * length))
+
+    assert len(message) <= _MCP_TOOL_ERROR_LOG_MAX_CHARS
+    if truncated:
+        assert message == "a" * (_MCP_TOOL_ERROR_LOG_MAX_CHARS - 1) + "…"
+    else:
+        assert message == "a" * length
+
+
 def _listing(*annotations: object) -> dict[str, Any]:
     """A ``tools/list`` payload whose tools carry the given raw annotations."""
     tools = []
@@ -3642,6 +3744,31 @@ def test_only_read_only_is_a_safe_reading():
 
 
 @pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (
+            "wss://mcp.example.test/ws?api_key=SECRET-abc123 rejected",
+            "wss://mcp.example.test/ws rejected",
+        ),
+        (
+            "Authorization: Bearer ey.SECRETJWT.sig",
+            "Authorization: Bearer ***.sig",
+        ),
+        ("x-api-key: SECRET-abc123", "x-api-key: ***c123"),
+        (
+            "config error: api_key=SECRET-abc123",
+            "config error: api_key=***c123",
+        ),
+    ],
+)
+def test_truncated_error_message_redacts_non_url_secret_shapes(message, expected):
+    """``_truncated_error_message`` must also mask header- and
+    assignment-shaped secrets that never sit inside a URL token, on top of
+    the URL redaction ``redact_urls_in_text`` already does."""
+    assert _truncated_error_message(RuntimeError(message)) == expected
+
+
+@pytest.mark.parametrize(
     ("text", "expected"),
     [
         ("HTTPS://H.EXAMPLE/P?K=SECRET", "https://H.EXAMPLE/P"),
@@ -3649,6 +3776,16 @@ def test_only_read_only_is_a_safe_reading():
         ("https://[::1]:8080/x?y=1 done", "https://[::1]:8080/x done"),
         ("https://user:pw@Host.Example:8443/p?x=1", "https://Host.Example:8443/p"),
         ("https://[::1/x?y=1 done", "<url redacted> done"),
+        ("wss://h/ws?api_key=SECRET rejected", "wss://h/ws rejected"),
+        ("ws://h/p?tok=SECRET redirect", "ws://h/p redirect"),
+        ("see (https://h/p?k=s) ok", "see (https://h/p) ok"),
+        ("msg: https://h/p?k=s.", "msg: https://h/p."),
+        ("see https://[::1]", "see https://[::1]"),
+        (
+            "https://en.example/wiki/Foo_(bar)",
+            "https://en.example/wiki/Foo_(bar)",
+        ),
+        ("url=https://h/p?k=s,next", "url=https://h/p"),
     ],
     ids=[
         "uppercase-scheme",
@@ -3656,9 +3793,26 @@ def test_only_read_only_is_a_safe_reading():
         "ipv6-brackets-kept",
         "userinfo-and-case",
         "unparsable",
+        "wss-query-dropped",
+        "ws-query-dropped",
+        "trailing-paren",
+        "trailing-period",
+        "bare-ipv6-authority",
+        "balanced-paren-in-path",
+        "comma-inside-query-is-part-of-the-url",
     ],
 )
 def test_redact_urls_in_text_edge_shapes(text, expected):
+    """``comma-inside-query-is-part-of-the-url`` documents a known gap: the
+    comma sits inside the query string, not at the end of the token, so the
+    trailing-punctuation strip (which only looks at the token's own last
+    character) does not reach it. The only way to also recover the ``next``
+    that follows it would be excluding ``,`` from the URL token's character
+    class, but a comma is a legal query-string character -- doing that
+    would split a secret that happens to contain a comma into two pieces
+    and leave the second piece in the log. This case pins the current,
+    deliberate trade-off; it must turn red if that trade-off is reversed.
+    """
     from xagent.core.tools.adapters.vibe.mcp_adapter import redact_urls_in_text
 
     assert redact_urls_in_text(text) == expected

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -3,6 +3,7 @@ import logging
 import re
 import subprocess
 import sys
+import time
 from contextlib import asynccontextmanager
 from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
@@ -20,6 +21,7 @@ from xagent.core.tools.adapters.vibe import mcp_adapter as mcp_adapter_module
 from xagent.core.tools.adapters.vibe.mcp_adapter import (
     _FIELD_TEXT_MAX_CHARS,
     _MCP_TOOL_ERROR_LOG_MAX_CHARS,
+    _MCP_TOOL_ERROR_RAW_MAX_CHARS,
     EmptyArgsModel,
     MCPFailurePhase,
     MCPServerLoadFailure,
@@ -29,10 +31,12 @@ from xagent.core.tools.adapters.vibe.mcp_adapter import (
     _compact_json,
     _exception_indicates_http_401,
     _mcp_return_value_as_string,
+    _split_url_token,
     _truncated_error_message,
     classify_non_idempotent_write,
     classify_write_hint,
     load_mcp_tools_as_agent_tools,
+    redact_urls_in_text,
 )
 from xagent.core.tools.adapters.vibe.tool_naming_limits import (
     MAX_AGENT_TOOL_NAME_LENGTH,
@@ -3869,8 +3873,10 @@ def test_truncated_error_message_redacts_non_url_secret_shapes(message, expected
         ("https://[::1/x?y=1 done", "<url redacted> done"),
         ("wss://h/ws?api_key=SECRET rejected", "wss://h/ws rejected"),
         ("ws://h/p?tok=SECRET redirect", "ws://h/p redirect"),
-        ("see (https://h/p?k=s) ok", "see (https://h/p) ok"),
-        ("msg: https://h/p?k=s.", "msg: https://h/p."),
+        ("see (https://h/p) ok", "see (https://h/p) ok"),
+        ("msg: https://h/p.", "msg: https://h/p."),
+        ("see (https://h/p?k=s) ok", "see (https://h/p ok"),
+        ("msg: https://h/p?k=s.", "msg: https://h/p"),
         ("see https://[::1]", "see https://[::1]"),
         (
             "https://en.example/wiki/Foo_(bar)",
@@ -3886,8 +3892,10 @@ def test_truncated_error_message_redacts_non_url_secret_shapes(message, expected
         "unparsable",
         "wss-query-dropped",
         "ws-query-dropped",
-        "trailing-paren",
-        "trailing-period",
+        "trailing-paren-no-query",
+        "trailing-period-no-query",
+        "trailing-paren-in-dropped-query",
+        "trailing-period-in-dropped-query",
         "bare-ipv6-authority",
         "balanced-paren-in-path",
         "comma-inside-query-is-part-of-the-url",
@@ -3903,7 +3911,115 @@ def test_redact_urls_in_text_edge_shapes(text, expected):
     would split a secret that happens to contain a comma into two pieces
     and leave the second piece in the log. This case pins the current,
     deliberate trade-off; it must turn red if that trade-off is reversed.
-    """
-    from xagent.core.tools.adapters.vibe.mcp_adapter import redact_urls_in_text
 
+    ``trailing-paren-in-dropped-query`` and ``trailing-period-in-dropped-query``
+    pin the fix for the mirror-image bug: the token's own trailing ``)``/
+    ``.`` sits right after a query string (``?k=s)`` / ``?k=s.``), so
+    stripping it as sentence punctuation *before* the query is located
+    would split a credential value ending in one of those characters off
+    its query, survive the query's removal, and get reattached to the
+    redacted URL. ``_split_url_token`` never looks past the query/fragment
+    boundary, so that trailing text is dropped with the rest of the query
+    instead -- these two cases have no trailing punctuation reattached,
+    unlike their no-query counterparts just above them.
+    """
     assert redact_urls_in_text(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("token", "expected_clean", "expected_trailing"),
+    [
+        ("https://h/p)))", "https://h/p", ")))"),
+        ("https://h/a(b)c", "https://h/a(b)c", ""),
+        ("https://[::1]", "https://[::1]", ""),
+        ("https://h/p,.;:", "https://h/p", ",.;:"),
+        ("https://h/p", "https://h/p", ""),
+    ],
+    ids=[
+        "unmatched-closing-bracket",
+        "matched-brackets-in-path",
+        "ipv6-authority-brackets",
+        "trailing-punctuation-run",
+        "no-trailing-punctuation",
+    ],
+)
+def test_split_url_token(token, expected_clean, expected_trailing):
+    """``_split_url_token`` is the boundary scan ``redact_urls_in_text`` uses
+    to separate a URL from sentence punctuation trailing it, extracted out
+    of ``_redact`` so it can be tested on its own. ``matched-brackets-in-path``
+    and ``ipv6-authority-brackets`` pin that a *balanced* bracket is never
+    treated as trailing punctuation, only an unmatched one is.
+    """
+    assert _split_url_token(token) == (expected_clean, expected_trailing)
+
+
+def test_split_url_token_stops_at_query_boundary():
+    """A trailing character that is actually the tail of a query value (a
+    credential ending in ``)``) must never be classified as sentence
+    punctuation: the scan stops at the first ``?``/``#`` in the token, so
+    nothing at or after that point can appear in either half of the
+    result. See ``test_redact_urls_in_text_does_not_reattach_query_tail``
+    for the same fix exercised through ``redact_urls_in_text``.
+    """
+    assert _split_url_token("https://h/p?api_key=S)))") == ("https://h/p", "")
+
+
+def test_redact_urls_in_text_is_linear_on_unmatched_closing_brackets():
+    """Before this fix, ``_redact``'s trailing-punctuation strip re-scanned
+    the whole token on every character it stripped (``token.count(...)``
+    plus ``token = token[:-1]``, both full-length operations run once per
+    stripped character), making it quadratic in the length of a run of
+    unmatched closing brackets -- measured at roughly 24s for a
+    300,000-character run before this fix. The budget below is loose on
+    purpose so a slow CI worker cannot trip it, while a quadratic
+    regression (tens of seconds here) still does.
+    """
+    text = "see https://mcp.example.com/x" + ")" * 300_000
+
+    start = time.perf_counter()
+    redact_urls_in_text(text)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 1.0
+
+
+def test_redact_urls_in_text_does_not_reattach_query_tail_as_trailing_punctuation():
+    """The trailing-punctuation strip used to run on the raw token before
+    the query string was located, so a credential value ending in a
+    character ``_split_url_token`` treats as sentence punctuation (a
+    closing paren, a period, or an unmatched bracket) had that tail split
+    off, survived the query being dropped, and was reattached to the
+    redacted URL -- leaking a few trailing characters of the credential.
+    The fix stops the boundary scan at the query separator, so the whole
+    query -- tail included -- is dropped together and nothing survives to
+    be reattached.
+    """
+    text = "connect failed for url 'https://mcp.example.com/p?api_key=S)))'"
+
+    result = redact_urls_in_text(text)
+
+    assert not result.endswith(")))'")
+    assert result == "connect failed for url 'https://mcp.example.com/p'"
+
+
+def test_truncated_error_message_bounds_raw_text_before_redaction(monkeypatch):
+    """``str(exc)`` is remote-controlled and has no length limit of its
+    own, while both redaction passes cost time proportional to their
+    input, so it must be capped to ``_MCP_TOOL_ERROR_RAW_MAX_CHARS``
+    before either one runs -- not just truncated to
+    ``_MCP_TOOL_ERROR_LOG_MAX_CHARS`` afterwards, which would leave both
+    passes running on the full, unbounded message.
+    """
+    seen_lengths = []
+    original_redact_urls = mcp_adapter_module.redact_urls_in_text
+
+    def spy(text):
+        seen_lengths.append(len(text))
+        return original_redact_urls(text)
+
+    monkeypatch.setattr(mcp_adapter_module, "redact_urls_in_text", spy)
+
+    message = _truncated_error_message(RuntimeError("x" * 100_000))
+
+    assert seen_lengths == [_MCP_TOOL_ERROR_RAW_MAX_CHARS]
+    assert len(message) <= _MCP_TOOL_ERROR_LOG_MAX_CHARS

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -13,7 +13,10 @@ from sqlalchemy.orm import sessionmaker
 
 from xagent.core.agent.runtime import PatternRuntime
 from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
-from xagent.core.tools.adapters.vibe.mcp_adapter import MCPToolAdapter
+from xagent.core.tools.adapters.vibe.mcp_adapter import (
+    MCPToolAdapter,
+    redact_urls_in_text,
+)
 from xagent.core.utils.encryption import encrypt_value
 from xagent.web.models.database import Base
 from xagent.web.models.mcp import MCPServer, UserMCPServer
@@ -1681,6 +1684,74 @@ async def test_hook_failure_warning_includes_failure_code(
     assert configs[0]["config"]["failure_code"] == "oauth_token_required"
     assert "oauth_token_required" in caplog.text
     assert "secret-reauth-detail" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_hook_failure_warning_redacts_and_bounds_resource(
+    db_session,
+    caplog,
+):
+    """The resource logged on a resolver failure can fall back to a
+    self-hosted MCP server's own URL, and custom connectors commonly carry
+    an API key or other secret in that URL's query string or userinfo. The
+    warning must strip those before logging, and it must still bound the
+    result the way every other field logged here already is."""
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    resource = (
+        "https://user:pw@mcp.example.com/oauth/"
+        + "r" * 160
+        + "?api_key=SECRET-abc123&tenant=acme"
+    )
+    _add_oauth_server(db, user, launch_config=_launch_config(resource=resource))
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        raise RuntimeError("resolver failed")
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    expected = web_tools_config._bounded_oauth_metadata(redact_urls_in_text(resource))
+    assert "SECRET-abc123" not in caplog.text
+    assert "tenant=acme" not in caplog.text
+    assert "user:pw@" not in caplog.text
+    assert "mcp.example.com" in caplog.text
+    assert f"resource={expected}" in caplog.text
+    assert expected.endswith("...")
+    assert len(expected) == 128
+
+
+@pytest.mark.asyncio
+async def test_hook_failure_warning_redacts_short_resource_query_string(
+    db_session,
+    caplog,
+):
+    """A resource short enough to survive the 128-character bound intact must
+    still lose its query string. Without this case the bound alone satisfies
+    the secret-absence assertions on the long resource above, so redaction
+    could regress without turning any test red."""
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    resource = "https://mcp.example.test/oauth?api_key=SECRET-abc123&tenant=acme"
+    assert len(resource) < 128
+    _add_oauth_server(db, user, launch_config=_launch_config(resource=resource))
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        raise RuntimeError("resolver failed")
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert "SECRET-abc123" not in caplog.text
+    assert "tenant=acme" not in caplog.text
+    assert "mcp.example.test" in caplog.text
+    assert "resource=https://mcp.example.test/oauth" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -1653,6 +1653,37 @@ async def test_hook_failure_does_not_fallback_and_later_servers_still_build(
 
 
 @pytest.mark.asyncio
+async def test_hook_failure_warning_includes_failure_code(
+    db_session,
+    caplog,
+):
+    """The warning logged for a resolver failure must carry the classified
+    failure code (e.g. 'oauth_token_required'), not just the exception's
+    class name -- the class name alone tells an on-call engineer nothing
+    about whether this is a routine reconnect-required case versus an
+    unexpected resolver bug."""
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    _add_oauth_server(db, user, launch_config=_launch_config())
+    _add_user_oauth(db, user, provider="google", access_token="user-token")
+
+    class ReauthorizationRequired(RuntimeError):
+        oauth_token_resolver_failure_code = "oauth_token_required"
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        raise ReauthorizationRequired("secret-reauth-detail")
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    assert configs[0]["config"]["failure_code"] == "oauth_token_required"
+    assert "oauth_token_required" in caplog.text
+    assert "secret-reauth-detail" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_hook_connector_runtime_error_propagates(db_session):
     db, user = db_session
     _add_oauth_server(db, user, launch_config=_launch_config())

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -1722,6 +1722,8 @@ async def test_hook_failure_warning_redacts_and_bounds_resource(
     assert f"resource={expected}" in caplog.text
     assert expected.endswith("...")
     assert len(expected) == 128
+    assert cfg.get_mcp_oauth_diagnostics()[0]["resource"] == expected
+    assert configs[0]["config"]["diagnostic"]["resource"] == expected
 
 
 @pytest.mark.asyncio
@@ -1752,6 +1754,12 @@ async def test_hook_failure_warning_redacts_short_resource_query_string(
     assert "tenant=acme" not in caplog.text
     assert "mcp.example.test" in caplog.text
     assert "resource=https://mcp.example.test/oauth" in caplog.text
+    assert cfg.get_mcp_oauth_diagnostics()[0]["resource"] == (
+        "https://mcp.example.test/oauth"
+    )
+    assert configs[0]["config"]["diagnostic"]["resource"] == (
+        "https://mcp.example.test/oauth"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -1762,6 +1762,25 @@ async def test_hook_failure_warning_redacts_short_resource_query_string(
     )
 
 
+def test_redacted_bounded_resource_treats_none_and_empty_string_alike():
+    """``_build_oauth_token_resolver_diagnostic`` and
+    ``_resolver_failure_config`` used to guard the same expression with
+    ``is not None`` and truthiness respectively, so the two calls would
+    have disagreed on a ``""`` resource (kept as ``""`` vs. treated as
+    absent) had one ever reached them -- neither of this value's two
+    producers (``mcp_runtime.py``'s resource selection and this module's
+    ``_oauth_token_configured_resource``) emits ``""``, so this was never
+    reachable, but the shared helper now makes the two call sites agree by
+    construction rather than by their producers' contract.
+    """
+    assert web_tools_config._redacted_bounded_resource(None) is None
+    assert web_tools_config._redacted_bounded_resource("") is None
+    resource = "https://mcp.example.com/oauth?api_key=SECRET-abc123"
+    assert web_tools_config._redacted_bounded_resource(
+        resource
+    ) == web_tools_config._bounded_oauth_metadata(redact_urls_in_text(resource))
+
+
 @pytest.mark.asyncio
 async def test_hook_connector_runtime_error_propagates(db_session):
     db, user = db_session


### PR DESCRIPTION
## What

Log the underlying error when an MCP tool call fails, when a runtime-binding target is not declared by the tool's schema, and when the OAuth token resolver hook fails. URLs embedded in a logged exception message lose their query string, userinfo and fragment -- or are dropped whole when their authority does not parse as `host[:port]`, when the token still carries an `@` the parsed authority does not, or when the text was truncated inside the token -- and header- and assignment-shaped secrets are masked, including assignments whose key carries a prefix such as `MCP_API_KEY=` and those whose prefix carries a credential word anywhere in it; the shapes neither helper recognises are listed at the end of the How section (#2272 and the tracking issue #2356).

Closes #2304.

## Why

Three places dropped the information needed to diagnose an MCP failure:

- `MCPToolAdapter.run_json_async` caught the exception from a tool call and logged only its class name. The server's actual error (JSON-RPC error text, HTTP status line) never reached the log, so a failing tool call could only be diagnosed by calling the server by hand.
- `_runtime_tool_arguments` silently skipped a runtime binding whose target key is not declared in the tool's input schema. The call went out without the bound value and nothing said why.
- `_resolver_failure_config` logged the hook failure with the server name and exception class only, not the failure code it had already classified.

## How

- Both exception handlers in `run_json_async` now log the exception's own message, passed through `_truncated_error_message`, which redacts URLs and bounds the result to `_MCP_TOOL_ERROR_LOG_MAX_CHARS`. `_truncated_error_message` first bounds `str(exc)` itself to `_MCP_TOOL_ERROR_RAW_MAX_CHARS` (4096 characters) before either redaction pass runs, since the raw message comes from a remote server and has no length limit of its own and both redaction passes cost time proportional to their input; the final `_MCP_TOOL_ERROR_LOG_MAX_CHARS` (500) cap on the logged message is unchanged. That raw cap can cut between a URL's password and its `@`, and what is left is byte-for-byte a legal `host:port` that no parse can reject on its own, so the cut appends a reserved truncation mark (`U+FFFE`, a Unicode noncharacter) and `redact_urls_in_text` replaces any token carrying it wholesale; the mark is stripped from the redacted text before anything is logged (see the URL bullet below). For a `BaseExceptionGroup`, the leaf exceptions are logged one per line (up to `_MCP_TOOL_ERROR_LOG_MAX_SUB_EXCEPTIONS`), walking nested groups and cause chains in level order so that every member of a fan-out failure gets a line before any single member's cause chain spends the rest of the budget, and so a group nested by the client's task groups does not log as an opaque inner group. The returned result dict is unchanged.
- `redact_urls_in_text` rewrites every `http(s)://` and `ws(s)://` token in a message to keep scheme, host, port, and path only: query string, userinfo, and fragment are dropped, because connector URLs and redirect targets commonly carry keys and codes there. WebSocket transports are included because `_create_websocket_session` cannot send headers, so a websocket connector has nowhere but the URL to put its credential. A token is replaced wholesale with `<url redacted>` when any of four conditions holds: it fails to parse as a URL; **its authority does not parse as `host[:port]`**; **it still carries an `@` that the parsed authority does not**; or **it carries the truncation mark described above**. The last three all cover userinfo that has lost its `@`, which an authority parse cannot recognise on its own, because `user:pass` is byte-for-byte a legal `host:port`. `urlsplit` ends the authority at the first `?` or `#`, so a password containing one of those characters pushes the `@` into the query string and leaves the remnant sitting where a host belongs (`https://alice:s?ecret@host/p`, `https://alice:123?ecret@host/p`, `https://SECRET_API_KEY?ecret@host/p`); reading the standard library's own `SplitResult.port` rejects a remnant that is not a legal authority, and the stray `@` still present in the token is what rejects one that is. A raw-text cut removes the `@` outright and leaves no evidence inside the token at all, which is why the truncating caller has to supply that evidence as the mark. One shape is kept by design: an isolated, non-truncated `https://alice:12345` carries no evidence against it and is indistinguishable from a host named `alice` on port 12345, so rejecting it would reject every legal `host:port`. The token itself now ends only at whitespace or an angle bracket -- a quote is no longer a boundary, because a quote is legal query-string content, and ending the token at one split an assignment's `key=` off with the query while its value stayed outside the token where the key-name-based masking pass could no longer see it; the cost is that the trailing quote HTTPX puts around a URL in its own error messages is consumed into the token and dropped with the query. Matching is case-insensitive; the authority is kept verbatim minus userinfo so IPv6 brackets and case survive; the boundary between the URL and trailing sentence punctuation is found only within the scheme+host+path portion of the token, and the scan never crosses the first `?` or `#` in the token -- so when the URL carries a query string, any punctuation immediately after it is dropped together with the query rather than re-appended (`see (https://h/p?k=s) ok` now redacts to `see (https://h/p ok`), while a URL with no query string still keeps its trailing punctuation as before. This boundary scan is implemented as a standalone function, `_split_url_token`, which counts each bracket type once per token and then walks a single index backward instead of re-scanning and re-slicing the string on every stripped character, so it stays linear on a token followed by a long run of unmatched closing brackets (300,000 characters: 24 ms, versus 25.7 s before this change).
- `redact_sensitive_text` (`core/utils/security.py`) now masks an assignment whose key carries an identifier prefix. Its pattern anchored on `\b` immediately before the credential word, so `MCP_API_KEY=`, `SERVICE_ACCESS_TOKEN=` or `DB_PASSWORD=` never matched: the `_` before `API_KEY` is a word character and produces no boundary. The pattern now finds every `identifier=` from a non-identifier boundary (a single identifier run, so it stays linear on a hostile 20 kB run of `a_a_a_...` with no `=`, where a nested `(prefix_)*word` quantifier took seconds); a small predicate decides which keys are credentials, the value is read only for a credential, and after any other key the scan resumes right after its `=`, so `host=db;password=...` still masks the password even with no space before it. A key is a credential when it ends in `api_key`, `access_token`, `token`, `password`, `secret` or `key`, and that word is the whole key or is joined to its prefix by `_`/`-`. An unknown `*_key` or `*_token` is treated as a credential (fail closed): `SECRET_KEY=`, `AWS_SECRET_ACCESS_KEY=`, `STRIPE_KEY=`, `PRIVATE_KEY=` are all masked, and so is an unrecognised `*_token`. Each suffix carries its own exemption list, because the same qualifier word can mean something different in front of `key` than in front of `token`: `primary_key=`, `sort_key=`, `partition_key=`, `PUBLIC_KEY=`, `cache_key=`, `idempotency_key=`, `s3_key=`, `routing_key=` are structural field names and stay readable, and separately `idempotency_token=`, `next_token=`, `page_token=`, `continuation_token=`, `cursor_token=`, `sync_token=`, `pagination_token=` name a paging cursor or a de-duplication id and also stay readable -- `public_token`, `s3_token` and `cache_token`, by contrast, can themselves be credentials, so the `key` exemptions are not reused for `token`. `api_key`, `access_token`, `password` and `secret` have no exemption list at all, so `page_access_token=` still masks. **The exemption is also conditional on the whole prefix, not just on the segment next to the suffix: if any `_`/`-` segment of the prefix is itself a credential word, the key is a credential however structural its last qualifier reads, so `secret_next_token=`, `access_page_token=`, `password_cache_key=`, `client_secret_page_token=` and `oauth_sync_token=` all mask while `next_token=`, `page_token=`, `cache_key=` and `sync_token=` stay readable.** The credential words recognised in a prefix are the single-word credential suffixes themselves plus `access`, `auth`, `bearer`, `client`, `oauth`, `private`, `refresh`, `session` and `signing`. The exemption only fires when the qualifier is joined to the suffix by `_`; a hyphen join is masked like any other credential assignment, because a hyphen is not a word character and the `\b`-anchored pattern already finds a boundary there -- so `cache-key=`, `next-token=`, `--page-token=` and `x-idempotency-token=` are masked even though their underscore-joined spellings (`cache_key=`, `next_token=`, `page_token=`, `idempotency_token=`) stay readable. This helper's output also reaches HTTP error responses and model-facing error text at its other call sites, which is why any of these names are left readable rather than masked outright. `key=` and `--api-key=` keep masking as before.
- No traceback is attached to these log lines. Python's traceback formatting would print the raw message a second time, unbounded and unredacted, undoing both the truncation and the redaction.
- The undeclared-target case in `_runtime_tool_arguments` now logs a warning naming the tool and the key before skipping. A malformed (non-string) key is still skipped silently, as before.
- The resolver-failure warning now includes the classified failure code and the configured resource identifier. That identifier is redacted and bounded once, by `_redacted_bounded_resource`, when the diagnostic dict is built; **the warning reads the value back out of that dict rather than recomputing it**, so the log line and the diagnostic cannot drift apart by construction instead of by both callers happening to be pure. `_redacted_bounded_resource` stays a named helper even with a single caller: it owns the resource field of the diagnostic and has its own unit test for the `None`/empty-string boundary. It reaches `redact_urls_in_text` directly -- the resource is the connector's own configured URL, not an exception message, so it passes through neither HTTPX nor the raw cap -- and therefore inherits every rule above from the shared helper rather than repeating any of them at the call site.

The MCP tool adapter never hands tool arguments, tool meta, or the connector's own connection headers to the logger. Text a server chooses to echo inside its own error message is redacted for the shapes the two helpers recognise -- any URL's query string, userinfo and fragment, `Authorization:` and `x-api-key:` header text, and `api_key=`-style assignments with or without an identifier prefix -- and is then bounded first to `_MCP_TOOL_ERROR_RAW_MAX_CHARS` (4096 characters, before either redaction pass runs) and finally to the `_MCP_TOOL_ERROR_LOG_MAX_CHARS` truncation cap (500 characters). Some shapes are recognised by neither helper and are not redacted: a secret carried in a URL path segment, including one that percent-encodes a query string into the path (`https://h/p%3Fapi_key%3DSECRET`), which #2272 tracks; a query value containing a raw `<` or `>`, which ends the URL token early and leaves the value outside it -- HTTPX percent-encodes both, so this needs a producer that does not, such as a JSON-RPC error string or a server-echoed message; and the keyword/shape gaps tracked in #2356 (camelCase and digit-suffixed key names, a value that runs across `;`, JSON-shaped credentials, a bare `Bearer` token, space-separated headers, and non-HTTP connection strings). For those shapes the cap bounds the volume but does not mask a short value.

## Tests

`tests/core/tools/adapters/vibe/test_mcp_adapter.py`:
- a plain exception logs its truncated message, with the untruncated payload absent from the whole captured log and no traceback attached;
- a two-level nested exception group logs each leaf and never an inner group, and no log record in a group failure carries a traceback either;
- a real `httpx.HTTPStatusError` for a URL carrying `api_key=...&tenant=...` logs the host and status but neither parameter; a second real `httpx.HTTPStatusError`, for a URL whose query value is itself wrapped in apostrophes (`api_key='SECRET'`, which HTTPX passes through unencoded), logs neither the value nor the key name; a message containing `https://user:pw@host/path?x=1` logs neither the password nor the query;
- `redact_urls_in_text` edge shapes: uppercase scheme, fragment, IPv6 authority, userinfo with mixed-case host, unparsable token, trailing punctuation dropped together with a query string versus kept when the token has no query string; `_split_url_token`'s own edge shapes (IPv6 brackets, paired parentheses in a path, a percent-escaped `)`, an empty token); a 300,000-character run of unmatched closing brackets stays linear (bounded against a 1-second budget); a spy on `redact_urls_in_text`'s input confirms `str(exc)` is bounded to `_MCP_TOOL_ERROR_RAW_MAX_CHARS` plus the truncation mark before redaction runs;
- a fifteen-row table over the authority checks pairs the shapes that must be rejected whole with the ones that must survive untouched, so the guards are pinned as both effective and non-widening. The rejected rows separate the two reasons: a remnant that does not parse as an authority at all (a password containing `?`, a password containing `#`, userinfo with no `@` left in the token), and a remnant that does parse but is betrayed by the `@` still in the token (`alice:123?ecret@host/p`, `SECRET_API_KEY:?ecret@host/p`, `SECRET_API_KEY?ecret@host/p`, `SECRET_API_KEY#ecret@host/p`, `alice:8080#ecret@host/p`, and an `@` anywhere outside the authority). The surviving rows are ordinary `user:pass@host`, a numeric port, a bracketed IPv6 authority with a port, an empty port, and the isolated `https://alice:12345` that carries no evidence against it;
- an end-to-end case builds an error message long enough that the 4096-character raw cap lands in the middle of a URL's credential, parametrized over an alphabetic password, an all-digit password, and a bare username, and asserts for each that the logged line ends in `<url redacted>`, contains no fragment of the credential, and carries no truncation mark; the same test asserts up front that the cut really lands where it intends, so a drifting construction turns the test red instead of passing vacuously. A separate case covers a cut landing outside any URL token and pins that the mark is stripped there too;
- the tool-side warnings: an undeclared binding target logs a single exact warning message naming the tool and the key, and the tool call still proceeds; a non-string binding key is skipped with no log line at all.

- a server error echoing `MCP_API_KEY=...` and `SERVICE_ACCESS_TOKEN=...` leaves neither raw value anywhere in the captured log, while the masked assignments (key name kept, value masked) are present.

`tests/core/model/test_security.py`: prefixed credential keys (`MCP_API_KEY=`, `SERVICE_ACCESS_TOKEN=`, `DB_PASSWORD=`, `x-client-secret=`) are masked; prefixed secret names ending in `key` (`AWS_SECRET_ACCESS_KEY=`, `SECRET_KEY=`, `STRIPE_KEY=`, `PRIVATE_KEY=`) are masked; structural keys (`primary_key=`, `sort_key=`, `partition_key=`, `PUBLIC_KEY=`, `cache_key=`, `idempotency_key=`) are left untouched; `*_token` names carry their own, separate exemption list (`idempotency_token=`, `next_token=`, `page_token=`, `continuation_token=` and five more spellings are left untouched, while 34 credential `*_token`/`*_key` names -- including every `*_key`-exempt qualifier paired with `_token` instead -- still mask); seven pairs pin the whole-prefix rule, each pairing a name whose prefix carries a credential word (`secret_next_token`, `access_page_token`, `password_cache_key`, `client_secret_page_token`, `oauth_sync_token`, `refresh_next_token`, `bearer_cache_key`) with the same structural qualifier standing alone, so the masked and the readable side are pinned together; 23 pairs of hyphen-joined and underscore-joined structural-qualifier names (covering every qualifier in both the `*_key` and `*_token` exemption lists) confirm the hyphen form is masked and the underscore form stays exempt; bare `key=` and `--api-key=` keep masking; a credential right after a non-credential assignment is masked across 14 different separators; a credential's value is masked as one piece up to `&` or whitespace; a credential name with no value attached is left as is and scanning continues past it; 100 kB of back-to-back `identifier=` and bare-assignment runs redact in bounded time.

`tests/web/tools/test_oauth_token_resolver_hook.py`: the hook-failure warning includes the failure code, and the diagnostic dict returned alongside it carries the same redacted resource as the warning log; a further case counts the calls to `_redacted_bounded_resource` during one failing resolution and requires exactly one, which is the only observable difference between reading the diagnostic and recomputing the value; and two cases drive a configured resource URL through the resolver-failure path to pin that this call site inherits both of the new URL rules from the shared helper -- one whose `@` has been pushed out of the authority, one whose query value is wrapped in apostrophes -- since it reaches the helper without passing through HTTPX or the raw cap.
