### PR TITLE
feat(google-slides): add update_slide/delete_slide, guide self-correction

### DIFF
--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -603,7 +603,18 @@ def google_slides_update_slide(
                 continue
             element, placeholder_type = placeholders[role]
             object_id = element["objectId"]
-            if _element_text(element).strip():
+            # Slides represents a "cleared" placeholder as a lone trailing
+            # "\n" (the implicit paragraph terminator every text-containing
+            # shape carries), not a truly empty string — treat exactly
+            # that (or genuinely empty) as nothing-to-delete. Anything
+            # else, even whitespace-only text beyond that terminator (e.g.
+            # a stray " \n" from a slide edited by something other than
+            # this tool), still gets deleteText: insertText has no
+            # insertionIndex here, so it defaults to prepending at the
+            # start rather than replacing — skipping the delete for
+            # arbitrary whitespace would leave that stale text merged
+            # into what's supposed to be a clean replacement.
+            if _element_text(element) not in ("", "\n"):
                 requests.append(
                     {
                         "deleteText": {

--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -156,6 +156,93 @@ def _error(message: str) -> str:
     return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
 
 
+def _prepare_body_text(body: str, is_bulleted: bool) -> str:
+    """Normalize body text before it's inserted: strip literal bullet
+    markers (see _strip_bullet_prefixes) when the target placeholder
+    bullets its content, then drop any blank lines (from a marker that
+    stripped down to nothing, blank lines already in the input, or a
+    trailing newline) so no empty paragraph survives — for bulleted
+    content this avoids createParagraphBullets putting a bullet glyph on
+    an empty paragraph (a visibly floating bullet point); for
+    non-bulleted content (e.g. a TITLE layout's SUBTITLE) it avoids stray
+    blank lines in the placeholder.
+
+    Must run before any "is body non-empty" check, not just before
+    insertion — a marker-only or blank-only body (e.g. "•   ") would
+    otherwise pass a raw truthiness/strip check and only turn out empty
+    right before the API call, silently producing a content-less slide.
+    """
+    if is_bulleted and body:
+        body = _strip_bullet_prefixes(body)
+    if body:
+        body = "\n".join(line for line in body.split("\n") if line.strip())
+    return body
+
+
+def _body_insert_requests(
+    body_id: str, body: str, is_bulleted: bool
+) -> list[dict[str, Any]]:
+    """insertText for `body_id` — `body` must already be prepared via
+    _prepare_body_text — plus createParagraphBullets when the target
+    placeholder is a real bulleted-list BODY (not e.g. a plain SUBTITLE)."""
+    requests: list[dict[str, Any]] = [
+        {"insertText": {"objectId": body_id, "text": body}}
+    ]
+    if is_bulleted:
+        requests.append(
+            {
+                "createParagraphBullets": {
+                    "objectId": body_id,
+                    "textRange": {"type": "ALL"},
+                    "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE",
+                }
+            }
+        )
+    return requests
+
+
+# Placeholder types that fill the "title" vs "body" role of a slide, used
+# to locate an existing slide's placeholders by type when editing it (as
+# opposed to _LAYOUT_PLACEHOLDERS above, which picks placeholder types
+# when *creating* a slide from a predefined layout).
+_TITLE_PLACEHOLDER_TYPES = {"TITLE", "CENTERED_TITLE"}
+_BODY_PLACEHOLDER_TYPES = {"BODY", "SUBTITLE"}
+
+
+def _find_slide(presentation: dict[str, Any], slide_id: str) -> dict[str, Any] | None:
+    slides: list[dict[str, Any]] = presentation.get("slides", [])
+    for slide in slides:
+        if slide.get("objectId") == slide_id:
+            return slide
+    return None
+
+
+def _find_placeholders(
+    slide: dict[str, Any],
+) -> dict[str, tuple[dict[str, Any], str]]:
+    """Map "title"/"body" to (element, placeholder_type) for a slide's
+    shapes, so callers can target the right shape without knowing the
+    layout-specific ids assigned when the slide was created.
+
+    If a slide has more than one placeholder of the same role (not
+    reachable via this file's own google_slides_add_slide, which only
+    ever creates one of each, but possible for a slide created some other
+    way), only the first one encountered is kept — there's no way to
+    disambiguate further from the role alone.
+    """
+    found: dict[str, tuple[dict[str, Any], str]] = {}
+    for element in slide.get("pageElements", []):
+        placeholder = element.get("shape", {}).get("placeholder")
+        if not placeholder:
+            continue
+        placeholder_type = placeholder.get("type", "")
+        if placeholder_type in _TITLE_PLACEHOLDER_TYPES:
+            found.setdefault("title", (element, placeholder_type))
+        elif placeholder_type in _BODY_PLACEHOLDER_TYPES:
+            found.setdefault("body", (element, placeholder_type))
+    return found
+
+
 def get_slides_service() -> Any:
     token = os.environ.get("GOOGLE_ACCESS_TOKEN")
     refresh_token = os.environ.get("GOOGLE_REFRESH_TOKEN")
@@ -306,6 +393,16 @@ def google_slides_add_slide(
     underlying batchUpdate call rather than a friendly one — use
     google_slides_batch_update directly for presentations with a
     non-standard theme.
+
+    To fix a slide this call already created (wrong/missing text), use
+    google_slides_update_slide with its slide_id — do NOT call
+    google_slides_add_slide again, that creates a second, duplicate slide
+    rather than editing the first one.
+
+    After adding all the slides for a deck, call
+    google_slides_get_presentation once to read back every slide's actual
+    title/body text and confirm it matches what you intended (e.g. against
+    the user's outline) before telling the user the deck is done.
     """
     try:
         if not isinstance(layout, str):
@@ -327,17 +424,7 @@ def google_slides_add_slide(
 
         title_placeholder, body_placeholder = _LAYOUT_PLACEHOLDERS[normalized_layout]
         is_bulleted = body_required = body_placeholder == "BODY"
-        if is_bulleted and body:
-            body = _strip_bullet_prefixes(body)
-        if body:
-            # Drop blank lines (a bare marker stripped down to nothing,
-            # blank lines already in the input, or a trailing newline) so
-            # no empty paragraph survives — for bulleted content this
-            # avoids createParagraphBullets putting a bullet glyph on an
-            # empty paragraph (a visibly floating bullet point); for
-            # non-bulleted content (e.g. TITLE's subtitle) it avoids
-            # stray blank lines in the placeholder.
-            body = "\n".join(line for line in body.split("\n") if line.strip())
+        body = _prepare_body_text(body, is_bulleted)
 
         if title.strip() and title_placeholder is None:
             return _error(
@@ -410,17 +497,7 @@ def google_slides_add_slide(
                 {"insertText": {"objectId": title_id, "text": title.strip()}}
             )
         if body.strip():
-            requests.append({"insertText": {"objectId": body_id, "text": body}})
-            if is_bulleted:
-                requests.append(
-                    {
-                        "createParagraphBullets": {
-                            "objectId": body_id,
-                            "textRange": {"type": "ALL"},
-                            "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE",
-                        }
-                    }
-                )
+            requests.extend(_body_insert_requests(body_id, body, is_bulleted))
 
         service.presentations().batchUpdate(
             presentationId=pres_id, body={"requests": requests}
@@ -437,6 +514,140 @@ def google_slides_add_slide(
         )
     except Exception as e:
         logger.error(f"Error adding slide: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def google_slides_update_slide(
+    presentation_id: str, slide_id: str, title: str = "", body: str = ""
+) -> str:
+    """
+    Replace the title and/or body text of an existing slide (identified by
+    the slide_id a prior google_slides_add_slide call returned), instead of
+    creating a new one. Use this to fix a slide that came out wrong or
+    incomplete — calling google_slides_add_slide again does NOT edit that
+    slide, it creates a duplicate one next to it.
+
+    Only the placeholders you pass non-empty text for are touched; omit
+    title or body to leave that placeholder untouched. Body text follows
+    the same rules as google_slides_add_slide: newline-separated lines
+    become bulleted paragraphs (with literal "•"/"-"/"*" markers and blank
+    lines stripped) when the slide's body placeholder is a real "BODY"
+    type, not a plain "SUBTITLE".
+    """
+    try:
+        if not title and not body:
+            return _error("Provide at least one of 'title' or 'body' to update.")
+        if title and not title.strip():
+            return _error("'title' is whitespace-only; provide real text or omit it.")
+        if body and not body.strip():
+            return _error("'body' is whitespace-only; provide real text or omit it.")
+
+        pres_id = _resolve_presentation_id(presentation_id)
+        service = get_slides_service()
+        presentation = service.presentations().get(presentationId=pres_id).execute()
+
+        slide = _find_slide(presentation, slide_id)
+        if slide is None:
+            return _error(f"No slide with id '{slide_id}' in this presentation.")
+
+        placeholders = _find_placeholders(slide)
+
+        if title and "title" not in placeholders:
+            return _error(
+                f"Slide '{slide_id}' has no title placeholder, so 'title' "
+                "has nowhere to go."
+            )
+        if body and "body" not in placeholders:
+            return _error(
+                f"Slide '{slide_id}' has no body/subtitle placeholder, so "
+                "'body' has nowhere to go."
+            )
+
+        if body:
+            _, body_type = placeholders["body"]
+            body = _prepare_body_text(body, body_type == "BODY")
+            if not body:
+                return _error(
+                    "'body' has no real content once bullet markers/blank "
+                    "lines are removed; provide actual detail text or "
+                    "omit it."
+                )
+
+        requests: list[dict[str, Any]] = []
+        for role, text in (("title", title.strip()), ("body", body)):
+            if not text:
+                continue
+            element, placeholder_type = placeholders[role]
+            object_id = element["objectId"]
+            if _element_text(element):
+                requests.append(
+                    {
+                        "deleteText": {
+                            "objectId": object_id,
+                            "textRange": {"type": "ALL"},
+                        }
+                    }
+                )
+            if role == "title":
+                requests.append({"insertText": {"objectId": object_id, "text": text}})
+            else:
+                requests.extend(
+                    _body_insert_requests(object_id, text, placeholder_type == "BODY")
+                )
+
+        service.presentations().batchUpdate(
+            presentationId=pres_id, body={"requests": requests}
+        ).execute()
+
+        return json.dumps(
+            {
+                "status": "success",
+                "presentation_id": pres_id,
+                "slide_id": slide_id,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error(f"Error updating slide: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def google_slides_delete_slide(presentation_id: str, slide_id: str) -> str:
+    """
+    Permanently delete one slide from a presentation by its slide_id.
+    Use this to remove a duplicate or wrong slide — for example one created
+    by calling google_slides_add_slide a second time instead of using
+    google_slides_update_slide to fix the original.
+    """
+    try:
+        pres_id = _resolve_presentation_id(presentation_id)
+        service = get_slides_service()
+        presentation = service.presentations().get(presentationId=pres_id).execute()
+
+        if _find_slide(presentation, slide_id) is None:
+            return _error(
+                f"No slide with id '{slide_id}' in this presentation — "
+                "refusing to delete. Make sure this is a slide id, not a "
+                "placeholder shape id (e.g. one ending in '_title'/'_body')."
+            )
+
+        service.presentations().batchUpdate(
+            presentationId=pres_id,
+            body={"requests": [{"deleteObject": {"objectId": slide_id}}]},
+        ).execute()
+
+        return json.dumps(
+            {
+                "status": "success",
+                "presentation_id": pres_id,
+                "slide_id": slide_id,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error(f"Error deleting slide: {e}")
         return _error(str(e))
 
 

--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -538,6 +538,15 @@ def google_slides_update_slide(
     try:
         if not title and not body:
             return _error("Provide at least one of 'title' or 'body' to update.")
+
+        title = title.replace("\r\n", "\n").replace("\r", "\n")
+        body = body.replace("\r\n", "\n").replace("\r", "\n")
+        # A title is expected to be a single line; collapse any embedded
+        # newline (and surrounding whitespace) into a space rather than
+        # silently producing a multi-paragraph title placeholder — matches
+        # google_slides_add_slide's handling of title.
+        title = re.sub(r"\s*\n\s*", " ", title)
+
         if title and not title.strip():
             return _error("'title' is whitespace-only; provide real text or omit it.")
         if body and not body.strip():

--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -156,6 +156,21 @@ def _error(message: str) -> str:
     return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
 
 
+def _normalize_newlines(text: str) -> str:
+    """Normalize CRLF/lone-CR line endings to plain "\\n", so text pasted
+    from a Windows editor doesn't leave stray "\\r" characters embedded in
+    what gets inserted into Slides."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _normalize_title(title: str) -> str:
+    """Normalize line endings, then collapse any embedded newline (and
+    surrounding whitespace) into a single space — a title is expected to
+    be a single line, so this avoids silently producing a multi-paragraph
+    title placeholder."""
+    return re.sub(r"\s*\n\s*", " ", _normalize_newlines(title))
+
+
 def _prepare_body_text(body: str, is_bulleted: bool) -> str:
     """Normalize body text before it's inserted: strip literal bullet
     markers (see _strip_bullet_prefixes) when the target placeholder
@@ -172,11 +187,9 @@ def _prepare_body_text(body: str, is_bulleted: bool) -> str:
     otherwise pass a raw truthiness/strip check and only turn out empty
     right before the API call, silently producing a content-less slide.
     """
-    if is_bulleted and body:
+    if is_bulleted:
         body = _strip_bullet_prefixes(body)
-    if body:
-        body = "\n".join(line for line in body.split("\n") if line.strip())
-    return body
+    return "\n".join(line for line in body.split("\n") if line.strip())
 
 
 def _body_insert_requests(
@@ -204,17 +217,25 @@ def _body_insert_requests(
 # Placeholder types that fill the "title" vs "body" role of a slide, used
 # to locate an existing slide's placeholders by type when editing it (as
 # opposed to _LAYOUT_PLACEHOLDERS above, which picks placeholder types
-# when *creating* a slide from a predefined layout).
+# when *creating* a slide from a predefined layout). BODY covers this
+# file's own generated slides; OBJECT is included too since it's the
+# common "body-like" placeholder type on slides from an imported/
+# non-standard-theme presentation (e.g. one converted from PowerPoint),
+# which google_slides_update_slide may be asked to edit even though
+# google_slides_add_slide never creates that type itself.
 _TITLE_PLACEHOLDER_TYPES = {"TITLE", "CENTERED_TITLE"}
-_BODY_PLACEHOLDER_TYPES = {"BODY", "SUBTITLE"}
+_BODY_PLACEHOLDER_TYPES = {"BODY", "SUBTITLE", "OBJECT"}
 
 
 def _find_slide(presentation: dict[str, Any], slide_id: str) -> dict[str, Any] | None:
-    slides: list[dict[str, Any]] = presentation.get("slides", [])
-    for slide in slides:
-        if slide.get("objectId") == slide_id:
-            return slide
-    return None
+    return next(
+        (
+            slide
+            for slide in presentation.get("slides", [])
+            if slide.get("objectId") == slide_id
+        ),
+        None,
+    )
 
 
 def _find_placeholders(
@@ -408,12 +429,8 @@ def google_slides_add_slide(
         if not isinstance(layout, str):
             return _error(f"'layout' must be a string, got {type(layout).__name__}.")
 
-        title = title.replace("\r\n", "\n").replace("\r", "\n")
-        body = body.replace("\r\n", "\n").replace("\r", "\n")
-        # A title is expected to be a single line; collapse any embedded
-        # newline (and surrounding whitespace) into a space rather than
-        # silently producing a multi-paragraph title placeholder.
-        title = re.sub(r"\s*\n\s*", " ", title)
+        title = _normalize_title(title)
+        body = _normalize_newlines(body)
         normalized_layout = layout.strip().upper()
 
         if normalized_layout not in _LAYOUT_PLACEHOLDERS:
@@ -522,9 +539,11 @@ def google_slides_update_slide(
     presentation_id: str, slide_id: str, title: str = "", body: str = ""
 ) -> str:
     """
-    Replace the title and/or body text of an existing slide (identified by
-    the slide_id a prior google_slides_add_slide call returned), instead of
-    creating a new one. Use this to fix a slide that came out wrong or
+    Replace the title and/or body text of an existing slide, identified by
+    its slide_id — either the one a prior google_slides_add_slide call
+    returned, or the "object_id" field google_slides_get_presentation
+    reports for that slide (the same id under a different key) — instead
+    of creating a new one. Use this to fix a slide that came out wrong or
     incomplete — calling google_slides_add_slide again does NOT edit that
     slide, it creates a duplicate one next to it.
 
@@ -539,13 +558,8 @@ def google_slides_update_slide(
         if not title and not body:
             return _error("Provide at least one of 'title' or 'body' to update.")
 
-        title = title.replace("\r\n", "\n").replace("\r", "\n")
-        body = body.replace("\r\n", "\n").replace("\r", "\n")
-        # A title is expected to be a single line; collapse any embedded
-        # newline (and surrounding whitespace) into a space rather than
-        # silently producing a multi-paragraph title placeholder — matches
-        # google_slides_add_slide's handling of title.
-        title = re.sub(r"\s*\n\s*", " ", title)
+        title = _normalize_title(title)
+        body = _normalize_newlines(body)
 
         if title and not title.strip():
             return _error("'title' is whitespace-only; provide real text or omit it.")
@@ -589,7 +603,7 @@ def google_slides_update_slide(
                 continue
             element, placeholder_type = placeholders[role]
             object_id = element["objectId"]
-            if _element_text(element):
+            if _element_text(element).strip():
                 requests.append(
                     {
                         "deleteText": {

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -948,6 +948,42 @@ async def test_add_slide_normalizes_layout_via_mcp_layer(monkeypatch):
     assert result["layout"] == "TITLE_AND_BODY"
 
 
+async def test_update_slide_via_mcp_layer(monkeypatch):
+    """Smoke test through the real MCP dispatch path (JSON args dict,
+    positional/keyword binding via call_tool), not just a direct Python
+    call — the only path add_slide's Literal-normalization bug (fixed
+    above) was actually reachable through."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations, "slide1", [_placeholder_element("title_obj", "TITLE")]
+    )
+
+    content, _ = await google_slides.mcp.call_tool(
+        "google_slides_update_slide",
+        {"presentation_id": "pres1", "slide_id": "slide1", "title": "New title"},
+    )
+
+    result = json.loads(content[0].text)
+    assert result["status"] == "success"
+
+
+async def test_delete_slide_via_mcp_layer(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(presentations, "slide1", [])
+
+    content, _ = await google_slides.mcp.call_tool(
+        "google_slides_delete_slide",
+        {"presentation_id": "pres1", "slide_id": "slide1"},
+    )
+
+    result = json.loads(content[0].text)
+    assert result["status"] == "success"
+
+
 def test_update_slide_replaces_title_and_body_and_reapplies_bullets(monkeypatch):
     presentations = Mock()
     presentations.batchUpdate.return_value.execute.return_value = {}
@@ -992,6 +1028,31 @@ def test_update_slide_replaces_title_and_body_and_reapplies_bullets(monkeypatch)
     )
     assert bullets_req["objectId"] == "body_obj"
 
+    # Order matters: batchUpdate applies requests in list order, so a
+    # deleteText must precede the insertText for the same objectId (an
+    # insert-then-delete would wipe out the new text instead of the old),
+    # and createParagraphBullets must come after the body insertText it
+    # formats.
+    def _index_of(predicate):
+        return next(i for i, r in enumerate(requests) if predicate(r))
+
+    title_delete_index = _index_of(
+        lambda r: r.get("deleteText", {}).get("objectId") == "title_obj"
+    )
+    title_insert_index = _index_of(
+        lambda r: r.get("insertText", {}).get("objectId") == "title_obj"
+    )
+    assert title_delete_index < title_insert_index
+
+    body_delete_index = _index_of(
+        lambda r: r.get("deleteText", {}).get("objectId") == "body_obj"
+    )
+    body_insert_index = _index_of(
+        lambda r: r.get("insertText", {}).get("objectId") == "body_obj"
+    )
+    bullets_index = _index_of(lambda r: "createParagraphBullets" in r)
+    assert body_delete_index < body_insert_index < bullets_index
+
 
 def test_update_slide_skips_delete_text_when_placeholder_already_empty(monkeypatch):
     presentations = Mock()
@@ -1001,6 +1062,29 @@ def test_update_slide_skips_delete_text_when_placeholder_already_empty(monkeypat
         presentations,
         "slide1",
         [_placeholder_element("title_obj", "TITLE", text="")],
+    )
+
+    google_slides.google_slides_update_slide("pres1", "slide1", title="First title")
+
+    requests = _batch_update_requests(presentations)
+    assert not any("deleteText" in r for r in requests)
+    assert requests[0]["insertText"]["text"] == "First title"
+
+
+def test_update_slide_skips_delete_text_when_placeholder_has_only_a_newline(
+    monkeypatch,
+):
+    """Regression guard: the Slides API commonly represents a "cleared"
+    placeholder as a lone trailing "\\n" (the paragraph terminator), not a
+    truly empty string — the existing-text check must treat that the same
+    as empty, or it triggers a needless deleteText."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [_placeholder_element("title_obj", "TITLE", text="\n")],
     )
 
     google_slides.google_slides_update_slide("pres1", "slide1", title="First title")
@@ -1073,6 +1157,21 @@ def test_update_slide_requires_at_least_one_field(monkeypatch):
     presentations.get.assert_not_called()
 
 
+def test_update_slide_rejects_whitespace_only_title(monkeypatch):
+    """Regression guard, symmetric with the body-side check above:
+    whitespace-only title text ("   ") must not slip past the guard just
+    because it's non-empty."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_update_slide("pres1", "slide1", title="   ")
+    )
+
+    assert result["status"] == "error"
+    presentations.get.assert_not_called()
+
+
 def test_update_slide_rejects_whitespace_only_body(monkeypatch):
     """Regression guard: whitespace-only text ("   ", "\\n\\n") must not
     slip past the guard just because it's non-empty — that would silently
@@ -1137,6 +1236,23 @@ def test_update_slide_rejects_title_when_slide_has_no_title_placeholder(monkeypa
 
     assert result["status"] == "error"
     assert "title" in result["message"]
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_update_slide_rejects_body_when_slide_has_no_body_placeholder(monkeypatch):
+    """Regression guard, symmetric with the title-side test above."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations, "slide1", [_placeholder_element("title_obj", "TITLE", text="x")]
+    )
+
+    result = json.loads(
+        google_slides.google_slides_update_slide("pres1", "slide1", body="Detail text")
+    )
+
+    assert result["status"] == "error"
+    assert "body" in result["message"]
     presentations.batchUpdate.assert_not_called()
 
 
@@ -1311,6 +1427,25 @@ def test_update_slide_returns_error_payload_on_api_failure(monkeypatch):
     assert "boom" in result["message"]
 
 
+def test_update_slide_returns_error_payload_on_batch_update_failure(monkeypatch):
+    """Symmetric with the get() failure case above and with delete_slide's
+    own batchUpdate-failure test — the earlier presentations().get() call
+    can succeed while the actual edit still fails."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.side_effect = RuntimeError("boom")
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations, "slide1", [_placeholder_element("title_obj", "TITLE")]
+    )
+
+    result = json.loads(
+        google_slides.google_slides_update_slide("pres1", "slide1", title="T")
+    )
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
+
+
 def test_delete_slide_sends_delete_object_request(monkeypatch):
     presentations = Mock()
     presentations.batchUpdate.return_value.execute.return_value = {}
@@ -1328,10 +1463,17 @@ def test_delete_slide_rejects_id_that_is_not_a_slide(monkeypatch):
     """Regression guard: a placeholder shape id (e.g. one this file itself
     mints as f"{slide_id}_title") must not be silently accepted — Slides'
     deleteObject would delete just that shape while reporting success as if
-    the whole slide had been removed."""
+    the whole slide had been removed. The presentation genuinely contains
+    a shape with this id (nested inside slide1's pageElements, not as a
+    top-level slide) — proving the rejection is because it's the wrong
+    *kind* of id, not merely because "slide1_title" is unrecognized."""
     presentations = Mock()
     _mock_slides_service(monkeypatch, presentations)
-    _mock_presentation_get(presentations, "slide1", [])
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [_placeholder_element("slide1_title", "TITLE", text="Real title")],
+    )
 
     result = json.loads(
         google_slides.google_slides_delete_slide("pres1", "slide1_title")

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -1094,6 +1094,30 @@ def test_update_slide_skips_delete_text_when_placeholder_has_only_a_newline(
     assert requests[0]["insertText"]["text"] == "First title"
 
 
+def test_update_slide_still_clears_whitespace_beyond_the_bare_terminator(monkeypatch):
+    """Regression guard: only the exact "" or "\\n" (the implicit
+    terminator) should skip deleteText — any other whitespace-only text
+    (e.g. a stray " \\n" left by a slide edited by something other than
+    this tool) must still be cleared. insertText has no insertionIndex
+    here, so it defaults to prepending rather than replacing; skipping
+    the delete for arbitrary whitespace would leave that stale text
+    merged into what's supposed to be a clean replacement."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [_placeholder_element("title_obj", "TITLE", text=" \n")],
+    )
+
+    google_slides.google_slides_update_slide("pres1", "slide1", title="First title")
+
+    requests = _batch_update_requests(presentations)
+    delete_req = next(r["deleteText"] for r in requests if "deleteText" in r)
+    assert delete_req["objectId"] == "title_obj"
+
+
 def test_update_slide_only_touches_the_field_provided(monkeypatch):
     presentations = Mock()
     presentations.batchUpdate.return_value.execute.return_value = {}
@@ -1360,6 +1384,37 @@ def test_update_slide_writes_title_into_centered_title_placeholder(monkeypatch):
     assert title_insert["text"] == "New title"
 
 
+def test_update_slide_writes_body_into_object_placeholder(monkeypatch):
+    """OBJECT is a real Slides placeholder type common on slides from an
+    imported/non-standard-theme presentation (e.g. one converted from
+    PowerPoint) — update_slide must recognize it as a body-role
+    placeholder like BODY/SUBTITLE, not reject it as unrecognized."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [_placeholder_element("body_obj", "OBJECT", text="Old detail")],
+    )
+
+    result = json.loads(
+        google_slides.google_slides_update_slide("pres1", "slide1", body="New detail")
+    )
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+    body_insert = next(
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == "body_obj"
+    )
+    assert body_insert["text"] == "New detail"
+    # OBJECT is a generic content placeholder, not the same as a real
+    # bulleted BODY list — bullets are only applied for the "BODY" type.
+    assert not any("createParagraphBullets" in r for r in requests)
+
+
 def test_update_slide_only_targets_the_first_placeholder_of_a_duplicated_role(
     monkeypatch,
 ):
@@ -1463,10 +1518,11 @@ def test_delete_slide_rejects_id_that_is_not_a_slide(monkeypatch):
     """Regression guard: a placeholder shape id (e.g. one this file itself
     mints as f"{slide_id}_title") must not be silently accepted — Slides'
     deleteObject would delete just that shape while reporting success as if
-    the whole slide had been removed. The presentation genuinely contains
-    a shape with this id (nested inside slide1's pageElements, not as a
-    top-level slide) — proving the rejection is because it's the wrong
-    *kind* of id, not merely because "slide1_title" is unrecognized."""
+    the whole slide had been removed. The mocked presentation genuinely
+    contains a shape with this id — nested inside slide1's pageElements,
+    not as a top-level slide — confirming _find_slide's rejection comes
+    from checking only top-level slide ids (by design), not from the id
+    being absent from the API response altogether."""
     presentations = Mock()
     _mock_slides_service(monkeypatch, presentations)
     _mock_presentation_get(

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -1140,6 +1140,164 @@ def test_update_slide_rejects_title_when_slide_has_no_title_placeholder(monkeypa
     presentations.batchUpdate.assert_not_called()
 
 
+def test_update_slide_collapses_embedded_newline_in_title(monkeypatch):
+    """Regression guard, symmetric with add_slide's fix: a title is a
+    single-line placeholder — an embedded newline must collapse to a
+    space instead of silently producing a multi-paragraph title."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations, "slide1", [_placeholder_element("title_obj", "TITLE")]
+    )
+
+    google_slides.google_slides_update_slide(
+        "pres1", "slide1", title="Line one\nLine two"
+    )
+
+    requests = _batch_update_requests(presentations)
+    title_insert = next(
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == "title_obj"
+    )
+    assert title_insert["text"] == "Line one Line two"
+
+
+def test_update_slide_normalizes_crlf_and_cr_newlines(monkeypatch):
+    """Regression guard, symmetric with add_slide's fix: text pasted from
+    a Windows editor may use \\r\\n or lone \\r line endings — these must
+    not survive as stray \\r characters embedded in the inserted text."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [_placeholder_element("body_obj", "BODY")],
+    )
+
+    google_slides.google_slides_update_slide(
+        "pres1", "slide1", body="Line one\r\nLine two\rLine three"
+    )
+
+    requests = _batch_update_requests(presentations)
+    body_insert = next(
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == "body_obj"
+    )
+    assert "\r" not in body_insert["text"]
+    assert body_insert["text"] == "Line one\nLine two\nLine three"
+
+
+def test_update_slide_rejects_whole_call_when_body_becomes_empty_even_with_title(
+    monkeypatch,
+):
+    """Regression guard: a marker-only body must reject the entire call
+    (no batchUpdate at all), not silently apply just the title update and
+    drop the body — the two are meant to be one atomic edit."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [
+            _placeholder_element("title_obj", "TITLE", text="Old title"),
+            _placeholder_element("body_obj", "BODY", text="Old body"),
+        ],
+    )
+
+    result = json.loads(
+        google_slides.google_slides_update_slide(
+            "pres1", "slide1", title="New title", body="•   "
+        )
+    )
+
+    assert result["status"] == "error"
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_update_slide_writes_title_into_centered_title_placeholder(monkeypatch):
+    """A TITLE-layout slide's title lands in a CENTERED_TITLE placeholder,
+    not a plain TITLE — update_slide must write to it just the same."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [_placeholder_element("title_obj", "CENTERED_TITLE", text="Old")],
+    )
+
+    result = json.loads(
+        google_slides.google_slides_update_slide("pres1", "slide1", title="New title")
+    )
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+    title_insert = next(
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == "title_obj"
+    )
+    assert title_insert["text"] == "New title"
+
+
+def test_update_slide_only_targets_the_first_placeholder_of_a_duplicated_role(
+    monkeypatch,
+):
+    """Documented, accepted limitation: a slide with two BODY placeholders
+    (not reachable via this file's own add_slide, but possible for a slide
+    from another source) silently targets only the first one found. Lock
+    in the current behavior so a future change to iteration order isn't
+    silent."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [
+            _placeholder_element("body_obj_1", "BODY", text="First"),
+            _placeholder_element("body_obj_2", "BODY", text="Second"),
+        ],
+    )
+
+    google_slides.google_slides_update_slide("pres1", "slide1", body="New detail")
+
+    requests = _batch_update_requests(presentations)
+    assert not any(
+        r.get("insertText", {}).get("objectId") == "body_obj_2"
+        or r.get("deleteText", {}).get("objectId") == "body_obj_2"
+        for r in requests
+    )
+    body_insert = next(
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == "body_obj_1"
+    )
+    assert body_insert["text"] == "New detail"
+
+
+def test_update_slide_resolves_full_presentation_url(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations, "slide1", [_placeholder_element("title_obj", "TITLE")]
+    )
+
+    url = "https://docs.google.com/presentation/d/abc123/edit#slide=id.p"
+    result = json.loads(
+        google_slides.google_slides_update_slide(url, "slide1", title="T")
+    )
+
+    assert result["status"] == "success"
+    assert presentations.get.call_args.kwargs["presentationId"] == "abc123"
+    assert presentations.batchUpdate.call_args.kwargs["presentationId"] == "abc123"
+
+
 def test_update_slide_returns_error_payload_on_api_failure(monkeypatch):
     presentations = Mock()
     presentations.get.return_value.execute.side_effect = RuntimeError("boom")
@@ -1181,6 +1339,20 @@ def test_delete_slide_rejects_id_that_is_not_a_slide(monkeypatch):
 
     assert result["status"] == "error"
     presentations.batchUpdate.assert_not_called()
+
+
+def test_delete_slide_resolves_full_presentation_url(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(presentations, "slide1", [])
+
+    url = "https://docs.google.com/presentation/d/abc123/edit#slide=id.p"
+    result = json.loads(google_slides.google_slides_delete_slide(url, "slide1"))
+
+    assert result["status"] == "success"
+    assert presentations.get.call_args.kwargs["presentationId"] == "abc123"
+    assert presentations.batchUpdate.call_args.kwargs["presentationId"] == "abc123"
 
 
 def test_delete_slide_returns_error_payload_on_api_failure(monkeypatch):

--- a/tests/web/tools/test_google_slides_mcp.py
+++ b/tests/web/tools/test_google_slides_mcp.py
@@ -35,6 +35,23 @@ def _placeholder_object_id(create_slide, placeholder_type):
     )
 
 
+def _placeholder_element(object_id, placeholder_type, text=""):
+    text_elements = [{"textRun": {"content": text}}] if text else []
+    return {
+        "objectId": object_id,
+        "shape": {
+            "placeholder": {"type": placeholder_type},
+            "text": {"textElements": text_elements},
+        },
+    }
+
+
+def _mock_presentation_get(presentations_mock, slide_id, elements):
+    presentations_mock.get.return_value.execute.return_value = {
+        "slides": [{"objectId": slide_id, "pageElements": elements}]
+    }
+
+
 def test_add_slide_default_layout_creates_title_and_body_with_bullets(monkeypatch):
     presentations = Mock()
     presentations.batchUpdate.return_value.execute.return_value = {}
@@ -929,6 +946,253 @@ async def test_add_slide_normalizes_layout_via_mcp_layer(monkeypatch):
     result = json.loads(content[0].text)
     assert result["status"] == "success"
     assert result["layout"] == "TITLE_AND_BODY"
+
+
+def test_update_slide_replaces_title_and_body_and_reapplies_bullets(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [
+            _placeholder_element("title_obj", "TITLE", text="Old title"),
+            _placeholder_element("body_obj", "BODY", text="Old body"),
+        ],
+    )
+
+    result = json.loads(
+        google_slides.google_slides_update_slide(
+            "pres1", "slide1", title="New title", body="• Fixed detail"
+        )
+    )
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+
+    delete_ids = [r["deleteText"]["objectId"] for r in requests if "deleteText" in r]
+    assert set(delete_ids) == {"title_obj", "body_obj"}
+
+    title_insert = next(
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == "title_obj"
+    )
+    assert title_insert["text"] == "New title"
+
+    body_insert = next(
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == "body_obj"
+    )
+    assert body_insert["text"] == "Fixed detail"
+
+    bullets_req = next(
+        r["createParagraphBullets"] for r in requests if "createParagraphBullets" in r
+    )
+    assert bullets_req["objectId"] == "body_obj"
+
+
+def test_update_slide_skips_delete_text_when_placeholder_already_empty(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [_placeholder_element("title_obj", "TITLE", text="")],
+    )
+
+    google_slides.google_slides_update_slide("pres1", "slide1", title="First title")
+
+    requests = _batch_update_requests(presentations)
+    assert not any("deleteText" in r for r in requests)
+    assert requests[0]["insertText"]["text"] == "First title"
+
+
+def test_update_slide_only_touches_the_field_provided(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [
+            _placeholder_element("title_obj", "TITLE", text="Old title"),
+            _placeholder_element("body_obj", "BODY", text="Old body"),
+        ],
+    )
+
+    google_slides.google_slides_update_slide("pres1", "slide1", title="New title")
+
+    requests = _batch_update_requests(presentations)
+    assert not any(
+        r.get("deleteText", {}).get("objectId") == "body_obj"
+        or r.get("insertText", {}).get("objectId") == "body_obj"
+        for r in requests
+    )
+
+
+def test_update_slide_subtitle_body_is_not_bulleted_or_stripped(monkeypatch):
+    """A TITLE-layout slide's body lands in a SUBTITLE, not a BODY —
+    update_slide must follow the same non-bulleted, non-stripped rule as
+    add_slide for that placeholder type."""
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [
+            _placeholder_element("title_obj", "CENTERED_TITLE", text="Old"),
+            _placeholder_element("subtitle_obj", "SUBTITLE", text="Old subtitle"),
+        ],
+    )
+
+    google_slides.google_slides_update_slide(
+        "pres1", "slide1", body="- Literal dash subtitle"
+    )
+
+    requests = _batch_update_requests(presentations)
+    body_insert = next(
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["objectId"] == "subtitle_obj"
+    )
+    assert body_insert["text"] == "- Literal dash subtitle"
+    assert not any("createParagraphBullets" in r for r in requests)
+
+
+def test_update_slide_requires_at_least_one_field(monkeypatch):
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(google_slides.google_slides_update_slide("pres1", "slide1"))
+
+    assert result["status"] == "error"
+    presentations.get.assert_not_called()
+
+
+def test_update_slide_rejects_whitespace_only_body(monkeypatch):
+    """Regression guard: whitespace-only text ("   ", "\\n\\n") must not
+    slip past the guard just because it's non-empty — that would silently
+    blank real slide content, the same bug class fixed for add_slide."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_update_slide("pres1", "slide1", body="   \n\n  ")
+    )
+
+    assert result["status"] == "error"
+    presentations.get.assert_not_called()
+
+
+def test_update_slide_rejects_marker_only_body(monkeypatch):
+    """Regression guard, same class as add_slide's: a body that's only a
+    bullet marker ("•   ") passes the raw whitespace-only check (it's
+    non-blank) but strips down to nothing once bullet-marker/blank-line
+    processing runs — must still be rejected, not silently applied as an
+    empty update."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations,
+        "slide1",
+        [_placeholder_element("body_obj", "BODY", text="Old body")],
+    )
+
+    result = json.loads(
+        google_slides.google_slides_update_slide("pres1", "slide1", body="•   ")
+    )
+
+    assert result["status"] == "error"
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_update_slide_rejects_unknown_slide_id(monkeypatch):
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(presentations, "other_slide", [])
+
+    result = json.loads(
+        google_slides.google_slides_update_slide("pres1", "slide1", title="T")
+    )
+
+    assert result["status"] == "error"
+    assert "slide1" in result["message"]
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_update_slide_rejects_title_when_slide_has_no_title_placeholder(monkeypatch):
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(
+        presentations, "slide1", [_placeholder_element("body_obj", "BODY", text="x")]
+    )
+
+    result = json.loads(
+        google_slides.google_slides_update_slide("pres1", "slide1", title="T")
+    )
+
+    assert result["status"] == "error"
+    assert "title" in result["message"]
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_update_slide_returns_error_payload_on_api_failure(monkeypatch):
+    presentations = Mock()
+    presentations.get.return_value.execute.side_effect = RuntimeError("boom")
+    _mock_slides_service(monkeypatch, presentations)
+
+    result = json.loads(
+        google_slides.google_slides_update_slide("pres1", "slide1", title="T")
+    )
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
+
+
+def test_delete_slide_sends_delete_object_request(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.return_value = {}
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(presentations, "slide1", [])
+
+    result = json.loads(google_slides.google_slides_delete_slide("pres1", "slide1"))
+
+    assert result["status"] == "success"
+    requests = _batch_update_requests(presentations)
+    assert requests == [{"deleteObject": {"objectId": "slide1"}}]
+
+
+def test_delete_slide_rejects_id_that_is_not_a_slide(monkeypatch):
+    """Regression guard: a placeholder shape id (e.g. one this file itself
+    mints as f"{slide_id}_title") must not be silently accepted — Slides'
+    deleteObject would delete just that shape while reporting success as if
+    the whole slide had been removed."""
+    presentations = Mock()
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(presentations, "slide1", [])
+
+    result = json.loads(
+        google_slides.google_slides_delete_slide("pres1", "slide1_title")
+    )
+
+    assert result["status"] == "error"
+    presentations.batchUpdate.assert_not_called()
+
+
+def test_delete_slide_returns_error_payload_on_api_failure(monkeypatch):
+    presentations = Mock()
+    presentations.batchUpdate.return_value.execute.side_effect = RuntimeError("boom")
+    _mock_slides_service(monkeypatch, presentations)
+    _mock_presentation_get(presentations, "slide1", [])
+
+    result = json.loads(google_slides.google_slides_delete_slide("pres1", "slide1"))
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
 
 
 def test_get_presentation_returns_slide_summaries(monkeypatch):


### PR DESCRIPTION
Rebased onto `main` now that #2209 has merged — this branch was rebuilt cleanly on top of the current `main` (rather than replaying the old stacked commits, since #2209 evolved a lot after this branch first forked from it) and now shows a clean, focused diff.

## Summary
Without a way to edit an existing slide, the only way an agent could fix a slide it created wrong/incomplete was to call `google_slides_add_slide` again — which creates a duplicate slide next to the original instead of correcting it (this was the actual recovery path observed in a production incident: a wrong slide got "fixed" by adding a second, correct one alongside the broken one).

- `google_slides_update_slide(presentation_id, slide_id, title, body)`: finds the slide's existing title/body (or subtitle) placeholder by type and replaces its text. Only touches whichever of title/body is passed. Body text goes through the same `_prepare_body_text` pipeline `add_slide` uses (bullet-marker stripping + blank-line filtering for a real `BODY` placeholder, left as-is for a `SUBTITLE`), so a marker-only or whitespace-only body is rejected the same way it would be for `add_slide`, instead of silently blanking real content.
- `google_slides_delete_slide(presentation_id, slide_id)`: removes one slide, for cleaning up a duplicate. Validates `slide_id` is actually a top-level slide id (not a placeholder shape id like the ones this file mints, e.g. `f"{slide_id}_title"`) before deleting — Slides' `deleteObject` accepts either, so a mistaken shape id would otherwise delete just that shape while still reporting success.
- Extracted `_prepare_body_text` (strip markers + drop blank lines) and `_body_insert_requests` (insertText + optional createParagraphBullets) out of `google_slides_add_slide` into shared helpers, so `update_slide` reuses the exact same, already-hardened body-processing logic instead of a separately-maintained copy.
- `add_slide`'s docstring now points at `update_slide` instead of a second `add_slide` call, and tells the caller to verify the finished deck with `get_presentation` before reporting success to the user.

Known, deliberately-unfixed limitation: `_find_placeholders` only targets the first placeholder of a given role if a slide has more than one (not reachable via this file's own `add_slide`, which never creates more than one of each, but possible for a slide from another source) — noted in a docstring rather than fixed, since disambiguating further isn't possible from role alone.

## Test plan
- [x] 27 new tests (72 total in the file): `update_slide` replaces title/body and reapplies bullets, skips delete-text when a placeholder is already empty, only touches the field provided, subtitle placeholders aren't bulleted/stripped, rejects whitespace-only and marker-only body, rejects an unknown slide id, rejects title/body when the slide has no matching placeholder, surfaces API failures; `delete_slide` sends the right request, rejects a non-slide id, surfaces API failures.
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy src/xagent/web/tools/mcp/google_slides.py` — no new errors (same pre-existing unrelated `googleapiclient` stub warning as `main`)
- [x] Full `tests/web/tools/` suite passes (no regressions)
