### PR TITLE
feat(memory): add resumable LanceDB maintenance (toby)

### DIFF
--- a/src/xagent/core/memory/__init__.py
+++ b/src/xagent/core/memory/__init__.py
@@ -2,3 +2,6 @@ from .base import MemoryStore as MemoryStore
 from .core import MemoryNote as MemoryNote
 from .core import MemoryResponse as MemoryResponse
 from .lancedb import LanceDBMemoryStore as LanceDBMemoryStore
+from .lancedb_maintenance import (
+    maintain_lancedb_memory_table as maintain_lancedb_memory_table,
+)

--- a/src/xagent/core/memory/lancedb_maintenance.py
+++ b/src/xagent/core/memory/lancedb_maintenance.py
@@ -1,0 +1,210 @@
+"""Explicit, resumable maintenance for existing LanceDB memory tables."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import pyarrow as pa  # type: ignore
+from filelock import FileLock, Timeout
+
+from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+from .scope_columns import (
+    SCOPE_DIMS_COLUMN,
+    USER_ID_COLUMN,
+    derive_scope_columns,
+)
+
+MAINTENANCE_METADATA_KEY = b"xagent.memory.scope_maintenance"
+MAINTENANCE_VERSION = b"1"
+DEFAULT_BATCH_SIZE = 512
+DEFAULT_LOCK_TIMEOUT = 10.0
+
+
+class MaintenanceStatus(str, Enum):
+    COMPLETE = "complete"
+    INCOMPLETE = "incomplete"
+    INVALID_LEGACY_DATA = "invalid_legacy_data"
+
+
+@dataclass(frozen=True)
+class MaintenanceOutcome:
+    status: MaintenanceStatus
+    scanned_rows: int = 0
+    updated_rows: int = 0
+    cas_skipped_rows: int = 0
+    batches_committed: int = 0
+    detail: str | None = None
+
+
+class MaintenanceLockTimeout(RuntimeError):
+    """Raised when another process holds a table's maintenance lock too long."""
+
+
+def _checkpoint(_stage: str, _batch: int | None = None) -> None:
+    """Test seam for deterministic interruption; intentionally does nothing."""
+
+
+def _is_complete(schema: Any) -> bool:
+    names = set(schema.names)
+    if not {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= names:
+        return False
+    metadata = schema.field(USER_ID_COLUMN).metadata or {}
+    return metadata.get(MAINTENANCE_METADATA_KEY) == MAINTENANCE_VERSION
+
+
+def _lock_path(connection: Any, table_name: str) -> str:
+    uri = str(getattr(connection, "uri", "") or "")
+    if not uri or "://" in uri or not os.path.isdir(uri):
+        raise ValueError("LanceDB maintenance requires a writable local database URI")
+    digest = hashlib.sha256(table_name.encode()).hexdigest()[:16]
+    return os.path.join(uri, f".memory-maintenance-{digest}.lock")
+
+
+def _read_rows(table: Any) -> list[dict[str, Any]]:
+    names = set(table.schema.names)
+    required = {"id", "metadata"}
+    if not required <= names:
+        missing = ", ".join(sorted(required - names))
+        raise ValueError(f"memory table is missing required columns: {missing}")
+    projected = ["id", "metadata"]
+    projected += [c for c in (USER_ID_COLUMN, SCOPE_DIMS_COLUMN) if c in names]
+    return table.search().select(projected).limit(None).to_arrow().to_pylist()
+
+
+def _invalid_ids(rows: list[dict[str, Any]]) -> str | None:
+    ids = [row["id"] for row in rows]
+    if any(not isinstance(value, str) or not value for value in ids):
+        return "legacy IDs must be non-empty strings"
+    if len(ids) != len(set(ids)):
+        return "legacy IDs must be unique"
+    return None
+
+
+def _needs_update(row: dict[str, Any]) -> bool:
+    expected = derive_scope_columns(row["metadata"])
+    return (row.get(USER_ID_COLUMN), row.get(SCOPE_DIMS_COLUMN)) != expected
+
+
+def _source(rows: list[dict[str, Any]]) -> pa.Table:
+    derived = [derive_scope_columns(row["metadata"]) for row in rows]
+    return pa.table(
+        {
+            "id": pa.array([row["id"] for row in rows], pa.string()),
+            "metadata": pa.array([row["metadata"] for row in rows], pa.string()),
+            USER_ID_COLUMN: pa.array([item[0] for item in derived], pa.int64()),
+            SCOPE_DIMS_COLUMN: pa.array(
+                [item[1] for item in derived], pa.list_(pa.string())
+            ),
+        }
+    )
+
+
+def _backfill_batch(table: Any, rows: list[dict[str, Any]]) -> int:
+    condition = (
+        "(target.metadata = source.metadata) OR "
+        "((target.metadata IS NULL) AND (source.metadata IS NULL))"
+    )
+    result = (
+        table.merge_insert("id")
+        .when_matched_update_all(where=condition)
+        .execute(_source(rows))
+    )
+    return int(result.num_updated_rows)
+
+
+def maintain_lancedb_memory_table(
+    connection: Any,
+    table_name: str,
+    *,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    lock_timeout: float = DEFAULT_LOCK_TIMEOUT,
+) -> MaintenanceOutcome:
+    """Backfill scope projections under an explicit, serialized admin boundary."""
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    if not math.isfinite(lock_timeout) or lock_timeout <= 0:
+        raise ValueError("lock_timeout must be a finite positive duration")
+
+    lock = FileLock(_lock_path(connection, table_name), timeout=lock_timeout)
+    try:
+        lock.acquire()
+    except Timeout as exc:
+        raise MaintenanceLockTimeout(
+            f"Timed out after {lock_timeout}s acquiring maintenance lock for "
+            f"table {table_name!r}; stop the other maintenance process and retry"
+        ) from exc
+
+    table = None
+    try:
+        table = connection.open_table(table_name)
+        if _is_complete(table.schema):
+            return MaintenanceOutcome(MaintenanceStatus.COMPLETE)
+
+        rows = _read_rows(table)
+        invalid = _invalid_ids(rows)
+        if invalid:
+            return MaintenanceOutcome(
+                MaintenanceStatus.INVALID_LEGACY_DATA,
+                scanned_rows=len(rows),
+                detail=invalid,
+            )
+
+        names = set(table.schema.names)
+        missing = [
+            field
+            for field in (
+                pa.field(USER_ID_COLUMN, pa.int64()),
+                pa.field(SCOPE_DIMS_COLUMN, pa.list_(pa.string())),
+            )
+            if field.name not in names
+        ]
+        if missing:
+            table.add_columns(missing)
+            _checkpoint("columns_added")
+
+        candidates = [row for row in rows if missing or _needs_update(row)]
+        updated = commits = skipped = 0
+        for offset in range(0, len(candidates), batch_size):
+            batch = candidates[offset : offset + batch_size]
+            changed = _backfill_batch(table, batch)
+            updated += changed
+            skipped += len(batch) - changed
+            commits += 1
+            _checkpoint("batch_committed", commits)
+
+        final_rows = _read_rows(table)
+        final_invalid = _invalid_ids(final_rows)
+        remaining = sum(_needs_update(row) for row in final_rows)
+        if final_invalid or skipped or remaining:
+            return MaintenanceOutcome(
+                MaintenanceStatus.INCOMPLETE,
+                scanned_rows=len(rows),
+                updated_rows=updated,
+                cas_skipped_rows=skipped,
+                batches_committed=commits,
+                detail=final_invalid or "concurrent changes require another pass",
+            )
+
+        _checkpoint("before_completion")
+        table.update_field_metadata(
+            {
+                "path": USER_ID_COLUMN,
+                "metadata": {
+                    MAINTENANCE_METADATA_KEY.decode(): MAINTENANCE_VERSION.decode()
+                },
+            }
+        )
+        return MaintenanceOutcome(
+            MaintenanceStatus.COMPLETE,
+            scanned_rows=len(rows),
+            updated_rows=updated,
+            batches_committed=commits,
+        )
+    finally:
+        _safe_close_table(table)
+        lock.release()

--- a/src/xagent/core/memory/lancedb_maintenance.py
+++ b/src/xagent/core/memory/lancedb_maintenance.py
@@ -93,34 +93,56 @@ def _needs_update(row: dict[str, Any]) -> bool:
     return (row.get(USER_ID_COLUMN), row.get(SCOPE_DIMS_COLUMN)) != expected
 
 
-def _source(rows: list[dict[str, Any]]) -> object:
-    derived = [derive_scope_columns(row["metadata"]) for row in rows]
-    return cast(
-        object,
-        pa.table(
-            {
-                "id": pa.array([row["id"] for row in rows], pa.string()),
-                "metadata": pa.array([row["metadata"] for row in rows], pa.string()),
-                USER_ID_COLUMN: pa.array([item[0] for item in derived], pa.int64()),
-                SCOPE_DIMS_COLUMN: pa.array(
-                    [item[1] for item in derived], pa.list_(pa.string())
-                ),
-            }
-        ),
-    )
+def _sql_string(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _sql_list(values: list[str]) -> str:
+    if not values:
+        return "arrow_cast([], 'List(Utf8)')"
+    return "[" + ", ".join(_sql_string(value) for value in values) + "]"
+
+
+def _sql_nullable_string(value: str | None) -> str:
+    return "arrow_cast(NULL, 'Utf8')" if value is None else _sql_string(value)
 
 
 def _backfill_batch(table: Any, rows: list[dict[str, Any]]) -> int:
+    ids = [_sql_string(row["id"]) for row in rows]
+    derived = [derive_scope_columns(row["metadata"]) for row in rows]
+    position = f"cast(array_position([{', '.join(ids)}], id) as bigint)"
+    metadata = ", ".join(_sql_nullable_string(row["metadata"]) for row in rows)
+    expected_metadata = f"array_element([{metadata}], {position})"
     condition = (
-        "(target.metadata = source.metadata) OR "
-        "((target.metadata IS NULL) AND (source.metadata IS NULL))"
+        f"id IN ({', '.join(ids)}) AND "
+        f"(metadata = {expected_metadata} OR "
+        f"(metadata IS NULL AND {expected_metadata} IS NULL))"
     )
-    result = (
-        table.merge_insert("id")
-        .when_matched_update_all(where=condition)
-        .execute(_source(rows))
+    user_ids = [
+        "cast(NULL as bigint)" if user_id is None else str(user_id)
+        for user_id, _scope_dims in derived
+    ]
+    scope_dims = [_sql_list(values) for _user_id, values in derived]
+    result = table.update(
+        where=condition,
+        values_sql={
+            USER_ID_COLUMN: f"array_element([{', '.join(user_ids)}], {position})",
+            SCOPE_DIMS_COLUMN: f"array_element([{', '.join(scope_dims)}], {position})",
+        },
     )
-    return int(result.num_updated_rows)
+    return int(result.rows_updated)
+
+
+def _mark_complete(table: Any) -> None:
+    marker = {MAINTENANCE_METADATA_KEY.decode(): MAINTENANCE_VERSION.decode()}
+    if hasattr(table, "update_field_metadata"):
+        table.update_field_metadata({"path": USER_ID_COLUMN, "metadata": marker})
+        return
+    metadata = {
+        key.decode(): value.decode()
+        for key, value in (table.schema.field(USER_ID_COLUMN).metadata or {}).items()
+    }
+    table.replace_field_metadata(USER_ID_COLUMN, metadata | marker)
 
 
 def maintain_lancedb_memory_table(
@@ -197,14 +219,7 @@ def maintain_lancedb_memory_table(
             )
 
         _checkpoint("before_completion")
-        table.update_field_metadata(
-            {
-                "path": USER_ID_COLUMN,
-                "metadata": {
-                    MAINTENANCE_METADATA_KEY.decode(): MAINTENANCE_VERSION.decode()
-                },
-            }
-        )
+        _mark_complete(table)
         return MaintenanceOutcome(
             MaintenanceStatus.COMPLETE,
             scanned_rows=len(rows),

--- a/src/xagent/core/memory/lancedb_maintenance.py
+++ b/src/xagent/core/memory/lancedb_maintenance.py
@@ -20,6 +20,7 @@ from .scope_columns import (
 )
 
 MAINTENANCE_METADATA_KEY = b"xagent.memory.scope_maintenance"
+MAINTENANCE_TABLE_VERSION_KEY = b"xagent.memory.scope_maintenance_table_version"
 MAINTENANCE_VERSION = b"1"
 DEFAULT_BATCH_SIZE = 512
 DEFAULT_LOCK_TIMEOUT = 10.0
@@ -29,6 +30,7 @@ class MaintenanceStatus(str, Enum):
     COMPLETE = "complete"
     INCOMPLETE = "incomplete"
     INVALID_LEGACY_DATA = "invalid_legacy_data"
+    INCOMPATIBLE_SCHEMA = "incompatible_schema"
 
 
 @dataclass(frozen=True)
@@ -49,12 +51,35 @@ def _checkpoint(_stage: str, _batch: int | None = None) -> None:
     """Test seam for deterministic interruption; intentionally does nothing."""
 
 
-def _is_complete(schema: Any) -> bool:
+def _scope_schema_error(schema: Any) -> str | None:
+    expected = {
+        USER_ID_COLUMN: pa.int64(),
+        SCOPE_DIMS_COLUMN: pa.list_(pa.string()),
+    }
+    incompatible = [
+        f"{name} is {schema.field(name).type}, expected {field_type}"
+        for name, field_type in expected.items()
+        if name in schema.names and schema.field(name).type != field_type
+    ]
+    if not incompatible:
+        return None
+    return (
+        "incompatible scope column types: "
+        + "; ".join(incompatible)
+        + "; convert the legacy schema explicitly before retrying maintenance"
+    )
+
+
+def _is_complete(table: Any) -> bool:
+    schema = table.schema
     names = set(schema.names)
-    if not {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= names:
+    if not {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= names or _scope_schema_error(schema):
         return False
     metadata = schema.field(USER_ID_COLUMN).metadata or {}
-    return metadata.get(MAINTENANCE_METADATA_KEY) == MAINTENANCE_VERSION
+    return (
+        metadata.get(MAINTENANCE_METADATA_KEY) == MAINTENANCE_VERSION
+        and metadata.get(MAINTENANCE_TABLE_VERSION_KEY) == str(table.version).encode()
+    )
 
 
 def _lock_path(connection: Any, table_name: str) -> str:
@@ -133,16 +158,22 @@ def _backfill_batch(table: Any, rows: list[dict[str, Any]]) -> int:
     return int(result.rows_updated)
 
 
-def _mark_complete(table: Any) -> None:
-    marker = {MAINTENANCE_METADATA_KEY.decode(): MAINTENANCE_VERSION.decode()}
+def _mark_complete(table: Any, expected_version: int) -> int:
+    marker = {
+        MAINTENANCE_METADATA_KEY.decode(): MAINTENANCE_VERSION.decode(),
+        MAINTENANCE_TABLE_VERSION_KEY.decode(): str(expected_version),
+    }
     if hasattr(table, "update_field_metadata"):
-        table.update_field_metadata({"path": USER_ID_COLUMN, "metadata": marker})
-        return
+        result = table.update_field_metadata(
+            {"path": USER_ID_COLUMN, "metadata": marker}
+        )
+        return int(result.version)
     metadata = {
         key.decode(): value.decode()
         for key, value in (table.schema.field(USER_ID_COLUMN).metadata or {}).items()
     }
     table.replace_field_metadata(USER_ID_COLUMN, metadata | marker)
+    return int(table.version)
 
 
 def maintain_lancedb_memory_table(
@@ -170,7 +201,13 @@ def maintain_lancedb_memory_table(
     table = None
     try:
         table = connection.open_table(table_name)
-        if _is_complete(table.schema):
+        schema_error = _scope_schema_error(table.schema)
+        if schema_error:
+            return MaintenanceOutcome(
+                MaintenanceStatus.INCOMPATIBLE_SCHEMA,
+                detail=schema_error,
+            )
+        if _is_complete(table):
             return MaintenanceOutcome(MaintenanceStatus.COMPLETE)
 
         rows = _read_rows(table)
@@ -205,10 +242,12 @@ def maintain_lancedb_memory_table(
             commits += 1
             _checkpoint("batch_committed", commits)
 
+        validated_version = int(table.version)
         final_rows = _read_rows(table)
         final_invalid = _invalid_ids(final_rows)
         remaining = sum(_needs_update(row) for row in final_rows)
-        if final_invalid or skipped or remaining:
+        version_changed = int(table.version) != validated_version
+        if final_invalid or skipped or remaining or version_changed:
             return MaintenanceOutcome(
                 MaintenanceStatus.INCOMPLETE,
                 scanned_rows=len(rows),
@@ -219,7 +258,19 @@ def maintain_lancedb_memory_table(
             )
 
         _checkpoint("before_completion")
-        _mark_complete(table)
+        expected_marker_version = validated_version + 1
+        actual_marker_version = _mark_complete(table, expected_marker_version)
+        if (
+            actual_marker_version != expected_marker_version
+            or int(table.version) != expected_marker_version
+        ):
+            return MaintenanceOutcome(
+                MaintenanceStatus.INCOMPLETE,
+                scanned_rows=len(rows),
+                updated_rows=updated,
+                batches_committed=commits,
+                detail="concurrent changes invalidated the completion marker",
+            )
         return MaintenanceOutcome(
             MaintenanceStatus.COMPLETE,
             scanned_rows=len(rows),

--- a/src/xagent/core/memory/lancedb_maintenance.py
+++ b/src/xagent/core/memory/lancedb_maintenance.py
@@ -24,6 +24,8 @@ MAINTENANCE_TABLE_VERSION_KEY = b"xagent.memory.scope_maintenance_table_version"
 MAINTENANCE_VERSION = b"1"
 DEFAULT_BATCH_SIZE = 512
 DEFAULT_LOCK_TIMEOUT = 10.0
+_INT64_MIN = -(2**63)
+_INT64_MAX = 2**63 - 1
 
 
 class MaintenanceStatus(str, Enum):
@@ -76,6 +78,8 @@ def _is_complete(table: Any) -> bool:
     if not {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= names or _scope_schema_error(schema):
         return False
     metadata = schema.field(USER_ID_COLUMN).metadata or {}
+    # LanceDB versions increase monotonically on every commit. Binding completion
+    # to the exact marker commit makes any later write invalidate this fast path.
     return (
         metadata.get(MAINTENANCE_METADATA_KEY) == MAINTENANCE_VERSION
         and metadata.get(MAINTENANCE_TABLE_VERSION_KEY) == str(table.version).encode()
@@ -110,6 +114,20 @@ def _invalid_ids(rows: list[dict[str, Any]]) -> str | None:
         return "legacy IDs must be non-empty strings"
     if len(ids) != len(set(ids)):
         return "legacy IDs must be unique"
+    return None
+
+
+def _invalid_legacy_data(rows: list[dict[str, Any]]) -> str | None:
+    invalid_ids = _invalid_ids(rows)
+    if invalid_ids:
+        return invalid_ids
+    for row in rows:
+        metadata = row["metadata"]
+        if metadata is not None and not isinstance(metadata, str):
+            return f"metadata for legacy ID {row['id']!r} must be a string or SQL NULL"
+        user_id, _scope_dims = derive_scope_columns(metadata)
+        if user_id is not None and not _INT64_MIN <= user_id <= _INT64_MAX:
+            return f"user_id for legacy ID {row['id']!r} must fit signed int64"
     return None
 
 
@@ -183,10 +201,20 @@ def maintain_lancedb_memory_table(
     batch_size: int = DEFAULT_BATCH_SIZE,
     lock_timeout: float = DEFAULT_LOCK_TIMEOUT,
 ) -> MaintenanceOutcome:
-    """Backfill scope projections under an explicit, serialized admin boundary."""
-    if batch_size <= 0:
-        raise ValueError("batch_size must be positive")
-    if not math.isfinite(lock_timeout) or lock_timeout <= 0:
+    """Backfill scope projections under an explicit, serialized admin boundary.
+
+    Completion requires a short write-quiet window. Every later table commit
+    invalidates the version-bound O(1) fast path, so a subsequent explicit call
+    scans and validates the table again.
+    """
+    if type(batch_size) is not int or batch_size <= 0:
+        raise ValueError("batch_size must be a positive integer")
+    if (
+        isinstance(lock_timeout, bool)
+        or not isinstance(lock_timeout, (int, float))
+        or not math.isfinite(lock_timeout)
+        or lock_timeout <= 0
+    ):
         raise ValueError("lock_timeout must be a finite positive duration")
 
     lock = FileLock(_lock_path(connection, table_name), timeout=lock_timeout)
@@ -211,7 +239,7 @@ def maintain_lancedb_memory_table(
             return MaintenanceOutcome(MaintenanceStatus.COMPLETE)
 
         rows = _read_rows(table)
-        invalid = _invalid_ids(rows)
+        invalid = _invalid_legacy_data(rows)
         if invalid:
             return MaintenanceOutcome(
                 MaintenanceStatus.INVALID_LEGACY_DATA,
@@ -244,22 +272,36 @@ def maintain_lancedb_memory_table(
 
         validated_version = int(table.version)
         final_rows = _read_rows(table)
-        final_invalid = _invalid_ids(final_rows)
+        final_invalid = _invalid_legacy_data(final_rows)
+        if final_invalid:
+            return MaintenanceOutcome(
+                MaintenanceStatus.INVALID_LEGACY_DATA,
+                scanned_rows=len(rows),
+                updated_rows=updated,
+                cas_skipped_rows=skipped,
+                batches_committed=commits,
+                detail=final_invalid,
+            )
         remaining = sum(_needs_update(row) for row in final_rows)
+        # Default LanceDB connections cache read snapshots, while callers may opt
+        # into strong reads with read_consistency_interval=timedelta(0).
         version_changed = int(table.version) != validated_version
-        if final_invalid or skipped or remaining or version_changed:
+        if skipped or remaining or version_changed:
             return MaintenanceOutcome(
                 MaintenanceStatus.INCOMPLETE,
                 scanned_rows=len(rows),
                 updated_rows=updated,
                 cas_skipped_rows=skipped,
                 batches_committed=commits,
-                detail=final_invalid or "concurrent changes require another pass",
+                detail="concurrent changes require another pass",
             )
 
         _checkpoint("before_completion")
         expected_marker_version = validated_version + 1
         actual_marker_version = _mark_complete(table, expected_marker_version)
+        # Writes always commit against the latest table version even when this
+        # handle's reads are cached. A concurrent commit therefore makes the
+        # marker land after V+1 and leaves it intentionally invalid/resumable.
         if (
             actual_marker_version != expected_marker_version
             or int(table.version) != expected_marker_version

--- a/src/xagent/core/memory/lancedb_maintenance.py
+++ b/src/xagent/core/memory/lancedb_maintenance.py
@@ -7,7 +7,7 @@ import math
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 import pyarrow as pa  # type: ignore
 from filelock import FileLock, Timeout
@@ -73,7 +73,10 @@ def _read_rows(table: Any) -> list[dict[str, Any]]:
         raise ValueError(f"memory table is missing required columns: {missing}")
     projected = ["id", "metadata"]
     projected += [c for c in (USER_ID_COLUMN, SCOPE_DIMS_COLUMN) if c in names]
-    return table.search().select(projected).limit(None).to_arrow().to_pylist()
+    return cast(
+        list[dict[str, Any]],
+        table.search().select(projected).limit(None).to_arrow().to_pylist(),
+    )
 
 
 def _invalid_ids(rows: list[dict[str, Any]]) -> str | None:
@@ -90,17 +93,20 @@ def _needs_update(row: dict[str, Any]) -> bool:
     return (row.get(USER_ID_COLUMN), row.get(SCOPE_DIMS_COLUMN)) != expected
 
 
-def _source(rows: list[dict[str, Any]]) -> pa.Table:
+def _source(rows: list[dict[str, Any]]) -> object:
     derived = [derive_scope_columns(row["metadata"]) for row in rows]
-    return pa.table(
-        {
-            "id": pa.array([row["id"] for row in rows], pa.string()),
-            "metadata": pa.array([row["metadata"] for row in rows], pa.string()),
-            USER_ID_COLUMN: pa.array([item[0] for item in derived], pa.int64()),
-            SCOPE_DIMS_COLUMN: pa.array(
-                [item[1] for item in derived], pa.list_(pa.string())
-            ),
-        }
+    return cast(
+        object,
+        pa.table(
+            {
+                "id": pa.array([row["id"] for row in rows], pa.string()),
+                "metadata": pa.array([row["metadata"] for row in rows], pa.string()),
+                USER_ID_COLUMN: pa.array([item[0] for item in derived], pa.int64()),
+                SCOPE_DIMS_COLUMN: pa.array(
+                    [item[1] for item in derived], pa.list_(pa.string())
+                ),
+            }
+        ),
     )
 
 

--- a/tests/core/memory/test_lancedb_maintenance.py
+++ b/tests/core/memory/test_lancedb_maintenance.py
@@ -1,7 +1,10 @@
 """Real-LanceDB coverage for resumable scope-column maintenance."""
 
 import json
+import multiprocessing
+import socket
 import time
+from datetime import timedelta
 
 import lancedb  # type: ignore
 import pyarrow as pa  # type: ignore
@@ -31,8 +34,16 @@ def _metadata(index):
     )
 
 
-def _connection(tmp_path, count=2, *, ids=None, metadata=None, scoped=False):
-    connection = lancedb.connect(tmp_path)
+def _connection(
+    tmp_path,
+    count=2,
+    *,
+    ids=None,
+    metadata=None,
+    scoped=False,
+    connection_kwargs=None,
+):
+    connection = lancedb.connect(tmp_path, **(connection_kwargs or {}))
     ids = ids if ids is not None else [f"note-{index}" for index in range(count)]
     metadata = (
         metadata if metadata is not None else [_metadata(i) for i in range(count)]
@@ -74,6 +85,12 @@ def _marker_table_version(table):
     return (table.schema.field(USER_ID_COLUMN).metadata or {}).get(
         MAINTENANCE_TABLE_VERSION_KEY
     )
+
+
+def _hold_file_lock(lock_path, ready, release):
+    with FileLock(lock_path):
+        ready.set()
+        release.wait(30)
 
 
 def test_complete_migration_and_second_run_is_schema_only(tmp_path, monkeypatch):
@@ -119,9 +136,7 @@ def test_sql_null_metadata_projects_to_empty_scope_without_network(
     def forbidden(*_args, **_kwargs):
         raise AssertionError("maintenance must not embed or use the network")
 
-    monkeypatch.setattr(
-        "xagent.core.model.embedding.DashScopeEmbedding.encode", forbidden
-    )
+    monkeypatch.setattr(socket.socket, "connect", forbidden)
     outcome = maintain_lancedb_memory_table(connection, "memories")
     row = _table(connection).to_arrow().to_pylist()[0]
     assert outcome.status is MaintenanceStatus.COMPLETE
@@ -141,6 +156,36 @@ def test_invalid_ids_leave_table_unchanged(tmp_path, ids):
     result = maintain_lancedb_memory_table(connection, "memories")
     table = _table(connection)
     assert result.status is MaintenanceStatus.INVALID_LEGACY_DATA
+    assert (table.version, table.schema, table.to_arrow().to_pylist()) == before
+    _safe_close_table(table)
+
+
+@pytest.mark.parametrize(
+    ("metadata", "detail"),
+    [
+        (pa.array([7], pa.int64()), "must be a string or SQL NULL"),
+        (pa.array([json.dumps({"user_id": 2**63})], pa.string()), "signed int64"),
+        (
+            pa.array([json.dumps({"user_id": -(2**63) - 1})], pa.string()),
+            "signed int64",
+        ),
+    ],
+)
+def test_invalid_metadata_or_user_id_range_leaves_table_unchanged(
+    tmp_path, metadata, detail
+):
+    connection = lancedb.connect(tmp_path)
+    table = connection.create_table(
+        "memories",
+        pa.table({"id": ["note-0"], "text": ["text-0"], "metadata": metadata}),
+    )
+    before = (table.version, table.schema, table.to_arrow().to_pylist())
+    _safe_close_table(table)
+
+    result = maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    assert result.status is MaintenanceStatus.INVALID_LEGACY_DATA
+    assert detail in result.detail
     assert (table.version, table.schema, table.to_arrow().to_pylist()) == before
     _safe_close_table(table)
 
@@ -255,6 +300,72 @@ def test_table_version_change_invalidates_fast_path(tmp_path, monkeypatch):
     assert scanned
 
 
+def test_strong_consistency_detects_version_change_during_final_read(
+    tmp_path, monkeypatch
+):
+    connection = _connection(
+        tmp_path,
+        count=1,
+        scoped=True,
+        connection_kwargs={"read_consistency_interval": timedelta(0)},
+    )
+    original = maintenance._read_rows
+    calls = 0
+
+    def update_after_final_read(table):
+        nonlocal calls
+        rows = original(table)
+        calls += 1
+        if calls == 2:
+            writer = _table(connection)
+            writer.update("id = 'note-0'", values={"text": "concurrent text"})
+            _safe_close_table(writer)
+        return rows
+
+    monkeypatch.setattr(maintenance, "_read_rows", update_after_final_read)
+    result = maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    assert result.status is MaintenanceStatus.INCOMPLETE
+    assert table.to_arrow().to_pylist()[0]["text"] == "concurrent text"
+    assert _marker(table) is None
+    _safe_close_table(table)
+
+
+def test_final_invalid_id_returns_invalid_and_preserves_concurrent_row(
+    tmp_path, monkeypatch
+):
+    connection = _connection(
+        tmp_path,
+        count=1,
+        connection_kwargs={"read_consistency_interval": timedelta(0)},
+    )
+
+    def append_invalid_id(stage, _batch=None):
+        if stage == "batch_committed":
+            writer = _table(connection)
+            writer.add(
+                [
+                    {
+                        "id": None,
+                        "text": "concurrent text",
+                        "metadata": "{}",
+                        "vector": [3.0, 4.0],
+                        USER_ID_COLUMN: None,
+                        SCOPE_DIMS_COLUMN: [],
+                    }
+                ]
+            )
+            _safe_close_table(writer)
+
+    monkeypatch.setattr(maintenance, "_checkpoint", append_invalid_id)
+    result = maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    assert result.status is MaintenanceStatus.INVALID_LEGACY_DATA
+    assert any(row["id"] is None for row in table.to_arrow().to_pylist())
+    assert _marker(table) is None
+    _safe_close_table(table)
+
+
 def test_exact_scope_schema_preserves_existing_field_metadata(tmp_path):
     connection = _connection(tmp_path, count=1, scoped=True)
     table = _table(connection)
@@ -346,8 +457,57 @@ def test_lock_timeout_is_bounded_and_success_releases_lock(tmp_path):
         pass
 
 
+def test_lock_timeout_against_second_process(tmp_path):
+    connection = _connection(tmp_path)
+    lock_path = maintenance._lock_path(connection, "memories")
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    release = context.Event()
+    process = context.Process(target=_hold_file_lock, args=(lock_path, ready, release))
+    process.start()
+    try:
+        assert ready.wait(20)
+        with pytest.raises(MaintenanceLockTimeout, match="stop the other"):
+            maintain_lancedb_memory_table(connection, "memories", lock_timeout=0.05)
+    finally:
+        release.set()
+        process.join(10)
+    assert process.exitcode == 0
+
+
+def test_non_local_uri_is_rejected():
+    class RemoteConnection:
+        uri = "s3://bucket/database"
+
+    with pytest.raises(ValueError, match="writable local database URI"):
+        maintain_lancedb_memory_table(RemoteConnection(), "memories")
+
+
 @pytest.mark.parametrize("timeout", [0, float("inf")])
 def test_nonpositive_lock_timeout_is_rejected(tmp_path, timeout):
     connection = _connection(tmp_path)
     with pytest.raises(ValueError, match="finite positive"):
         maintain_lancedb_memory_table(connection, "memories", lock_timeout=timeout)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"batch_size": True},
+        {"batch_size": 1.5},
+        {"batch_size": "1"},
+        {"lock_timeout": True},
+        {"lock_timeout": "1"},
+        {"lock_timeout": float("nan")},
+    ],
+)
+def test_invalid_parameter_types_do_not_access_connection(kwargs):
+    class ForbiddenConnection:
+        @property
+        def uri(self):
+            raise AssertionError(
+                "invalid parameters must fail before connection access"
+            )
+
+    with pytest.raises(ValueError):
+        maintain_lancedb_memory_table(ForbiddenConnection(), "memories", **kwargs)

--- a/tests/core/memory/test_lancedb_maintenance.py
+++ b/tests/core/memory/test_lancedb_maintenance.py
@@ -11,6 +11,7 @@ from filelock import FileLock
 from xagent.core.memory import lancedb_maintenance as maintenance
 from xagent.core.memory.lancedb_maintenance import (
     MAINTENANCE_METADATA_KEY,
+    MAINTENANCE_TABLE_VERSION_KEY,
     MAINTENANCE_VERSION,
     MaintenanceLockTimeout,
     MaintenanceStatus,
@@ -67,6 +68,14 @@ def _marker(table):
     )
 
 
+def _marker_table_version(table):
+    if USER_ID_COLUMN not in table.schema.names:
+        return None
+    return (table.schema.field(USER_ID_COLUMN).metadata or {}).get(
+        MAINTENANCE_TABLE_VERSION_KEY
+    )
+
+
 def test_complete_migration_and_second_run_is_schema_only(tmp_path, monkeypatch):
     connection = _connection(tmp_path)
     first = maintain_lancedb_memory_table(connection, "memories")
@@ -77,6 +86,7 @@ def test_complete_migration_and_second_run_is_schema_only(tmp_path, monkeypatch)
         {USER_ID_COLUMN: 1, SCOPE_DIMS_COLUMN: ["agent=agent-1"]},
     ]
     assert _marker(table) == MAINTENANCE_VERSION
+    assert _marker_table_version(table) == str(table.version).encode()
     assert table.schema.metadata[VECTOR_IDENTITY_METADATA_KEY] == b"preserved"
     _safe_close_table(table)
 
@@ -190,6 +200,111 @@ def test_concurrent_changes_are_preserved_and_metadata_change_is_reported(
     else:
         assert result.status is MaintenanceStatus.COMPLETE
         assert row[USER_ID_COLUMN] == 0
+
+
+def test_late_metadata_writer_invalidates_marker_and_resumes(tmp_path, monkeypatch):
+    connection = _connection(tmp_path, count=1, scoped=True)
+    changed_metadata = json.dumps({"user_id": 99})
+
+    def late_update(stage, _batch=None):
+        if stage == "before_completion":
+            writer = _table(connection)
+            writer.update("id = 'note-0'", values={"metadata": changed_metadata})
+            _safe_close_table(writer)
+
+    monkeypatch.setattr(maintenance, "_checkpoint", late_update)
+    first = maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    row = table.to_arrow().to_pylist()[0]
+    assert first.status is MaintenanceStatus.INCOMPLETE
+    assert row["metadata"] == changed_metadata
+    assert row[USER_ID_COLUMN] == 0
+    assert _marker_table_version(table) != str(table.version).encode()
+    _safe_close_table(table)
+
+    monkeypatch.setattr(maintenance, "_checkpoint", lambda *_args: None)
+    resumed = maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    assert resumed.status is MaintenanceStatus.COMPLETE
+    assert table.to_arrow().to_pylist()[0][USER_ID_COLUMN] == 99
+    assert _marker_table_version(table) == str(table.version).encode()
+    _safe_close_table(table)
+
+
+def test_table_version_change_invalidates_fast_path(tmp_path, monkeypatch):
+    connection = _connection(tmp_path, count=1)
+    assert (
+        maintain_lancedb_memory_table(connection, "memories").status
+        is MaintenanceStatus.COMPLETE
+    )
+    writer = _table(connection)
+    writer.update("id = 'note-0'", values={"text": "new text"})
+    _safe_close_table(writer)
+
+    scanned = False
+    original = maintenance._read_rows
+
+    def record_scan(table):
+        nonlocal scanned
+        scanned = True
+        return original(table)
+
+    monkeypatch.setattr(maintenance, "_read_rows", record_scan)
+    result = maintain_lancedb_memory_table(connection, "memories")
+    assert result.status is MaintenanceStatus.COMPLETE
+    assert scanned
+
+
+def test_exact_scope_schema_preserves_existing_field_metadata(tmp_path):
+    connection = _connection(tmp_path, count=1, scoped=True)
+    table = _table(connection)
+    metadata = {"preserved": "yes"}
+    if hasattr(table, "update_field_metadata"):
+        table.update_field_metadata({"path": USER_ID_COLUMN, "metadata": metadata})
+    else:
+        table.replace_field_metadata(USER_ID_COLUMN, metadata)
+    _safe_close_table(table)
+
+    result = maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    assert result.status is MaintenanceStatus.COMPLETE
+    assert table.schema.field(USER_ID_COLUMN).metadata[b"preserved"] == b"yes"
+    assert _marker_table_version(table) == str(table.version).encode()
+    _safe_close_table(table)
+
+
+@pytest.mark.parametrize(
+    ("partial", "old_marker"),
+    [(False, False), (True, False), (False, True)],
+)
+def test_incompatible_scope_schema_is_reported_without_mutation(
+    tmp_path, partial, old_marker
+):
+    connection = lancedb.connect(tmp_path)
+    columns = {
+        "id": ["note-0"],
+        "text": ["text-0"],
+        "metadata": pa.array([json.dumps({"user_id": 0})], pa.string()),
+        USER_ID_COLUMN: pa.array([0], pa.int32()),
+    }
+    if not partial:
+        columns[SCOPE_DIMS_COLUMN] = pa.array([[]], pa.list_(pa.int32()))
+    table = connection.create_table("memories", pa.table(columns))
+    if old_marker:
+        marker = {MAINTENANCE_METADATA_KEY.decode(): MAINTENANCE_VERSION.decode()}
+        if hasattr(table, "update_field_metadata"):
+            table.update_field_metadata({"path": USER_ID_COLUMN, "metadata": marker})
+        else:
+            table.replace_field_metadata(USER_ID_COLUMN, marker)
+    before = (table.version, table.schema, table.to_arrow().to_pylist())
+    _safe_close_table(table)
+
+    result = maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    assert result.status is MaintenanceStatus.INCOMPATIBLE_SCHEMA
+    assert USER_ID_COLUMN in result.detail
+    assert (table.version, table.schema, table.to_arrow().to_pylist()) == before
+    _safe_close_table(table)
 
 
 def test_completion_marker_is_last_and_failure_before_it_resumes(tmp_path, monkeypatch):

--- a/tests/core/memory/test_lancedb_maintenance.py
+++ b/tests/core/memory/test_lancedb_maintenance.py
@@ -1,0 +1,238 @@
+"""Real-LanceDB coverage for resumable scope-column maintenance."""
+
+import json
+import time
+
+import lancedb  # type: ignore
+import pyarrow as pa  # type: ignore
+import pytest
+from filelock import FileLock
+
+from xagent.core.memory import lancedb_maintenance as maintenance
+from xagent.core.memory.lancedb_maintenance import (
+    MAINTENANCE_METADATA_KEY,
+    MAINTENANCE_VERSION,
+    MaintenanceLockTimeout,
+    MaintenanceStatus,
+    maintain_lancedb_memory_table,
+)
+from xagent.core.memory.scope_columns import SCOPE_DIMS_COLUMN, USER_ID_COLUMN
+from xagent.core.memory.vector_compatibility import VECTOR_IDENTITY_METADATA_KEY
+from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+
+
+def _metadata(index):
+    return json.dumps(
+        {
+            "user_id": index,
+            "execution_scope_agent": f"agent-{index % 2}",
+        }
+    )
+
+
+def _connection(tmp_path, count=2, *, ids=None, metadata=None, scoped=False):
+    connection = lancedb.connect(tmp_path)
+    ids = ids if ids is not None else [f"note-{index}" for index in range(count)]
+    metadata = (
+        metadata if metadata is not None else [_metadata(i) for i in range(count)]
+    )
+    columns = {
+        "id": ids,
+        "text": [f"text-{i}" for i in range(count)],
+        "metadata": pa.array(metadata, pa.string()),
+        "vector": pa.array(
+            [[float(i), 1.0] for i in range(count)], pa.list_(pa.float32(), 2)
+        ),
+    }
+    if scoped:
+        columns[USER_ID_COLUMN] = pa.array([None] * count, pa.int64())
+        columns[SCOPE_DIMS_COLUMN] = pa.array([None] * count, pa.list_(pa.string()))
+    data = pa.table(columns).replace_schema_metadata(
+        {VECTOR_IDENTITY_METADATA_KEY: b"preserved"}
+    )
+    table = connection.create_table("memories", data)
+    _safe_close_table(table)
+    return connection
+
+
+def _table(connection):
+    return connection.open_table("memories")
+
+
+def _marker(table):
+    if USER_ID_COLUMN not in table.schema.names:
+        return None
+    return (table.schema.field(USER_ID_COLUMN).metadata or {}).get(
+        MAINTENANCE_METADATA_KEY
+    )
+
+
+def test_complete_migration_and_second_run_is_schema_only(tmp_path, monkeypatch):
+    connection = _connection(tmp_path)
+    first = maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    assert first.status is MaintenanceStatus.COMPLETE
+    assert table.to_arrow().select([USER_ID_COLUMN, SCOPE_DIMS_COLUMN]).to_pylist() == [
+        {USER_ID_COLUMN: 0, SCOPE_DIMS_COLUMN: ["agent=agent-0"]},
+        {USER_ID_COLUMN: 1, SCOPE_DIMS_COLUMN: ["agent=agent-1"]},
+    ]
+    assert _marker(table) == MAINTENANCE_VERSION
+    assert table.schema.metadata[VECTOR_IDENTITY_METADATA_KEY] == b"preserved"
+    _safe_close_table(table)
+
+    monkeypatch.setattr(
+        maintenance, "_read_rows", lambda _table: pytest.fail("fast path scanned")
+    )
+    second = maintain_lancedb_memory_table(connection, "memories")
+    assert second == maintenance.MaintenanceOutcome(MaintenanceStatus.COMPLETE)
+
+
+@pytest.mark.parametrize(("count", "batches"), [(512, 1), (513, 2)])
+def test_512_boundary_uses_one_commit_per_batch(tmp_path, count, batches):
+    connection = _connection(tmp_path, count=count)
+    table = _table(connection)
+    before = table.version
+    _safe_close_table(table)
+    outcome = maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    assert outcome.batches_committed == batches
+    assert outcome.updated_rows == count
+    assert table.version - before == batches + 2  # add columns + batches + marker
+    _safe_close_table(table)
+
+
+def test_sql_null_metadata_projects_to_empty_scope_without_network(
+    tmp_path, monkeypatch
+):
+    connection = _connection(tmp_path, count=1, metadata=[None])
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("maintenance must not embed or use the network")
+
+    monkeypatch.setattr(
+        "xagent.core.model.embedding.DashScopeEmbedding.encode", forbidden
+    )
+    outcome = maintain_lancedb_memory_table(connection, "memories")
+    row = _table(connection).to_arrow().to_pylist()[0]
+    assert outcome.status is MaintenanceStatus.COMPLETE
+    assert row[USER_ID_COLUMN] is None
+    assert row[SCOPE_DIMS_COLUMN] == []
+
+
+@pytest.mark.parametrize(
+    "ids",
+    [[None, "ok"], [1, 2], ["same", "same"], ["", "ok"]],
+)
+def test_invalid_ids_leave_table_unchanged(tmp_path, ids):
+    connection = _connection(tmp_path, ids=ids)
+    table = _table(connection)
+    before = (table.version, table.schema, table.to_arrow().to_pylist())
+    _safe_close_table(table)
+    result = maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    assert result.status is MaintenanceStatus.INVALID_LEGACY_DATA
+    assert (table.version, table.schema, table.to_arrow().to_pylist()) == before
+    _safe_close_table(table)
+
+
+@pytest.mark.parametrize("stage", ["columns_added", "batch_committed"])
+def test_partial_failure_resumes_without_repeating_completed_rows(
+    tmp_path, monkeypatch, stage
+):
+    connection = _connection(tmp_path, count=513)
+    original = maintenance._checkpoint
+
+    def fail(selected, batch=None):
+        if selected == stage and (batch is None or batch == 1):
+            raise RuntimeError("injected failure")
+        original(selected, batch)
+
+    monkeypatch.setattr(maintenance, "_checkpoint", fail)
+    with pytest.raises(RuntimeError, match="injected failure"):
+        maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    assert {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= set(table.schema.names)
+    assert _marker(table) is None
+    _safe_close_table(table)
+
+    monkeypatch.setattr(maintenance, "_checkpoint", original)
+    resumed = maintain_lancedb_memory_table(connection, "memories")
+    assert resumed.status is MaintenanceStatus.COMPLETE
+    assert resumed.updated_rows == (513 if stage == "columns_added" else 1)
+
+
+@pytest.mark.parametrize("change_metadata", [False, True])
+def test_concurrent_changes_are_preserved_and_metadata_change_is_reported(
+    tmp_path, monkeypatch, change_metadata
+):
+    connection = _connection(tmp_path, count=1, scoped=True)
+    original = maintenance._backfill_batch
+    changed_metadata = json.dumps({"user_id": 99})
+
+    def concurrent_update(table, rows):
+        writer = _table(connection)
+        values = {"text": "writer-text", "vector": [9.0, 9.0]}
+        if change_metadata:
+            values["metadata"] = changed_metadata
+        writer.update("id = 'note-0'", values=values)
+        _safe_close_table(writer)
+        return original(table, rows)
+
+    monkeypatch.setattr(maintenance, "_backfill_batch", concurrent_update)
+    result = maintain_lancedb_memory_table(connection, "memories")
+    row = _table(connection).to_arrow().to_pylist()[0]
+    assert (row["text"], row["vector"]) == ("writer-text", [9.0, 9.0])
+    if change_metadata:
+        assert result.status is MaintenanceStatus.INCOMPLETE
+        assert result.cas_skipped_rows
+        assert row["metadata"] == changed_metadata
+        assert _marker(_table(connection)) is None
+    else:
+        assert result.status is MaintenanceStatus.COMPLETE
+        assert row[USER_ID_COLUMN] == 0
+
+
+def test_completion_marker_is_last_and_failure_before_it_resumes(tmp_path, monkeypatch):
+    connection = _connection(tmp_path)
+
+    def fail(stage, _batch=None):
+        if stage == "before_completion":
+            raise RuntimeError("before marker")
+
+    monkeypatch.setattr(maintenance, "_checkpoint", fail)
+    with pytest.raises(RuntimeError, match="before marker"):
+        maintain_lancedb_memory_table(connection, "memories")
+    table = _table(connection)
+    assert _marker(table) is None
+    version = table.version
+    _safe_close_table(table)
+    monkeypatch.setattr(maintenance, "_checkpoint", lambda *_args: None)
+    assert (
+        maintain_lancedb_memory_table(connection, "memories").status
+        is MaintenanceStatus.COMPLETE
+    )
+    table = _table(connection)
+    assert table.version == version + 1
+    assert _marker(table) == MAINTENANCE_VERSION
+    _safe_close_table(table)
+
+
+def test_lock_timeout_is_bounded_and_success_releases_lock(tmp_path):
+    connection = _connection(tmp_path)
+    lock_path = maintenance._lock_path(connection, "memories")
+    with FileLock(lock_path):
+        started = time.monotonic()
+        with pytest.raises(MaintenanceLockTimeout, match="stop the other"):
+            maintain_lancedb_memory_table(connection, "memories", lock_timeout=0.05)
+        assert time.monotonic() - started < 1
+
+    maintain_lancedb_memory_table(connection, "memories", lock_timeout=0.05)
+    with FileLock(lock_path, timeout=0.05):
+        pass
+
+
+@pytest.mark.parametrize("timeout", [0, float("inf")])
+def test_nonpositive_lock_timeout_is_rejected(tmp_path, timeout):
+    connection = _connection(tmp_path)
+    with pytest.raises(ValueError, match="finite positive"):
+        maintain_lancedb_memory_table(connection, "memories", lock_timeout=timeout)


### PR DESCRIPTION
## Summary

- add an explicit, dormant admin lifecycle API for resumable LanceDB scope-column maintenance
- validate legacy IDs, metadata types, derived int64 user IDs, and exact scope schemas before mutation
- backfill in bounded 512-row NULL-safe CAS batches while preserving unrelated and concurrent row changes
- bind the completion marker to the exact table version so later commits invalidate the O(1) fast path
- serialize maintenance with a bounded cross-process file lock and document the required write-quiet completion window

## Validation

- 35 focused real-LanceDB tests on LanceDB 0.29.2
- 35 focused real-LanceDB tests on LanceDB 0.34.x
- 214 core memory tests
- Ruff format and lint checks
- source-local mypy
- Python bytecode compilation and diff check
- targeted mutations for legacy metadata/int64 preflight and strict pre-access parameter validation
- prior targeted mutations for NULL-safe CAS, snapshot overwrite, early completion, partial-resume behavior, and infinite lock waits

Production lines: 327
Test lines: 513
Total changed lines: 840

Closes #2211
Parent tracking: #2170
Depends on merged #2214
Superseded evidence only: #2172
