### PR TITLE
fix(agent): discard the parked tool plan before the waiting_for_user checkpoint (#2216)

### DIFF
--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -32,9 +32,12 @@ flag never changes observable results, only latency:
   A batch that arrives here from a fresh LLM response carries no final_answer
   alongside a work tool: response normalization removes it first, because its
   answer text was written before those tools ran. That holds for fresh
-  responses only - pending_tool_calls restored from a checkpoint are replayed
-  without re-normalization, so a batch written by an earlier build can still
-  reach this loop carrying one, and takes the branches above unchanged.
+  responses only - pending_tool_calls restored from an interrupt checkpoint
+  are replayed without re-normalization, so a batch written by an earlier
+  build can still reach this loop carrying one, and takes the branches above
+  unchanged. A waiting_for_user resume is the exception: it cancels any
+  restored pending calls before the loop (legacy pre-#2216 checkpoints), so
+  the resumed turn replans instead of replaying.
 - I5 (interrupt / resume): an interrupt during a concurrent batch preserves
   calls that already completed and leaves only interrupted calls pending. A
   cancelled call may still have committed externally before cancellation was
@@ -1728,7 +1731,20 @@ class ReActPattern(AgentPattern):
             # siblings (#2216). Pause-time semantics already discarded them in
             # memory, so cancel them here too: the resumed turn must replan
             # from the user's answer, never replay a stale call.
-            self._discard_pending_tool_plan_after_pause(context)
+            logger.warning(
+                "ReAct cancelling %d stale pending tool call(s) restored from a "
+                "legacy waiting_for_user checkpoint (#2216): %s",
+                len(self.pending_tool_calls),
+                [call.get("name") for call in self.pending_tool_calls],
+            )
+            self._discard_pending_tool_plan_after_pause(
+                context,
+                reason=(
+                    "Discarded stale tool plan restored from a checkpoint "
+                    "written before user input arrived; the agent replans "
+                    "from the user's response."
+                ),
+            )
         waiting_task = self.waiting_for_user_request.get("task_text")
         if waiting_task and self.task_text is None:
             self.task_text = str(waiting_task)
@@ -2683,7 +2699,9 @@ class ReActPattern(AgentPattern):
         )
         self._forget_tool_call_content(tool_call)
 
-    def _discard_pending_tool_plan_after_pause(self, context: Any) -> None:
+    def _discard_pending_tool_plan_after_pause(
+        self, context: Any, *, reason: str | None = None
+    ) -> None:
         """Close unexecuted calls so resume always starts with a fresh LLM plan."""
 
         discarded_calls = self.pending_tool_calls
@@ -2693,7 +2711,8 @@ class ReActPattern(AgentPattern):
         self._cancel_tool_calls(
             discarded_calls,
             context,
-            reason=(
+            reason=reason
+            or (
                 "Discarded because an earlier tool requires user input; "
                 "the agent will replan after the user responds."
             ),
@@ -3038,9 +3057,27 @@ class ReActPattern(AgentPattern):
                     # parked.
                     self._discard_pending_tool_plan_after_pause(context)
                     if self.waiting_for_user_request is not None:
-                        self.waiting_for_user_request["message_count"] = len(
-                            getattr(context, "messages", [])
-                        )
+                        # Rebind rather than mutate: get_state() hands this
+                        # dict out by reference, so a fresh dict keeps any
+                        # state captured earlier from aliasing this update.
+                        self.waiting_for_user_request = {
+                            **self.waiting_for_user_request,
+                            "message_count": len(getattr(context, "messages", [])),
+                        }
+                        if control_result is not None:
+                            # The draft returned by _handle_control_tool was
+                            # built from the pre-discard message count; rebuild
+                            # it so turn_marker matches what an answer-less
+                            # resume re-derives from the persisted request
+                            # (clarification.py documents turn_marker as
+                            # stable for the lifetime of the waiting turn).
+                            control_result["clarification_draft"] = (
+                                draft_from_waiting_request(
+                                    self.waiting_for_user_request,
+                                    execution_id=getattr(context, "execution_id", None),
+                                    step_id=None,
+                                )
+                            )
                 await runtime.checkpoint(
                     str(control_result.get("status", "control_tool"))
                     if control_result is not None

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1722,6 +1722,13 @@ class ReActPattern(AgentPattern):
             response=response or "",
             tools=tools,
         )
+        if self.pending_tool_calls:
+            # Waiting checkpoints written before the pause path discarded the
+            # plan pre-checkpoint still carry the parked batch's unexecuted
+            # siblings (#2216). Pause-time semantics already discarded them in
+            # memory, so cancel them here too: the resumed turn must replan
+            # from the user's answer, never replay a stale call.
+            self._discard_pending_tool_plan_after_pause(context)
         waiting_task = self.waiting_for_user_request.get("task_text")
         if waiting_task and self.task_text is None:
             self.task_text = str(waiting_task)
@@ -3015,6 +3022,25 @@ class ReActPattern(AgentPattern):
                 )
                 self.pending_tool_calls = self.pending_tool_calls[1:]
                 self._forget_tool_call_content(tool_call)
+                control_waits_for_user = (
+                    control_result is not None
+                    and control_result.get("status") == "waiting_for_user"
+                )
+                if control_waits_for_user:
+                    # Discard before the checkpoint below persists this state:
+                    # a resume restores pending_tool_calls verbatim, and a
+                    # sibling left in it replays without a fresh LLM plan --
+                    # a stale bundled final_answer even completes the resumed
+                    # turn with zero iterations (#2216). The cancellations
+                    # append tool results, so refresh the waiting request's
+                    # message watermark the way the tool-pause path snapshots
+                    # it after cancelling, keeping an answer-less resume
+                    # parked.
+                    self._discard_pending_tool_plan_after_pause(context)
+                    if self.waiting_for_user_request is not None:
+                        self.waiting_for_user_request["message_count"] = len(
+                            getattr(context, "messages", [])
+                        )
                 await runtime.checkpoint(
                     str(control_result.get("status", "control_tool"))
                     if control_result is not None
@@ -3027,8 +3053,7 @@ class ReActPattern(AgentPattern):
                     if control_result.get("status") == "completed":
                         self.pending_tool_calls = []
                         return control_result
-                    if control_result.get("status") == "waiting_for_user":
-                        self._discard_pending_tool_plan_after_pause(context)
+                    if control_waits_for_user:
                         return control_result
                 continue
 

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5400,8 +5400,43 @@ def _ask_then_stale_final_answer_llm() -> FakeLLM:
     )
 
 
-async def _park_on_question_with_stale_sibling() -> dict[str, Any]:
-    """Run one turn that parks on ask_user_question with a bundled sibling.
+def _send_message_then_stale_final_answer_llm() -> FakeLLM:
+    """One response bundling send_message(expect_response) with a stale
+    final_answer."""
+
+    return FakeLLM(
+        responses=[
+            {
+                "content": "Choose A or B",
+                "tool_calls": [
+                    {
+                        "id": "call_question",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": (
+                                '{"message":"Choose A or B",'
+                                '"message_type":"question",'
+                                '"expect_response":true}'
+                            ),
+                        },
+                    },
+                    {
+                        "id": "call_stale_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Choose A or B"}',
+                        },
+                    },
+                ],
+            }
+        ]
+    )
+
+
+async def _park_on_question_with_stale_sibling(
+    llm: FakeLLM | None = None,
+) -> dict[str, Any]:
+    """Run one turn that parks on a control tool with a bundled sibling.
 
     Returns the ``waiting_for_user`` checkpoint payload the runtime persisted
     at pause time -- the exact state a production resume restores.
@@ -5415,7 +5450,7 @@ async def _park_on_question_with_stale_sibling() -> dict[str, Any]:
     first = await pattern.run(
         context=context,
         tools=[],
-        llm=_ask_then_stale_final_answer_llm(),
+        llm=llm or _ask_then_stale_final_answer_llm(),
         runtime=runtime,
     )
 
@@ -5494,11 +5529,38 @@ async def test_react_resume_from_waiting_checkpoint_replans_instead_of_replaying
     assert resumed["response"] == "You chose B."
 
 
+@pytest.mark.asyncio
+async def test_react_send_message_waiting_checkpoint_resume_replans() -> None:
+    """send_message(expect_response=True) parks through the same control
+    branch as ask_user_question; its persisted waiting checkpoint must carry
+    an empty plan and resume by replanning, not by replaying the stale
+    sibling (#2216)."""
+
+    checkpoint = await _park_on_question_with_stale_sibling(
+        llm=_send_message_then_stale_final_answer_llm()
+    )
+
+    assert checkpoint["pattern_state"]["pending_tool_calls"] == []
+    restored_context = ExecutionContext.from_dict(checkpoint["context"])
+    restored_context.add_user_message("B")
+    restored_pattern = ReActPattern(max_iterations=3)
+    restored_pattern.load_state(checkpoint["pattern_state"])
+    resumed_llm = FakeLLM([{"content": "You chose B.", "done": True}])
+
+    resumed = await restored_pattern.run(
+        context=restored_context, tools=[], llm=resumed_llm
+    )
+
+    assert resumed["success"] is True
+    assert len(resumed_llm.calls) == 1
+    assert resumed["response"] == "You chose B."
+
+
 def _legacy_waiting_state_and_context(
-    stale_pending: dict[str, Any],
+    *stale_pendings: dict[str, Any],
 ) -> tuple[dict[str, Any], ExecutionContext]:
     """Build the state a pre-fix waiting_for_user checkpoint persisted: the
-    parked question plus the batch's unexecuted sibling still pending."""
+    parked question plus the batch's unexecuted siblings still pending."""
 
     context = ExecutionContext()
     context.add_user_message("Ask, then answer")
@@ -5513,14 +5575,17 @@ def _legacy_waiting_state_and_context(
                     "arguments": '{"message": "Choose A or B", "interactions": []}',
                 },
             },
-            {
-                "id": stale_pending["id"],
-                "type": "function",
-                "function": {
-                    "name": stale_pending["name"],
-                    "arguments": json.dumps(stale_pending["args"]),
-                },
-            },
+            *(
+                {
+                    "id": stale_pending["id"],
+                    "type": "function",
+                    "function": {
+                        "name": stale_pending["name"],
+                        "arguments": json.dumps(stale_pending["args"]),
+                    },
+                }
+                for stale_pending in stale_pendings
+            ),
         ],
     )
     context.add_tool_result(
@@ -5545,64 +5610,68 @@ def _legacy_waiting_state_and_context(
             "task_text": "Ask, then answer",
             "message_count": len(context.messages),
         },
-        "pending_tool_calls": [stale_pending],
+        "pending_tool_calls": list(stale_pendings),
     }
     return state, context
 
 
+_STALE_FINAL_ANSWER = {
+    "id": "call_stale_final",
+    "name": "final_answer",
+    "args": {"answer": "Choose A or B"},
+}
+_STALE_WORK_TOOL = {
+    "id": "call_stale_calc",
+    "name": "calculator",
+    "args": {"expression": "5+5"},
+}
+
+
 @pytest.mark.asyncio
-async def test_react_resume_waiting_cancels_stale_final_answer_from_legacy_checkpoint() -> (
-    None
-):
+@pytest.mark.parametrize(
+    "stale_pendings",
+    [
+        pytest.param([_STALE_FINAL_ANSWER], id="stale-final-answer"),
+        pytest.param([_STALE_WORK_TOOL], id="stale-work-tool"),
+        pytest.param(
+            [_STALE_FINAL_ANSWER, _STALE_WORK_TOOL],
+            id="stale-final-answer-and-work-tool",
+        ),
+    ],
+)
+async def test_react_resume_waiting_cancels_stale_pending_from_legacy_checkpoint(
+    stale_pendings: list[dict[str, Any]],
+) -> None:
     """Checkpoints written before the discard-order fix still carry the parked
-    batch's siblings; the waiting-resume path must cancel them, not replay."""
+    batch's siblings; the waiting-resume path must cancel them all -- never
+    finalize off a stale final_answer, never execute a stale work tool -- and
+    the healed state must re-persist with an empty plan."""
 
-    state, context = _legacy_waiting_state_and_context(
-        {
-            "id": "call_stale_final",
-            "name": "final_answer",
-            "args": {"answer": "Choose A or B"},
-        }
-    )
-    context.add_user_message("B")
-    pattern = ReActPattern(max_iterations=3)
-    pattern.load_state(state)
-    resumed_llm = FakeLLM([{"content": "You chose B.", "done": True}])
-
-    resumed = await pattern.run(context=context, tools=[], llm=resumed_llm)
-
-    assert resumed["success"] is True
-    assert len(resumed_llm.calls) == 1
-    assert resumed["response"] == "You chose B."
-    assert pattern.tool_ledger["call_stale_final"].status == "cancelled"
-
-
-@pytest.mark.asyncio
-async def test_react_resume_waiting_cancels_stale_work_tool_from_legacy_checkpoint() -> (
-    None
-):
-    """A stale work-tool sibling restored from a legacy checkpoint must not
-    execute on resume -- the resumed turn replans from the user's answer."""
-
-    state, context = _legacy_waiting_state_and_context(
-        {
-            "id": "call_stale_calc",
-            "name": "calculator",
-            "args": {"expression": "5+5"},
-        }
-    )
+    state, context = _legacy_waiting_state_and_context(*stale_pendings)
     context.add_user_message("B")
     pattern = ReActPattern(max_iterations=3)
     pattern.load_state(state)
     tool = FakeTool()
     resumed_llm = FakeLLM([{"content": "You chose B.", "done": True}])
+    runtime = PatternRuntime()
 
-    resumed = await pattern.run(context=context, tools=[tool], llm=resumed_llm)
+    resumed = await pattern.run(
+        context=context, tools=[tool], llm=resumed_llm, runtime=runtime
+    )
 
     assert resumed["success"] is True
-    assert tool.calls == []
+    assert resumed["response"] == "You chose B."
     assert len(resumed_llm.calls) == 1
-    assert pattern.tool_ledger["call_stale_calc"].status == "cancelled"
+    assert tool.calls == []
+    for stale_pending in stale_pendings:
+        assert pattern.tool_ledger[stale_pending["id"]].status == "cancelled"
+    resume_checkpoints = [
+        checkpoint
+        for checkpoint in runtime.checkpoints
+        if checkpoint["label"] == "tool_interaction_response_received"
+    ]
+    assert resume_checkpoints
+    assert resume_checkpoints[-1]["pattern_state"]["pending_tool_calls"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5370,6 +5370,241 @@ async def test_react_pattern_replans_after_waiting_control_tool() -> None:
     assert "cancelled" in cancelled_tool_result["content"]
 
 
+def _ask_then_stale_final_answer_llm() -> FakeLLM:
+    """One response bundling ask_user_question with a stale final_answer."""
+
+    return FakeLLM(
+        responses=[
+            {
+                "content": "Choose A or B",
+                "tool_calls": [
+                    {
+                        "id": "call_question",
+                        "function": {
+                            "name": "ask_user_question",
+                            "arguments": (
+                                '{"message":"Choose A or B","interactions":[]}'
+                            ),
+                        },
+                    },
+                    {
+                        "id": "call_stale_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Choose A or B"}',
+                        },
+                    },
+                ],
+            }
+        ]
+    )
+
+
+async def _park_on_question_with_stale_sibling() -> dict[str, Any]:
+    """Run one turn that parks on ask_user_question with a bundled sibling.
+
+    Returns the ``waiting_for_user`` checkpoint payload the runtime persisted
+    at pause time -- the exact state a production resume restores.
+    """
+
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext()
+    context.add_user_message("Ask, then answer")
+    runtime = PatternRuntime()
+
+    first = await pattern.run(
+        context=context,
+        tools=[],
+        llm=_ask_then_stale_final_answer_llm(),
+        runtime=runtime,
+    )
+
+    assert first["status"] == "waiting_for_user"
+    waiting_checkpoints = [
+        checkpoint
+        for checkpoint in runtime.checkpoints
+        if checkpoint["label"] == "waiting_for_user"
+    ]
+    assert waiting_checkpoints
+    return waiting_checkpoints[-1]
+
+
+@pytest.mark.asyncio
+async def test_react_waiting_checkpoint_persists_discarded_pending_plan() -> None:
+    """#2216: the checkpoint written when a control tool parks the run must
+    already reflect the discarded tool plan. Persisting the batch's unexecuted
+    siblings made a resume replay them instead of replanning."""
+
+    checkpoint = await _park_on_question_with_stale_sibling()
+
+    assert checkpoint["pattern_state"]["pending_tool_calls"] == []
+    persisted_context = ExecutionContext.from_dict(checkpoint["context"])
+    cancelled = [
+        message
+        for message in persisted_context.messages
+        if message.role == "tool" and message.tool_call_id == "call_stale_final"
+    ]
+    assert len(cancelled) == 1
+
+
+@pytest.mark.asyncio
+async def test_react_resume_from_waiting_checkpoint_without_answer_stays_parked() -> (
+    None
+):
+    """The pause-time cancellation results in the persisted context must not
+    make a resume without a new user message look like an answered question."""
+
+    checkpoint = await _park_on_question_with_stale_sibling()
+
+    restored_context = ExecutionContext.from_dict(checkpoint["context"])
+    restored_pattern = ReActPattern(max_iterations=3)
+    restored_pattern.load_state(checkpoint["pattern_state"])
+    resumed_llm = FakeLLM([{"content": "Should not run"}])
+
+    resumed = await restored_pattern.run(
+        context=restored_context, tools=[], llm=resumed_llm
+    )
+
+    assert resumed["status"] == "waiting_for_user"
+    assert resumed["message"] == "Choose A or B"
+    assert resumed_llm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_react_resume_from_waiting_checkpoint_replans_instead_of_replaying() -> (
+    None
+):
+    """#2216 production signature: resuming the parked run with the user's
+    answer must reason over it, never finalize off a stale sibling call."""
+
+    checkpoint = await _park_on_question_with_stale_sibling()
+
+    restored_context = ExecutionContext.from_dict(checkpoint["context"])
+    restored_context.add_user_message("B")
+    restored_pattern = ReActPattern(max_iterations=3)
+    restored_pattern.load_state(checkpoint["pattern_state"])
+    resumed_llm = FakeLLM([{"content": "You chose B.", "done": True}])
+
+    resumed = await restored_pattern.run(
+        context=restored_context, tools=[], llm=resumed_llm
+    )
+
+    assert resumed["success"] is True
+    assert len(resumed_llm.calls) == 1
+    assert resumed["response"] == "You chose B."
+
+
+def _legacy_waiting_state_and_context(
+    stale_pending: dict[str, Any],
+) -> tuple[dict[str, Any], ExecutionContext]:
+    """Build the state a pre-fix waiting_for_user checkpoint persisted: the
+    parked question plus the batch's unexecuted sibling still pending."""
+
+    context = ExecutionContext()
+    context.add_user_message("Ask, then answer")
+    context.add_assistant_message(
+        "Choose A or B",
+        tool_calls=[
+            {
+                "id": "call_question",
+                "type": "function",
+                "function": {
+                    "name": "ask_user_question",
+                    "arguments": '{"message": "Choose A or B", "interactions": []}',
+                },
+            },
+            {
+                "id": stale_pending["id"],
+                "type": "function",
+                "function": {
+                    "name": stale_pending["name"],
+                    "arguments": json.dumps(stale_pending["args"]),
+                },
+            },
+        ],
+    )
+    context.add_tool_result(
+        tool_name="ask_user_question",
+        result={
+            "status": "waiting_for_user",
+            "message": "Choose A or B",
+            "message_type": "question",
+            "interactions": [],
+        },
+        tool_call_id="call_question",
+    )
+    state = {
+        "status": "waiting_for_user",
+        "waiting_for_user_request": {
+            "event_id": "evt_legacy",
+            "tool_call_id": "call_question",
+            "tool_name": "ask_user_question",
+            "message": "Choose A or B",
+            "message_type": "question",
+            "interactions": [],
+            "task_text": "Ask, then answer",
+            "message_count": len(context.messages),
+        },
+        "pending_tool_calls": [stale_pending],
+    }
+    return state, context
+
+
+@pytest.mark.asyncio
+async def test_react_resume_waiting_cancels_stale_final_answer_from_legacy_checkpoint() -> (
+    None
+):
+    """Checkpoints written before the discard-order fix still carry the parked
+    batch's siblings; the waiting-resume path must cancel them, not replay."""
+
+    state, context = _legacy_waiting_state_and_context(
+        {
+            "id": "call_stale_final",
+            "name": "final_answer",
+            "args": {"answer": "Choose A or B"},
+        }
+    )
+    context.add_user_message("B")
+    pattern = ReActPattern(max_iterations=3)
+    pattern.load_state(state)
+    resumed_llm = FakeLLM([{"content": "You chose B.", "done": True}])
+
+    resumed = await pattern.run(context=context, tools=[], llm=resumed_llm)
+
+    assert resumed["success"] is True
+    assert len(resumed_llm.calls) == 1
+    assert resumed["response"] == "You chose B."
+    assert pattern.tool_ledger["call_stale_final"].status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_react_resume_waiting_cancels_stale_work_tool_from_legacy_checkpoint() -> (
+    None
+):
+    """A stale work-tool sibling restored from a legacy checkpoint must not
+    execute on resume -- the resumed turn replans from the user's answer."""
+
+    state, context = _legacy_waiting_state_and_context(
+        {
+            "id": "call_stale_calc",
+            "name": "calculator",
+            "args": {"expression": "5+5"},
+        }
+    )
+    context.add_user_message("B")
+    pattern = ReActPattern(max_iterations=3)
+    pattern.load_state(state)
+    tool = FakeTool()
+    resumed_llm = FakeLLM([{"content": "You chose B.", "done": True}])
+
+    resumed = await pattern.run(context=context, tools=[tool], llm=resumed_llm)
+
+    assert resumed["success"] is True
+    assert tool.calls == []
+    assert len(resumed_llm.calls) == 1
+    assert pattern.tool_ledger["call_stale_calc"].status == "cancelled"
+
+
 @pytest.mark.asyncio
 async def test_react_pattern_resume_binds_original_task_to_store_memory() -> None:
     llm = FakeLLM(


### PR DESCRIPTION
## Problem

Fixes #2216. When a control tool (`ask_user_question`, or `send_message` expecting a reply) parked a ReAct run, the `waiting_for_user` checkpoint was written **before** `_discard_pending_tool_plan_after_pause` ran, so the persisted `pending_tool_calls` still carried the batch's unexecuted sibling calls. A resume restores that state verbatim:

- a stale bundled `final_answer` sibling completed the resumed turn with **zero LLM iterations**, re-emitting the prior turn's question as the new `ai_message` and silently discarding the user's submitted answer (the exact production trace signature in #2216);
- a stale work-tool sibling replayed without a fresh LLM plan.

Only the control-tool pause path had this ordering inverted; the tool-pause path (`_pause_for_tool_results`) already discards before checkpointing.

## Fix

- **Discard before persisting**: in the control branch of `_execute_pending_tool_calls`, run `_discard_pending_tool_plan_after_pause` before the `waiting_for_user` checkpoint, so durable state honors the documented invariant that a resume always starts with a fresh LLM plan. The cancellations append tool results, so the waiting request's `message_count` watermark is refreshed the same way the tool-pause path snapshots it — keeping an answer-less resume parked (`turn_marker` is descriptive-only per `task_interaction_staging.py`; identity stays on `event_id`, and `pending_user_response_marker` does not read `message_count`).
- **Heal legacy checkpoints**: `_resume_waiting_for_user_if_needed` cancels any stale `pending_tool_calls` restored from checkpoints written before this fix, so already-parked production executions resume by replanning instead of replaying. Interrupt-resume paths (status != `waiting_for_user`) that legitimately replay pending calls are untouched.

## Tests

Five regression tests in `tests/core/agent/test_react.py`, all restoring from the runtime-persisted checkpoint payload (the same state a production resume loads), covering: the checkpoint carries an empty plan plus the sibling's cancellation; an answer-less resume stays parked; a resume with an answer performs an LLM iteration instead of replaying the stale `final_answer` (the #2216 signature); and legacy-checkpoint healing for both a stale `final_answer` and a stale work tool.

`pytest tests/core/agent/` passes (react, runner, auto, dag and sibling files); `ruff format/check` and `mypy` clean on the touched files.

## Out of scope

- **Duplicate write-tool records on the retroactive catch-up turn** — tracked separately per #2216's own note (duplicate-write guard).
- **Legacy-heal transcript contiguity**: on a pre-fix checkpoint with stale siblings, the healed cancellation lands after the injected user answer, so the sanitized LLM view elides the question turn (question/answer still reach the model via the framed answer message and the system-context evidence) — #2223.
- **Loop-level zero-iteration runtime guard** suggested in #2216's fix direction: this PR pins the invariant with regression tests instead of a hard runtime assertion; defense-in-depth guard tracked in #2224.
- #1328 and #2023 remain distinct resume-path defects, as scoped in #2216.
