### PR TITLE
fix(google-slides): support per-slide layout and require body for content slides

### DIFF
--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -80,6 +80,15 @@ _LAYOUT_PLACEHOLDERS: dict[str, tuple[str | None, str | None]] = {
 #   - "*" is only treated as a marker when followed by real whitespace
 #     ("* item") or nothing; a bare glued "*" ("*emphasis* text") is left
 #     alone so markdown-style emphasis isn't corrupted.
+#
+# The "glued to a letter" lookahead is Unicode-aware (Python's default
+# \w), so e.g. "-中文条目" is recognized and stripped the same way
+# "-Nospace" is — intentional, not an ASCII-only oversight.
+#
+# Only "•"/"-"/"*" are recognized. Other list conventions (numbered lists
+# like "1.", or other dash/arrow glyphs like "–"/"—"/"→") are left as
+# literal text and will visually double up with Slides' own bullet glyph
+# once createParagraphBullets is applied.
 _BULLET_PREFIX_PATTERN = re.compile(
     r"^(\s*)(?:"
     r"•(?:[ \t]+|(?=\S)|$)"
@@ -96,7 +105,9 @@ def _leading_whitespace_to_tabs(leading: str) -> str:
     non-nesting text). Each literal tab in the input counts as one level;
     otherwise every 2 spaces — the typical hand-typed nested-bullet
     convention — counts as one level, with any non-empty indentation
-    counting as at least one level."""
+    counting as at least one level. Mixing tabs and spaces in the same
+    run is not combined: if any tab is present, only the tabs are
+    counted and any spaces in that same leading run are ignored."""
     if not leading:
         return ""
     level = leading.count("\t") or max(1, len(leading) // 2)
@@ -252,13 +263,18 @@ def google_slides_add_slide(
     Append a slide with a title and body text to a Google Slides presentation.
     The body supports plain text; use newlines to separate bullet lines — each
     line is rendered as its own bulleted paragraph (don't type literal "•"/"-"
-    markers, Slides adds the bullet glyph itself).
+    markers, Slides adds the bullet glyph itself — only "•"/"-"/"*" are
+    recognized as markers to strip; other conventions like numbered lists
+    ("1.") or other dash/arrow glyphs ("–"/"—"/"→") are inserted as
+    literal text and will visually double up with Slides' own bullet).
 
     layout picks the slide's predefined layout, which decides which of
     title/body actually have a placeholder to land in:
       - "TITLE_AND_BODY" (default): title + full bulleted body content.
         body is required here — this layout rejects an empty body rather
-        than silently creating a title-only slide.
+        than silently creating a title-only slide. An empty title is
+        still allowed as long as body has content (e.g. a title-less
+        continuation slide) — this is intentional, not a gap.
       - "TITLE": a cover/section-opening slide — title is the big centered
         title, body (optional) becomes the subtitle line (not bulleted).
       - "TITLE_ONLY", "SECTION_HEADER": title only, no body placeholder —
@@ -272,10 +288,24 @@ def google_slides_add_slide(
     no title placeholder) still need at least a non-empty title — or, for
     "TITLE", a non-empty body/subtitle instead — since otherwise the call
     would produce a completely empty slide; that combination is rejected.
+
+    This assumes the presentation uses a standard/default theme. A custom
+    theme whose master doesn't expose the placeholder types listed above
+    for a given layout will fail with a raw Slides API error from the
+    underlying batchUpdate call rather than a friendly one — use
+    google_slides_batch_update directly for presentations with a
+    non-standard theme.
     """
     try:
+        if not isinstance(layout, str):
+            return _error(f"'layout' must be a string, got {type(layout).__name__}.")
+
         title = title.replace("\r\n", "\n").replace("\r", "\n")
         body = body.replace("\r\n", "\n").replace("\r", "\n")
+        # A title is expected to be a single line; collapse any embedded
+        # newline (and surrounding whitespace) into a space rather than
+        # silently producing a multi-paragraph title placeholder.
+        title = re.sub(r"\s*\n\s*", " ", title)
         normalized_layout = layout.strip().upper()
 
         if normalized_layout not in _LAYOUT_PLACEHOLDERS:
@@ -288,21 +318,24 @@ def google_slides_add_slide(
         is_bulleted = body_required = body_placeholder == "BODY"
         if is_bulleted and body:
             body = _strip_bullet_prefixes(body)
-            # Drop lines left blank by stripping a bare marker, or blank
-            # lines/a trailing newline already in the input — otherwise
-            # createParagraphBullets (applied to the whole text range
-            # below) puts a bullet glyph on an empty paragraph, a visibly
-            # floating bullet point.
+        if body:
+            # Drop blank lines (a bare marker stripped down to nothing,
+            # blank lines already in the input, or a trailing newline) so
+            # no empty paragraph survives — for bulleted content this
+            # avoids createParagraphBullets putting a bullet glyph on an
+            # empty paragraph (a visibly floating bullet point); for
+            # non-bulleted content (e.g. TITLE's subtitle) it avoids
+            # stray blank lines in the placeholder.
             body = "\n".join(line for line in body.split("\n") if line.strip())
 
-        if title and title_placeholder is None:
+        if title.strip() and title_placeholder is None:
             return _error(
                 f"layout '{normalized_layout}' has no title placeholder, "
                 "so 'title' would be silently dropped. Use a different "
                 "layout, or google_slides_batch_update for a custom "
                 "text box."
             )
-        if body and body_placeholder is None:
+        if body.strip() and body_placeholder is None:
             return _error(
                 f"layout '{normalized_layout}' has no body placeholder, "
                 "so 'body' would be silently dropped. Use a layout "

--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 import uuid
-from typing import Any, NamedTuple
+from typing import Any, Literal
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build  # type: ignore[import-not-found]
@@ -22,23 +22,14 @@ mcp = FastMCP("google-slides-mcp")
 _PRESENTATION_URL_ID_PATTERN = re.compile(r"/presentation/d/([a-zA-Z0-9_-]+)")
 
 
-class _LayoutSpec(NamedTuple):
-    """(title_placeholder, body_placeholder) types Slides creates for a
-    predefined layout, plus the two policies that depend on that shape:
-    `bulleted` (does body land in a real list-style BODY placeholder?) and
-    `body_required` (must body be non-empty?). Kept as explicit fields
-    instead of comparing `body_placeholder == "BODY"` at each call site, so
-    a future layout can't silently pick up the wrong policy just because
-    its body placeholder happens to be named "BODY"."""
+_Layout = Literal["TITLE", "TITLE_AND_BODY", "TITLE_ONLY", "SECTION_HEADER", "BLANK"]
 
-    title_placeholder: str | None
-    body_placeholder: str | None
-    bulleted: bool
-    body_required: bool
-
-
-# Predefined layouts we know how to fill in. `None` means that slot doesn't
-# exist on the layout at all.
+# Predefined layouts we know how to fill in, mapped to the (title_placeholder,
+# body_placeholder) types Slides creates for each one. `None` means that slot
+# doesn't exist on the layout at all. This table only records that factual
+# placeholder shape; `is_bulleted`/`body_required` policy is derived from it
+# once in google_slides_add_slide (both happen to be True only for
+# TITLE_AND_BODY today, i.e. exactly when body_placeholder == "BODY").
 #
 # Deliberately limited to the layouts whose placeholder composition is well
 # established (matching Google's official Apps Script PredefinedLayout docs
@@ -48,55 +39,79 @@ class _LayoutSpec(NamedTuple):
 # (SECTION_TITLE_AND_DESCRIPTION, ONE_COLUMN_TEXT, MAIN_POINT, BIG_NUMBER)
 # are intentionally left out rather than guessed at — use
 # google_slides_batch_update for those until verified against a live API.
-_LAYOUT_PLACEHOLDERS: dict[str, _LayoutSpec] = {
-    "TITLE": _LayoutSpec(
-        "CENTERED_TITLE", "SUBTITLE", bulleted=False, body_required=False
-    ),
-    "TITLE_AND_BODY": _LayoutSpec("TITLE", "BODY", bulleted=True, body_required=True),
-    "TITLE_ONLY": _LayoutSpec("TITLE", None, bulleted=False, body_required=False),
-    "SECTION_HEADER": _LayoutSpec("TITLE", None, bulleted=False, body_required=False),
-    "BLANK": _LayoutSpec(None, None, bulleted=False, body_required=False),
+_LAYOUT_PLACEHOLDERS: dict[str, tuple[str | None, str | None]] = {
+    "TITLE": ("CENTERED_TITLE", "SUBTITLE"),
+    "TITLE_AND_BODY": ("TITLE", "BODY"),
+    "TITLE_ONLY": ("TITLE", None),
+    "SECTION_HEADER": ("TITLE", None),
+    "BLANK": (None, None),
 }
 
 # Leading "•"/"-"/"*" marker at the start of a line, with or without a
-# following space so a marker glued to a word (e.g. "•First") is still
-# recognized. Captures any leading whitespace so it survives the
-# substitution — Slides' createParagraphBullets infers nesting level from
-# leading tab characters in the inserted text, so stripping only the
-# marker (not the indentation in front of it) keeps multi-level bullets
-# intact.
+# following space (so a marker glued to a word, e.g. "•First", or with
+# nothing after it at all, e.g. a bare "•" on its own line, is still
+# recognized). Captures any leading Unicode whitespace so it can be
+# converted to nesting-level tabs by _leading_whitespace_to_tabs below.
 #
 # "-" and "*" also have common non-bullet meanings, so the "glued, no
 # space" case is deliberately narrower for them than for "•" (which has no
 # other meaning in plain text):
-#   - "-" glued to a digit ("-5% growth") or another "-" ("-- Author") is
-#     left alone entirely, so a negative number's sign or an em-dash
-#     convention is never silently eaten.
+#   - "-" is only glued-recognized when followed directly by a letter
+#     ("-Nospace"); anything else — a digit, another "-", a currency
+#     symbol, a decimal point — is left alone, so a negative number's
+#     sign ("-5%", "-$5m", "-.5%") or an em-dash/en-dash convention
+#     ("-- Author", "-– Author") is never silently eaten.
 #   - "*" is only treated as a marker when followed by real whitespace
-#     ("* item"); a bare glued "*" ("*emphasis* text") is left alone so
-#     markdown-style emphasis isn't corrupted.
+#     ("* item") or nothing; a bare glued "*" ("*emphasis* text") is left
+#     alone so markdown-style emphasis isn't corrupted.
 _BULLET_PREFIX_PATTERN = re.compile(
-    r"^([ \t]*)(?:"
-    r"•(?:[ \t]+|(?=\S))"
-    r"|-(?:[ \t]+|(?=[^\s\d\-]))"
-    r"|\*[ \t]+"
+    r"^(\s*)(?:"
+    r"•(?:[ \t]+|(?=\S)|$)"
+    r"|-(?:[ \t]+|(?=[^\W\d_])|$)"
+    r"|\*(?:[ \t]+|$)"
     r")"
 )
 
 
+def _leading_whitespace_to_tabs(leading: str) -> str:
+    """Convert captured leading whitespace into the literal tab
+    characters Slides' createParagraphBullets actually uses to infer
+    nesting level (plain spaces are otherwise inserted as literal,
+    non-nesting text). Each literal tab in the input counts as one level;
+    otherwise every 2 spaces — the typical hand-typed nested-bullet
+    convention — counts as one level, with any non-empty indentation
+    counting as at least one level."""
+    if not leading:
+        return ""
+    level = leading.count("\t") or max(1, len(leading) // 2)
+    return "\t" * level
+
+
 def _strip_bullet_prefixes(text: str) -> str:
-    """Drop a leading "•"/"-"/"*" marker from each line, preserving any
-    leading whitespace before it. See _BULLET_PREFIX_PATTERN for the
-    narrower rules that keep this from corrupting non-bullet content.
+    """Drop a leading "•"/"-"/"*" marker from each line — repeatedly, so a
+    line with more than one leading marker (e.g. "• - nested") is fully
+    unwrapped rather than leaving a residual marker as literal text — and
+    convert any leading indentation into nesting-level tabs. See
+    _BULLET_PREFIX_PATTERN for the narrower rules that keep this from
+    corrupting non-bullet content.
 
     The public docstrings tell callers not to type literal bullet glyphs,
     but callers may do so anyway; once we ask Slides to render real
     bulleted paragraphs (see createParagraphBullets below) those glyphs
     would double up with Slides' own bullet, so strip them first.
     """
-    return "\n".join(
-        _BULLET_PREFIX_PATTERN.sub(r"\1", line) for line in text.split("\n")
-    )
+
+    def _strip_line(line: str) -> str:
+        while True:
+            match = _BULLET_PREFIX_PATTERN.match(line)
+            if match is None:
+                return line
+            stripped = _leading_whitespace_to_tabs(match.group(1)) + line[match.end() :]
+            if stripped == line:
+                return line
+            line = stripped
+
+    return "\n".join(_strip_line(line) for line in text.split("\n"))
 
 
 def _error(message: str) -> str:
@@ -215,7 +230,7 @@ def google_slides_add_slide(
     presentation_id: str,
     title: str = "",
     body: str = "",
-    layout: str = "TITLE_AND_BODY",
+    layout: _Layout = "TITLE_AND_BODY",
 ) -> str:
     """
     Append a slide with a title and body text to a Google Slides presentation.
@@ -235,42 +250,53 @@ def google_slides_add_slide(
       - "BLANK": no placeholders at all; use google_slides_batch_update to
         add free-form text boxes/images instead.
 
-    Layouts that don't already require a body (i.e. everything except
-    TITLE_AND_BODY) still need at least a non-empty title — or, for
+    Layouts with a title placeholder that don't already require a body
+    (TITLE, TITLE_ONLY, SECTION_HEADER — not TITLE_AND_BODY, whose own
+    body-required rule above already covers it, and not BLANK, which has
+    no title placeholder) still need at least a non-empty title — or, for
     "TITLE", a non-empty body/subtitle instead — since otherwise the call
     would produce a completely empty slide; that combination is rejected.
     """
     try:
-        if layout not in _LAYOUT_PLACEHOLDERS:
+        title = title.replace("\r\n", "\n").replace("\r", "\n")
+        body = body.replace("\r\n", "\n").replace("\r", "\n")
+        normalized_layout = layout.strip().upper()
+
+        if normalized_layout not in _LAYOUT_PLACEHOLDERS:
             return _error(
                 f"Unknown layout '{layout}'. Supported layouts: "
                 f"{', '.join(sorted(_LAYOUT_PLACEHOLDERS))}"
             )
 
-        title_placeholder, body_placeholder, is_bulleted, body_required = (
-            _LAYOUT_PLACEHOLDERS[layout]
-        )
+        title_placeholder, body_placeholder = _LAYOUT_PLACEHOLDERS[normalized_layout]
+        is_bulleted = body_required = body_placeholder == "BODY"
         if is_bulleted and body:
             body = _strip_bullet_prefixes(body)
+            # Drop lines left blank by stripping a bare marker, or blank
+            # lines/a trailing newline already in the input — otherwise
+            # createParagraphBullets (applied to the whole text range
+            # below) puts a bullet glyph on an empty paragraph, a visibly
+            # floating bullet point.
+            body = "\n".join(line for line in body.split("\n") if line.strip())
 
         if title and title_placeholder is None:
             return _error(
-                f"layout '{layout}' has no title placeholder, so "
-                "'title' would be silently dropped. Use a different "
+                f"layout '{normalized_layout}' has no title placeholder, "
+                "so 'title' would be silently dropped. Use a different "
                 "layout, or google_slides_batch_update for a custom "
                 "text box."
             )
         if body and body_placeholder is None:
             return _error(
-                f"layout '{layout}' has no body placeholder, so "
-                "'body' would be silently dropped. Use a layout "
+                f"layout '{normalized_layout}' has no body placeholder, "
+                "so 'body' would be silently dropped. Use a layout "
                 "with a body/subtitle placeholder (e.g. "
                 "TITLE_AND_BODY, TITLE) or omit body."
             )
         if body_required and not body.strip():
             return _error(
-                f"layout '{layout}' expects body content but none "
-                "was provided. Include this slide's full bullet/"
+                f"layout '{normalized_layout}' expects body content but "
+                "none was provided. Include this slide's full bullet/"
                 "detail text in 'body' — don't create the slide "
                 "with just a title."
             )
@@ -281,7 +307,8 @@ def google_slides_add_slide(
             and not body.strip()
         ):
             return _error(
-                f"layout '{layout}' needs at least a non-empty 'title'"
+                f"layout '{normalized_layout}' needs at least a non-empty "
+                "'title'"
                 + (" or 'body'" if body_placeholder is not None else "")
                 + " — as given, this call would create a completely "
                 "empty slide."
@@ -312,14 +339,16 @@ def google_slides_add_slide(
 
         create_slide: dict[str, Any] = {
             "objectId": slide_id,
-            "slideLayoutReference": {"predefinedLayout": layout},
+            "slideLayoutReference": {"predefinedLayout": normalized_layout},
         }
         if placeholder_mappings:
             create_slide["placeholderIdMappings"] = placeholder_mappings
 
         requests: list[dict[str, Any]] = [{"createSlide": create_slide}]
         if title.strip():
-            requests.append({"insertText": {"objectId": title_id, "text": title}})
+            requests.append(
+                {"insertText": {"objectId": title_id, "text": title.strip()}}
+            )
         if body.strip():
             requests.append({"insertText": {"objectId": body_id, "text": body}})
             if is_bulleted:
@@ -342,6 +371,7 @@ def google_slides_add_slide(
                 "status": "success",
                 "presentation_id": pres_id,
                 "slide_id": slide_id,
+                "layout": normalized_layout,
             },
             ensure_ascii=False,
         )

--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -3,11 +3,12 @@ import logging
 import os
 import re
 import uuid
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build  # type: ignore[import-not-found]
 from mcp.server.fastmcp import FastMCP
+from pydantic import BeforeValidator
 
 from .utils import resolve_id_from_url, setup_proxy_env
 
@@ -22,7 +23,22 @@ mcp = FastMCP("google-slides-mcp")
 _PRESENTATION_URL_ID_PATTERN = re.compile(r"/presentation/d/([a-zA-Z0-9_-]+)")
 
 
-_Layout = Literal["TITLE", "TITLE_AND_BODY", "TITLE_ONLY", "SECTION_HEADER", "BLANK"]
+def _normalize_layout(value: object) -> object:
+    """Case/whitespace-normalize `layout` before FastMCP's Pydantic layer
+    validates it against the Literal below. Without this, an MCP tool
+    call (the only way a real agent ever invokes this tool — direct
+    Python calls, used by this file's own tests, bypass FastMCP
+    validation entirely) with e.g. "title_and_body" would be rejected by
+    Pydantic's case-sensitive Literal check *before* the function body's
+    own normalization ever ran, making that normalization dead code for
+    every real caller."""
+    return value.strip().upper() if isinstance(value, str) else value
+
+
+_Layout = Annotated[
+    Literal["TITLE", "TITLE_AND_BODY", "TITLE_ONLY", "SECTION_HEADER", "BLANK"],
+    BeforeValidator(_normalize_layout),
+]
 
 # Predefined layouts we know how to fill in, mapped to the (title_placeholder,
 # body_placeholder) types Slides creates for each one. `None` means that slot

--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -24,15 +24,20 @@ _PRESENTATION_URL_ID_PATTERN = re.compile(r"/presentation/d/([a-zA-Z0-9_-]+)")
 # Predefined layouts we know how to fill in, mapped to the (title_placeholder,
 # body_placeholder) types Slides creates for each one. `None` means that slot
 # doesn't exist on the layout at all.
+#
+# Deliberately limited to the layouts whose placeholder composition is well
+# established (matching Google's official Apps Script PredefinedLayout docs
+# and this file's pre-existing TITLE_AND_BODY mapping). Google's docs
+# explicitly warn a predefined layout's placeholder set "may have been
+# changed" and don't enumerate it for every layout, so less-common ones
+# (SECTION_TITLE_AND_DESCRIPTION, ONE_COLUMN_TEXT, MAIN_POINT, BIG_NUMBER)
+# are intentionally left out rather than guessed at — use
+# google_slides_batch_update for those until verified against a live API.
 _LAYOUT_PLACEHOLDERS: dict[str, tuple[str | None, str | None]] = {
     "TITLE": ("CENTERED_TITLE", "SUBTITLE"),
     "TITLE_AND_BODY": ("TITLE", "BODY"),
     "TITLE_ONLY": ("TITLE", None),
     "SECTION_HEADER": ("TITLE", None),
-    "SECTION_TITLE_AND_DESCRIPTION": ("TITLE", "BODY"),
-    "ONE_COLUMN_TEXT": ("TITLE", "BODY"),
-    "MAIN_POINT": ("TITLE", None),
-    "BIG_NUMBER": ("TITLE", "BODY"),
     "BLANK": (None, None),
 }
 
@@ -47,6 +52,10 @@ def _strip_bullet_prefixes(text: str) -> str:
     glyphs would double up with Slides' own bullet, so strip them first.
     """
     return "\n".join(_BULLET_PREFIX_PATTERN.sub("", line) for line in text.split("\n"))
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message})
 
 
 def get_slides_service() -> Any:
@@ -174,62 +183,40 @@ def google_slides_add_slide(
       - "TITLE_AND_BODY" (default): title + full bulleted body content.
       - "TITLE": a cover/section-opening slide — title is the big centered
         title, body (optional) becomes the subtitle line (not bulleted).
-      - "TITLE_ONLY", "SECTION_HEADER", "MAIN_POINT": title only, no body
-        placeholder — pass body="" or the call is rejected.
-      - "SECTION_TITLE_AND_DESCRIPTION", "ONE_COLUMN_TEXT", "BIG_NUMBER":
-        title + bulleted body, like TITLE_AND_BODY with a different look.
+      - "TITLE_ONLY", "SECTION_HEADER": title only, no body placeholder —
+        pass body="" or the call is rejected.
       - "BLANK": no placeholders at all; use google_slides_batch_update to
         add free-form text boxes/images instead.
     """
     try:
         if layout not in _LAYOUT_PLACEHOLDERS:
-            return json.dumps(
-                {
-                    "status": "error",
-                    "message": (
-                        f"Unknown layout '{layout}'. Supported layouts: "
-                        f"{', '.join(sorted(_LAYOUT_PLACEHOLDERS))}"
-                    ),
-                }
+            return _error(
+                f"Unknown layout '{layout}'. Supported layouts: "
+                f"{', '.join(sorted(_LAYOUT_PLACEHOLDERS))}"
             )
 
         title_placeholder, body_placeholder = _LAYOUT_PLACEHOLDERS[layout]
 
         if title and title_placeholder is None:
-            return json.dumps(
-                {
-                    "status": "error",
-                    "message": (
-                        f"layout '{layout}' has no title placeholder, so "
-                        "'title' would be silently dropped. Use a different "
-                        "layout, or google_slides_batch_update for a custom "
-                        "text box."
-                    ),
-                }
+            return _error(
+                f"layout '{layout}' has no title placeholder, so "
+                "'title' would be silently dropped. Use a different "
+                "layout, or google_slides_batch_update for a custom "
+                "text box."
             )
         if body and body_placeholder is None:
-            return json.dumps(
-                {
-                    "status": "error",
-                    "message": (
-                        f"layout '{layout}' has no body placeholder, so "
-                        "'body' would be silently dropped. Use a layout "
-                        "with a body/subtitle placeholder (e.g. "
-                        "TITLE_AND_BODY, TITLE) or omit body."
-                    ),
-                }
+            return _error(
+                f"layout '{layout}' has no body placeholder, so "
+                "'body' would be silently dropped. Use a layout "
+                "with a body/subtitle placeholder (e.g. "
+                "TITLE_AND_BODY, TITLE) or omit body."
             )
-        if not body and body_placeholder == "BODY":
-            return json.dumps(
-                {
-                    "status": "error",
-                    "message": (
-                        f"layout '{layout}' expects body content but none "
-                        "was provided. Include this slide's full bullet/"
-                        "detail text in 'body' — don't create the slide "
-                        "with just a title."
-                    ),
-                }
+        if not body.strip() and body_placeholder == "BODY":
+            return _error(
+                f"layout '{layout}' expects body content but none "
+                "was provided. Include this slide's full bullet/"
+                "detail text in 'body' — don't create the slide "
+                "with just a title."
             )
 
         pres_id = _resolve_presentation_id(presentation_id)
@@ -267,15 +254,16 @@ def google_slides_add_slide(
         if title:
             requests.append({"insertText": {"objectId": title_id, "text": title}})
         if body:
+            is_bulleted = body_placeholder == "BODY"
             requests.append(
                 {
                     "insertText": {
                         "objectId": body_id,
-                        "text": _strip_bullet_prefixes(body),
+                        "text": _strip_bullet_prefixes(body) if is_bulleted else body,
                     }
                 }
             )
-            if body_placeholder == "BODY":
+            if is_bulleted:
                 requests.append(
                     {
                         "createParagraphBullets": {
@@ -300,7 +288,7 @@ def google_slides_add_slide(
         )
     except Exception as e:
         logger.error(f"Error adding slide: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return _error(str(e))
 
 
 @mcp.tool()

--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -21,6 +21,33 @@ mcp = FastMCP("google-slides-mcp")
 
 _PRESENTATION_URL_ID_PATTERN = re.compile(r"/presentation/d/([a-zA-Z0-9_-]+)")
 
+# Predefined layouts we know how to fill in, mapped to the (title_placeholder,
+# body_placeholder) types Slides creates for each one. `None` means that slot
+# doesn't exist on the layout at all.
+_LAYOUT_PLACEHOLDERS: dict[str, tuple[str | None, str | None]] = {
+    "TITLE": ("CENTERED_TITLE", "SUBTITLE"),
+    "TITLE_AND_BODY": ("TITLE", "BODY"),
+    "TITLE_ONLY": ("TITLE", None),
+    "SECTION_HEADER": ("TITLE", None),
+    "SECTION_TITLE_AND_DESCRIPTION": ("TITLE", "BODY"),
+    "ONE_COLUMN_TEXT": ("TITLE", "BODY"),
+    "MAIN_POINT": ("TITLE", None),
+    "BIG_NUMBER": ("TITLE", "BODY"),
+    "BLANK": (None, None),
+}
+
+_BULLET_PREFIX_PATTERN = re.compile(r"^[ \t]*[•\-\*][ \t]+")
+
+
+def _strip_bullet_prefixes(text: str) -> str:
+    """Drop a leading "•"/"-"/"*" marker from each line.
+
+    Callers pass body text with literal bullet glyphs; once we ask Slides to
+    render real bulleted paragraphs (see createParagraphBullets below) those
+    glyphs would double up with Slides' own bullet, so strip them first.
+    """
+    return "\n".join(_BULLET_PREFIX_PATTERN.sub("", line) for line in text.split("\n"))
+
 
 def get_slides_service() -> Any:
     token = os.environ.get("GOOGLE_ACCESS_TOKEN")
@@ -131,13 +158,80 @@ def google_slides_create_presentation(title: str) -> str:
 
 @mcp.tool()
 def google_slides_add_slide(
-    presentation_id: str, title: str = "", body: str = ""
+    presentation_id: str,
+    title: str = "",
+    body: str = "",
+    layout: str = "TITLE_AND_BODY",
 ) -> str:
     """
     Append a slide with a title and body text to a Google Slides presentation.
-    The body supports plain text; use newlines to separate bullet lines.
+    The body supports plain text; use newlines to separate bullet lines — each
+    line is rendered as its own bulleted paragraph (don't type literal "•"/"-"
+    markers, Slides adds the bullet glyph itself).
+
+    layout picks the slide's predefined layout, which decides which of
+    title/body actually have a placeholder to land in:
+      - "TITLE_AND_BODY" (default): title + full bulleted body content.
+      - "TITLE": a cover/section-opening slide — title is the big centered
+        title, body (optional) becomes the subtitle line (not bulleted).
+      - "TITLE_ONLY", "SECTION_HEADER", "MAIN_POINT": title only, no body
+        placeholder — pass body="" or the call is rejected.
+      - "SECTION_TITLE_AND_DESCRIPTION", "ONE_COLUMN_TEXT", "BIG_NUMBER":
+        title + bulleted body, like TITLE_AND_BODY with a different look.
+      - "BLANK": no placeholders at all; use google_slides_batch_update to
+        add free-form text boxes/images instead.
     """
     try:
+        if layout not in _LAYOUT_PLACEHOLDERS:
+            return json.dumps(
+                {
+                    "status": "error",
+                    "message": (
+                        f"Unknown layout '{layout}'. Supported layouts: "
+                        f"{', '.join(sorted(_LAYOUT_PLACEHOLDERS))}"
+                    ),
+                }
+            )
+
+        title_placeholder, body_placeholder = _LAYOUT_PLACEHOLDERS[layout]
+
+        if title and title_placeholder is None:
+            return json.dumps(
+                {
+                    "status": "error",
+                    "message": (
+                        f"layout '{layout}' has no title placeholder, so "
+                        "'title' would be silently dropped. Use a different "
+                        "layout, or google_slides_batch_update for a custom "
+                        "text box."
+                    ),
+                }
+            )
+        if body and body_placeholder is None:
+            return json.dumps(
+                {
+                    "status": "error",
+                    "message": (
+                        f"layout '{layout}' has no body placeholder, so "
+                        "'body' would be silently dropped. Use a layout "
+                        "with a body/subtitle placeholder (e.g. "
+                        "TITLE_AND_BODY, TITLE) or omit body."
+                    ),
+                }
+            )
+        if not body and body_placeholder == "BODY":
+            return json.dumps(
+                {
+                    "status": "error",
+                    "message": (
+                        f"layout '{layout}' expects body content but none "
+                        "was provided. Include this slide's full bullet/"
+                        "detail text in 'body' — don't create the slide "
+                        "with just a title."
+                    ),
+                }
+            )
+
         pres_id = _resolve_presentation_id(presentation_id)
         service = get_slides_service()
 
@@ -145,28 +239,52 @@ def google_slides_add_slide(
         title_id = f"{slide_id}_title"
         body_id = f"{slide_id}_body"
 
+        placeholder_mappings: list[dict[str, Any]] = []
+        if title_placeholder is not None:
+            placeholder_mappings.append(
+                {
+                    "layoutPlaceholder": {"type": title_placeholder},
+                    "objectId": title_id,
+                }
+            )
+        if body_placeholder is not None:
+            placeholder_mappings.append(
+                {
+                    "layoutPlaceholder": {"type": body_placeholder},
+                    "objectId": body_id,
+                }
+            )
+
         requests: list[dict[str, Any]] = [
             {
                 "createSlide": {
                     "objectId": slide_id,
-                    "slideLayoutReference": {"predefinedLayout": "TITLE_AND_BODY"},
-                    "placeholderIdMappings": [
-                        {
-                            "layoutPlaceholder": {"type": "TITLE"},
-                            "objectId": title_id,
-                        },
-                        {
-                            "layoutPlaceholder": {"type": "BODY"},
-                            "objectId": body_id,
-                        },
-                    ],
+                    "slideLayoutReference": {"predefinedLayout": layout},
+                    "placeholderIdMappings": placeholder_mappings,
                 }
             }
         ]
         if title:
             requests.append({"insertText": {"objectId": title_id, "text": title}})
         if body:
-            requests.append({"insertText": {"objectId": body_id, "text": body}})
+            requests.append(
+                {
+                    "insertText": {
+                        "objectId": body_id,
+                        "text": _strip_bullet_prefixes(body),
+                    }
+                }
+            )
+            if body_placeholder == "BODY":
+                requests.append(
+                    {
+                        "createParagraphBullets": {
+                            "objectId": body_id,
+                            "textRange": {"type": "ALL"},
+                            "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE",
+                        }
+                    }
+                )
 
         service.presentations().batchUpdate(
             presentationId=pres_id, body={"requests": requests}

--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -114,13 +114,23 @@ def _leading_whitespace_to_tabs(leading: str) -> str:
     return "\t" * level
 
 
+# Upper bound on how many leading markers _strip_line unwraps from one
+# line. Real content never nests anywhere near this deep (the case this
+# exists for, "• - nested", needs 2); the cap exists purely to bound the
+# work: each iteration re-scans the line from its new start, so without a
+# cap a degenerate line of N glued markers (e.g. "•" * 200_000, from a
+# runaway/malformed LLM completion — body has no length limit) makes
+# _strip_line O(n^2), measured to take over a second at N=200_000.
+_MAX_MARKER_STRIPS_PER_LINE = 8
+
+
 def _strip_bullet_prefixes(text: str) -> str:
-    """Drop a leading "•"/"-"/"*" marker from each line — repeatedly, so a
-    line with more than one leading marker (e.g. "• - nested") is fully
-    unwrapped rather than leaving a residual marker as literal text — and
-    convert any leading indentation into nesting-level tabs. See
-    _BULLET_PREFIX_PATTERN for the narrower rules that keep this from
-    corrupting non-bullet content.
+    """Drop a leading "•"/"-"/"*" marker from each line — repeatedly, up
+    to _MAX_MARKER_STRIPS_PER_LINE times, so a line with more than one
+    leading marker (e.g. "• - nested") is fully unwrapped rather than
+    leaving a residual marker as literal text — and convert any leading
+    indentation into nesting-level tabs. See _BULLET_PREFIX_PATTERN for
+    the narrower rules that keep this from corrupting non-bullet content.
 
     The public docstrings tell callers not to type literal bullet glyphs,
     but callers may do so anyway; once we ask Slides to render real
@@ -129,7 +139,7 @@ def _strip_bullet_prefixes(text: str) -> str:
     """
 
     def _strip_line(line: str) -> str:
-        while True:
+        for _ in range(_MAX_MARKER_STRIPS_PER_LINE):
             match = _BULLET_PREFIX_PATTERN.match(line)
             if match is None:
                 return line
@@ -137,6 +147,7 @@ def _strip_bullet_prefixes(text: str) -> str:
             if stripped == line:
                 return line
             line = stripped
+        return line
 
     return "\n".join(_strip_line(line) for line in text.split("\n"))
 

--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 import uuid
-from typing import Any
+from typing import Any, NamedTuple
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build  # type: ignore[import-not-found]
@@ -21,9 +21,24 @@ mcp = FastMCP("google-slides-mcp")
 
 _PRESENTATION_URL_ID_PATTERN = re.compile(r"/presentation/d/([a-zA-Z0-9_-]+)")
 
-# Predefined layouts we know how to fill in, mapped to the (title_placeholder,
-# body_placeholder) types Slides creates for each one. `None` means that slot
-# doesn't exist on the layout at all.
+
+class _LayoutSpec(NamedTuple):
+    """(title_placeholder, body_placeholder) types Slides creates for a
+    predefined layout, plus the two policies that depend on that shape:
+    `bulleted` (does body land in a real list-style BODY placeholder?) and
+    `body_required` (must body be non-empty?). Kept as explicit fields
+    instead of comparing `body_placeholder == "BODY"` at each call site, so
+    a future layout can't silently pick up the wrong policy just because
+    its body placeholder happens to be named "BODY"."""
+
+    title_placeholder: str | None
+    body_placeholder: str | None
+    bulleted: bool
+    body_required: bool
+
+
+# Predefined layouts we know how to fill in. `None` means that slot doesn't
+# exist on the layout at all.
 #
 # Deliberately limited to the layouts whose placeholder composition is well
 # established (matching Google's official Apps Script PredefinedLayout docs
@@ -33,29 +48,41 @@ _PRESENTATION_URL_ID_PATTERN = re.compile(r"/presentation/d/([a-zA-Z0-9_-]+)")
 # (SECTION_TITLE_AND_DESCRIPTION, ONE_COLUMN_TEXT, MAIN_POINT, BIG_NUMBER)
 # are intentionally left out rather than guessed at — use
 # google_slides_batch_update for those until verified against a live API.
-_LAYOUT_PLACEHOLDERS: dict[str, tuple[str | None, str | None]] = {
-    "TITLE": ("CENTERED_TITLE", "SUBTITLE"),
-    "TITLE_AND_BODY": ("TITLE", "BODY"),
-    "TITLE_ONLY": ("TITLE", None),
-    "SECTION_HEADER": ("TITLE", None),
-    "BLANK": (None, None),
+_LAYOUT_PLACEHOLDERS: dict[str, _LayoutSpec] = {
+    "TITLE": _LayoutSpec(
+        "CENTERED_TITLE", "SUBTITLE", bulleted=False, body_required=False
+    ),
+    "TITLE_AND_BODY": _LayoutSpec("TITLE", "BODY", bulleted=True, body_required=True),
+    "TITLE_ONLY": _LayoutSpec("TITLE", None, bulleted=False, body_required=False),
+    "SECTION_HEADER": _LayoutSpec("TITLE", None, bulleted=False, body_required=False),
+    "BLANK": _LayoutSpec(None, None, bulleted=False, body_required=False),
 }
 
-_BULLET_PREFIX_PATTERN = re.compile(r"^[ \t]*[•\-\*][ \t]+")
+# Leading "•"/"-"/"*" marker (with or without a following space, so a marker
+# glued to text like "•First" is still recognized) at the start of a line.
+# Captures any leading whitespace so it survives the substitution — Slides'
+# createParagraphBullets infers nesting level from leading tab characters
+# in the inserted text, so stripping only the marker (not the indentation
+# in front of it) keeps multi-level bullets intact.
+_BULLET_PREFIX_PATTERN = re.compile(r"^([ \t]*)[•\-\*][ \t]*")
 
 
 def _strip_bullet_prefixes(text: str) -> str:
-    """Drop a leading "•"/"-"/"*" marker from each line.
+    """Drop a leading "•"/"-"/"*" marker from each line, preserving any
+    leading whitespace before it.
 
-    Callers pass body text with literal bullet glyphs; once we ask Slides to
-    render real bulleted paragraphs (see createParagraphBullets below) those
-    glyphs would double up with Slides' own bullet, so strip them first.
+    The public docstrings tell callers not to type literal bullet glyphs,
+    but callers may do so anyway; once we ask Slides to render real
+    bulleted paragraphs (see createParagraphBullets below) those glyphs
+    would double up with Slides' own bullet, so strip them first.
     """
-    return "\n".join(_BULLET_PREFIX_PATTERN.sub("", line) for line in text.split("\n"))
+    return "\n".join(
+        _BULLET_PREFIX_PATTERN.sub(r"\1", line) for line in text.split("\n")
+    )
 
 
 def _error(message: str) -> str:
-    return json.dumps({"status": "error", "message": message})
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
 
 
 def get_slides_service() -> Any:
@@ -137,7 +164,7 @@ def google_slides_get_presentation(presentation_id: str) -> str:
         )
     except Exception as e:
         logger.error(f"Error getting presentation: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return _error(str(e))
 
 
 @mcp.tool()
@@ -162,7 +189,7 @@ def google_slides_create_presentation(title: str) -> str:
         )
     except Exception as e:
         logger.error(f"Error creating presentation: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return _error(str(e))
 
 
 @mcp.tool()
@@ -181,12 +208,18 @@ def google_slides_add_slide(
     layout picks the slide's predefined layout, which decides which of
     title/body actually have a placeholder to land in:
       - "TITLE_AND_BODY" (default): title + full bulleted body content.
+        body is required here — this layout rejects an empty body rather
+        than silently creating a title-only slide.
       - "TITLE": a cover/section-opening slide — title is the big centered
         title, body (optional) becomes the subtitle line (not bulleted).
       - "TITLE_ONLY", "SECTION_HEADER": title only, no body placeholder —
         pass body="" or the call is rejected.
       - "BLANK": no placeholders at all; use google_slides_batch_update to
         add free-form text boxes/images instead.
+
+    Every layout with a title placeholder also needs at least a non-empty
+    title (or, for "TITLE", a non-empty body/subtitle instead) — a call
+    that would otherwise produce a completely empty slide is rejected.
     """
     try:
         if layout not in _LAYOUT_PLACEHOLDERS:
@@ -195,7 +228,11 @@ def google_slides_add_slide(
                 f"{', '.join(sorted(_LAYOUT_PLACEHOLDERS))}"
             )
 
-        title_placeholder, body_placeholder = _LAYOUT_PLACEHOLDERS[layout]
+        title_placeholder, body_placeholder, is_bulleted, body_required = (
+            _LAYOUT_PLACEHOLDERS[layout]
+        )
+        if is_bulleted and body:
+            body = _strip_bullet_prefixes(body)
 
         if title and title_placeholder is None:
             return _error(
@@ -211,12 +248,24 @@ def google_slides_add_slide(
                 "with a body/subtitle placeholder (e.g. "
                 "TITLE_AND_BODY, TITLE) or omit body."
             )
-        if not body.strip() and body_placeholder == "BODY":
+        if body_required and not body.strip():
             return _error(
                 f"layout '{layout}' expects body content but none "
                 "was provided. Include this slide's full bullet/"
                 "detail text in 'body' — don't create the slide "
                 "with just a title."
+            )
+        if (
+            title_placeholder is not None
+            and not body_required
+            and not title.strip()
+            and not body.strip()
+        ):
+            return _error(
+                f"layout '{layout}' needs at least a non-empty 'title'"
+                + (" or 'body'" if body_placeholder is not None else "")
+                + " — as given, this call would create a completely "
+                "empty slide."
             )
 
         pres_id = _resolve_presentation_id(presentation_id)
@@ -242,27 +291,18 @@ def google_slides_add_slide(
                 }
             )
 
-        requests: list[dict[str, Any]] = [
-            {
-                "createSlide": {
-                    "objectId": slide_id,
-                    "slideLayoutReference": {"predefinedLayout": layout},
-                    "placeholderIdMappings": placeholder_mappings,
-                }
-            }
-        ]
-        if title:
+        create_slide: dict[str, Any] = {
+            "objectId": slide_id,
+            "slideLayoutReference": {"predefinedLayout": layout},
+        }
+        if placeholder_mappings:
+            create_slide["placeholderIdMappings"] = placeholder_mappings
+
+        requests: list[dict[str, Any]] = [{"createSlide": create_slide}]
+        if title.strip():
             requests.append({"insertText": {"objectId": title_id, "text": title}})
         if body:
-            is_bulleted = body_placeholder == "BODY"
-            requests.append(
-                {
-                    "insertText": {
-                        "objectId": body_id,
-                        "text": _strip_bullet_prefixes(body) if is_bulleted else body,
-                    }
-                }
-            )
+            requests.append({"insertText": {"objectId": body_id, "text": body}})
             if is_bulleted:
                 requests.append(
                     {
@@ -322,7 +362,7 @@ def google_slides_batch_update(presentation_id: str, requests_json: str) -> str:
         )
     except Exception as e:
         logger.error(f"Error applying batch update: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return _error(str(e))
 
 
 if __name__ == "__main__":

--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -58,18 +58,36 @@ _LAYOUT_PLACEHOLDERS: dict[str, _LayoutSpec] = {
     "BLANK": _LayoutSpec(None, None, bulleted=False, body_required=False),
 }
 
-# Leading "•"/"-"/"*" marker (with or without a following space, so a marker
-# glued to text like "•First" is still recognized) at the start of a line.
-# Captures any leading whitespace so it survives the substitution — Slides'
-# createParagraphBullets infers nesting level from leading tab characters
-# in the inserted text, so stripping only the marker (not the indentation
-# in front of it) keeps multi-level bullets intact.
-_BULLET_PREFIX_PATTERN = re.compile(r"^([ \t]*)[•\-\*][ \t]*")
+# Leading "•"/"-"/"*" marker at the start of a line, with or without a
+# following space so a marker glued to a word (e.g. "•First") is still
+# recognized. Captures any leading whitespace so it survives the
+# substitution — Slides' createParagraphBullets infers nesting level from
+# leading tab characters in the inserted text, so stripping only the
+# marker (not the indentation in front of it) keeps multi-level bullets
+# intact.
+#
+# "-" and "*" also have common non-bullet meanings, so the "glued, no
+# space" case is deliberately narrower for them than for "•" (which has no
+# other meaning in plain text):
+#   - "-" glued to a digit ("-5% growth") or another "-" ("-- Author") is
+#     left alone entirely, so a negative number's sign or an em-dash
+#     convention is never silently eaten.
+#   - "*" is only treated as a marker when followed by real whitespace
+#     ("* item"); a bare glued "*" ("*emphasis* text") is left alone so
+#     markdown-style emphasis isn't corrupted.
+_BULLET_PREFIX_PATTERN = re.compile(
+    r"^([ \t]*)(?:"
+    r"•(?:[ \t]+|(?=\S))"
+    r"|-(?:[ \t]+|(?=[^\s\d\-]))"
+    r"|\*[ \t]+"
+    r")"
+)
 
 
 def _strip_bullet_prefixes(text: str) -> str:
     """Drop a leading "•"/"-"/"*" marker from each line, preserving any
-    leading whitespace before it.
+    leading whitespace before it. See _BULLET_PREFIX_PATTERN for the
+    narrower rules that keep this from corrupting non-bullet content.
 
     The public docstrings tell callers not to type literal bullet glyphs,
     but callers may do so anyway; once we ask Slides to render real
@@ -217,9 +235,10 @@ def google_slides_add_slide(
       - "BLANK": no placeholders at all; use google_slides_batch_update to
         add free-form text boxes/images instead.
 
-    Every layout with a title placeholder also needs at least a non-empty
-    title (or, for "TITLE", a non-empty body/subtitle instead) — a call
-    that would otherwise produce a completely empty slide is rejected.
+    Layouts that don't already require a body (i.e. everything except
+    TITLE_AND_BODY) still need at least a non-empty title — or, for
+    "TITLE", a non-empty body/subtitle instead — since otherwise the call
+    would produce a completely empty slide; that combination is rejected.
     """
     try:
         if layout not in _LAYOUT_PLACEHOLDERS:
@@ -301,7 +320,7 @@ def google_slides_add_slide(
         requests: list[dict[str, Any]] = [{"createSlide": create_slide}]
         if title.strip():
             requests.append({"insertText": {"objectId": title_id, "text": title}})
-        if body:
+        if body.strip():
             requests.append({"insertText": {"objectId": body_id, "text": body}})
             if is_bulleted:
                 requests.append(

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -8,10 +8,11 @@ from xagent.web.tools.mcp import google_slides
 
 @pytest.fixture(autouse=True)
 def _credentials(monkeypatch):
+    # Every test below replaces get_slides_service() wholesale via
+    # _mock_slides_service, so nothing here exercises real credential
+    # building — this just guards against a stray, unmocked call blowing up
+    # with a confusing "missing env var" error instead of the actual assertion.
     monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
-    monkeypatch.delenv("GOOGLE_REFRESH_TOKEN", raising=False)
-    monkeypatch.delenv("GOOGLE_CLIENT_ID", raising=False)
-    monkeypatch.delenv("GOOGLE_CLIENT_SECRET", raising=False)
 
 
 def _mock_slides_service(monkeypatch, presentations_mock):
@@ -68,6 +69,18 @@ def test_add_slide_default_layout_creates_title_and_body_with_bullets(monkeypatc
     assert bullets_req["objectId"] == mappings["BODY"]
     assert bullets_req["textRange"] == {"type": "ALL"}
 
+    # createParagraphBullets must come after the insertText that populates
+    # the body — applying it to an empty range fails against the real API.
+    body_insert_index = next(
+        i
+        for i, r in enumerate(requests)
+        if "insertText" in r and r["insertText"]["objectId"] == mappings["BODY"]
+    )
+    bullets_index = next(
+        i for i, r in enumerate(requests) if "createParagraphBullets" in r
+    )
+    assert bullets_index > body_insert_index
+
 
 def test_add_slide_strips_literal_bullet_markers_before_inserting(monkeypatch):
     presentations = Mock()
@@ -86,6 +99,67 @@ def test_add_slide_strips_literal_bullet_markers_before_inserting(monkeypatch):
     assert body_text == (
         "First point\nSecond point\nThird point\nFourth point (no marker)"
     )
+
+
+def test_add_slide_strips_marker_glued_to_text_without_trailing_space(monkeypatch):
+    """A marker with no space after it (e.g. "•First", "-Nospace") must
+    still be recognized — otherwise the literal marker survives next to
+    Slides' own bullet glyph, a visible double bullet."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    google_slides.google_slides_add_slide(
+        "pres1", title="T", body="•First point\n-Nospace"
+    )
+
+    requests = _batch_update_requests(presentations)
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and "First point" in r["insertText"]["text"]
+    )
+    assert body_text == "First point\nNospace"
+
+
+def test_add_slide_preserves_nested_bullet_indentation(monkeypatch):
+    """Slides infers bullet nesting level from leading whitespace/tabs in
+    the inserted text; stripping the marker must not also strip the
+    indentation in front of it, or multi-level bullets flatten to one
+    level."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    body = "- Top\n  - Nested\n    - Deeper"
+    google_slides.google_slides_add_slide("pres1", title="T", body=body)
+
+    requests = _batch_update_requests(presentations)
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and "Top" in r["insertText"]["text"]
+    )
+    assert body_text == "Top\n  Nested\n    Deeper"
+
+
+def test_add_slide_rejects_marker_only_body_for_content_layout(monkeypatch):
+    """A body that's only a bullet marker ("•   ") strips to an empty
+    string before insertion — the body-required guard must check the
+    post-stripping text, not the raw string, or this recreates the
+    content-less-slide bug via a different input shape."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="T", body="•   ", layout="TITLE_AND_BODY"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "body" in result["message"]
+    presentations.batchUpdate.assert_not_called()
 
 
 def test_add_slide_title_layout_uses_subtitle_and_skips_bullets(monkeypatch):
@@ -132,9 +206,59 @@ def test_add_slide_title_only_layouts_need_no_body(monkeypatch, layout):
 
     assert result["status"] == "success"
     requests = _batch_update_requests(presentations)
-    assert requests[0]["createSlide"]["slideLayoutReference"] == {
-        "predefinedLayout": layout
+    create_slide = requests[0]["createSlide"]
+    assert create_slide["slideLayoutReference"] == {"predefinedLayout": layout}
+    mappings = {
+        m["layoutPlaceholder"]["type"] for m in create_slide["placeholderIdMappings"]
     }
+    assert mappings == {"TITLE"}
+
+
+@pytest.mark.parametrize("layout", ["TITLE_ONLY", "SECTION_HEADER"])
+def test_add_slide_rejects_empty_title_for_title_only_layout(monkeypatch, layout):
+    """Regression guard, symmetric with the body-required check: a layout
+    whose only content slot is the title must not silently create a fully
+    empty slide when title is also omitted."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(google_slides.google_slides_add_slide("pres1", layout=layout))
+
+    assert result["status"] == "error"
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_add_slide_rejects_completely_empty_title_layout(monkeypatch):
+    """The TITLE (cover) layout accepts an empty body (subtitle is
+    optional), but title and body can't both be empty — that's a
+    completely blank cover slide."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(google_slides.google_slides_add_slide("pres1", layout="TITLE"))
+
+    assert result["status"] == "error"
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_add_slide_skips_whitespace_only_title_insertion(monkeypatch):
+    """A whitespace-only title on a content layout (where body carries the
+    real content) must not be inserted verbatim — leave the placeholder
+    empty instead of filling it with whitespace."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    google_slides.google_slides_add_slide(
+        "pres1", title="   ", body="Real content", layout="TITLE_AND_BODY"
+    )
+
+    requests = _batch_update_requests(presentations)
+    title_object_id = requests[0]["createSlide"]["placeholderIdMappings"][0]["objectId"]
+    assert not any(
+        "insertText" in r and r["insertText"]["objectId"] == title_object_id
+        for r in requests
+    )
 
 
 def test_add_slide_rejects_unknown_layout(monkeypatch):
@@ -242,18 +366,46 @@ def test_add_slide_title_layout_allows_missing_body(monkeypatch):
     assert result["status"] == "success"
 
 
-def test_add_slide_blank_layout_rejects_title_and_body(monkeypatch):
+def test_add_slide_blank_layout_rejects_title_alone(monkeypatch):
     presentations = Mock()
     _mock_slides_service(monkeypatch, presentations)
 
     result = json.loads(
-        google_slides.google_slides_add_slide(
-            "pres1", title="T", body="B", layout="BLANK"
-        )
+        google_slides.google_slides_add_slide("pres1", title="T", layout="BLANK")
     )
 
     assert result["status"] == "error"
     presentations.batchUpdate.assert_not_called()
+
+
+def test_add_slide_blank_layout_rejects_body_alone(monkeypatch):
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", body="B", layout="BLANK")
+    )
+
+    assert result["status"] == "error"
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_add_slide_blank_layout_allows_empty_and_omits_placeholder_mappings(
+    monkeypatch,
+):
+    """BLANK is meant to be empty (custom content is added afterwards via
+    google_slides_batch_update); the empty-slide guard must not reject it,
+    and createSlide should omit placeholderIdMappings rather than sending
+    an empty list."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(google_slides.google_slides_add_slide("pres1", layout="BLANK"))
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+    assert "placeholderIdMappings" not in requests[0]["createSlide"]
 
 
 def test_add_slide_resolves_full_presentation_url(monkeypatch):

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -1,4 +1,5 @@
 import json
+import time
 from unittest.mock import Mock
 
 import pytest
@@ -296,6 +297,23 @@ def test_add_slide_fully_unwraps_a_line_with_more_than_one_leading_marker(monkey
     assert body_text == "nested"
 
 
+def test_strip_bullet_prefixes_bounds_work_on_a_degenerate_glued_marker_run():
+    """Regression guard for a real perf/DoS finding: _strip_line used to
+    re-scan the whole remaining line on every stripped marker with no
+    cap, making a line of N glued "•" characters (body has no length
+    limit; plausible from a runaway/malformed LLM completion) O(n^2) —
+    measured at over a second for N=200_000. _MAX_MARKER_STRIPS_PER_LINE
+    must keep this bounded regardless of N."""
+    line = "•" * 200_000 + "Hello"
+
+    start = time.perf_counter()
+    result = google_slides._strip_bullet_prefixes(line)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 1.0
+    assert result.endswith("Hello")
+
+
 def test_add_slide_drops_blank_lines_and_trailing_newline_from_bulleted_body(
     monkeypatch,
 ):
@@ -401,6 +419,27 @@ def test_add_slide_rejects_empty_title_for_title_only_layout(monkeypatch, layout
     _mock_slides_service(monkeypatch, presentations)
 
     result = json.loads(google_slides.google_slides_add_slide("pres1", layout=layout))
+
+    assert result["status"] == "error"
+    assert "completely empty slide" in result["message"]
+    presentations.batchUpdate.assert_not_called()
+
+
+@pytest.mark.parametrize("layout", ["TITLE_ONLY", "SECTION_HEADER"])
+def test_add_slide_rejects_title_that_is_only_a_newline(monkeypatch, layout):
+    """Regression guard: before the newline-collapse + .strip()-based
+    guards were added together, title="\\n" was truthy under the old bare
+    truthiness check and slipped past the empty-slide guard, producing a
+    createSlide with no insertText for the title at all (insertion always
+    used title.strip()) — a silently blank slide. Collapsing "\\n" to " "
+    and then stripping it must route this through the empty-slide guard
+    with its real message, not a misleading one from elsewhere."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="\n", layout=layout)
+    )
 
     assert result["status"] == "error"
     assert "completely empty slide" in result["message"]

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -143,6 +143,29 @@ def test_add_slide_preserves_nested_bullet_indentation(monkeypatch):
     assert body_text == "Top\n  Nested\n    Deeper"
 
 
+def test_add_slide_does_not_corrupt_non_bullet_content_starting_with_marker_chars(
+    monkeypatch,
+):
+    """ "-"/"*" have common non-bullet meanings (a negative number's sign,
+    an em-dash, markdown emphasis) — a leading marker glued to a digit or
+    to another marker character, or a bare "*" with no trailing space,
+    must be left alone rather than silently mangled."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    body = "-5% growth\n-- Author Name\n**Note\n*emphasis* not a bullet"
+    google_slides.google_slides_add_slide("pres1", title="T", body=body)
+
+    requests = _batch_update_requests(presentations)
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and "growth" in r["insertText"]["text"]
+    )
+    assert body_text == body
+
+
 def test_add_slide_rejects_marker_only_body_for_content_layout(monkeypatch):
     """A body that's only a bullet marker ("•   ") strips to an empty
     string before insertion — the body-required guard must check the
@@ -351,6 +374,32 @@ def test_add_slide_title_layout_preserves_literal_dash_in_subtitle(monkeypatch):
         if "insertText" in r and "Complete Guide" in r["insertText"]["text"]
     )
     assert body_text == "- The Complete Guide"
+
+
+def test_add_slide_skips_whitespace_only_body_insertion_on_title_layout(monkeypatch):
+    """Regression guard, symmetric with the whitespace-only-title fix: a
+    whitespace-only body on a layout where body is optional (e.g. TITLE's
+    subtitle) must not be inserted verbatim — leave the placeholder
+    untouched instead of writing invisible whitespace into it."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="Cover", body="   ", layout="TITLE"
+        )
+    )
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+    subtitle_object_id = requests[0]["createSlide"]["placeholderIdMappings"][1][
+        "objectId"
+    ]
+    assert not any(
+        "insertText" in r and r["insertText"]["objectId"] == subtitle_object_id
+        for r in requests
+    )
 
 
 def test_add_slide_title_layout_allows_missing_body(monkeypatch):

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -118,7 +118,7 @@ def test_add_slide_title_layout_uses_subtitle_and_skips_bullets(monkeypatch):
     assert not any("createParagraphBullets" in r for r in requests)
 
 
-@pytest.mark.parametrize("layout", ["TITLE_ONLY", "SECTION_HEADER", "MAIN_POINT"])
+@pytest.mark.parametrize("layout", ["TITLE_ONLY", "SECTION_HEADER"])
 def test_add_slide_title_only_layouts_need_no_body(monkeypatch, layout):
     presentations = Mock()
     presentations.batchUpdate.return_value.execute.return_value = {}
@@ -150,7 +150,7 @@ def test_add_slide_rejects_unknown_layout(monkeypatch):
     presentations.batchUpdate.assert_not_called()
 
 
-@pytest.mark.parametrize("layout", ["TITLE_ONLY", "SECTION_HEADER", "MAIN_POINT"])
+@pytest.mark.parametrize("layout", ["TITLE_ONLY", "SECTION_HEADER"])
 def test_add_slide_rejects_body_on_layout_without_body_placeholder(monkeypatch, layout):
     """Regression guard: these layouts have no body placeholder, so silently
     accepting `body` would drop it exactly like the reported bug — reject the
@@ -184,6 +184,49 @@ def test_add_slide_rejects_missing_body_for_content_layout(monkeypatch):
     assert result["status"] == "error"
     assert "body" in result["message"]
     presentations.batchUpdate.assert_not_called()
+
+
+def test_add_slide_rejects_whitespace_only_body_for_content_layout(monkeypatch):
+    """Regression guard: a whitespace-only body ("   ", "\\n\\n") must not
+    slip past the "body required" check just because it's non-empty — that
+    would recreate the exact content-less-slide bug the check exists for."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1",
+            title="Q3 Pipeline Highlights",
+            body="   \n\n  ",
+            layout="TITLE_AND_BODY",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "body" in result["message"]
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_add_slide_title_layout_preserves_literal_dash_in_subtitle(monkeypatch):
+    """Regression guard: bullet-marker stripping must only apply to text
+    that's actually being turned into a bulleted list (a real BODY
+    placeholder) — a SUBTITLE is never bulleted, so a literal leading "-"
+    the caller intended as part of the subtitle text must survive."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    google_slides.google_slides_add_slide(
+        "pres1", title="Guide", body="- The Complete Guide", layout="TITLE"
+    )
+
+    requests = _batch_update_requests(presentations)
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and "Complete Guide" in r["insertText"]["text"]
+    )
+    assert body_text == "- The Complete Guide"
 
 
 def test_add_slide_title_layout_allows_missing_body(monkeypatch):

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -690,6 +690,33 @@ async def test_add_slide_rejects_unknown_layout_via_mcp_layer(monkeypatch):
     presentations.batchUpdate.assert_not_called()
 
 
+async def test_add_slide_normalizes_layout_via_mcp_layer(monkeypatch):
+    """Regression guard: `layout`'s Literal type is validated by FastMCP's
+    Pydantic layer *before* the function body runs — a naive Literal
+    annotation would reject a differently-cased/spaced value there,
+    making the function's own layout.strip().upper() dead code for every
+    real (non-test, non-direct-call) caller. `_normalize_layout` must run
+    as a BeforeValidator so normalization happens ahead of the Literal
+    check, not after it."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    content, _ = await google_slides.mcp.call_tool(
+        "google_slides_add_slide",
+        {
+            "presentation_id": "pres1",
+            "title": "T",
+            "body": "detail",
+            "layout": " title_and_body ",
+        },
+    )
+
+    result = json.loads(content[0].text)
+    assert result["status"] == "success"
+    assert result["layout"] == "TITLE_AND_BODY"
+
+
 def test_get_presentation_returns_slide_summaries(monkeypatch):
     presentations = Mock()
     presentations.get.return_value.execute.return_value = {

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -76,6 +76,7 @@ def test_add_slide_default_layout_creates_title_and_body_with_bullets(monkeypatc
     )
     assert bullets_req["objectId"] == mappings["BODY"]
     assert bullets_req["textRange"] == {"type": "ALL"}
+    assert bullets_req["bulletPreset"] == "BULLET_DISC_CIRCLE_SQUARE"
 
     # createParagraphBullets must come after the insertText that populates
     # the body — applying it to an empty range fails against the real API.
@@ -96,13 +97,17 @@ def test_add_slide_strips_literal_bullet_markers_before_inserting(monkeypatch):
     _mock_slides_service(monkeypatch, presentations)
 
     body = "• First point\n- Second point\n* Third point\nFourth point (no marker)"
-    google_slides.google_slides_add_slide("pres1", title="T", body=body)
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="T", body=body)
+    )
 
+    assert result["status"] == "success"
     requests = _batch_update_requests(presentations)
+    body_object_id = _placeholder_object_id(requests[0]["createSlide"], "BODY")
     body_text = next(
         r["insertText"]["text"]
         for r in requests
-        if "insertText" in r and "First point" in r["insertText"]["text"]
+        if "insertText" in r and r["insertText"]["objectId"] == body_object_id
     )
     assert body_text == (
         "First point\nSecond point\nThird point\nFourth point (no marker)"
@@ -117,15 +122,19 @@ def test_add_slide_strips_marker_glued_to_text_without_trailing_space(monkeypatc
     presentations.batchUpdate.return_value.execute.return_value = {}
     _mock_slides_service(monkeypatch, presentations)
 
-    google_slides.google_slides_add_slide(
-        "pres1", title="T", body="•First point\n-Nospace"
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="T", body="•First point\n-Nospace"
+        )
     )
 
+    assert result["status"] == "success"
     requests = _batch_update_requests(presentations)
+    body_object_id = _placeholder_object_id(requests[0]["createSlide"], "BODY")
     body_text = next(
         r["insertText"]["text"]
         for r in requests
-        if "insertText" in r and "First point" in r["insertText"]["text"]
+        if "insertText" in r and r["insertText"]["objectId"] == body_object_id
     )
     assert body_text == "First point\nNospace"
 
@@ -140,19 +149,71 @@ def test_add_slide_preserves_nested_bullet_indentation(monkeypatch):
     _mock_slides_service(monkeypatch, presentations)
 
     body = "- Top\n  - Nested\n    - Deeper"
-    google_slides.google_slides_add_slide("pres1", title="T", body=body)
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="T", body=body)
+    )
 
+    assert result["status"] == "success"
     requests = _batch_update_requests(presentations)
+    body_object_id = _placeholder_object_id(requests[0]["createSlide"], "BODY")
     body_text = next(
         r["insertText"]["text"]
         for r in requests
-        if "insertText" in r and "Top" in r["insertText"]["text"]
+        if "insertText" in r and r["insertText"]["objectId"] == body_object_id
     )
     # Slides infers nesting level from leading *tabs*, not spaces — plain
     # spaces would just be inserted as literal, non-nesting text — so
     # 2-space indentation must be converted to real tab characters, one
     # tab per level, for the nesting to actually render in Slides.
     assert body_text == "Top\n\tNested\n\t\tDeeper"
+
+
+def test_add_slide_preserves_literal_tab_indentation(monkeypatch):
+    """A caller who already typed real tab characters (rather than
+    spaces) for nesting must have them preserved 1:1 — this is the input
+    shape Slides' createParagraphBullets actually keys off."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    body = "- Top\n\t- Nested\n\t\t- Deeper"
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="T", body=body)
+    )
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+    body_object_id = _placeholder_object_id(requests[0]["createSlide"], "BODY")
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == body_object_id
+    )
+    assert body_text == "Top\n\tNested\n\t\tDeeper"
+
+
+def test_add_slide_mixed_tab_and_space_indentation_uses_tab_count_only(monkeypatch):
+    """Documented limitation: mixing tabs and spaces in one line's leading
+    whitespace is not combined — if any tab is present, the tab count
+    wins and spaces in that same run are ignored."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    body = "- Top\n\t  - Mixed"
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="T", body=body)
+    )
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+    body_object_id = _placeholder_object_id(requests[0]["createSlide"], "BODY")
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == body_object_id
+    )
+    assert body_text == "Top\n\tMixed"
 
 
 def test_add_slide_does_not_corrupt_non_bullet_content_starting_with_marker_chars(
@@ -173,13 +234,17 @@ def test_add_slide_does_not_corrupt_non_bullet_content_starting_with_marker_char
         "-5% growth\n-$5m loss\n-.5% decline\n-- Author Name\n-– Author\n"
         "**Note\n*emphasis* not a bullet"
     )
-    google_slides.google_slides_add_slide("pres1", title="T", body=body)
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="T", body=body)
+    )
 
+    assert result["status"] == "success"
     requests = _batch_update_requests(presentations)
+    body_object_id = _placeholder_object_id(requests[0]["createSlide"], "BODY")
     body_text = next(
         r["insertText"]["text"]
         for r in requests
-        if "insertText" in r and "growth" in r["insertText"]["text"]
+        if "insertText" in r and r["insertText"]["objectId"] == body_object_id
     )
     assert body_text == body
 
@@ -194,15 +259,19 @@ def test_add_slide_strips_bare_marker_with_nothing_after_it(monkeypatch):
     presentations.batchUpdate.return_value.execute.return_value = {}
     _mock_slides_service(monkeypatch, presentations)
 
-    google_slides.google_slides_add_slide(
-        "pres1", title="T", body="Point one\n•\nPoint two"
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="T", body="Point one\n•\nPoint two"
+        )
     )
 
+    assert result["status"] == "success"
     requests = _batch_update_requests(presentations)
+    body_object_id = _placeholder_object_id(requests[0]["createSlide"], "BODY")
     body_text = next(
         r["insertText"]["text"]
         for r in requests
-        if "insertText" in r and "Point one" in r["insertText"]["text"]
+        if "insertText" in r and r["insertText"]["objectId"] == body_object_id
     )
     assert body_text == "Point one\nPoint two"
 
@@ -385,6 +454,23 @@ def test_add_slide_rejects_unknown_layout(monkeypatch):
     presentations.batchUpdate.assert_not_called()
 
 
+def test_add_slide_rejects_non_string_layout_from_direct_call(monkeypatch):
+    """layout's Literal typing is only enforced by FastMCP's validation
+    layer, which a direct Python call bypasses entirely — a non-string
+    value (e.g. an int) must still surface as a clean error rather than
+    an unhandled AttributeError from calling .strip() on it."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="T", layout=123)
+    )
+
+    assert result["status"] == "error"
+    assert "'layout' must be a string" in result["message"]
+    presentations.batchUpdate.assert_not_called()
+
+
 @pytest.mark.parametrize("layout", ["TITLE_ONLY", "SECTION_HEADER"])
 def test_add_slide_rejects_body_on_layout_without_body_placeholder(monkeypatch, layout):
     """Regression guard: these layouts have no body placeholder, so silently
@@ -402,6 +488,42 @@ def test_add_slide_rejects_body_on_layout_without_body_placeholder(monkeypatch, 
     assert result["status"] == "error"
     assert "has no body placeholder" in result["message"]
     presentations.batchUpdate.assert_not_called()
+
+
+@pytest.mark.parametrize("layout", ["TITLE_ONLY", "SECTION_HEADER"])
+def test_add_slide_allows_whitespace_only_body_on_layout_without_body_placeholder(
+    monkeypatch, layout
+):
+    """Regression guard: the "no body placeholder" rejection must key off
+    stripped content, matching insertion (which already treats a
+    whitespace-only body as absent) — otherwise body="\\n" is hard-rejected
+    even though nothing would actually have been dropped."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="T", body="\n", layout=layout
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_add_slide_allows_whitespace_only_title_on_blank_layout(monkeypatch):
+    """Regression guard, symmetric with the above: BLANK has no title
+    placeholder either, and a whitespace-only title must not be
+    hard-rejected when it would be treated as absent anyway."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="   ", layout="BLANK")
+    )
+
+    assert result["status"] == "success"
 
 
 def test_add_slide_rejects_missing_body_for_content_layout(monkeypatch):
@@ -451,17 +573,47 @@ def test_add_slide_title_layout_preserves_literal_dash_in_subtitle(monkeypatch):
     presentations.batchUpdate.return_value.execute.return_value = {}
     _mock_slides_service(monkeypatch, presentations)
 
-    google_slides.google_slides_add_slide(
-        "pres1", title="Guide", body="- The Complete Guide", layout="TITLE"
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="Guide", body="- The Complete Guide", layout="TITLE"
+        )
     )
 
+    assert result["status"] == "success"
     requests = _batch_update_requests(presentations)
+    subtitle_object_id = _placeholder_object_id(requests[0]["createSlide"], "SUBTITLE")
     body_text = next(
         r["insertText"]["text"]
         for r in requests
-        if "insertText" in r and "Complete Guide" in r["insertText"]["text"]
+        if "insertText" in r and r["insertText"]["objectId"] == subtitle_object_id
     )
     assert body_text == "- The Complete Guide"
+
+
+def test_add_slide_drops_blank_lines_on_non_bulleted_body(monkeypatch):
+    """Blank-line filtering must not be limited to bulleted content — a
+    blank line or trailing newline in a non-bulleted body (e.g. TITLE's
+    subtitle) would otherwise leave stray blank paragraphs in the
+    placeholder even though there's no floating-bullet symptom to notice."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="Guide", body="\n\nSubtitle\n", layout="TITLE"
+        )
+    )
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+    subtitle_object_id = _placeholder_object_id(requests[0]["createSlide"], "SUBTITLE")
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == subtitle_object_id
+    )
+    assert body_text == "Subtitle"
 
 
 def test_add_slide_skips_whitespace_only_body_insertion_on_title_layout(monkeypatch):
@@ -591,14 +743,16 @@ def test_add_slide_returns_error_payload_without_ascii_escaping(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("layout", "kwargs"),
+    ("layout", "kwargs", "expected_layout"),
     [
-        ("title_and_body", {"body": "detail"}),
-        (" TITLE ", {}),
-        ("Title_Only", {}),
+        ("title_and_body", {"body": "detail"}, "TITLE_AND_BODY"),
+        (" TITLE ", {}, "TITLE"),
+        ("Title_Only", {}, "TITLE_ONLY"),
     ],
 )
-def test_add_slide_normalizes_layout_case_and_whitespace(monkeypatch, layout, kwargs):
+def test_add_slide_normalizes_layout_case_and_whitespace(
+    monkeypatch, layout, kwargs, expected_layout
+):
     """An LLM caller may not reproduce the exact enum casing/spacing —
     normalize before rejecting as unknown."""
     presentations = Mock()
@@ -612,7 +766,7 @@ def test_add_slide_normalizes_layout_case_and_whitespace(monkeypatch, layout, kw
     )
 
     assert result["status"] == "success"
-    assert result["layout"] == layout.strip().upper()
+    assert result["layout"] == expected_layout
 
 
 def test_add_slide_echoes_the_effective_layout_on_success(monkeypatch):
@@ -638,6 +792,27 @@ def test_add_slide_strips_padding_whitespace_from_title_before_inserting(monkeyp
     _mock_slides_service(monkeypatch, presentations)
 
     google_slides.google_slides_add_slide("pres1", title="  Q3 Review  ", body="detail")
+
+    requests = _batch_update_requests(presentations)
+    title_object_id = _placeholder_object_id(requests[0]["createSlide"], "TITLE")
+    title_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == title_object_id
+    )
+    assert title_text == "Q3 Review"
+
+
+def test_add_slide_collapses_embedded_newline_in_title(monkeypatch):
+    """A title is expected to be a single line — an embedded newline
+    (e.g. from a caller accidentally pasting multi-line content into
+    title) must be collapsed to a space rather than silently producing a
+    multi-paragraph title placeholder."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    google_slides.google_slides_add_slide("pres1", title="Q3\nReview", body="detail")
 
     requests = _batch_update_requests(presentations)
     title_object_id = _placeholder_object_id(requests[0]["createSlide"], "TITLE")
@@ -748,6 +923,22 @@ def test_get_presentation_returns_slide_summaries(monkeypatch):
     assert result["slides"][0]["text"] == ["Hello"]
 
 
+def test_get_presentation_resolves_full_presentation_url(monkeypatch):
+    presentations = Mock()
+    presentations.get.return_value.execute.return_value = {
+        "presentationId": "abc123",
+        "title": "My Deck",
+        "slides": [],
+    }
+    _mock_slides_service(monkeypatch, presentations)
+
+    url = "https://docs.google.com/presentation/d/abc123/edit#slide=id.p"
+    result = json.loads(google_slides.google_slides_get_presentation(url))
+
+    assert result["status"] == "success"
+    assert presentations.get.call_args.kwargs["presentationId"] == "abc123"
+
+
 def test_get_presentation_returns_error_payload_on_api_failure(monkeypatch):
     presentations = Mock()
     presentations.get.return_value.execute.side_effect = RuntimeError("boom")
@@ -815,6 +1006,36 @@ def test_batch_update_rejects_non_list_json(monkeypatch):
 
     assert result["status"] == "error"
     presentations.batchUpdate.assert_not_called()
+
+
+def test_batch_update_rejects_malformed_json(monkeypatch):
+    """Not merely wrong-shaped JSON (a dict instead of a list, covered
+    above) but genuinely invalid JSON syntax — must surface as a clean
+    error payload rather than an unhandled JSONDecodeError."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_batch_update("pres1", "{not valid json")
+    )
+
+    assert result["status"] == "error"
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_batch_update_resolves_full_presentation_url(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {
+        "presentationId": "abc123",
+        "replies": [],
+    }
+    _mock_slides_service(monkeypatch, presentations)
+
+    url = "https://docs.google.com/presentation/d/abc123/edit#slide=id.p"
+    result = json.loads(google_slides.google_slides_batch_update(url, "[]"))
+
+    assert result["status"] == "success"
+    assert presentations.batchUpdate.call_args.kwargs["presentationId"] == "abc123"
 
 
 def test_batch_update_returns_error_payload_on_api_failure(monkeypatch):

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -26,6 +26,14 @@ def _batch_update_requests(presentations_mock):
     return presentations_mock.batchUpdate.call_args.kwargs["body"]["requests"]
 
 
+def _placeholder_object_id(create_slide, placeholder_type):
+    return next(
+        m["objectId"]
+        for m in create_slide["placeholderIdMappings"]
+        if m["layoutPlaceholder"]["type"] == placeholder_type
+    )
+
+
 def test_add_slide_default_layout_creates_title_and_body_with_bullets(monkeypatch):
     presentations = Mock()
     presentations.batchUpdate.return_value.execute.return_value = {}
@@ -140,21 +148,31 @@ def test_add_slide_preserves_nested_bullet_indentation(monkeypatch):
         for r in requests
         if "insertText" in r and "Top" in r["insertText"]["text"]
     )
-    assert body_text == "Top\n  Nested\n    Deeper"
+    # Slides infers nesting level from leading *tabs*, not spaces — plain
+    # spaces would just be inserted as literal, non-nesting text — so
+    # 2-space indentation must be converted to real tab characters, one
+    # tab per level, for the nesting to actually render in Slides.
+    assert body_text == "Top\n\tNested\n\t\tDeeper"
 
 
 def test_add_slide_does_not_corrupt_non_bullet_content_starting_with_marker_chars(
     monkeypatch,
 ):
     """ "-"/"*" have common non-bullet meanings (a negative number's sign,
-    an em-dash, markdown emphasis) — a leading marker glued to a digit or
-    to another marker character, or a bare "*" with no trailing space,
-    must be left alone rather than silently mangled."""
+    a currency figure, a decimal, an em-/en-dash, markdown emphasis) — a
+    leading marker glued to a digit, symbol, or another marker character,
+    or a bare "*" with no trailing space, must be left alone rather than
+    silently mangled. This is a regression guard for a real bug: an
+    earlier fix for "•First" (marker glued to a word) also silently
+    stripped the sign off negative figures like "-$5m loss"."""
     presentations = Mock()
     presentations.batchUpdate.return_value.execute.return_value = {}
     _mock_slides_service(monkeypatch, presentations)
 
-    body = "-5% growth\n-- Author Name\n**Note\n*emphasis* not a bullet"
+    body = (
+        "-5% growth\n-$5m loss\n-.5% decline\n-- Author Name\n-– Author\n"
+        "**Note\n*emphasis* not a bullet"
+    )
     google_slides.google_slides_add_slide("pres1", title="T", body=body)
 
     requests = _batch_update_requests(presentations)
@@ -164,6 +182,74 @@ def test_add_slide_does_not_corrupt_non_bullet_content_starting_with_marker_char
         if "insertText" in r and "growth" in r["insertText"]["text"]
     )
     assert body_text == body
+
+
+def test_add_slide_strips_bare_marker_with_nothing_after_it(monkeypatch):
+    """A line that's only a bullet marker with nothing after it at all
+    (e.g. a stray "•" or "-" on its own line) previously wasn't recognized
+    by the stripping regex (which required a character or whitespace
+    after the marker), so it survived as literal text right next to
+    Slides' own bullet glyph — a visible double bullet."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    google_slides.google_slides_add_slide(
+        "pres1", title="T", body="Point one\n•\nPoint two"
+    )
+
+    requests = _batch_update_requests(presentations)
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and "Point one" in r["insertText"]["text"]
+    )
+    assert body_text == "Point one\nPoint two"
+
+
+def test_add_slide_fully_unwraps_a_line_with_more_than_one_leading_marker(monkeypatch):
+    """ "• - nested" must not leave a residual "-" as literal text inside a
+    paragraph Slides is about to bullet — strip leading markers repeatedly
+    until none remain, not just the outermost one."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    google_slides.google_slides_add_slide("pres1", title="T", body="• - nested")
+
+    requests = _batch_update_requests(presentations)
+    body_object_id = _placeholder_object_id(requests[0]["createSlide"], "BODY")
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == body_object_id
+    )
+    assert body_text == "nested"
+
+
+def test_add_slide_drops_blank_lines_and_trailing_newline_from_bulleted_body(
+    monkeypatch,
+):
+    """A blank line inside body, or a trailing newline (very common in
+    generated text), would otherwise become an empty paragraph that still
+    gets createParagraphBullets applied to it — a visible floating bullet
+    with no text next to it."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    google_slides.google_slides_add_slide(
+        "pres1", title="T", body="Point one\n\nPoint two\n"
+    )
+
+    requests = _batch_update_requests(presentations)
+    body_object_id = _placeholder_object_id(requests[0]["createSlide"], "BODY")
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == body_object_id
+    )
+    assert body_text == "Point one\nPoint two"
 
 
 def test_add_slide_rejects_marker_only_body_for_content_layout(monkeypatch):
@@ -181,7 +267,7 @@ def test_add_slide_rejects_marker_only_body_for_content_layout(monkeypatch):
     )
 
     assert result["status"] == "error"
-    assert "body" in result["message"]
+    assert "expects body content but none was provided" in result["message"]
     presentations.batchUpdate.assert_not_called()
 
 
@@ -248,6 +334,7 @@ def test_add_slide_rejects_empty_title_for_title_only_layout(monkeypatch, layout
     result = json.loads(google_slides.google_slides_add_slide("pres1", layout=layout))
 
     assert result["status"] == "error"
+    assert "completely empty slide" in result["message"]
     presentations.batchUpdate.assert_not_called()
 
 
@@ -261,6 +348,7 @@ def test_add_slide_rejects_completely_empty_title_layout(monkeypatch):
     result = json.loads(google_slides.google_slides_add_slide("pres1", layout="TITLE"))
 
     assert result["status"] == "error"
+    assert "completely empty slide" in result["message"]
     presentations.batchUpdate.assert_not_called()
 
 
@@ -277,7 +365,7 @@ def test_add_slide_skips_whitespace_only_title_insertion(monkeypatch):
     )
 
     requests = _batch_update_requests(presentations)
-    title_object_id = requests[0]["createSlide"]["placeholderIdMappings"][0]["objectId"]
+    title_object_id = _placeholder_object_id(requests[0]["createSlide"], "TITLE")
     assert not any(
         "insertText" in r and r["insertText"]["objectId"] == title_object_id
         for r in requests
@@ -312,7 +400,7 @@ def test_add_slide_rejects_body_on_layout_without_body_placeholder(monkeypatch, 
     )
 
     assert result["status"] == "error"
-    assert "body" in result["message"]
+    assert "has no body placeholder" in result["message"]
     presentations.batchUpdate.assert_not_called()
 
 
@@ -329,7 +417,7 @@ def test_add_slide_rejects_missing_body_for_content_layout(monkeypatch):
     )
 
     assert result["status"] == "error"
-    assert "body" in result["message"]
+    assert "expects body content but none was provided" in result["message"]
     presentations.batchUpdate.assert_not_called()
 
 
@@ -350,7 +438,7 @@ def test_add_slide_rejects_whitespace_only_body_for_content_layout(monkeypatch):
     )
 
     assert result["status"] == "error"
-    assert "body" in result["message"]
+    assert "expects body content but none was provided" in result["message"]
     presentations.batchUpdate.assert_not_called()
 
 
@@ -393,9 +481,7 @@ def test_add_slide_skips_whitespace_only_body_insertion_on_title_layout(monkeypa
 
     assert result["status"] == "success"
     requests = _batch_update_requests(presentations)
-    subtitle_object_id = requests[0]["createSlide"]["placeholderIdMappings"][1][
-        "objectId"
-    ]
+    subtitle_object_id = _placeholder_object_id(requests[0]["createSlide"], "SUBTITLE")
     assert not any(
         "insertText" in r and r["insertText"]["objectId"] == subtitle_object_id
         for r in requests
@@ -424,6 +510,7 @@ def test_add_slide_blank_layout_rejects_title_alone(monkeypatch):
     )
 
     assert result["status"] == "error"
+    assert "has no title placeholder" in result["message"]
     presentations.batchUpdate.assert_not_called()
 
 
@@ -436,6 +523,7 @@ def test_add_slide_blank_layout_rejects_body_alone(monkeypatch):
     )
 
     assert result["status"] == "error"
+    assert "has no body placeholder" in result["message"]
     presentations.batchUpdate.assert_not_called()
 
 
@@ -479,6 +567,235 @@ def test_add_slide_returns_error_payload_on_api_failure(monkeypatch):
     result = json.loads(
         google_slides.google_slides_add_slide("pres1", title="T", body="detail")
     )
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
+
+
+def test_add_slide_returns_error_payload_without_ascii_escaping(monkeypatch):
+    """_error() must use ensure_ascii=False like every success payload in
+    this file, or non-ASCII error text (e.g. from a caller's own input
+    echoed back, or a non-ASCII exception message) gets mangled into
+    \\uXXXX escapes instead of staying human-readable."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.side_effect = RuntimeError(
+        "读取失败 — 😀"
+    )
+    _mock_slides_service(monkeypatch, presentations)
+
+    raw = google_slides.google_slides_add_slide("pres1", title="T", body="detail")
+
+    assert "\\u" not in raw
+    assert "读取失败" in raw
+    assert json.loads(raw)["status"] == "error"
+
+
+@pytest.mark.parametrize(
+    ("layout", "kwargs"),
+    [
+        ("title_and_body", {"body": "detail"}),
+        (" TITLE ", {}),
+        ("Title_Only", {}),
+    ],
+)
+def test_add_slide_normalizes_layout_case_and_whitespace(monkeypatch, layout, kwargs):
+    """An LLM caller may not reproduce the exact enum casing/spacing —
+    normalize before rejecting as unknown."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="T", layout=layout, **kwargs
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["layout"] == layout.strip().upper()
+
+
+def test_add_slide_echoes_the_effective_layout_on_success(monkeypatch):
+    """The caller passed no explicit layout, relying on the default — the
+    response should confirm which layout was actually applied."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="T", body="detail")
+    )
+
+    assert result["layout"] == "TITLE_AND_BODY"
+
+
+def test_add_slide_strips_padding_whitespace_from_title_before_inserting(monkeypatch):
+    """Unlike body (whose leading whitespace is meaningful for bullet
+    nesting), a title has no reason to keep incidental leading/trailing
+    padding — insert the trimmed text, not the raw string."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    google_slides.google_slides_add_slide("pres1", title="  Q3 Review  ", body="detail")
+
+    requests = _batch_update_requests(presentations)
+    title_object_id = _placeholder_object_id(requests[0]["createSlide"], "TITLE")
+    title_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == title_object_id
+    )
+    assert title_text == "Q3 Review"
+
+
+def test_add_slide_normalizes_crlf_and_cr_newlines(monkeypatch):
+    """Text pasted from a Windows editor may use \\r\\n or lone \\r line
+    endings; leaving stray \\r characters embedded in the inserted text is
+    a latent artifact even though it doesn't break bullet-marker matching
+    (which only anchors on line starts)."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    google_slides.google_slides_add_slide(
+        "pres1", title="T", body="Line one\r\nLine two\rLine three"
+    )
+
+    requests = _batch_update_requests(presentations)
+    body_object_id = _placeholder_object_id(requests[0]["createSlide"], "BODY")
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == body_object_id
+    )
+    assert "\r" not in body_text
+    assert body_text == "Line one\nLine two\nLine three"
+
+
+async def test_add_slide_rejects_unknown_layout_via_mcp_layer(monkeypatch):
+    """layout is typed as a Literal enum so FastMCP validates it before the
+    function body ever runs — exercise the real call path, which direct
+    function calls (used by every other test in this file) bypass."""
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    with pytest.raises(ToolError, match="validation error"):
+        await google_slides.mcp.call_tool(
+            "google_slides_add_slide",
+            {"presentation_id": "pres1", "title": "T", "layout": "TWO_COLUMNS"},
+        )
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_get_presentation_returns_slide_summaries(monkeypatch):
+    presentations = Mock()
+    presentations.get.return_value.execute.return_value = {
+        "presentationId": "pres1",
+        "title": "My Deck",
+        "slides": [
+            {
+                "objectId": "slide1",
+                "pageElements": [
+                    {
+                        "objectId": "shape1",
+                        "shape": {
+                            "text": {
+                                "textElements": [{"textRun": {"content": "Hello"}}]
+                            }
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(google_slides.google_slides_get_presentation("pres1"))
+
+    assert result["status"] == "success"
+    assert result["title"] == "My Deck"
+    assert result["slide_count"] == 1
+    assert result["slides"][0]["text"] == ["Hello"]
+
+
+def test_get_presentation_returns_error_payload_on_api_failure(monkeypatch):
+    presentations = Mock()
+    presentations.get.return_value.execute.side_effect = RuntimeError("boom")
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(google_slides.google_slides_get_presentation("pres1"))
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
+
+
+def test_create_presentation_returns_link_and_id(monkeypatch):
+    presentations = Mock()
+    presentations.create.return_value.execute.return_value = {
+        "presentationId": "pres1",
+        "title": "New Deck",
+    }
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(google_slides.google_slides_create_presentation("New Deck"))
+
+    assert result["status"] == "success"
+    assert result["presentation_id"] == "pres1"
+    assert result["link"] == "https://docs.google.com/presentation/d/pres1/edit"
+
+
+def test_create_presentation_returns_error_payload_on_api_failure(monkeypatch):
+    presentations = Mock()
+    presentations.create.return_value.execute.side_effect = RuntimeError("boom")
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(google_slides.google_slides_create_presentation("New Deck"))
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
+
+
+def test_batch_update_forwards_requests_and_returns_replies(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {
+        "presentationId": "pres1",
+        "replies": [{"createShape": {"objectId": "shape1"}}],
+    }
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_batch_update(
+            "pres1", '[{"createShape": {"objectId": "shape1"}}]'
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["replies"] == [{"createShape": {"objectId": "shape1"}}]
+    sent_requests = presentations.batchUpdate.call_args.kwargs["body"]["requests"]
+    assert sent_requests == [{"createShape": {"objectId": "shape1"}}]
+
+
+def test_batch_update_rejects_non_list_json(monkeypatch):
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_batch_update("pres1", '{"not": "a list"}')
+    )
+
+    assert result["status"] == "error"
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_batch_update_returns_error_payload_on_api_failure(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.side_effect = RuntimeError("boom")
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(google_slides.google_slides_batch_update("pres1", "[]"))
 
     assert result["status"] == "error"
     assert "boom" in result["message"]

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -1,0 +1,240 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.web.tools.mcp import google_slides
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
+    monkeypatch.delenv("GOOGLE_REFRESH_TOKEN", raising=False)
+    monkeypatch.delenv("GOOGLE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("GOOGLE_CLIENT_SECRET", raising=False)
+
+
+def _mock_slides_service(monkeypatch, presentations_mock):
+    service = Mock()
+    service.presentations.return_value = presentations_mock
+    monkeypatch.setattr(google_slides, "get_slides_service", lambda: service)
+    return service
+
+
+def _batch_update_requests(presentations_mock):
+    return presentations_mock.batchUpdate.call_args.kwargs["body"]["requests"]
+
+
+def test_add_slide_default_layout_creates_title_and_body_with_bullets(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="Q3 Pipeline Highlights", body="Line one\nLine two"
+        )
+    )
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+
+    create_slide = requests[0]["createSlide"]
+    assert create_slide["slideLayoutReference"] == {
+        "predefinedLayout": "TITLE_AND_BODY"
+    }
+    mappings = {
+        m["layoutPlaceholder"]["type"]: m["objectId"]
+        for m in create_slide["placeholderIdMappings"]
+    }
+    assert set(mappings) == {"TITLE", "BODY"}
+
+    title_req = next(
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == mappings["TITLE"]
+    )
+    assert title_req["text"] == "Q3 Pipeline Highlights"
+    body_req = next(
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == mappings["BODY"]
+    )
+    assert body_req["text"] == "Line one\nLine two"
+
+    bullets_req = next(
+        r["createParagraphBullets"] for r in requests if "createParagraphBullets" in r
+    )
+    assert bullets_req["objectId"] == mappings["BODY"]
+    assert bullets_req["textRange"] == {"type": "ALL"}
+
+
+def test_add_slide_strips_literal_bullet_markers_before_inserting(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    body = "• First point\n- Second point\n* Third point\nFourth point (no marker)"
+    google_slides.google_slides_add_slide("pres1", title="T", body=body)
+
+    requests = _batch_update_requests(presentations)
+    body_text = next(
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and "First point" in r["insertText"]["text"]
+    )
+    assert body_text == (
+        "First point\nSecond point\nThird point\nFourth point (no marker)"
+    )
+
+
+def test_add_slide_title_layout_uses_subtitle_and_skips_bullets(monkeypatch):
+    """The TITLE (cover) layout maps body to a SUBTITLE placeholder, which
+    should not get a createParagraphBullets request — a subtitle line isn't a
+    bulleted list."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1",
+            title="Q3 2026 Sales & CRM Review",
+            body="Pipeline Updates, Key Wins, and Q4 Strategy",
+            layout="TITLE",
+        )
+    )
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+
+    create_slide = requests[0]["createSlide"]
+    assert create_slide["slideLayoutReference"] == {"predefinedLayout": "TITLE"}
+    mappings = {
+        m["layoutPlaceholder"]["type"]: m["objectId"]
+        for m in create_slide["placeholderIdMappings"]
+    }
+    assert set(mappings) == {"CENTERED_TITLE", "SUBTITLE"}
+    assert not any("createParagraphBullets" in r for r in requests)
+
+
+@pytest.mark.parametrize("layout", ["TITLE_ONLY", "SECTION_HEADER", "MAIN_POINT"])
+def test_add_slide_title_only_layouts_need_no_body(monkeypatch, layout):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="Section Break", layout=layout
+        )
+    )
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+    assert requests[0]["createSlide"]["slideLayoutReference"] == {
+        "predefinedLayout": layout
+    }
+
+
+def test_add_slide_rejects_unknown_layout(monkeypatch):
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="T", layout="TWO_COLUMNS")
+    )
+
+    assert result["status"] == "error"
+    assert "TWO_COLUMNS" in result["message"]
+    presentations.batchUpdate.assert_not_called()
+
+
+@pytest.mark.parametrize("layout", ["TITLE_ONLY", "SECTION_HEADER", "MAIN_POINT"])
+def test_add_slide_rejects_body_on_layout_without_body_placeholder(monkeypatch, layout):
+    """Regression guard: these layouts have no body placeholder, so silently
+    accepting `body` would drop it exactly like the reported bug — reject the
+    call instead so the caller finds out immediately."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="T", body="This would be lost", layout=layout
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "body" in result["message"]
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_add_slide_rejects_missing_body_for_content_layout(monkeypatch):
+    """Regression guard for the reported bug: a content layout (a real BODY
+    placeholder) must not silently create a slide with no detail text."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="Q3 Pipeline Highlights", layout="TITLE_AND_BODY"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "body" in result["message"]
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_add_slide_title_layout_allows_missing_body(monkeypatch):
+    """A cover slide's subtitle is optional, unlike a real BODY placeholder."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="Cover", layout="TITLE")
+    )
+
+    assert result["status"] == "success"
+
+
+def test_add_slide_blank_layout_rejects_title_and_body(monkeypatch):
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide(
+            "pres1", title="T", body="B", layout="BLANK"
+        )
+    )
+
+    assert result["status"] == "error"
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_add_slide_resolves_full_presentation_url(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+
+    url = "https://docs.google.com/presentation/d/abc123/edit#slide=id.p"
+    result = json.loads(
+        google_slides.google_slides_add_slide(url, title="T", body="detail line")
+    )
+
+    assert result["status"] == "success"
+    assert presentations.batchUpdate.call_args.kwargs["presentationId"] == "abc123"
+
+
+def test_add_slide_returns_error_payload_on_api_failure(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.side_effect = RuntimeError("boom")
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_add_slide("pres1", title="T", body="detail")
+    )
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]


### PR DESCRIPTION
## Summary
- `google_slides_add_slide` always forced `predefinedLayout` to `TITLE_AND_BODY`, so a user-requested layout (e.g. a Title/cover slide) could never be honored — title/subtitle text got crammed into a single title placeholder instead of a real layout with a subtitle. Add a `layout` parameter with a placeholder map, and reject the call (instead of silently dropping text) when `title`/`body` don't fit the chosen layout's placeholders.
- Supported layouts: `TITLE`, `TITLE_AND_BODY` (default), `TITLE_ONLY`, `SECTION_HEADER`, `BLANK`. Deliberately limited to layouts whose placeholder composition is well established — Google's docs don't enumerate placeholder types for every predefined layout and warn they "may have been changed", so less-common ones (`SECTION_TITLE_AND_DESCRIPTION`, `ONE_COLUMN_TEXT`, `MAIN_POINT`, `BIG_NUMBER`) are intentionally left out rather than guessed at; use `google_slides_batch_update` for those until verified against a live API.
- Content layouts (those with a real `BODY` placeholder) now require non-empty `body` instead of silently creating a title-only slide — this was reported separately as "generated slides only include titles, missing bullet point details". Layouts whose only content slot is the title now symmetrically require non-empty `title` too, instead of silently creating a completely empty slide.
- `body` text is now rendered as real bulleted paragraphs (`createParagraphBullets`) instead of literal `•`/`-`/`*` characters typed into plain text; any such literal markers the caller already typed are stripped first (preserving leading indentation, so multi-level bullets keep their nesting) to avoid double bullets.

## Test plan
- [x] `tests/web/tools/test_google_slides_mcp.py` (24 tests): default layout + bullets (with request-order assertion), nested-bullet indentation preserved, marker glued to text with no trailing space, marker-only body rejected, `TITLE` layout uses `SUBTITLE` and skips bullets, title-only layouts (with placeholder-mapping assertion), empty-title rejection on title-only layouts, whitespace-only title skipped rather than inserted, unknown-layout rejection, body-on-bodyless-layout rejection, missing-body-on-content-layout rejection, whitespace-only body rejection, `BLANK` layout (title-only rejection, body-only rejection, empty call succeeds with `placeholderIdMappings` omitted), URL id resolution, API failure passthrough.
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy src/xagent/web/tools/mcp/google_slides.py` — no new errors (pre-existing unrelated `googleapiclient` stub warning confirmed present on `main` too)
- [x] Full `tests/web/tools/` suite passes (no regressions)

## Review history
Addressed a full self-review pass before initially opening this PR, and a second round of maintainer review (nested-bullet indentation, marker-glued-to-text, marker-only-body bypass, empty-title guard, `_error()` consistency, `_LAYOUT_PLACEHOLDERS` explicit fields, docstring gaps, `BLANK`'s `placeholderIdMappings`, and several test-hardening asks) — see commit history and PR discussion for details. One review item (`_PRESENTATION_URL_ID_PATTERN` missing `/u/N/` multi-account URL support) was left unfixed as pre-existing and out of this PR's scope, per the reviewer's own note.
