### PR TITLE
feat(memory): add compatibility capability surface (toby)

### DIFF
--- a/src/xagent/core/memory/vector_compatibility.py
+++ b/src/xagent/core/memory/vector_compatibility.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Any, Mapping
+from typing import Any, Mapping, Protocol
 
 import pyarrow as pa  # type: ignore
 
@@ -26,6 +26,32 @@ _DEFAULT_ENDPOINTS = {
 _PROVIDER_ALIASES = {"openai_embedding": "openai", "openai-compatible": "openai"}
 _IDENTITY_FIELDS = {"provider", "model", "endpoint", "dimension", "instruct"}
 _REQUIRED_SCHEMA = {"id": pa.string(), "text": pa.string(), "metadata": pa.string()}
+
+
+class _ArrowDataType(Protocol):
+    """Structural subset used from a PyArrow data type."""
+
+    @property
+    def value_type(self) -> object: ...
+
+    @property
+    def list_size(self) -> int: ...
+
+
+class _ArrowField(Protocol):
+    """Structural subset used from a PyArrow field."""
+
+    @property
+    def type(self) -> _ArrowDataType: ...
+
+
+class _ArrowSchema(Protocol):
+    """Structural PyArrow schema boundary available without importing its type."""
+
+    @property
+    def metadata(self) -> Mapping[bytes, bytes] | None: ...
+
+    def field(self, name: str) -> _ArrowField: ...
 
 
 class VectorCompatibility(str, Enum):
@@ -100,7 +126,7 @@ def canonical_embedding_identity(
 
 
 def classify_vector_compatibility(
-    schema: pa.Schema,
+    schema: _ArrowSchema,
     expected_identity: EmbeddingIdentity | EmbeddingModelConfig | Mapping[str, Any],
 ) -> VectorCompatibility:
     """Purely classify an Arrow schema and its metadata; perform no I/O."""

--- a/src/xagent/core/memory/vector_compatibility.py
+++ b/src/xagent/core/memory/vector_compatibility.py
@@ -1,0 +1,152 @@
+"""Read-only vector-space compatibility capabilities for persistent memory."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+import pyarrow as pa  # type: ignore
+
+from ..model.model import EmbeddingModelConfig
+from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+
+VECTOR_IDENTITY_METADATA_KEY = b"xagent.memory.vector_space"
+DASHSCOPE_DEFAULT_ENDPOINT = (
+    "https://dashscope.aliyuncs.com/api/v1/services/embeddings/"
+    "text-embedding/text-embedding"
+)
+
+_DEFAULT_ENDPOINTS = {
+    "dashscope": DASHSCOPE_DEFAULT_ENDPOINT,
+    "openai": "https://api.openai.com/v1/embeddings",
+    "xinference": "http://localhost:9997",
+}
+_PROVIDER_ALIASES = {"openai_embedding": "openai", "openai-compatible": "openai"}
+_IDENTITY_FIELDS = {"provider", "model", "endpoint", "dimension", "instruct"}
+_REQUIRED_SCHEMA = {"id": pa.string(), "text": pa.string(), "metadata": pa.string()}
+
+
+class VectorCompatibility(str, Enum):
+    """Compatibility of persisted vectors with one configured vector space."""
+
+    LEGACY_COMPATIBLE = "legacy_compatible"
+    MATCHING = "matching"
+    MISMATCHING = "mismatching"
+
+
+@dataclass(frozen=True)
+class EmbeddingIdentity:
+    """Canonical fields that uniquely identify an embedding vector space."""
+
+    provider: str
+    model: str
+    endpoint: str
+    dimension: int
+    instruct: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+HISTORICAL_DASHSCOPE_IDENTITY = EmbeddingIdentity(
+    "dashscope", "text-embedding-v4", DASHSCOPE_DEFAULT_ENDPOINT, 1024, None
+)
+
+
+def canonical_embedding_identity(
+    identity: EmbeddingIdentity | EmbeddingModelConfig | Mapping[str, Any],
+) -> EmbeddingIdentity:
+    """Normalize the complete runtime embedding identity or raise ``ValueError``."""
+    if isinstance(identity, EmbeddingIdentity):
+        values = identity.as_dict()
+    elif isinstance(identity, EmbeddingModelConfig):
+        values = {
+            "provider": identity.model_provider,
+            "model": identity.model_name,
+            "endpoint": identity.base_url,
+            "dimension": identity.dimension,
+            "instruct": identity.instruct,
+        }
+    else:
+        values = dict(identity)
+        if set(values) != _IDENTITY_FIELDS:
+            raise ValueError("embedding identity must contain exactly five fields")
+
+    provider = str(values.get("provider") or "").strip().lower()
+    provider = _PROVIDER_ALIASES.get(provider, provider)
+    model = str(values.get("model") or "").strip()
+    endpoint_value = values.get("endpoint") or _DEFAULT_ENDPOINTS.get(provider)
+    endpoint = str(endpoint_value or "").strip().rstrip("/")
+    dimension_value = values.get("dimension")
+    instruct = values.get("instruct") if provider == "dashscope" else None
+    if provider == "openai" and endpoint.endswith("/v1"):
+        endpoint += "/embeddings"
+    if (
+        not provider
+        or not model
+        or not endpoint
+        or not isinstance(dimension_value, int)
+        or isinstance(dimension_value, bool)
+        or not isinstance(instruct, (str, type(None)))
+    ):
+        raise ValueError("embedding identity contains an invalid field")
+    if dimension_value <= 0:
+        raise ValueError("embedding dimension must be a positive integer")
+    return EmbeddingIdentity(
+        provider, model, endpoint, dimension_value, instruct or None
+    )
+
+
+def classify_vector_compatibility(
+    schema: pa.Schema,
+    expected_identity: EmbeddingIdentity | EmbeddingModelConfig | Mapping[str, Any],
+) -> VectorCompatibility:
+    """Purely classify an Arrow schema and its metadata; perform no I/O."""
+    try:
+        expected = canonical_embedding_identity(expected_identity)
+        vector_type = schema.field("vector").type
+        schema_matches = all(
+            schema.field(name).type == field_type
+            for name, field_type in _REQUIRED_SCHEMA.items()
+        )
+    except (KeyError, TypeError, ValueError):
+        return VectorCompatibility.MISMATCHING
+    if not (
+        schema_matches
+        and pa.types.is_fixed_size_list(vector_type)
+        and vector_type.value_type == pa.float32()
+        and vector_type.list_size == expected.dimension
+    ):
+        return VectorCompatibility.MISMATCHING
+
+    encoded = (schema.metadata or {}).get(VECTOR_IDENTITY_METADATA_KEY)
+    if encoded is None:
+        return (
+            VectorCompatibility.LEGACY_COMPATIBLE
+            if expected == HISTORICAL_DASHSCOPE_IDENTITY
+            else VectorCompatibility.MISMATCHING
+        )
+    try:
+        stored = json.loads(encoded.decode("utf-8"))
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+        return VectorCompatibility.MISMATCHING
+    return (
+        VectorCompatibility.MATCHING
+        if stored == expected.as_dict()
+        else VectorCompatibility.MISMATCHING
+    )
+
+
+def inspect_lancedb_vector_compatibility(
+    connection: Any,
+    table_name: str,
+    expected_identity: EmbeddingIdentity | EmbeddingModelConfig | Mapping[str, Any],
+) -> VectorCompatibility:
+    """Inspect one existing LanceDB table using only its Arrow schema metadata."""
+    table = connection.open_table(table_name)
+    try:
+        return classify_vector_compatibility(table.schema, expected_identity)
+    finally:
+        _safe_close_table(table)

--- a/tests/core/memory/test_vector_compatibility.py
+++ b/tests/core/memory/test_vector_compatibility.py
@@ -1,0 +1,167 @@
+"""Real-LanceDB tests for the read-only vector compatibility capability."""
+
+import json
+
+import lancedb  # type: ignore
+import pyarrow as pa  # type: ignore
+import pytest
+
+from xagent.core.memory.vector_compatibility import (
+    DASHSCOPE_DEFAULT_ENDPOINT,
+    HISTORICAL_DASHSCOPE_IDENTITY,
+    VECTOR_IDENTITY_METADATA_KEY,
+    VectorCompatibility,
+    canonical_embedding_identity,
+    inspect_lancedb_vector_compatibility,
+)
+from xagent.core.model.embedding import DashScopeEmbedding
+from xagent.core.model.model import EmbeddingModelConfig
+from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+
+
+def _identity(**changes):
+    values = HISTORICAL_DASHSCOPE_IDENTITY.as_dict()
+    values.update(changes)
+    return values
+
+
+def _table_data(dimension=1024, metadata=None):
+    table = pa.table(
+        {
+            "id": ["note-1"],
+            "text": ["remember this"],
+            "metadata": ["{}"],
+            "vector": pa.array([[0.0] * dimension], pa.list_(pa.float32(), dimension)),
+        }
+    )
+    return table.replace_schema_metadata(metadata) if metadata is not None else table
+
+
+def _create_table(tmp_path, *, dimension=1024, identity=None, raw_metadata=None):
+    connection = lancedb.connect(tmp_path)
+    metadata = raw_metadata
+    if identity is not None:
+        metadata = {VECTOR_IDENTITY_METADATA_KEY: json.dumps(identity).encode("utf-8")}
+    table = connection.create_table(
+        "memories", data=_table_data(dimension=dimension, metadata=metadata)
+    )
+    _safe_close_table(table)
+    return connection
+
+
+def _inspect(connection, expected=None):
+    return inspect_lancedb_vector_compatibility(
+        connection, "memories", expected or HISTORICAL_DASHSCOPE_IDENTITY
+    )
+
+
+def test_known_historical_table_is_legacy_compatible(tmp_path):
+    assert _inspect(_create_table(tmp_path)) is VectorCompatibility.LEGACY_COMPATIBLE
+
+
+def test_canonical_identity_normalizes_runtime_fields():
+    config = EmbeddingModelConfig(
+        id="embedding",
+        model_provider=" OpenAI-Compatible ",
+        model_name=" text-embedding-3-small ",
+        base_url="https://api.openai.com/v1/",
+        dimension=1536,
+        instruct="ignored by this provider",
+    )
+    assert canonical_embedding_identity(config).as_dict() == {
+        "provider": "openai",
+        "model": "text-embedding-3-small",
+        "endpoint": "https://api.openai.com/v1/embeddings",
+        "dimension": 1536,
+        "instruct": None,
+    }
+
+
+def test_exact_persisted_identity_is_matching(tmp_path):
+    connection = _create_table(tmp_path, identity=_identity())
+    assert _inspect(connection) is VectorCompatibility.MATCHING
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("provider", "openai"),
+        ("model", "text-embedding-v3"),
+        ("endpoint", "https://proxy.example/v1/embeddings"),
+        ("dimension", 512),
+        ("instruct", "Represent this sentence for retrieval"),
+    ],
+)
+def test_each_identity_field_mismatch_is_rejected(tmp_path, field, value):
+    expected = _identity(**{field: value})
+    connection = _create_table(tmp_path, dimension=expected["dimension"])
+    assert _inspect(connection, expected) is VectorCompatibility.MISMATCHING
+
+
+@pytest.mark.parametrize("missing", sorted(_identity()))
+def test_persisted_identity_requires_every_canonical_field(tmp_path, missing):
+    stored = _identity()
+    stored.pop(missing)
+    connection = _create_table(tmp_path, identity=stored)
+    assert _inspect(connection) is VectorCompatibility.MISMATCHING
+
+
+def test_malformed_identity_metadata_is_mismatching(tmp_path):
+    connection = _create_table(
+        tmp_path, raw_metadata={VECTOR_IDENTITY_METADATA_KEY: b"not-json"}
+    )
+    assert _inspect(connection) is VectorCompatibility.MISMATCHING
+
+
+def test_noncanonical_schema_is_mismatching(tmp_path):
+    connection = lancedb.connect(tmp_path)
+    table = connection.create_table(
+        "memories",
+        pa.table(
+            {
+                "id": pa.array([1], pa.int64()),
+                "text": ["remember this"],
+                "metadata": ["{}"],
+                "vector": pa.array(
+                    [
+                        [0.0] * 1024,
+                    ],
+                    pa.list_(pa.float64(), 1024),
+                ),
+            }
+        ),
+    )
+    _safe_close_table(table)
+    assert _inspect(connection) is VectorCompatibility.MISMATCHING
+
+
+def test_inspection_never_embeds_or_mutates_table(tmp_path, monkeypatch):
+    connection = _create_table(tmp_path, identity=_identity())
+    table = connection.open_table("memories")
+    try:
+        version_before = table.version
+        schema_before = table.schema
+        rows_before = table.to_arrow().to_pylist()
+    finally:
+        _safe_close_table(table)
+
+    def forbidden_encode(*_args, **_kwargs):
+        raise AssertionError("inspection must not call an embedding API")
+
+    monkeypatch.setattr(DashScopeEmbedding, "encode", forbidden_encode)
+    config = EmbeddingModelConfig(
+        id="historical",
+        model_provider="dashscope",
+        model_name="text-embedding-v4",
+        base_url=DASHSCOPE_DEFAULT_ENDPOINT,
+        dimension=1024,
+    )
+    assert _inspect(connection, config) is VectorCompatibility.MATCHING
+
+    table = connection.open_table("memories")
+    try:
+        assert table.version == version_before
+        assert table.schema == schema_before
+        assert table.to_arrow().to_pylist() == rows_before
+    finally:
+        _safe_close_table(table)


### PR DESCRIPTION
## Summary

- add a pure three-state vector compatibility classifier
- canonicalize provider, model, endpoint, dimension, and applicable instruction identity
- expose a schema-only LanceDB inspector with no runtime wiring or mutation
- recognize only the proven DashScope v4/default/1024 contract as legacy-compatible

## Validation

- 27 focused memory compatibility and schema-classifier tests
- Ruff format and lint checks
- Python bytecode compilation
- mutation checks for relaxed legacy identity, omitted canonical fields, embedding calls, and inspection writes

Closes #2210
Part of #2170
Supersedes the layer-A portion of #2172