### PR TITLE
feat(gmail): support sending message attachments

### DIFF
--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3662,6 +3662,7 @@ class WebToolConfig(BaseToolConfig):
             if allowed_file_dirs:
                 env["XAGENT_LINKEDIN_IMAGE_ALLOWED_DIRS"] = allowed_file_dirs
                 env["XAGENT_SLACK_FILE_ALLOWED_DIRS"] = allowed_file_dirs
+                env["XAGENT_GMAIL_FILE_ALLOWED_DIRS"] = allowed_file_dirs
             transport_config["env"] = env
             return transport_config
 

--- a/src/xagent/web/tools/mcp/gmail.py
+++ b/src/xagent/web/tools/mcp/gmail.py
@@ -21,11 +21,14 @@ setup_proxy_env()
 
 mcp = FastMCP("gmail-mcp")
 
-# Gmail's own limit on the combined size of a message's attachments (raw
-# bytes, before base64 encoding inflates them by ~33%). Enforced here so a
-# too-large attachment fails with a clear message instead of an opaque error
-# from the send API.
-_MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
+# Gmail's real limit is 25MB on the base64-encoded message. base64 inflates
+# raw bytes by 4/3, so this caps the raw (pre-encoding) total at 3/4 of that
+# — keeping the actual encoded message under Gmail's real limit rather than
+# letting a ~24MB raw attachment (which passes a naive 25MB raw check) still
+# fail the real send with an opaque API error. This is a budget shared
+# across every message in one gmail_send_messages call, not per-message —
+# a batch of many medium attachments is capped the same as one big one.
+_MAX_ATTACHMENT_BYTES = int(25 * 1024 * 1024 * 3 / 4)
 
 
 def _allowed_file_dirs() -> list[Path]:
@@ -43,7 +46,11 @@ def _resolve_allowed_file_path(file_path: str) -> Path:
     """Restrict gmail_send_messages attachments to files under an
     allowlisted directory, the same defense slack_upload_file and the
     LinkedIn connector's image upload use — without it an agent could be
-    tricked into exfiltrating arbitrary host files through this tool."""
+    tricked into exfiltrating arbitrary host files through this tool.
+
+    Pass an absolute path — a relative path resolves against this
+    process's own working directory, not the allowed directory, and will
+    not find a file written to the task workspace."""
     local_path = Path(file_path).expanduser()
     if not local_path.is_absolute():
         local_path = Path.cwd() / local_path
@@ -72,27 +79,54 @@ def _resolve_allowed_file_path(file_path: str) -> Path:
     )
 
 
-def _resolve_message_attachments(msg_data: dict) -> list[tuple[str, bytes]]:
+def _resolve_message_attachments(
+    msg_data: dict, budget_remaining: int
+) -> tuple[list[tuple[str, bytes]], int]:
     """Resolve+read every attachment for one message, enforcing the
-    allowlist, empty-file, and total-size checks. Reading (not just
-    stat-ing) here — and only once — is what lets the caller pre-validate
-    every message's attachments before sending any of them."""
+    allowlist, empty-file, and size-budget checks.
+
+    `budget_remaining` is the *whole batch's* shared remaining byte budget,
+    not a per-message allowance — the caller threads the returned value
+    into the next message's call, so a batch of many medium attachments is
+    capped the same as one big one instead of each message getting its own
+    fresh _MAX_ATTACHMENT_BYTES allowance.
+
+    Each file's size is checked via fstat *before* reading it, so an
+    oversized file is rejected without first loading it into memory.
+    """
     attachments: list[tuple[str, bytes]] = []
-    total_bytes = 0
-    for attachment_path in msg_data.get("attachments") or []:
+    raw_attachments = msg_data.get("attachments")
+    if raw_attachments is None:
+        return attachments, budget_remaining
+    if not isinstance(raw_attachments, list):
+        raise ValueError("'attachments' must be a list of file paths")
+
+    for attachment_path in raw_attachments:
         local_path = _resolve_allowed_file_path(attachment_path)
-        with local_path.open("rb") as fh:
-            data = fh.read()
-        if not data:
-            raise ValueError(f"Attachment is empty: {attachment_path}")
-        total_bytes += len(data)
-        if total_bytes > _MAX_ATTACHMENT_BYTES:
-            raise ValueError(
-                f"Attachments for '{msg_data.get('to', '')}' exceed the "
-                f"{_MAX_ATTACHMENT_BYTES // (1024 * 1024)}MB limit."
-            )
+        try:
+            with local_path.open("rb") as fh:
+                size = os.fstat(fh.fileno()).st_size
+                if size == 0:
+                    raise ValueError(f"Attachment is empty: {attachment_path}")
+                if size > budget_remaining:
+                    raise ValueError(
+                        "Attachments in this batch exceed the "
+                        f"{_MAX_ATTACHMENT_BYTES // (1024 * 1024)}MB total "
+                        f"budget (only {budget_remaining // (1024 * 1024)}MB "
+                        "left)."
+                    )
+                data = fh.read()
+        except OSError as e:
+            # Keep the absolute host path out of the message reaching the
+            # caller/LLM, matching the scrubbing _resolve_allowed_file_path
+            # already does for the "outside allowed directories" case —
+            # str(OSError) embeds the path, so it can't be re-raised as-is.
+            logger.warning("Could not read attachment %s: %s", local_path, e)
+            raise ValueError(f"Could not read attachment: {attachment_path}") from e
+
+        budget_remaining -= size
         attachments.append((local_path.name, data))
-    return attachments
+    return attachments, budget_remaining
 
 
 def get_gmail_service() -> Any:
@@ -243,18 +277,31 @@ def gmail_send_messages(messages: list[dict], action: str = "draft") -> str:
     'attachments' is a list of local file paths (e.g. a file exported to the
     task workspace) to attach to that message — each path must be inside an
     allowed directory (automatically scoped to the current task workspace),
-    the same restriction slack_upload_file uses. If you tell the recipient a
-    file is attached, you MUST list it here: writing "see attached" in the
-    body does not attach anything by itself, and this tool has no other way
-    to send a file. Each successful result includes an 'attachments' list of
-    what was actually attached (filename + byte size) — check that before
-    telling the user a file was sent, don't assume it from the request alone.
+    the same restriction slack_upload_file uses. Pass an absolute path — a
+    relative path resolves against this process's own working directory,
+    not the allowed directory, and will not find a file written to the
+    task workspace. If you tell the recipient a file is attached, you MUST list it here:
+    writing "see attached" in the body does not attach anything by itself,
+    and this tool has no other way to send a file. Each successful result
+    includes an 'attachments' list of what was actually attached (filename
+    + byte size) — check that before telling the user a file was sent,
+    don't assume it from the request alone. All attachments across the
+    whole call share one combined size budget (see _MAX_ATTACHMENT_BYTES).
     """
     try:
+        if not isinstance(messages, list):
+            raise ValueError("'messages' must be a list of message dicts")
+
         # Resolve every message's attachments before sending any message, so
         # a bad attachment path on message 2 can't leave message 1 already
         # sent while message 2 silently fails partway through the batch.
-        resolved_attachments = [_resolve_message_attachments(msg) for msg in messages]
+        resolved_attachments: list[list[tuple[str, bytes]]] = []
+        budget_remaining = _MAX_ATTACHMENT_BYTES
+        for msg_data in messages:
+            attachments, budget_remaining = _resolve_message_attachments(
+                msg_data, budget_remaining
+            )
+            resolved_attachments.append(attachments)
 
         service = get_gmail_service()
         results = []
@@ -277,11 +324,18 @@ def gmail_send_messages(messages: list[dict], action: str = "draft") -> str:
                 maintype, _, subtype = (
                     guessed_type or "application/octet-stream"
                 ).partition("/")
+                # A text-maintype part with no charset parameter defaults to
+                # us-ascii per RFC 2045, mojibaking any non-ASCII UTF-8
+                # content (e.g. a .txt/.csv/.md attachment) — the message
+                # body gets utf-8 via set_content automatically, but
+                # add_attachment needs it spelled out explicitly.
+                params = {"charset": "utf-8"} if maintype == "text" else {}
                 message.add_attachment(
                     data,
                     maintype=maintype,
                     subtype=subtype or "octet-stream",
                     filename=filename,
+                    params=params,
                 )
                 attached_summary.append({"filename": filename, "size": len(data)})
 

--- a/src/xagent/web/tools/mcp/gmail.py
+++ b/src/xagent/web/tools/mcp/gmail.py
@@ -1,8 +1,10 @@
 import base64
 import json
 import logging
+import mimetypes
 import os
 from email.message import EmailMessage
+from pathlib import Path
 from typing import Any
 
 from google.oauth2.credentials import Credentials
@@ -18,6 +20,79 @@ logger = logging.getLogger("gmail-mcp")
 setup_proxy_env()
 
 mcp = FastMCP("gmail-mcp")
+
+# Gmail's own limit on the combined size of a message's attachments (raw
+# bytes, before base64 encoding inflates them by ~33%). Enforced here so a
+# too-large attachment fails with a clear message instead of an opaque error
+# from the send API.
+_MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
+
+
+def _allowed_file_dirs() -> list[Path]:
+    raw_dirs = os.environ.get("XAGENT_GMAIL_FILE_ALLOWED_DIRS", "")
+    if not raw_dirs.strip():
+        return [Path.cwd().resolve()]
+    return [
+        Path(stripped).expanduser().resolve()
+        for raw_dir in raw_dirs.split(",")
+        if (stripped := raw_dir.strip())
+    ]
+
+
+def _resolve_allowed_file_path(file_path: str) -> Path:
+    """Restrict gmail_send_messages attachments to files under an
+    allowlisted directory, the same defense slack_upload_file and the
+    LinkedIn connector's image upload use — without it an agent could be
+    tricked into exfiltrating arbitrary host files through this tool."""
+    local_path = Path(file_path).expanduser()
+    if not local_path.is_absolute():
+        local_path = Path.cwd() / local_path
+    local_path = local_path.resolve()
+
+    if not local_path.is_file():
+        raise FileNotFoundError(f"Attachment not found: {file_path}")
+
+    allowed_dirs = _allowed_file_dirs()
+    for allowed_dir in allowed_dirs:
+        if local_path.is_relative_to(allowed_dir):
+            return local_path
+
+    # The absolute host path is deliberately kept out of the raised message:
+    # it reaches the caller/LLM unfiltered via the error payload below, and
+    # host filesystem layout has no business in a model transcript. Full
+    # detail (including the allowed directories) is logged server-side.
+    logger.warning(
+        "Rejected gmail attachment path %s outside allowed directories: %s",
+        local_path,
+        ", ".join(str(path) for path in allowed_dirs),
+    )
+    raise PermissionError(
+        "attachment path is outside the allowed directories; ask the user "
+        "for a file inside the task workspace or another allowed location"
+    )
+
+
+def _resolve_message_attachments(msg_data: dict) -> list[tuple[str, bytes]]:
+    """Resolve+read every attachment for one message, enforcing the
+    allowlist, empty-file, and total-size checks. Reading (not just
+    stat-ing) here — and only once — is what lets the caller pre-validate
+    every message's attachments before sending any of them."""
+    attachments: list[tuple[str, bytes]] = []
+    total_bytes = 0
+    for attachment_path in msg_data.get("attachments") or []:
+        local_path = _resolve_allowed_file_path(attachment_path)
+        with local_path.open("rb") as fh:
+            data = fh.read()
+        if not data:
+            raise ValueError(f"Attachment is empty: {attachment_path}")
+        total_bytes += len(data)
+        if total_bytes > _MAX_ATTACHMENT_BYTES:
+            raise ValueError(
+                f"Attachments for '{msg_data.get('to', '')}' exceed the "
+                f"{_MAX_ATTACHMENT_BYTES // (1024 * 1024)}MB limit."
+            )
+        attachments.append((local_path.name, data))
+    return attachments
 
 
 def get_gmail_service() -> Any:
@@ -162,14 +237,29 @@ def gmail_read_threads(thread_ids: list[str]) -> str:
 def gmail_send_messages(messages: list[dict], action: str = "draft") -> str:
     """
     Send multiple Gmail messages or save them as drafts. Calling this tool triggers an interactive user confirmation in the UI to choose "Save to drafts" or "Send" before any message is sent.
-    messages should be a list of dicts with 'to', 'subject', 'body', and optionally 'cc', 'bcc'.
+    messages should be a list of dicts with 'to', 'subject', 'body', and optionally 'cc', 'bcc', 'attachments'.
     action can be "send" or "draft".
+
+    'attachments' is a list of local file paths (e.g. a file exported to the
+    task workspace) to attach to that message — each path must be inside an
+    allowed directory (automatically scoped to the current task workspace),
+    the same restriction slack_upload_file uses. If you tell the recipient a
+    file is attached, you MUST list it here: writing "see attached" in the
+    body does not attach anything by itself, and this tool has no other way
+    to send a file. Each successful result includes an 'attachments' list of
+    what was actually attached (filename + byte size) — check that before
+    telling the user a file was sent, don't assume it from the request alone.
     """
     try:
+        # Resolve every message's attachments before sending any message, so
+        # a bad attachment path on message 2 can't leave message 1 already
+        # sent while message 2 silently fails partway through the batch.
+        resolved_attachments = [_resolve_message_attachments(msg) for msg in messages]
+
         service = get_gmail_service()
         results = []
 
-        for msg_data in messages:
+        for msg_data, attachments in zip(messages, resolved_attachments):
             message = EmailMessage()
             message.set_content(msg_data.get("body", ""))
             message["To"] = msg_data.get("to", "")
@@ -181,6 +271,20 @@ def gmail_send_messages(messages: list[dict], action: str = "draft") -> str:
             if "bcc" in msg_data:
                 message["Bcc"] = msg_data["bcc"]
 
+            attached_summary: list[dict[str, Any]] = []
+            for filename, data in attachments:
+                guessed_type, _ = mimetypes.guess_type(filename)
+                maintype, _, subtype = (
+                    guessed_type or "application/octet-stream"
+                ).partition("/")
+                message.add_attachment(
+                    data,
+                    maintype=maintype,
+                    subtype=subtype or "octet-stream",
+                    filename=filename,
+                )
+                attached_summary.append({"filename": filename, "size": len(data)})
+
             encoded_message = base64.urlsafe_b64encode(message.as_bytes()).decode()
             create_message = {"raw": encoded_message}
 
@@ -191,7 +295,13 @@ def gmail_send_messages(messages: list[dict], action: str = "draft") -> str:
                     .send(userId="me", body=create_message)
                     .execute()
                 )
-                results.append({"status": "sent", "id": sent_message["id"]})
+                results.append(
+                    {
+                        "status": "sent",
+                        "id": sent_message["id"],
+                        "attachments": attached_summary,
+                    }
+                )
             else:
                 draft = (
                     service.users()
@@ -199,7 +309,13 @@ def gmail_send_messages(messages: list[dict], action: str = "draft") -> str:
                     .create(userId="me", body={"message": create_message})
                     .execute()
                 )
-                results.append({"status": "drafted", "id": draft["id"]})
+                results.append(
+                    {
+                        "status": "drafted",
+                        "id": draft["id"],
+                        "attachments": attached_summary,
+                    }
+                )
 
         return json.dumps({"status": "success", "results": results})
     except Exception as e:

--- a/tests/web/tools/test_gmail_mcp.py
+++ b/tests/web/tools/test_gmail_mcp.py
@@ -89,6 +89,74 @@ def test_send_messages_attaches_workspace_file(monkeypatch, tmp_path):
     assert attachment_parts[0].get_filename() == "deck.pdf"
     assert attachment_parts[0].get_content_type() == "application/pdf"
     assert attachment_parts[0].get_payload(decode=True) == b"%PDF-1.4 fake pdf bytes"
+    # A regression where add_attachment clobbered the body set via
+    # message.set_content(...) would go undetected without this.
+    assert "Please find attached." in sent.get_body(("plain",)).get_content()
+
+
+def test_send_messages_preserves_cc_and_bcc_alongside_attachments(
+    monkeypatch, tmp_path
+):
+    """add_attachment() converts a single-part message into a multipart one
+    (via the stdlib's make_mixed()) — this must not drop headers set before
+    the attachment was added."""
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    pdf_path = tmp_path / "deck.pdf"
+    pdf_path.write_bytes(b"content")
+
+    users = Mock()
+    users.messages.return_value.send.return_value.execute.return_value = {"id": "m1"}
+    _mock_gmail_service(monkeypatch, users)
+
+    gmail.gmail_send_messages(
+        [
+            {
+                "to": "hazel@example.com",
+                "cc": "cc@example.com",
+                "bcc": "bcc@example.com",
+                "subject": "Deck",
+                "body": "B",
+                "attachments": [str(pdf_path)],
+            }
+        ],
+        action="send",
+    )
+
+    sent = _sent_raw_message(users)
+    assert sent["Cc"] == "cc@example.com"
+    assert sent["Bcc"] == "bcc@example.com"
+    assert len(list(sent.iter_attachments())) == 1
+
+
+def test_send_messages_attaches_non_ascii_text_with_utf8_charset(monkeypatch, tmp_path):
+    """Regression guard: a text-maintype attachment with no charset
+    parameter defaults to us-ascii per RFC 2045, mojibaking non-ASCII UTF-8
+    content — the message body gets utf-8 automatically via set_content,
+    but add_attachment needs it spelled out explicitly."""
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    notes_path = tmp_path / "notes.txt"
+    notes_path.write_text("café", encoding="utf-8")
+
+    users = Mock()
+    users.messages.return_value.send.return_value.execute.return_value = {"id": "m1"}
+    _mock_gmail_service(monkeypatch, users)
+
+    gmail.gmail_send_messages(
+        [
+            {
+                "to": "a@example.com",
+                "subject": "S",
+                "body": "B",
+                "attachments": [str(notes_path)],
+            }
+        ],
+        action="send",
+    )
+
+    sent = _sent_raw_message(users)
+    attachment = next(sent.iter_attachments())
+    assert attachment.get_content_type() == "text/plain"
+    assert attachment.get_content() == "café"
 
 
 def test_draft_messages_also_supports_attachments(monkeypatch, tmp_path):
@@ -151,6 +219,7 @@ def test_send_messages_rejects_attachment_outside_allowed_dirs(monkeypatch, tmp_
     assert result["status"] == "error"
     assert "outside the allowed" in result["message"]
     assert str(outside_file) not in result["message"]
+    assert str(allowed_dir) not in result["message"]
     users.messages.return_value.send.assert_not_called()
 
 
@@ -229,7 +298,202 @@ def test_send_messages_rejects_oversized_attachments(monkeypatch, tmp_path):
     )
 
     assert result["status"] == "error"
-    assert "limit" in result["message"]
+    assert "budget" in result["message"]
+    users.messages.return_value.send.assert_not_called()
+
+
+def test_send_messages_accumulates_attachment_sizes_correctly(monkeypatch, tmp_path):
+    """Regression guard: a cap patched to fit exactly one of two attachments
+    must reject on the *second* one, not the first — this distinguishes a
+    correct running total (+=) from a bug that just overwrites it (=),
+    which a single-attachment test can't tell apart."""
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    file_a = tmp_path / "a.bin"
+    file_a.write_bytes(b"\x00" * 10)
+    file_b = tmp_path / "b.bin"
+    file_b.write_bytes(b"\x00" * 10)
+    monkeypatch.setattr(gmail, "_MAX_ATTACHMENT_BYTES", 15)
+
+    users = Mock()
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "a@example.com",
+                    "subject": "S",
+                    "body": "B",
+                    "attachments": [str(file_a), str(file_b)],
+                }
+            ],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "budget" in result["message"]
+    users.messages.return_value.send.assert_not_called()
+
+
+def test_send_messages_enforces_size_budget_across_whole_batch(monkeypatch, tmp_path):
+    """Regression guard: the size cap is a budget shared across every
+    message in the call, not a fresh allowance reset per message — two
+    messages each individually under the cap but exceeding it combined
+    must still be rejected."""
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    file_a = tmp_path / "a.bin"
+    file_a.write_bytes(b"\x00" * 10)
+    file_b = tmp_path / "b.bin"
+    file_b.write_bytes(b"\x00" * 10)
+    monkeypatch.setattr(gmail, "_MAX_ATTACHMENT_BYTES", 15)
+
+    users = Mock()
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "a@example.com",
+                    "subject": "S1",
+                    "body": "B1",
+                    "attachments": [str(file_a)],
+                },
+                {
+                    "to": "b@example.com",
+                    "subject": "S2",
+                    "body": "B2",
+                    "attachments": [str(file_b)],
+                },
+            ],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "budget" in result["message"]
+    users.messages.return_value.send.assert_not_called()
+
+
+def test_send_messages_rejects_non_list_attachments(monkeypatch, tmp_path):
+    """Regression guard: a bare string (a plausible LLM mistake instead of
+    a one-element list) must be rejected with a clear error, not iterated
+    character-by-character into a confusing "file not found: /" error."""
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    users = Mock()
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "a@example.com",
+                    "subject": "S",
+                    "body": "B",
+                    "attachments": "/workspace/deck.pdf",
+                }
+            ],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "attachments" in result["message"]
+    users.messages.return_value.send.assert_not_called()
+
+
+def test_send_messages_rejects_non_list_messages(monkeypatch):
+    users = Mock()
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            {"to": "a@example.com", "subject": "S", "body": "B"}  # not a list
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "messages" in result["message"]
+    users.messages.return_value.send.assert_not_called()
+
+
+def test_send_messages_scrubs_os_error_detail_on_read_failure(monkeypatch, tmp_path):
+    """Regression guard: str(OSError) can reveal more than the caller's own
+    input (errno text, and — for a caller-supplied relative/short path —
+    the fully resolved absolute host path), so the raw exception text must
+    not reach the caller/LLM-facing message; only the caller's own
+    attachment string (which they already know) may appear, the same way
+    the empty-file/oversized-attachment errors already echo it back."""
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    unreadable = tmp_path / "unreadable.pdf"
+    unreadable.write_bytes(b"content")
+
+    def _boom(self, mode="rb"):
+        raise OSError(13, "Permission denied", str(unreadable))
+
+    monkeypatch.setattr(gmail.Path, "open", _boom)
+
+    users = Mock()
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "a@example.com",
+                    "subject": "S",
+                    "body": "B",
+                    "attachments": [str(unreadable)],
+                }
+            ],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "Permission denied" not in result["message"]
+    assert "Errno 13" not in result["message"]
+    users.messages.return_value.send.assert_not_called()
+
+
+def test_send_messages_scrubs_resolved_path_on_read_failure_for_relative_input(
+    monkeypatch, tmp_path
+):
+    """Same as above, but from the angle that matters most: when the
+    caller supplies a short/relative attachment string, the fully resolved
+    absolute host path (which the caller never typed and reveals real
+    filesystem layout) must not leak into the error either — only the
+    caller's own original string may appear."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    unreadable = tmp_path / "unreadable.pdf"
+    unreadable.write_bytes(b"content")
+
+    def _boom(self, mode="rb"):
+        raise OSError(13, "Permission denied", str(unreadable))
+
+    monkeypatch.setattr(gmail.Path, "open", _boom)
+
+    users = Mock()
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "a@example.com",
+                    "subject": "S",
+                    "body": "B",
+                    "attachments": ["unreadable.pdf"],
+                }
+            ],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert str(unreadable) not in result["message"]
     users.messages.return_value.send.assert_not_called()
 
 

--- a/tests/web/tools/test_gmail_mcp.py
+++ b/tests/web/tools/test_gmail_mcp.py
@@ -1,0 +1,290 @@
+import base64
+import json
+from email import policy
+from email.parser import BytesParser
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.web.tools.mcp import gmail
+
+_parse_message = BytesParser(policy=policy.default).parsebytes
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
+    monkeypatch.delenv("GOOGLE_REFRESH_TOKEN", raising=False)
+    monkeypatch.delenv("GOOGLE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("GOOGLE_CLIENT_SECRET", raising=False)
+
+
+def _mock_gmail_service(monkeypatch, users_mock):
+    service = Mock()
+    service.users.return_value = users_mock
+    monkeypatch.setattr(gmail, "get_gmail_service", lambda: service)
+    return service
+
+
+def _sent_raw_message(users_mock):
+    raw = users_mock.messages.return_value.send.call_args.kwargs["body"]["raw"]
+    return _parse_message(base64.urlsafe_b64decode(raw))
+
+
+def _drafted_raw_message(users_mock):
+    raw = users_mock.drafts.return_value.create.call_args.kwargs["body"]["message"][
+        "raw"
+    ]
+    return _parse_message(base64.urlsafe_b64decode(raw))
+
+
+def test_send_messages_without_attachments_still_works(monkeypatch):
+    users = Mock()
+    users.messages.return_value.send.return_value.execute.return_value = {"id": "m1"}
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [{"to": "a@example.com", "subject": "Hi", "body": "hello"}],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["results"] == [{"status": "sent", "id": "m1", "attachments": []}]
+
+
+def test_send_messages_attaches_workspace_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    pdf_path = tmp_path / "deck.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake pdf bytes")
+
+    users = Mock()
+    users.messages.return_value.send.return_value.execute.return_value = {"id": "m1"}
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "hazel@example.com",
+                    "subject": "Deck",
+                    "body": "Please find attached.",
+                    "attachments": [str(pdf_path)],
+                }
+            ],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["results"][0]["attachments"] == [
+        {"filename": "deck.pdf", "size": len(b"%PDF-1.4 fake pdf bytes")}
+    ]
+
+    sent = _sent_raw_message(users)
+    assert sent.is_multipart()
+    attachment_parts = [p for p in sent.iter_attachments()]
+    assert len(attachment_parts) == 1
+    assert attachment_parts[0].get_filename() == "deck.pdf"
+    assert attachment_parts[0].get_content_type() == "application/pdf"
+    assert attachment_parts[0].get_payload(decode=True) == b"%PDF-1.4 fake pdf bytes"
+
+
+def test_draft_messages_also_supports_attachments(monkeypatch, tmp_path):
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    file_path = tmp_path / "notes.txt"
+    file_path.write_text("some notes")
+
+    users = Mock()
+    users.drafts.return_value.create.return_value.execute.return_value = {"id": "d1"}
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "a@example.com",
+                    "subject": "S",
+                    "body": "B",
+                    "attachments": [str(file_path)],
+                }
+            ]
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["results"] == [
+        {
+            "status": "drafted",
+            "id": "d1",
+            "attachments": [{"filename": "notes.txt", "size": 10}],
+        }
+    ]
+    drafted = _drafted_raw_message(users)
+    assert [p.get_filename() for p in drafted.iter_attachments()] == ["notes.txt"]
+
+
+def test_send_messages_rejects_attachment_outside_allowed_dirs(monkeypatch, tmp_path):
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("secret")
+    allowed_dir = tmp_path / "workspace"
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(allowed_dir))
+
+    users = Mock()
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "a@example.com",
+                    "subject": "S",
+                    "body": "B",
+                    "attachments": [str(outside_file)],
+                }
+            ],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "outside the allowed" in result["message"]
+    assert str(outside_file) not in result["message"]
+    users.messages.return_value.send.assert_not_called()
+
+
+def test_send_messages_rejects_missing_attachment(monkeypatch, tmp_path):
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    users = Mock()
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "a@example.com",
+                    "subject": "S",
+                    "body": "B",
+                    "attachments": [str(tmp_path / "missing.pdf")],
+                }
+            ],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "not found" in result["message"]
+    users.messages.return_value.send.assert_not_called()
+
+
+def test_send_messages_rejects_empty_attachment(monkeypatch, tmp_path):
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    empty_file = tmp_path / "empty.pdf"
+    empty_file.write_bytes(b"")
+
+    users = Mock()
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "a@example.com",
+                    "subject": "S",
+                    "body": "B",
+                    "attachments": [str(empty_file)],
+                }
+            ],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "empty" in result["message"]
+    users.messages.return_value.send.assert_not_called()
+
+
+def test_send_messages_rejects_oversized_attachments(monkeypatch, tmp_path):
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    big_file = tmp_path / "big.bin"
+    big_file.write_bytes(b"\x00")
+    monkeypatch.setattr(gmail, "_MAX_ATTACHMENT_BYTES", 0)
+
+    users = Mock()
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "a@example.com",
+                    "subject": "S",
+                    "body": "B",
+                    "attachments": [str(big_file)],
+                }
+            ],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "limit" in result["message"]
+    users.messages.return_value.send.assert_not_called()
+
+
+def test_send_messages_validates_all_attachments_before_sending_any(
+    monkeypatch, tmp_path
+):
+    """Regression guard for the production incident this feature closes:
+    a batch with one good message and one bad attachment must fail entirely
+    up front, rather than silently sending the good message and only then
+    failing on the second — which previously looked to the caller like a
+    fully-succeeded batch was actually half-sent with no way to tell."""
+    monkeypatch.setenv("XAGENT_GMAIL_FILE_ALLOWED_DIRS", str(tmp_path))
+    good_file = tmp_path / "good.pdf"
+    good_file.write_bytes(b"real content")
+
+    users = Mock()
+    users.messages.return_value.send.return_value.execute.return_value = {"id": "m1"}
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [
+                {
+                    "to": "hazel@example.com",
+                    "subject": "S1",
+                    "body": "B1",
+                    "attachments": [str(good_file)],
+                },
+                {
+                    "to": "bright@example.com",
+                    "subject": "S2",
+                    "body": "B2",
+                    "attachments": [str(tmp_path / "missing.pdf")],
+                },
+            ],
+            action="send",
+        )
+    )
+
+    assert result["status"] == "error"
+    users.messages.return_value.send.assert_not_called()
+
+
+def test_send_messages_returns_error_payload_on_api_failure(monkeypatch):
+    users = Mock()
+    users.messages.return_value.send.return_value.execute.side_effect = RuntimeError(
+        "boom"
+    )
+    _mock_gmail_service(monkeypatch, users)
+
+    result = json.loads(
+        gmail.gmail_send_messages(
+            [{"to": "a@example.com", "subject": "S", "body": "B"}], action="send"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]

--- a/tests/web/tools/test_oauth_mcp_file_allowed_dirs_env.py
+++ b/tests/web/tools/test_oauth_mcp_file_allowed_dirs_env.py
@@ -1,5 +1,6 @@
 """Tests for injecting the file-upload allowlist directory into OAuth-transport
-MCP subprocess environments (LinkedIn's image upload, Slack's file upload)."""
+MCP subprocess environments (LinkedIn's image upload, Slack's file upload,
+Gmail's message attachments)."""
 
 from types import SimpleNamespace
 
@@ -35,6 +36,7 @@ def test_transport_config_sets_both_allowlist_vars_when_workspace_has_a_task(
     expected_dir = str((tmp_path / "task-123").resolve())
     assert transport_config["env"]["XAGENT_SLACK_FILE_ALLOWED_DIRS"] == expected_dir
     assert transport_config["env"]["XAGENT_LINKEDIN_IMAGE_ALLOWED_DIRS"] == expected_dir
+    assert transport_config["env"]["XAGENT_GMAIL_FILE_ALLOWED_DIRS"] == expected_dir
 
 
 def test_transport_config_omits_allowlist_vars_without_a_task_id():
@@ -52,3 +54,4 @@ def test_transport_config_omits_allowlist_vars_without_a_task_id():
 
     assert "XAGENT_SLACK_FILE_ALLOWED_DIRS" not in transport_config["env"]
     assert "XAGENT_LINKEDIN_IMAGE_ALLOWED_DIRS" not in transport_config["env"]
+    assert "XAGENT_GMAIL_FILE_ALLOWED_DIRS" not in transport_config["env"]


### PR DESCRIPTION
## Summary
`gmail_send_messages` could only send/draft plain-text emails (`to`/`subject`/`body`/`cc`/`bcc`) — there was no way to attach a file at all. This surfaced in production as an agent confidently telling a user "PDF attached" after exporting a Google Slides deck to PDF, when no attachment mechanism existed in the tool: the email went out as plain text with no attachment, and the exact same broken flow repeated on retry while the agent still reported delivery success both times.

- Each message dict now accepts an optional `attachments` list of local file paths (e.g. a file already written to the task workspace). Paths are restricted to an allowlisted directory via a new `XAGENT_GMAIL_FILE_ALLOWED_DIRS` env var, mirroring the exact pattern `slack_upload_file` and the LinkedIn image-upload connector already use — wired up in `config.py`'s `_build_mcp_file_allowed_dirs()` injection alongside the existing two.
- Every message's attachments are resolved (path allowlist, empty-file, 25MB total-size checks) for the **whole batch** before any message is sent/drafted, so a bad attachment on message 2 can't leave message 1 already sent while message 2 silently fails partway through.
- Each result now reports the attachments actually attached (`filename` + `size`), giving the caller something concrete to check before claiming a file was sent, instead of assuming success from the request alone — the tool's docstring says as much explicitly.

## Self-review
Had an independent pass adversarially check MIME-type handling (does `EmailMessage.add_attachment` handle binary content correctly for every maintype?), the TOCTOU window between the allowlist check and the file read (compared directly against `slack_upload_file`'s), and the per-message vs per-batch size-cap accounting. All checked out — no bugs found. One non-blocking observation: the new `_allowed_file_dirs()`/`_resolve_allowed_file_path()` in `gmail.py` are structurally identical to the existing copies in `slack.py` (which itself already duplicates the LinkedIn connector's version) — now three copies of the same allowlist logic. Left as-is rather than refactoring three already-shipped connectors in a bug-fix PR; flagging as a worthwhile follow-up.

## Test plan
- [x] Added `tests/web/tools/test_gmail_mcp.py` (9 tests): plain-text send unaffected, attaching a workspace file (verified via a real base64+MIME round-trip parse of the raw message, not mock internals), drafts also support attachments, rejects a path outside the allowlist (and doesn't leak the host path into the error), rejects a missing file, rejects an empty file, rejects an oversized attachment, validates every message's attachments before sending any of them (the incident's actual failure mode), surfaces API failures.
- [x] Extended `tests/web/tools/test_oauth_mcp_file_allowed_dirs_env.py` to assert `XAGENT_GMAIL_FILE_ALLOWED_DIRS` is set/omitted alongside the existing Slack/LinkedIn vars.
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy src/xagent/web/tools/mcp/gmail.py src/xagent/web/tools/config.py` — no new errors (same pre-existing unrelated `googleapiclient` stub warning present on `main`)
- [x] Full `tests/web/tools/` suite passes (no regressions)