### PR TITLE
feat(google-drive): write downloaded/exported files to disk instead of decoding them as text

### DIFF
--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3663,6 +3663,12 @@ class WebToolConfig(BaseToolConfig):
                 env["XAGENT_LINKEDIN_IMAGE_ALLOWED_DIRS"] = allowed_file_dirs
                 env["XAGENT_SLACK_FILE_ALLOWED_DIRS"] = allowed_file_dirs
                 env["XAGENT_GMAIL_FILE_ALLOWED_DIRS"] = allowed_file_dirs
+                # Unlike the three above (read-only upload allowlists), Google
+                # Drive uses this as a write target root for
+                # google_drive_download_file — it downloads/exports into
+                # <this dir>/output/, mirroring TaskWorkspace.output_dir so
+                # the result shows up alongside other generated deliverables.
+                env["XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS"] = allowed_file_dirs
             transport_config["env"] = env
             return transport_config
 

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1853,6 +1853,26 @@ class WebToolConfig(BaseToolConfig):
                 seen.add(dir_path)
         return ",".join(unique_dirs)
 
+    def _build_mcp_task_output_dir(self) -> str:
+        """Single write-target root for connectors that create new files in
+        the task workspace (currently just Google Drive's download tool).
+
+        Deliberately distinct from _build_mcp_file_allowed_dirs() above:
+        that one is a read allowlist that may reasonably include
+        allowed_external_dirs (e.g. read-only KB folders) alongside the
+        task dir, and multiple consumers of it pick whichever entry a
+        requested path happens to fall under. A write target has no such
+        "any of these" semantics — writing into an external read-only dir
+        by picking the wrong list entry would be wrong, not just
+        suboptimal — so this only ever returns the task dir itself, never
+        an external dir, and is empty whenever there's no task workspace.
+        """
+        task_id = self._workspace_config.get("task_id")
+        if not task_id:
+            return ""
+        base_dir = Path(str(self._workspace_config.get("base_dir", get_uploads_dir())))
+        return str((base_dir / str(task_id)).expanduser().resolve())
+
     def _get_is_admin_from_request(self, request: Any) -> bool:
         """Extract is_admin flag from the request user, defaulting to False.
 
@@ -3663,12 +3683,15 @@ class WebToolConfig(BaseToolConfig):
                 env["XAGENT_LINKEDIN_IMAGE_ALLOWED_DIRS"] = allowed_file_dirs
                 env["XAGENT_SLACK_FILE_ALLOWED_DIRS"] = allowed_file_dirs
                 env["XAGENT_GMAIL_FILE_ALLOWED_DIRS"] = allowed_file_dirs
-                # Unlike the three above (read-only upload allowlists), Google
-                # Drive uses this as a write target root for
-                # google_drive_download_file — it downloads/exports into
-                # <this dir>/output/, mirroring TaskWorkspace.output_dir so
-                # the result shows up alongside other generated deliverables.
-                env["XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS"] = allowed_file_dirs
+            # Distinct from the three read allowlists above: Google Drive's
+            # download tool writes NEW files into the task workspace, so it
+            # gets its own single-value, task-dir-only var rather than
+            # reusing the read-allowlist shape (see
+            # _build_mcp_task_output_dir's docstring for why that would be
+            # wrong, not just differently-shaped).
+            task_output_dir = self._build_mcp_task_output_dir()
+            if task_output_dir:
+                env["XAGENT_GOOGLE_DRIVE_OUTPUT_DIR"] = task_output_dir
             transport_config["env"] = env
             return transport_config
 

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -228,8 +228,10 @@ def google_drive_download_file(
     Ignored for a file that already has real binary content of its own
     (mime_type is not required and has no effect there).
     filename: optional name for the written file; defaults to the Drive
-    file's own name (with an extension appended if exporting to a mime_type
-    whose extension doesn't already match).
+    file's own name. Either way, if exporting a Workspace document the
+    mime_type's extension is appended when not already present (so a bare
+    filename="report" for an "application/pdf" export still ends up
+    "report.pdf").
     """
     try:
         service = get_drive_service()
@@ -254,19 +256,22 @@ def google_drive_download_file(
                 )
             request = service.files().export_media(fileId=file_id, mimeType=mime_type)
             extension = mimetypes.guess_extension(mime_type) or ""
-            safe_drive_name = _safe_output_filename(drive_name)
-            default_name = (
-                safe_drive_name
-                if safe_drive_name.endswith(extension)
-                else safe_drive_name + extension
-            )
         else:
             request = service.files().get_media(fileId=file_id)
-            default_name = _safe_output_filename(drive_name)
+            extension = ""
 
         data = _download_media(request)
 
-        chosen_name = _safe_output_filename(filename) if filename else default_name
+        # Ensure the export's extension is present regardless of whether
+        # the name came from Drive's own file name or an explicit
+        # `filename` argument — the caller passing a bare "report" for a
+        # PDF export shouldn't lose the ".pdf" any more than the default
+        # name would. Case-insensitive so "Report.PDF" doesn't become
+        # "Report.PDF.pdf".
+        chosen_name = _safe_output_filename(filename or drive_name)
+        if extension and not chosen_name.lower().endswith(extension.lower()):
+            chosen_name += extension
+
         output_path = _unique_output_path(_output_dir(), chosen_name)
         output_path.write_bytes(data)
 

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -29,7 +29,11 @@ mcp = FastMCP("google-drive-mcp")
 # (PDFs, Office/OOXML formats, images, etc.) must go through
 # google_drive_download_file instead — decoding arbitrary binary content as
 # UTF-8 with errors="replace" silently corrupts it into unusable garbage.
-_TEXT_MIME_TYPES = {"application/json", "application/xml"}
+# RTF is included because it's specified as 7-bit-ASCII-clean (escape
+# sequences carry any non-ASCII content), so it round-trips through UTF-8
+# decoding safely, unlike the binary formats this allowlist exists to keep
+# out.
+_TEXT_MIME_TYPES = {"application/json", "application/xml", "application/rtf"}
 
 
 def _is_text_mime_type(mime_type: str) -> bool:
@@ -38,18 +42,48 @@ def _is_text_mime_type(mime_type: str) -> bool:
 
 _UNSAFE_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.() -]")
 
+# Comfortably under the ~255-byte NAME_MAX most filesystems enforce, leaving
+# room for the " (N)" suffix _unique_output_path may append on top.
+_MAX_FILENAME_LENGTH = 200
+# Generous for any real extension, including compound ones like ".tar.gz" —
+# a "suffix" longer than this isn't behaving like an extension anymore (see
+# _safe_output_filename), so it gets truncated too rather than left to blow
+# the overall length cap on its own.
+_MAX_SUFFIX_LENGTH = 20
+
 
 def _output_dir() -> Path:
     """Root directory google_drive_download_file writes into: the current
     task's workspace output/ subdirectory, mirroring TaskWorkspace.output_dir
     so downloaded files show up alongside other generated deliverables."""
-    raw_dirs = os.environ.get("XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS", "")
-    base = next((d for raw in raw_dirs.split(",") if (d := raw.strip())), "") or str(
-        Path.cwd()
-    )
-    output_dir = (Path(base).expanduser().resolve()) / "output"
+    base = os.environ.get("XAGENT_GOOGLE_DRIVE_OUTPUT_DIR", "").strip()
+    if not base:
+        raise RuntimeError(
+            "No task workspace configured for this connector "
+            "(XAGENT_GOOGLE_DRIVE_OUTPUT_DIR is unset) — "
+            "google_drive_download_file needs a task workspace to write "
+            "into."
+        )
+    output_dir = Path(base).expanduser().resolve() / "output"
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir
+
+
+def _split_stem_suffix(base: str) -> tuple[str, str]:
+    """Like Path(base).stem/.suffix, except a name that's *entirely* a
+    leading dot plus extension (e.g. ".pdf") is treated as having that
+    extension. pathlib's own split refuses to do this — it follows the
+    Unix dotfile convention where a single leading dot with nothing before
+    it never counts as an extension separator, leaving Path(".pdf").suffix
+    empty — but Drive occasionally hands back names in exactly this shape,
+    and silently losing the extension breaks the downloaded file's type.
+    Only that narrow shape is special-cased; e.g. "..pdf" or "..." already
+    split the way we want via plain pathlib and are left alone.
+    """
+    suffix = Path(base).suffix
+    if not suffix and base.startswith(".") and base.count(".") == 1 and len(base) > 1:
+        return "", base
+    return Path(base).stem, suffix
 
 
 def _safe_output_filename(name: str) -> str:
@@ -64,9 +98,11 @@ def _safe_output_filename(name: str) -> str:
     still come out as "....pdf" (something ending in .pdf), not "pdf".
     """
     base = Path(name).name
-    stem = _UNSAFE_FILENAME_CHARS.sub("_", Path(base).stem).strip("._")
-    suffix = _UNSAFE_FILENAME_CHARS.sub("_", Path(base).suffix)
-    return (stem or "file") + suffix
+    stem, suffix = _split_stem_suffix(base)
+    stem = _UNSAFE_FILENAME_CHARS.sub("_", stem).strip("._") or "file"
+    suffix = _UNSAFE_FILENAME_CHARS.sub("_", suffix)[:_MAX_SUFFIX_LENGTH]
+    max_stem_length = max(1, _MAX_FILENAME_LENGTH - len(suffix))
+    return stem[:max_stem_length] + suffix
 
 
 def _download_media(request: Any) -> bytes:

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -1,7 +1,10 @@
 import io
 import json
 import logging
+import mimetypes
 import os
+import re
+from pathlib import Path
 from typing import Any
 
 from google.oauth2.credentials import Credentials
@@ -21,6 +24,55 @@ logger = logging.getLogger("google-drive-mcp")
 setup_proxy_env()
 
 mcp = FastMCP("google-drive-mcp")
+
+# mime types safe to decode as UTF-8 text and return inline. Anything else
+# (PDFs, Office/OOXML formats, images, etc.) must go through
+# google_drive_download_file instead — decoding arbitrary binary content as
+# UTF-8 with errors="replace" silently corrupts it into unusable garbage.
+_TEXT_MIME_TYPES = {"application/json", "application/xml"}
+
+
+def _is_text_mime_type(mime_type: str) -> bool:
+    return mime_type.startswith("text/") or mime_type in _TEXT_MIME_TYPES
+
+
+_UNSAFE_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.() -]")
+
+
+def _output_dir() -> Path:
+    """Root directory google_drive_download_file writes into: the current
+    task's workspace output/ subdirectory, mirroring TaskWorkspace.output_dir
+    so downloaded files show up alongside other generated deliverables."""
+    raw_dirs = os.environ.get("XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS", "")
+    base = next((d for raw in raw_dirs.split(",") if (d := raw.strip())), "") or str(
+        Path.cwd()
+    )
+    output_dir = (Path(base).expanduser().resolve()) / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def _safe_output_filename(name: str) -> str:
+    """Collapse a Drive file name into a single path segment so it can't
+    escape the output directory (e.g. via ".." or embedded "/") — the name
+    comes from user/Drive data, not a trusted constant."""
+    candidate = _UNSAFE_FILENAME_CHARS.sub("_", Path(name).name).strip("._") or "file"
+    return candidate
+
+
+def _unique_output_path(output_dir: Path, filename: str) -> Path:
+    """Avoid silently overwriting a same-named file already in the output
+    dir (e.g. downloading the same deck twice) by appending " (1)", " (2)",
+    etc. — mirrors common download-manager behavior rather than either
+    clobbering data or forcing the caller to pick a unique name upfront."""
+    candidate = output_dir / filename
+    if not candidate.exists():
+        return candidate
+    stem, suffix = Path(filename).stem, Path(filename).suffix
+    counter = 1
+    while (candidate := output_dir / f"{stem} ({counter}){suffix}").exists():
+        counter += 1
+    return candidate
 
 
 def get_drive_service() -> Any:
@@ -75,10 +127,31 @@ def google_drive_search(query: str = "", max_results: int = 10) -> str:
 @mcp.tool()
 def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -> str:
     """
-    Download or export file content from Google Drive by file_id.
-    If it's a Google Workspace document (Docs, Sheets), it will be exported to the requested mime_type.
+    Download or export a text file's content from Google Drive by file_id,
+    returned inline as a string. If it's a Google Workspace document (Docs,
+    Sheets), it will be exported to the requested mime_type.
+
+    mime_type must be a text format (e.g. "text/plain", "text/csv",
+    "application/json") — this tool decodes the result as UTF-8 text, which
+    would corrupt a binary format like a PDF or image into garbage. For a
+    PDF, an Office format, an image, or any other binary content, use
+    google_drive_download_file instead, which writes the real bytes to a
+    file instead of decoding them as text.
     """
     try:
+        if not _is_text_mime_type(mime_type):
+            return json.dumps(
+                {
+                    "status": "error",
+                    "message": (
+                        f"mime_type '{mime_type}' is not a text format — this "
+                        "tool would corrupt binary content by decoding it as "
+                        "UTF-8. Use google_drive_download_file instead to "
+                        "get the real bytes as a file."
+                    ),
+                }
+            )
+
         service = get_drive_service()
         file_metadata = (
             service.files().get(fileId=file_id, fields="id, name, mimeType").execute()
@@ -107,6 +180,88 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
         )
     except Exception as e:
         logger.error(f"Error getting file content: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_drive_download_file(
+    file_id: str, mime_type: str = "", filename: str = ""
+) -> str:
+    """
+    Download or export a Google Drive file to a real file in the task
+    workspace, returning its path — use this for any binary content (PDF,
+    image, Office format, etc.) that google_drive_get_file_content would
+    otherwise corrupt by decoding as text. The returned path can be passed
+    directly to another tool that reads local files, e.g. gmail_send_messages's
+    'attachments'.
+
+    mime_type: required when file_id is a Google Workspace document (Docs,
+    Sheets, Slides) — the format to export to (e.g. "application/pdf").
+    Ignored for a file that already has real binary content of its own
+    (mime_type is not required and has no effect there).
+    filename: optional name for the written file; defaults to the Drive
+    file's own name (with an extension appended if exporting to a mime_type
+    whose extension doesn't already match).
+    """
+    try:
+        service = get_drive_service()
+        file_metadata = (
+            service.files().get(fileId=file_id, fields="id, name, mimeType").execute()
+        )
+        file_mime_type = file_metadata.get("mimeType", "")
+        drive_name = file_metadata.get("name") or file_id
+
+        if "application/vnd.google-apps" in file_mime_type:
+            if not mime_type:
+                return json.dumps(
+                    {
+                        "status": "error",
+                        "message": (
+                            f"'{drive_name}' is a Google Workspace document "
+                            "(mimeType "
+                            f"'{file_mime_type}'); specify mime_type to "
+                            'export it to (e.g. "application/pdf").'
+                        ),
+                    }
+                )
+            request = service.files().export_media(fileId=file_id, mimeType=mime_type)
+            extension = mimetypes.guess_extension(mime_type) or ""
+            # Sanitize the base name *before* appending the extension: doing
+            # it after would let a degenerate name (e.g. all dots/spaces,
+            # which _safe_output_filename's trailing ".strip('._')" removes)
+            # eat into the extension's leading dot too, producing a bare
+            # "pdf" instead of "file.pdf".
+            safe_drive_name = _safe_output_filename(drive_name)
+            default_name = (
+                safe_drive_name
+                if safe_drive_name.endswith(extension)
+                else safe_drive_name + extension
+            )
+        else:
+            request = service.files().get_media(fileId=file_id)
+            default_name = _safe_output_filename(drive_name)
+
+        fh = io.BytesIO()
+        downloader = MediaIoBaseDownload(fh, request)
+        done = False
+        while done is False:
+            status, done = downloader.next_chunk()
+        data = fh.getvalue()
+
+        chosen_name = _safe_output_filename(filename) if filename else default_name
+        output_path = _unique_output_path(_output_dir(), chosen_name)
+        output_path.write_bytes(data)
+
+        return json.dumps(
+            {
+                "status": "success",
+                "file": file_metadata,
+                "path": str(output_path),
+                "size": len(data),
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error downloading file: {e}")
         return json.dumps({"status": "error", "message": str(e)})
 
 

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -53,11 +53,29 @@ def _output_dir() -> Path:
 
 
 def _safe_output_filename(name: str) -> str:
-    """Collapse a Drive file name into a single path segment so it can't
-    escape the output directory (e.g. via ".." or embedded "/") — the name
-    comes from user/Drive data, not a trusted constant."""
-    candidate = _UNSAFE_FILENAME_CHARS.sub("_", Path(name).name).strip("._") or "file"
-    return candidate
+    """Collapse a Drive file name into a single safe path segment so it
+    can't escape the output directory (e.g. via ".." or embedded "/") — the
+    name comes from user/Drive data, not a trusted constant.
+
+    Stem and suffix are sanitized separately: sanitizing the whole string
+    in one pass would let the trailing ".strip('._')" eat into the
+    extension's own leading dot whenever the stem sanitizes down to nothing
+    (e.g. an all-non-ASCII or all-punctuation name) — "季度报告.pdf" must
+    still come out as "....pdf" (something ending in .pdf), not "pdf".
+    """
+    base = Path(name).name
+    stem = _UNSAFE_FILENAME_CHARS.sub("_", Path(base).stem).strip("._")
+    suffix = _UNSAFE_FILENAME_CHARS.sub("_", Path(base).suffix)
+    return (stem or "file") + suffix
+
+
+def _download_media(request: Any) -> bytes:
+    fh = io.BytesIO()
+    downloader = MediaIoBaseDownload(fh, request)
+    done = False
+    while done is False:
+        status, done = downloader.next_chunk()
+    return fh.getvalue()
 
 
 def _unique_output_path(output_dir: Path, filename: str) -> Path:
@@ -159,23 +177,33 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
         file_mime_type = file_metadata.get("mimeType", "")
 
         if "application/vnd.google-apps" in file_mime_type:
-            # Export Google Workspace document
+            # Export Google Workspace document — always produces content in
+            # the requested (already-validated-as-text) mime_type.
             request = service.files().export_media(fileId=file_id, mimeType=mime_type)
         else:
-            # Download regular file
+            # Regular file: get_media ignores mime_type entirely and
+            # returns the file's own real bytes, so it's file_mime_type —
+            # not the requested mime_type — that determines whether
+            # decoding as UTF-8 is safe.
+            if not _is_text_mime_type(file_mime_type):
+                return json.dumps(
+                    {
+                        "status": "error",
+                        "message": (
+                            f"'{file_metadata.get('name', file_id)}' is not a "
+                            f"text file (mimeType '{file_mime_type}') — this "
+                            "tool would corrupt it by decoding as UTF-8. Use "
+                            "google_drive_download_file instead."
+                        ),
+                    }
+                )
             request = service.files().get_media(fileId=file_id)
-
-        fh = io.BytesIO()
-        downloader = MediaIoBaseDownload(fh, request)
-        done = False
-        while done is False:
-            status, done = downloader.next_chunk()
 
         return json.dumps(
             {
                 "status": "success",
                 "file": file_metadata,
-                "content": fh.getvalue().decode("utf-8", errors="replace"),
+                "content": _download_media(request).decode("utf-8", errors="replace"),
             }
         )
     except Exception as e:
@@ -226,11 +254,6 @@ def google_drive_download_file(
                 )
             request = service.files().export_media(fileId=file_id, mimeType=mime_type)
             extension = mimetypes.guess_extension(mime_type) or ""
-            # Sanitize the base name *before* appending the extension: doing
-            # it after would let a degenerate name (e.g. all dots/spaces,
-            # which _safe_output_filename's trailing ".strip('._')" removes)
-            # eat into the extension's leading dot too, producing a bare
-            # "pdf" instead of "file.pdf".
             safe_drive_name = _safe_output_filename(drive_name)
             default_name = (
                 safe_drive_name
@@ -241,12 +264,7 @@ def google_drive_download_file(
             request = service.files().get_media(fileId=file_id)
             default_name = _safe_output_filename(drive_name)
 
-        fh = io.BytesIO()
-        downloader = MediaIoBaseDownload(fh, request)
-        done = False
-        while done is False:
-            status, done = downloader.next_chunk()
-        data = fh.getvalue()
+        data = _download_media(request)
 
         chosen_name = _safe_output_filename(filename) if filename else default_name
         output_path = _unique_output_path(_output_dir(), chosen_name)

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -1,0 +1,295 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.web.tools.mcp import google_drive
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
+    monkeypatch.delenv("GOOGLE_REFRESH_TOKEN", raising=False)
+    monkeypatch.delenv("GOOGLE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("GOOGLE_CLIENT_SECRET", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _output_dir_env(tmp_path, monkeypatch):
+    """Every test gets its own isolated output root so nothing here ever
+    writes into the real working directory."""
+    monkeypatch.setenv("XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS", str(tmp_path))
+    return tmp_path
+
+
+def _mock_drive_service(monkeypatch, files_mock):
+    service = Mock()
+    service.files.return_value = files_mock
+    monkeypatch.setattr(google_drive, "get_drive_service", lambda: service)
+    return service
+
+
+class _FakeDownloader:
+    """Mirrors googleapiclient.http.MediaIoBaseDownload's interface closely
+    enough for this file's download loop: write `content` into the target
+    buffer across one call to next_chunk()."""
+
+    def __init__(self, fh, request, content: bytes = b"") -> None:
+        self._fh = fh
+        self._content = content
+
+    def next_chunk(self):
+        self._fh.write(self._content)
+        return None, True
+
+
+def _patch_downloader(monkeypatch, content: bytes):
+    monkeypatch.setattr(
+        google_drive,
+        "MediaIoBaseDownload",
+        lambda fh, request: _FakeDownloader(fh, request, content),
+    )
+
+
+# ---------------------------------------------------------------------------
+# google_drive_get_file_content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mime_type", ["text/plain", "text/csv", "text/markdown", "application/json"]
+)
+def test_get_file_content_accepts_text_mime_types(monkeypatch, mime_type):
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "notes.txt",
+        "mimeType": "text/plain",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"hello world")
+
+    result = json.loads(google_drive.google_drive_get_file_content("f1", mime_type))
+
+    assert result["status"] == "success"
+    assert result["content"] == "hello world"
+
+
+@pytest.mark.parametrize(
+    "mime_type",
+    [
+        "application/pdf",
+        "image/png",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ],
+)
+def test_get_file_content_rejects_binary_mime_types(monkeypatch, mime_type):
+    """Regression guard: decoding binary content as UTF-8 with
+    errors="replace" silently corrupts it — reject before even calling the
+    API rather than return garbage that looks superficially like success."""
+    files = Mock()
+    _mock_drive_service(monkeypatch, files)
+
+    result = json.loads(google_drive.google_drive_get_file_content("f1", mime_type))
+
+    assert result["status"] == "error"
+    assert "google_drive_download_file" in result["message"]
+    files.get.assert_not_called()
+
+
+def test_get_file_content_returns_error_payload_on_api_failure(monkeypatch):
+    files = Mock()
+    files.get.return_value.execute.side_effect = RuntimeError("boom")
+    _mock_drive_service(monkeypatch, files)
+
+    result = json.loads(google_drive.google_drive_get_file_content("f1", "text/plain"))
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# google_drive_download_file
+# ---------------------------------------------------------------------------
+
+
+def test_download_file_writes_regular_binary_file(monkeypatch, tmp_path):
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "photo.png",
+        "mimeType": "image/png",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"\x89PNG-fake-bytes")
+
+    result = json.loads(google_drive.google_drive_download_file("f1"))
+
+    assert result["status"] == "success"
+    assert result["size"] == len(b"\x89PNG-fake-bytes")
+    output_path = tmp_path / "output" / "photo.png"
+    assert result["path"] == str(output_path)
+    assert output_path.read_bytes() == b"\x89PNG-fake-bytes"
+    files.get_media.assert_called_once_with(fileId="f1")
+    files.export_media.assert_not_called()
+
+
+def test_download_file_exports_workspace_doc_with_extension_appended(
+    monkeypatch, tmp_path
+):
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "Onboarding Deck",
+        "mimeType": "application/vnd.google-apps.presentation",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"%PDF-1.4 fake pdf")
+
+    result = json.loads(
+        google_drive.google_drive_download_file("f1", mime_type="application/pdf")
+    )
+
+    assert result["status"] == "success"
+    output_path = tmp_path / "output" / "Onboarding Deck.pdf"
+    assert result["path"] == str(output_path)
+    assert output_path.read_bytes() == b"%PDF-1.4 fake pdf"
+    files.export_media.assert_called_once_with(fileId="f1", mimeType="application/pdf")
+    files.get_media.assert_not_called()
+
+
+def test_download_file_requires_mime_type_for_workspace_doc(monkeypatch):
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "Onboarding Deck",
+        "mimeType": "application/vnd.google-apps.presentation",
+    }
+    _mock_drive_service(monkeypatch, files)
+
+    result = json.loads(google_drive.google_drive_download_file("f1"))
+
+    assert result["status"] == "error"
+    assert "mime_type" in result["message"]
+    files.export_media.assert_not_called()
+
+
+def test_download_file_uses_explicit_filename(monkeypatch, tmp_path):
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "Onboarding Deck",
+        "mimeType": "application/vnd.google-apps.presentation",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(
+        google_drive.google_drive_download_file(
+            "f1", mime_type="application/pdf", filename="custom.pdf"
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["path"] == str(tmp_path / "output" / "custom.pdf")
+
+
+def test_download_file_sanitizes_path_traversal_in_filename(monkeypatch, tmp_path):
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "../../etc/passwd",
+        "mimeType": "text/plain",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(google_drive.google_drive_download_file("f1"))
+
+    assert result["status"] == "success"
+    output_path = Path(result["path"])
+    assert output_path.parent == tmp_path / "output"
+    assert output_path.is_relative_to(tmp_path / "output")
+
+
+def test_download_file_sanitizes_unsafe_characters_in_filename(monkeypatch, tmp_path):
+    """Regression guard: a name with characters Path.name alone would leave
+    untouched (no "/" to strip) must still be neutralized by the character
+    allowlist — otherwise this test would pass even with the sanitizer
+    reduced to a no-op Path(name).name call."""
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "weird:name?.txt",
+        "mimeType": "text/plain",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(google_drive.google_drive_download_file("f1"))
+
+    assert result["status"] == "success"
+    output_path = Path(result["path"])
+    assert output_path.parent == tmp_path / "output"
+    assert ":" not in output_path.name
+    assert "?" not in output_path.name
+    assert output_path.name.endswith(".txt")
+
+
+def test_download_file_preserves_extension_for_degenerate_drive_name(
+    monkeypatch, tmp_path
+):
+    """Regression guard: sanitizing a degenerate name (all characters the
+    allowlist/strip would remove) must happen *before* the export extension
+    is appended — otherwise the trailing ".strip('._')" eats into the
+    extension's own leading dot and produces a bare "pdf" instead of a
+    usable "file.pdf"."""
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "...",
+        "mimeType": "application/vnd.google-apps.presentation",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(
+        google_drive.google_drive_download_file("f1", mime_type="application/pdf")
+    )
+
+    assert result["status"] == "success"
+    output_path = Path(result["path"])
+    assert output_path.name == "file.pdf"
+
+
+def test_download_file_dedupes_existing_filename(monkeypatch, tmp_path):
+    (tmp_path / "output").mkdir()
+    (tmp_path / "output" / "deck.pdf").write_bytes(b"already here")
+
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "deck.pdf",
+        "mimeType": "application/pdf",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"new content")
+
+    result = json.loads(google_drive.google_drive_download_file("f1"))
+
+    assert result["status"] == "success"
+    assert result["path"] == str(tmp_path / "output" / "deck (1).pdf")
+    # The original file must survive untouched.
+    assert (tmp_path / "output" / "deck.pdf").read_bytes() == b"already here"
+
+
+def test_download_file_returns_error_payload_on_api_failure(monkeypatch):
+    files = Mock()
+    files.get.return_value.execute.side_effect = RuntimeError("boom")
+    _mock_drive_service(monkeypatch, files)
+
+    result = json.loads(google_drive.google_drive_download_file("f1"))
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -236,6 +236,55 @@ def test_download_file_uses_explicit_filename(monkeypatch, tmp_path):
     assert result["path"] == str(tmp_path / "output" / "custom.pdf")
 
 
+def test_download_file_appends_extension_to_explicit_filename_missing_one(
+    monkeypatch, tmp_path
+):
+    """Regression guard: an explicit filename with no extension must still
+    get the export mime_type's extension appended, exactly like the
+    default (Drive-name-derived) filename already does — the caller
+    shouldn't lose the .pdf just because they named the file themselves."""
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "Onboarding Deck",
+        "mimeType": "application/vnd.google-apps.presentation",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(
+        google_drive.google_drive_download_file(
+            "f1", mime_type="application/pdf", filename="report"
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["path"] == str(tmp_path / "output" / "report.pdf")
+
+
+def test_download_file_does_not_double_extension_on_case_mismatch(
+    monkeypatch, tmp_path
+):
+    """Regression guard: matching the target extension must be
+    case-insensitive — a Drive name already ending in ".PDF" (any case)
+    exported to "application/pdf" must not become "....PDF.pdf"."""
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "Report.PDF",
+        "mimeType": "application/vnd.google-apps.document",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(
+        google_drive.google_drive_download_file("f1", mime_type="application/pdf")
+    )
+
+    assert result["status"] == "success"
+    assert result["path"] == str(tmp_path / "output" / "Report.PDF")
+
+
 def test_download_file_sanitizes_path_traversal_in_filename(monkeypatch, tmp_path):
     files = Mock()
     files.get.return_value.execute.return_value = {

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -19,7 +19,7 @@ def _credentials(monkeypatch):
 def _output_dir_env(tmp_path, monkeypatch):
     """Every test gets its own isolated output root so nothing here ever
     writes into the real working directory."""
-    monkeypatch.setenv("XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS", str(tmp_path))
+    monkeypatch.setenv("XAGENT_GOOGLE_DRIVE_OUTPUT_DIR", str(tmp_path))
     return tmp_path
 
 
@@ -137,6 +137,44 @@ def test_get_file_content_accepts_regular_text_file(monkeypatch):
 
     assert result["status"] == "success"
     assert result["content"] == "hello world"
+
+
+def test_get_file_content_accepts_rtf(monkeypatch):
+    """Regression guard: RTF is 7-bit-ASCII-clean per spec (non-ASCII
+    content is escaped, not raw bytes), so it round-trips through UTF-8
+    decoding safely — the binary-content guard must not reject it."""
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "notes.rtf",
+        "mimeType": "application/rtf",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, rb"{\rtf1 hello}")
+
+    result = json.loads(
+        google_drive.google_drive_get_file_content("f1", "application/rtf")
+    )
+
+    assert result["status"] == "success"
+
+
+def test_get_file_content_exports_workspace_doc(monkeypatch):
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "Notes",
+        "mimeType": "application/vnd.google-apps.document",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"exported text")
+
+    result = json.loads(google_drive.google_drive_get_file_content("f1", "text/plain"))
+
+    assert result["status"] == "success"
+    assert result["content"] == "exported text"
+    files.export_media.assert_called_once_with(fileId="f1", mimeType="text/plain")
+    files.get_media.assert_not_called()
 
 
 def test_get_file_content_returns_error_payload_on_api_failure(monkeypatch):
@@ -375,6 +413,121 @@ def test_download_file_preserves_extension_for_non_ascii_drive_name(
     assert result["status"] == "success"
     output_path = Path(result["path"])
     assert output_path.name == "file.pdf"
+
+
+def test_download_file_preserves_extension_only_drive_name(monkeypatch, tmp_path):
+    """Regression guard: Path(".pdf").suffix is '' per pathlib's dotfile
+    convention (a leading dot with nothing before it never counts as an
+    extension separator) — so a Drive name that's *exactly* an extension
+    must still be recognized as one, not silently reduced to "pdf" with
+    the leading dot dropped."""
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": ".pdf",
+        "mimeType": "application/pdf",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(google_drive.google_drive_download_file("f1"))
+
+    assert result["status"] == "success"
+    output_path = Path(result["path"])
+    assert output_path.name == "file.pdf"
+
+
+def test_download_file_sanitizes_path_traversal_in_explicit_filename(
+    monkeypatch, tmp_path
+):
+    """Regression guard: only the Drive-reported name was tested for
+    traversal/unsafe-character sanitization elsewhere — an explicit
+    `filename` argument goes through the exact same _safe_output_filename
+    call and must be sanitized identically."""
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "report.txt",
+        "mimeType": "text/plain",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(
+        google_drive.google_drive_download_file("f1", filename="../../etc/passwd")
+    )
+
+    assert result["status"] == "success"
+    output_path = Path(result["path"])
+    assert output_path.parent == tmp_path / "output"
+    assert output_path.is_relative_to(tmp_path / "output")
+
+
+def test_download_file_truncates_overlong_filename(monkeypatch, tmp_path):
+    """Regression guard: an unbounded sanitized filename can exceed the
+    ~255-byte NAME_MAX most filesystems enforce, making the final
+    write_bytes() raise OSError/ENAMETOOLONG and fail the whole call
+    instead of just using a shorter name."""
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": ("a" * 500) + ".pdf",
+        "mimeType": "application/pdf",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(google_drive.google_drive_download_file("f1"))
+
+    assert result["status"] == "success"
+    output_path = Path(result["path"])
+    assert len(output_path.name) <= 210
+    assert output_path.name.endswith(".pdf")
+
+
+def test_download_file_truncates_overlong_suffix_too(monkeypatch, tmp_path):
+    """Regression guard: the length cap must also bound the suffix, not
+    just the stem — a name like "a." + 300 chars has almost its entire
+    length in what _split_stem_suffix treats as the "extension" (everything
+    from the last dot onward), so truncating only the stem would still
+    leave a 300+ char filename."""
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "a." + ("x" * 300),
+        "mimeType": "text/plain",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(google_drive.google_drive_download_file("f1"))
+
+    assert result["status"] == "success"
+    output_path = Path(result["path"])
+    assert len(output_path.name) <= 30
+
+
+def test_download_file_errors_when_no_task_workspace_is_configured(
+    monkeypatch, tmp_path
+):
+    """Regression guard: an unset output-dir env var must fail loudly
+    rather than silently writing into whatever directory the MCP
+    subprocess happens to have as its cwd."""
+    monkeypatch.delenv("XAGENT_GOOGLE_DRIVE_OUTPUT_DIR", raising=False)
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "report.pdf",
+        "mimeType": "application/pdf",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(google_drive.google_drive_download_file("f1"))
+
+    assert result["status"] == "error"
+    assert "XAGENT_GOOGLE_DRIVE_OUTPUT_DIR" in result["message"]
+    assert not (tmp_path / "output").exists()
 
 
 def test_download_file_dedupes_existing_filename(monkeypatch, tmp_path):

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -98,6 +98,47 @@ def test_get_file_content_rejects_binary_mime_types(monkeypatch, mime_type):
     files.get.assert_not_called()
 
 
+def test_get_file_content_rejects_regular_file_whose_real_mime_type_is_binary(
+    monkeypatch,
+):
+    """Regression guard for the actual bug this tool exists to fix: for a
+    regular (non-Workspace) file, get_media() ignores the mime_type
+    parameter entirely and returns the file's own real bytes — so it's
+    file_mime_type (from Drive's metadata), not the request's mime_type
+    default of "text/plain", that must gate whether decoding as UTF-8 is
+    safe. Calling with the default text/plain param on an actual PDF must
+    still be rejected, not silently corrupted."""
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "report.pdf",
+        "mimeType": "application/pdf",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"%PDF-1.4 real pdf bytes")
+
+    result = json.loads(google_drive.google_drive_get_file_content("f1"))
+
+    assert result["status"] == "error"
+    assert "google_drive_download_file" in result["message"]
+
+
+def test_get_file_content_accepts_regular_text_file(monkeypatch):
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "notes.txt",
+        "mimeType": "text/plain",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"hello world")
+
+    result = json.loads(google_drive.google_drive_get_file_content("f1"))
+
+    assert result["status"] == "success"
+    assert result["content"] == "hello world"
+
+
 def test_get_file_content_returns_error_payload_on_api_failure(monkeypatch):
     files = Mock()
     files.get.return_value.execute.side_effect = RuntimeError("boom")
@@ -257,6 +298,30 @@ def test_download_file_preserves_extension_for_degenerate_drive_name(
     result = json.loads(
         google_drive.google_drive_download_file("f1", mime_type="application/pdf")
     )
+
+    assert result["status"] == "success"
+    output_path = Path(result["path"])
+    assert output_path.name == "file.pdf"
+
+
+def test_download_file_preserves_extension_for_non_ascii_drive_name(
+    monkeypatch, tmp_path
+):
+    """Regression guard: a name whose entire stem is non-ASCII (e.g. CJK)
+    sanitizes down to nothing on its own, but the extension must survive —
+    this is the regular-file (get_media) branch, which has no separate
+    "extension" variable to fall back on the way the Workspace-export
+    branch does, so the fix has to live in _safe_output_filename itself."""
+    files = Mock()
+    files.get.return_value.execute.return_value = {
+        "id": "f1",
+        "name": "季度报告.pdf",
+        "mimeType": "application/pdf",
+    }
+    _mock_drive_service(monkeypatch, files)
+    _patch_downloader(monkeypatch, b"content")
+
+    result = json.loads(google_drive.google_drive_download_file("f1"))
 
     assert result["status"] == "success"
     output_path = Path(result["path"])

--- a/tests/web/tools/test_oauth_mcp_file_allowed_dirs_env.py
+++ b/tests/web/tools/test_oauth_mcp_file_allowed_dirs_env.py
@@ -1,6 +1,7 @@
 """Tests for injecting the file-upload allowlist directory into OAuth-transport
 MCP subprocess environments (LinkedIn's image upload, Slack's file upload,
-Gmail's message attachments, Google Drive's download output directory)."""
+Gmail's message attachments) and Google Drive's dedicated write-target
+output directory."""
 
 from types import SimpleNamespace
 
@@ -37,9 +38,7 @@ def test_transport_config_sets_both_allowlist_vars_when_workspace_has_a_task(
     assert transport_config["env"]["XAGENT_SLACK_FILE_ALLOWED_DIRS"] == expected_dir
     assert transport_config["env"]["XAGENT_LINKEDIN_IMAGE_ALLOWED_DIRS"] == expected_dir
     assert transport_config["env"]["XAGENT_GMAIL_FILE_ALLOWED_DIRS"] == expected_dir
-    assert (
-        transport_config["env"]["XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS"] == expected_dir
-    )
+    assert transport_config["env"]["XAGENT_GOOGLE_DRIVE_OUTPUT_DIR"] == expected_dir
 
 
 def test_transport_config_omits_allowlist_vars_without_a_task_id():
@@ -58,4 +57,59 @@ def test_transport_config_omits_allowlist_vars_without_a_task_id():
     assert "XAGENT_SLACK_FILE_ALLOWED_DIRS" not in transport_config["env"]
     assert "XAGENT_LINKEDIN_IMAGE_ALLOWED_DIRS" not in transport_config["env"]
     assert "XAGENT_GMAIL_FILE_ALLOWED_DIRS" not in transport_config["env"]
-    assert "XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS" not in transport_config["env"]
+    assert "XAGENT_GOOGLE_DRIVE_OUTPUT_DIR" not in transport_config["env"]
+
+
+def test_drive_output_dir_excludes_external_dirs_unlike_the_read_allowlists(
+    tmp_path,
+):
+    """XAGENT_GOOGLE_DRIVE_OUTPUT_DIR must never pick up
+    allowed_external_dirs the way the read allowlists do — those can be a
+    read-only KB folder, and picking one as a *write* target would be
+    wrong, not just a different (but still safe) choice."""
+    external_dir = tmp_path / "kb"
+    external_dir.mkdir()
+    cfg = WebToolConfig(
+        db=None,
+        request=None,
+        task_id="task-123",
+        workspace_base_dir=str(tmp_path),
+    )
+    cfg._workspace_config["allowed_external_dirs"] = [str(external_dir)]
+
+    transport_config = cfg._build_oauth_mcp_stdio_transport_config(
+        server=SimpleNamespace(name="Slack"),
+        app_info=_app_info("slack", "SLACK_ACCESS_TOKEN"),
+        access_token="user-access-token",
+    )
+
+    task_dir = str((tmp_path / "task-123").resolve())
+    assert transport_config["env"]["XAGENT_GOOGLE_DRIVE_OUTPUT_DIR"] == task_dir
+    # The read allowlists, by contrast, legitimately include the external
+    # dir alongside the task dir.
+    assert str(external_dir.resolve()) in transport_config["env"][
+        "XAGENT_SLACK_FILE_ALLOWED_DIRS"
+    ].split(",")
+
+
+def test_drive_output_dir_omitted_when_only_external_dirs_are_configured(
+    tmp_path,
+):
+    """No task_id at all (only allowed_external_dirs) must leave
+    XAGENT_GOOGLE_DRIVE_OUTPUT_DIR unset entirely rather than falling back
+    to one of those external dirs as a write target."""
+    external_dir = tmp_path / "kb"
+    external_dir.mkdir()
+    cfg = WebToolConfig(db=None, request=None)
+    cfg._workspace_config["allowed_external_dirs"] = [str(external_dir)]
+
+    transport_config = cfg._build_oauth_mcp_stdio_transport_config(
+        server=SimpleNamespace(name="Slack"),
+        app_info=_app_info("slack", "SLACK_ACCESS_TOKEN"),
+        access_token="user-access-token",
+    )
+
+    assert "XAGENT_GOOGLE_DRIVE_OUTPUT_DIR" not in transport_config["env"]
+    assert str(external_dir.resolve()) in transport_config["env"][
+        "XAGENT_SLACK_FILE_ALLOWED_DIRS"
+    ].split(",")

--- a/tests/web/tools/test_oauth_mcp_file_allowed_dirs_env.py
+++ b/tests/web/tools/test_oauth_mcp_file_allowed_dirs_env.py
@@ -1,6 +1,6 @@
 """Tests for injecting the file-upload allowlist directory into OAuth-transport
 MCP subprocess environments (LinkedIn's image upload, Slack's file upload,
-Gmail's message attachments)."""
+Gmail's message attachments, Google Drive's download output directory)."""
 
 from types import SimpleNamespace
 
@@ -37,6 +37,9 @@ def test_transport_config_sets_both_allowlist_vars_when_workspace_has_a_task(
     assert transport_config["env"]["XAGENT_SLACK_FILE_ALLOWED_DIRS"] == expected_dir
     assert transport_config["env"]["XAGENT_LINKEDIN_IMAGE_ALLOWED_DIRS"] == expected_dir
     assert transport_config["env"]["XAGENT_GMAIL_FILE_ALLOWED_DIRS"] == expected_dir
+    assert (
+        transport_config["env"]["XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS"] == expected_dir
+    )
 
 
 def test_transport_config_omits_allowlist_vars_without_a_task_id():
@@ -55,3 +58,4 @@ def test_transport_config_omits_allowlist_vars_without_a_task_id():
     assert "XAGENT_SLACK_FILE_ALLOWED_DIRS" not in transport_config["env"]
     assert "XAGENT_LINKEDIN_IMAGE_ALLOWED_DIRS" not in transport_config["env"]
     assert "XAGENT_GMAIL_FILE_ALLOWED_DIRS" not in transport_config["env"]
+    assert "XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS" not in transport_config["env"]


### PR DESCRIPTION
## Summary
`google_drive_get_file_content` always decoded the downloaded/exported bytes as UTF-8 (`errors="replace"`) before returning them inline — correct for a text file, but silently corrupting any binary content (PDF, image, Office export) into garbage. This was one link in the chain behind a production incident: an agent tried to route a Slides-exported PDF through Drive and into an email attachment, and this tool's inline-text-decode step was one of the places that pipeline had no working path through (see #2220 for the Gmail-side half of the same incident).

- `google_drive_get_file_content` now rejects a non-text `mime_type` up front (an allowlist: anything starting with `text/`, plus `application/json`/`application/xml`), pointing the caller at the new tool instead of silently corrupting the result.
- New `google_drive_download_file(file_id, mime_type="", filename="")` downloads or exports a file the same way, but writes the raw bytes to the task workspace's `output/` directory (mirroring `TaskWorkspace.output_dir`, so the file shows up alongside other generated deliverables) and returns the path — usable directly by another tool that reads local files, e.g. #2220's `gmail_send_messages` `attachments`. `mime_type` is required when exporting a Google Workspace document (Docs/Sheets/Slides) and ignored otherwise. The written filename is sanitized (Drive names are untrusted input) and deduplicated (" (1)", " (2)", ...) instead of silently clobbering an existing same-named file.
- Wired a new `XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS` env var into `config.py` alongside the existing Slack/LinkedIn allowlist vars, so the subprocess knows which directory's `output/` subdirectory to write into.

This PR is independent of #2220 (no code dependency either direction) but the two together close the full "Slides → PDF → email" pipeline the incident needed.

## Self-review
An adversarial pass found and I fixed two real issues before opening this PR:
- Sanitizing the target filename *after* appending the export extension let the sanitizer's dot-stripping (for a degenerate Drive name like `"..."`) eat into the extension's own leading dot, producing a bare `pdf` instead of the intended `file.pdf`. Fixed by sanitizing the base name first, then appending the extension.
- The original path-traversal test (`"../../etc/passwd"`) was fully neutralized by `Path.name` alone before the character-allowlist regex ever ran, so it didn't actually prove the regex step does anything. Added a second test (`"weird:name?.txt"`) that only the regex step can clean up, plus a regression test for the extension-stripping fix.
- Left as a known, non-blocking tradeoff (documented in the finding, not fixed here): the dedup-then-write sequence isn't atomic, so two concurrent downloads resolving to the same default filename could still race; and the allowed-dirs env-parsing loop is now a third near-identical copy of the same pattern in `slack.py`/`config.py` — a shared helper would be a good follow-up across all three connectors.

## Test plan
- [x] Added `tests/web/tools/test_google_drive_mcp.py` (17 tests): text mime types still work through `get_file_content`, binary mime types are rejected before any API call, regular binary file download, Workspace-doc export with extension appended, missing `mime_type` on a Workspace doc is rejected, explicit `filename` override, path-traversal and unsafe-character sanitization, degenerate-name extension preservation, dedup on an existing filename, API failure passthrough.
- [x] Extended `tests/web/tools/test_oauth_mcp_file_allowed_dirs_env.py` to assert `XAGENT_GOOGLE_DRIVE_FILE_ALLOWED_DIRS` is set/omitted alongside the existing Slack/LinkedIn vars.
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy src/xagent/web/tools/mcp/google_drive.py src/xagent/web/tools/config.py` — no new errors (same pre-existing unrelated `googleapiclient` stub warning present on `main`)
- [x] Full `tests/web/tools/` suite passes (no regressions)