### PR TITLE
feat(tools): add a tzdata-backed local-time validation tool

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/base.py
+++ b/src/xagent/core/tools/adapters/vibe/base.py
@@ -55,7 +55,9 @@ BINDING_AUTHORIZED_CATEGORIES: frozenset[str] = frozenset({ToolCategory.SSH.valu
 # names outside the category match. An explicit NONE (zero-tools) spec still
 # excludes them. Legacy allow-list / per-user override paths do a plain name
 # intersection and are not aware of this set, so they can still drop these.
-INTRINSIC_TOOL_NAMES: frozenset[str] = frozenset({"get_current_time"})
+INTRINSIC_TOOL_NAMES: frozenset[str] = frozenset(
+    {"get_current_time", "validate_local_time"}
+)
 
 
 class ToolMetadata(BaseModel):

--- a/src/xagent/core/tools/adapters/vibe/current_time_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/current_time_tool.py
@@ -1,6 +1,7 @@
+import re
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
-from typing import Any, Mapping, Optional, Type
+from typing import Any, Literal, Mapping, Optional, Type
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError, available_timezones
 
 from pydantic import BaseModel, Field
@@ -77,10 +78,15 @@ def _resolve_zone(name: Optional[str]) -> Optional[ZoneInfo]:
 
 
 def _format_offset(offset: timedelta) -> str:
+    # Seconds are shown only when non-zero: dropping them would contradict the
+    # local/utc pair reported beside this string. Liberia ran -00:44:30 until
+    # 1972, so it is reachable from an ordinary historical date, not just LMT.
     sign = "-" if offset < timedelta(0) else "+"
     hours, remainder = divmod(abs(offset), timedelta(hours=1))
-    minutes = remainder // timedelta(minutes=1)
-    return f"{sign}{hours:02d}:{minutes:02d}"
+    minutes, remainder = divmod(remainder, timedelta(minutes=1))
+    seconds = remainder // timedelta(seconds=1)
+    stamp = f"{sign}{hours:02d}:{minutes:02d}"
+    return f"{stamp}:{seconds:02d}" if seconds else stamp
 
 
 def current_time(timezone_name: Optional[str] = None) -> CurrentTimeResult:
@@ -126,7 +132,10 @@ class CurrentTimeTool(AbstractBaseTool):
             "long something took, checking whether a deadline has passed, or "
             "resolving a relative date during a turn that may have crossed "
             "midnight. Pass the timezone named in the system prompt's "
-            "date-and-time line to get local time alongside UTC."
+            "date-and-time line to get local time alongside UTC. This reports "
+            "only the present moment: to turn some other local date and time "
+            "into UTC, or to check whether one exists in a zone that changes "
+            "its clocks, call the validate_local_time tool if it is available."
         )
 
     def args_type(self) -> Type[BaseModel]:
@@ -147,3 +156,184 @@ class CurrentTimeTool(AbstractBaseTool):
 async def create_current_time_tool(config: WebToolConfig) -> list[AbstractBaseTool]:
     """Create the current-time tool."""
     return [CurrentTimeTool()]
+
+
+class ValidateLocalTimeArgs(BaseModel):
+    local_time: str = Field(
+        description=(
+            "The local wall-clock date-time to check, as 'YYYY-MM-DD HH:MM' or "
+            "'YYYY-MM-DD HH:MM:SS' (a space or 'T' between date and time). A "
+            "reading of the clock in the named zone, so it carries no offset "
+            "and no trailing 'Z'. The time of day is required."
+        )
+    )
+    # Field name is the wire contract; it locally shadows the datetime.timezone
+    # import, which this class body does not use.
+    timezone: str = Field(
+        description=(
+            "IANA zone name in Region/City form, for example "
+            "'Australia/Sydney'. When the question does not name a zone, copy "
+            "the one from the system prompt's date-and-time line rather than "
+            "the example here. An abbreviation ('EST'), a bare city "
+            "('Sydney'), an 'Etc/*' name, or an unknown name is an error, not "
+            "a fallback to UTC."
+        )
+    )
+
+
+class LocalTimeMapping(BaseModel):
+    local: str = Field(description="The local wall-clock time.")
+    abbreviation: str = Field(
+        description="Zone abbreviation at this instant, e.g. 'AEST' or '+1030'."
+    )
+    utc_offset: str = Field(description="Offset from UTC at this instant.")
+    utc: str = Field(description="The matching UTC time.")
+
+
+class ValidateLocalTimeResult(BaseModel):
+    # Not named 'status': that key is the framework's tool-result control
+    # channel (see core/agent/result.py), where 'error' fails the call.
+    local_time_status: Literal["unique", "nonexistent", "ambiguous"] = Field(
+        description="Whether the local time exists once, not at all, or twice."
+    )
+    mappings: list[LocalTimeMapping] = Field(
+        description="Valid UTC instants for this local time, earliest first."
+    )
+    # Field name is the wire contract; it locally shadows the datetime.timezone
+    # import, which this class body does not use.
+    timezone: str = Field(description="The resolved (case-normalized) zone name.")
+
+
+def _stamp(moment: datetime) -> str:
+    # isoformat, not strftime: %Y is platform-delegated and glibc renders a
+    # year below 1000 unpadded, which an eastward offset reaches in 'utc'
+    # even for a 4-digit local year.
+    return moment.replace(tzinfo=None).isoformat(sep=" ", timespec="seconds")
+
+
+def _mapping(local: datetime, utc: datetime) -> LocalTimeMapping:
+    offset = local.utcoffset()
+    return LocalTimeMapping(
+        local=_stamp(local),
+        abbreviation=local.tzname() or "",
+        utc_offset=_format_offset(offset if offset is not None else timedelta(0)),
+        utc=_stamp(utc),
+    )
+
+
+def validate_local_time(local_time: str, timezone_name: str) -> ValidateLocalTimeResult:
+    """Resolve a wall-clock time in a zone to every UTC instant it names."""
+    zone = _resolve_zone(timezone_name)
+    if zone is None:
+        raise ValueError(f"Unknown IANA timezone: {timezone_name!r}")
+    # Region/City only (plus UTC). These are all real tzdata entries that do
+    # not mean what a caller naming them means: 'EST' is a fixed -05:00 that
+    # never observes DST, 'Etc/GMT+10' inverts the sign to -10:00, 'Factory'
+    # is a placeholder. Here the offset IS the answer, so guessing wrong is
+    # worse than refusing. get_current_time keeps accepting them: there a bad
+    # zone only skews a displayed clock.
+    if zone.key != "UTC" and ("/" not in zone.key or zone.key.startswith("Etc/")):
+        raise ValueError(
+            "timezone must be a Region/City IANA name such as "
+            f"'Australia/Sydney' or 'UTC', not {timezone_name!r}"
+        )
+    # Matched strictly rather than left to fromisoformat, which also accepts
+    # forms this contract does not offer: a bare date would silently be read
+    # as midnight, and on 3.14 '24:00' as the next day's midnight, answering
+    # for a date the caller never named.
+    text = local_time.strip()
+    if not re.fullmatch(
+        r"[0-9]{4}-[0-9]{2}-[0-9]{2}[ T]"
+        r"(?:[01][0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9])?",
+        text,
+    ):
+        raise ValueError(
+            "local_time must be 'YYYY-MM-DD HH:MM' or 'YYYY-MM-DD HH:MM:SS', "
+            "with no offset or 'Z'"
+        )
+    try:
+        naive = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(f"local_time is not a real date and time: {text!r}") from exc
+
+    # PEP 495: fold 0 and 1 are the two candidate readings. Each is kept only
+    # if it converts back to the requested wall time -- a candidate that does
+    # not is the zone telling us this reading does not exist. Trusting one
+    # fold's offset instead would misreport zones whose fold=0 reading returns
+    # an offset they never have (America/Nuuk under tzdata 2025c).
+    by_instant: dict[datetime, datetime] = {}
+    for fold in (0, 1):
+        local = naive.replace(fold=fold, tzinfo=zone)
+        try:
+            utc = local.astimezone(timezone.utc)
+            round_trip = utc.astimezone(zone).replace(tzinfo=None)
+        except (OverflowError, OSError) as exc:
+            raise ValueError(
+                f"local_time converts outside the representable date range: {text!r}"
+            ) from exc
+        if round_trip == naive:
+            by_instant.setdefault(utc, local)
+
+    mappings = [_mapping(by_instant[utc], utc) for utc in sorted(by_instant)]
+    status: Literal["unique", "nonexistent", "ambiguous"] = (
+        "nonexistent"
+        if not mappings
+        else "unique"
+        if len(mappings) == 1
+        else "ambiguous"
+    )
+    return ValidateLocalTimeResult(
+        local_time_status=status, mappings=mappings, timezone=zone.key
+    )
+
+
+class ValidateLocalTimeTool(AbstractBaseTool):
+    """Resolves a given wall-clock time to UTC from tzdata, which the model
+    must not infer: daylight-saving gaps, overlaps, offsets and abbreviations
+    are all read from the zone database."""
+
+    category = ToolCategory.OTHER
+    read_only = True  # pure tzdata lookup ⇒ concurrency-safe
+
+    def __init__(self) -> None:
+        self._visibility = ToolVisibility.PUBLIC
+
+    @property
+    def name(self) -> str:
+        return "validate_local_time"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Check whether a specific local date-time exists in an IANA "
+            "timezone and which UTC instants it maps to. Call this instead of "
+            "working out a daylight-saving change yourself. When clocks spring "
+            "forward the local time is skipped and no UTC instant matches "
+            "(local_time_status 'nonexistent', no mappings); when they go back "
+            "it occurs twice ('ambiguous', two mappings). Quote the offset and "
+            "abbreviation from each mapping rather than recalling which one the "
+            "zone uses in a given season, and note that only the local clock "
+            "jumps at such a change -- UTC itself runs continuously. For the "
+            "time right now use get_current_time instead."
+        )
+
+    def args_type(self) -> Type[BaseModel]:
+        return ValidateLocalTimeArgs
+
+    def return_type(self) -> Type[BaseModel]:
+        return ValidateLocalTimeResult
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        parsed = ValidateLocalTimeArgs.model_validate(args)
+        return validate_local_time(parsed.local_time, parsed.timezone).model_dump()
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        return self.run_json_sync(args)
+
+
+@register_tool(selection_gate="intrinsic")
+async def create_validate_local_time_tool(
+    config: WebToolConfig,
+) -> list[AbstractBaseTool]:
+    """Create the local-time validation tool."""
+    return [ValidateLocalTimeTool()]

--- a/tests/core/tools/adapters/vibe/test_basic_tools_web_search_provider.py
+++ b/tests/core/tools/adapters/vibe/test_basic_tools_web_search_provider.py
@@ -134,10 +134,14 @@ async def test_web_search_category_selection_keeps_web_fetch_tool(monkeypatch):
 
     tools = await ToolFactory.create_all_tools(config)
 
-    # get_current_time is intrinsic: it rides along every non-NONE selection
-    # regardless of category, so a web_search-only agent sees it too (#1729).
-    # It sorts last, being category OTHER rather than BASIC.
-    assert _tool_names(tools) == ["fetch_web_content", "get_current_time"]
+    # The time tools are intrinsic: they ride along every non-NONE selection
+    # regardless of category, so a web_search-only agent sees them too
+    # (#1729). They sort last, being category OTHER rather than BASIC.
+    assert _tool_names(tools) == [
+        "fetch_web_content",
+        "get_current_time",
+        "validate_local_time",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/test_validate_local_time_tool.py
+++ b/tests/core/tools/test_validate_local_time_tool.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import asyncio
+import zoneinfo
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+from pydantic import ValidationError
+
+from xagent.core.tools.adapters.vibe.current_time_tool import (
+    ValidateLocalTimeTool,
+    validate_local_time,
+)
+from xagent.core.tools.adapters.vibe.factory import ToolFactory, ToolRegistry
+from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
+
+# The sibling suite owns this stub; both tools go through the same pipeline.
+from .test_current_time_tool import _FakeConfig
+
+
+def _rows(local_time: str, zone: str) -> list[tuple[str, str, str, str]]:
+    result = validate_local_time(local_time, zone)
+    return [(m.local, m.abbreviation, m.utc_offset, m.utc) for m in result.mappings]
+
+
+def test_skipped_local_time_does_not_exist() -> None:
+    # Sydney springs forward at 02:00 on 4 Oct 2026, so 02:30 never occurs.
+    result = validate_local_time("2026-10-04 02:30", "Australia/Sydney")
+
+    assert result.local_time_status == "nonexistent"
+    assert result.mappings == []
+    assert result.timezone == "Australia/Sydney"
+
+
+def test_repeated_local_time_reports_both_instants() -> None:
+    # Sydney goes back at 03:00 on 5 Apr 2026, so 02:30 occurs twice. The
+    # abbreviation and offset on each row are what the model must quote
+    # instead of recalling which one applies in a given season.
+    result = validate_local_time("2026-04-05 02:30", "Australia/Sydney")
+
+    assert result.local_time_status == "ambiguous"
+    assert _rows("2026-04-05 02:30", "Australia/Sydney") == [
+        ("2026-04-05 02:30:00", "AEDT", "+11:00", "2026-04-04 15:30:00"),
+        ("2026-04-05 02:30:00", "AEST", "+10:00", "2026-04-04 16:30:00"),
+    ]
+
+
+def test_ordinary_local_time_maps_to_one_instant() -> None:
+    assert _rows("2026-06-01 09:00", "Australia/Sydney") == [
+        ("2026-06-01 09:00:00", "AEST", "+10:00", "2026-05-31 23:00:00")
+    ]
+
+
+@pytest.fixture
+def bundled_tzdata_only() -> Iterator[None]:
+    """Run against the tzdata wheel, as in a container with no system zoneinfo.
+
+    Required, not incidental: the fold-validation this fixture exercises is
+    indistinguishable from trusting one fold under a tzdata release where no
+    zone has the Nuuk shape (macOS ships 2026c, which has none).
+    """
+    original = zoneinfo.TZPATH
+    zoneinfo.reset_tzpath([])
+    ZoneInfo.clear_cache()
+    try:
+        yield
+    finally:
+        zoneinfo.reset_tzpath(original)
+        ZoneInfo.clear_cache()
+
+
+def test_a_reading_a_fold_reports_but_cannot_convert_back_is_dropped(
+    bundled_tzdata_only: None,
+) -> None:
+    # Nuuk's fold=0 reading claims -01:00, an offset it does not have at the
+    # resulting instant; fold=1 claims -02:00 and converts back exactly.
+    # Trusting one fold's offset instead of validating each candidate reports
+    # this real, single instant as ambiguous with a fabricated second reading.
+    result = validate_local_time("2023-10-28 23:30", "America/Nuuk")
+
+    assert result.local_time_status == "unique"
+    assert result.mappings[0].utc == "2023-10-29 01:30:00"
+    assert result.mappings[0].utc_offset == "-02:00"
+
+
+@pytest.mark.parametrize(
+    "zone",
+    ["Australia/Sydney", "Australia/Lord_Howe", "Pacific/Apia", "America/St_Johns"],
+)
+@pytest.mark.parametrize(
+    "local_time", ["2026-10-04 02:15", "2026-04-05 02:30", "2011-12-30 12:00"]
+)
+def test_every_reported_mapping_round_trips(zone: str, local_time: str) -> None:
+    # The one invariant behind all three classifications, asserted without
+    # fixed expectations so it holds under any tzdata release: a reported
+    # instant must convert back to exactly the wall time that was asked about.
+    asked = datetime.fromisoformat(local_time)
+
+    for mapping in validate_local_time(local_time, zone).mappings:
+        instant = datetime.fromisoformat(mapping.utc).replace(tzinfo=timezone.utc)
+        assert instant.astimezone(ZoneInfo(zone)).replace(tzinfo=None) == asked
+
+
+def test_half_hour_offset_is_reported_with_its_minutes() -> None:
+    # Lord Howe has no lettered abbreviation, so the model has to quote the
+    # numeric one it is given. Pinned on standard time, where the offset
+    # actually carries the half hour.
+    assert _rows("2026-06-01 12:00", "Australia/Lord_Howe") == [
+        ("2026-06-01 12:00:00", "+1030", "+10:30", "2026-06-01 01:30:00")
+    ]
+
+
+def test_a_half_hour_shift_keeps_both_readings_distinct() -> None:
+    assert _rows("2026-04-05 01:45", "Australia/Lord_Howe") == [
+        ("2026-04-05 01:45:00", "+11", "+11:00", "2026-04-04 14:45:00"),
+        ("2026-04-05 01:45:00", "+1030", "+10:30", "2026-04-04 15:15:00"),
+    ]
+
+
+def test_sub_minute_offset_keeps_its_seconds() -> None:
+    # Liberia ran -00:44:30 until 1972. Truncating to whole minutes would make
+    # utc_offset contradict the local/utc pair in the same row, and the
+    # description tells the model to quote that offset.
+    assert _rows("1971-01-01 12:00", "Africa/Monrovia") == [
+        ("1971-01-01 12:00:00", "MMT", "-00:44:30", "1971-01-01 12:44:30")
+    ]
+
+
+@pytest.mark.parametrize(
+    "zone",
+    [
+        "EST",  # a fixed -05:00 that never observes DST
+        "MST",
+        "GMT",
+        "CET",
+        "Etc/GMT+10",  # POSIX sign inversion: actually -10:00
+        "Factory",
+    ],
+)
+def test_a_name_that_does_not_mean_a_place_is_rejected(zone: str) -> None:
+    # These all resolve, so the offset would be returned with no signal that
+    # it is not the zone the caller meant. Here the offset is the answer.
+    with pytest.raises(ValueError, match="Region/City"):
+        validate_local_time("2026-07-15 12:00", zone)
+
+
+@pytest.mark.parametrize("zone", ["UTC", "utc", "America/New_York", "us/eastern"])
+def test_a_name_that_does_mean_a_place_is_accepted(zone: str) -> None:
+    assert validate_local_time("2026-07-15 12:00", zone).mappings
+
+
+def test_zone_name_is_case_insensitive() -> None:
+    assert validate_local_time("2026-06-01 09:00", "australia/sydney").timezone == (
+        "Australia/Sydney"
+    )
+
+
+@pytest.mark.parametrize("zone", ["Not/AZone", "", "   ", "/etc/passwd"])
+def test_unknown_zone_is_rejected(zone: str) -> None:
+    with pytest.raises(ValueError, match="Unknown IANA timezone"):
+        validate_local_time("2026-06-01 09:00", zone)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "not a time",
+        "",
+        "2026-10-04",  # a bare date would silently mean midnight
+        "2026-06-01 09:00+10:00",
+        "2026-06-01T09:00:00Z",
+        "2026-06-01 09:00:00.5",
+        "2026-6-1 9:00",
+        "20260601T0900",
+        "2026-06-01 09:00\x00",
+        "٢٠٢٦-٠٦-٠١ ٠٩:٠٠",  # \d would admit non-ASCII digits
+        "2026-06-01 0٩:00",
+        "2026-06-01 09:60",
+    ],
+)
+def test_malformed_local_time_is_rejected(bad: str) -> None:
+    with pytest.raises(ValueError, match="local_time must be"):
+        validate_local_time(bad, "Australia/Sydney")
+
+
+@pytest.mark.parametrize("bad", ["2026-10-03 24:00", "2026-10-03 24:00:00"])
+def test_hour_24_is_rejected_rather_than_rolled_to_the_next_day(bad: str) -> None:
+    # Python 3.14's fromisoformat reads '24:00' as the next day's midnight,
+    # which would answer for a date the caller never named. requires-python
+    # allows 3.14, so the bound lives in the pattern.
+    with pytest.raises(ValueError, match="local_time must be"):
+        validate_local_time(bad, "Australia/Sydney")
+
+
+def test_well_formed_but_unreal_date_is_rejected() -> None:
+    with pytest.raises(ValueError, match="not a real date and time"):
+        validate_local_time("2026-02-29 09:00", "Australia/Sydney")
+
+
+def test_conversion_leaving_the_representable_range_is_a_value_error() -> None:
+    with pytest.raises(ValueError, match="representable date range"):
+        validate_local_time("9999-12-31 23:59", "America/New_York")
+
+
+def test_year_below_1000_is_zero_padded() -> None:
+    # An eastward offset reaches year 999 from a 4-digit local year. glibc's
+    # strftime("%Y") would render it unpadded; this can only fail there, since
+    # macOS pads either way.
+    only = validate_local_time("1000-01-01 09:00", "Australia/Sydney").mappings[0]
+
+    assert (only.local, only.utc) == ("1000-01-01 09:00:00", "0999-12-31 22:55:08")
+
+
+def test_tool_runs_through_the_json_surface() -> None:
+    tool = ValidateLocalTimeTool()
+
+    assert tool.run_json_sync(
+        {"local_time": "2026-10-04 02:30", "timezone": "Australia/Sydney"}
+    ) == {
+        "local_time_status": "nonexistent",
+        "mappings": [],
+        "timezone": "Australia/Sydney",
+    }
+    assert asyncio.run(
+        tool.run_json_async(
+            {"local_time": "2026-06-01 09:00", "timezone": "Australia/Sydney"}
+        )
+    ) == {
+        "local_time_status": "unique",
+        "mappings": [
+            {
+                "local": "2026-06-01 09:00:00",
+                "abbreviation": "AEST",
+                "utc_offset": "+10:00",
+                "utc": "2026-05-31 23:00:00",
+            }
+        ],
+        "timezone": "Australia/Sydney",
+    }
+
+
+def test_json_surface_rejects_a_missing_field() -> None:
+    with pytest.raises(ValidationError):
+        ValidateLocalTimeTool().run_json_sync({"timezone": "Australia/Sydney"})
+
+
+def test_status_field_avoids_the_tool_result_control_channel() -> None:
+    # A top-level 'status' of 'error' fails the whole tool call, and
+    # 'waiting_for_user' suspends the turn (core/agent/result.py).
+    payload = ValidateLocalTimeTool().run_json_sync(
+        {"local_time": "2026-06-01 09:00", "timezone": "Australia/Sydney"}
+    )
+
+    assert "status" not in payload
+
+
+def test_description_hands_off_from_the_current_time_tool() -> None:
+    from xagent.core.tools.adapters.vibe.current_time_tool import CurrentTimeTool
+
+    # The system prompt names only get_current_time, so the hand-off has to
+    # come from its description.
+    assert "validate_local_time" in CurrentTimeTool().description
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        (ToolSelectionSpec.from_raw(tool_categories=None), 1),  # ALL
+        (ToolSelectionSpec.from_raw(tool_categories=["web_search"]), 1),  # non-basic
+        (ToolSelectionSpec.from_raw(tool_categories=[]), 0),  # explicit NONE
+    ],
+)
+async def test_intrinsic_tool_is_assembled_for_non_none_specs(
+    spec: ToolSelectionSpec, expected: int
+) -> None:
+    tools = await ToolFactory.create_all_tools(
+        _FakeConfig(spec), apply_user_override_filter=False
+    )
+
+    assert [t.name for t in tools].count("validate_local_time") == expected
+
+
+async def test_intrinsic_creator_is_skipped_for_explicit_none() -> None:
+    # Pinned at the registry level: the post-build name filter is a second
+    # guard that would otherwise mask a missing selection_gate.
+    tools = await ToolRegistry.create_registered_tools(
+        _FakeConfig(ToolSelectionSpec.from_raw(tool_categories=[]))
+    )
+
+    assert "validate_local_time" not in [getattr(t, "name", None) for t in tools]


### PR DESCRIPTION
## Background

A customer asked the agent: in Australia/Sydney, does 2:30am on Sunday, 4 October 2026 exist, and is 2:30am on Sunday, 5 April 2026 ambiguous?

All three conclusions were right, but the explanation of the DST change was wrong twice: it said the clocks jump forward "at 2:00am **AEDT**" (before the change Sydney is on AEST), and "DST transition in UTC: 15:00 UTC -> 16:00 UTC", i.e. UTC skipping an hour. **UTC never jumps** — only the local clock does, going straight from 01:59:59 to 03:00:00.

Root cause: the only time tool available was `get_current_time`, which reports what time it is *now* and cannot check a *specific* date. With nothing to call, the agent reasoned about DST in prose and got the details wrong. The conclusions happened to be right; the next date they need not be.

## Invariant

Any claim about whether a given wall-clock time exists, and which UTC instants it names, comes from a tzdata lookup rather than from model recall.

## Change

A new intrinsic tool, `validate_local_time`:

- **Input**: a local wall-clock time (`YYYY-MM-DD HH:MM[:SS]`, no offset) plus an IANA `Region/City` zone name.
- **Output** `local_time_status`: `nonexistent` (skipped, no mapping), `ambiguous` (occurs twice, two mappings), or `unique` (one mapping). Each mapping carries the UTC instant, the UTC offset and the zone abbreviation actually in effect, earliest first.
- Classification validates each `fold` candidate by converting it back to the requested wall time and keeping only what round-trips. This does not depend on any single fold reading being sane — see the `America/Nuuk` case below.
- stdlib `zoneinfo` only; **no new dependency**.
- Registered `selection_gate="intrinsic"` like `get_current_time`, so it is present for any non-NONE tool selection.
- An unknown zone, a name that resolves but does not mean a place (`EST`, `Etc/GMT+10`, `Factory`), a malformed time, a bare date, or an input carrying an offset or `Z` all **raise**. A validation tool must not appear to succeed.

The two cases from the incident:

| input | status | mappings |
|---|---|---|
| `2026-10-04 02:30` Australia/Sydney | `nonexistent` | none |
| `2026-04-05 02:30` Australia/Sydney | `ambiguous` | AEDT +11:00 → 15:30Z; AEST +10:00 → 16:30Z |

### Details worth knowing

**Why candidates are validated rather than one fold trusted.** Under IANA 2025c — the `tzdata` wheel this repo installs, and the fallback in any container without `/usr/share/zoneinfo` — `America/Nuuk`'s `fold=0` reading returns an offset the zone does not have at the resulting instant. Trusting it reported `2023-10-28 23:30` as nonexistent when it is a real, single instant (`2023-10-29 01:30Z`). Swept 598 zones × every transition against an exact oracle under both 2025c and 2026c: no classification, abbreviation or ordering mismatches.

**`_format_offset` now emits seconds when non-zero.** Truncating to whole minutes made `utc_offset` contradict the `local`/`utc` pair in the same row. Not an antiquity concern: `Africa/Monrovia` ran `-00:44:30` until 1972-01-07, and 6,595 of 491,557 swept mappings were affected. `get_current_time` is unaffected — no zone has a sub-minute offset at the present moment.

**Hours are bounded in the pattern, not left to `fromisoformat`.** On Python 3.14 (permitted by `requires-python = ">=3.11"`) `fromisoformat("2026-10-04 24:00")` returns the *next day's* midnight, which would answer for a date the caller never named.

**Timestamps use `isoformat`, not `strftime`.** `%Y` is platform-delegated and glibc does not zero-pad a year below 1000, which an eastward offset reaches in `utc` even from a 4-digit local year.

**The result field is `local_time_status`, not `status`.** A top-level `status` is the framework's tool-result control channel, where `error` fails the whole call.

## Entry points

- `validate_local_time` tool calls, in any execution pattern
- the intrinsic assembly path in `ToolFactory.create_all_tools`

## Non-goals

- **No system-prompt change.** The two time paragraphs still name only `get_current_time`; the hand-off lives in that tool's description, hedged with "if it is available" per `execution.py:598`. Whether prompt-level guidance is warranted should be decided from observed call rates.
- No behaviour change to `get_current_time`, including its tolerance for abbreviation zone names.
- No conversion between two zones, and no date arithmetic beyond local → UTC.
- Nothing about how a widget or session propagates a timezone.

## Files

| File | Change |
|---|---|
| `current_time_tool.py` | The tool, plus seconds in the shared `_format_offset` |
| `base.py` | `INTRINSIC_TOOL_NAMES` gains the new name; without it the tool is dropped by category filtering |
| `test_validate_local_time_tool.py` | New tests |
| `test_basic_tools_web_search_provider.py` | An existing assembly assertion updated for the new intrinsic tool |

198 lines of source, 292 of tests.

## Verification

- Both incident cases; ordinary unique mappings; half-hour offsets on standard time and across an overlap (`Australia/Lord_Howe`, including its numeric `+1030` abbreviation); the sub-minute `Africa/Monrovia` offset; the `America/Nuuk` fold case, run against the bundled tzdata wheel via a fixture that empties `TZPATH` — required, since the bug cannot reproduce under the 2026c that macOS ships.
- Rejection of unknown zones, non-place names, malformed input, a bare date, hour 24, non-ASCII digits, unreal dates, and conversions leaving the representable range.
- A round-trip invariant asserted without fixed expectations, so it holds under any tzdata release.
- Assembly pinned at both levels: tool counts under ALL / a single non-basic category / explicit NONE, plus a registry-level assertion that an explicit zero-tools agent never builds the tool.
- Every guard mutation-tested to confirm it fails when the behaviour it protects is removed — including reproducing the earlier fold-trusting logic to check the Nuuk test catches it.
- Full `pre-commit` (ruff / ruff format / mypy / isort / codespell) clean; the assembly and agent-context suites pass.

## Blocking criteria

- `2026-10-04 02:30` Sydney must be `nonexistent` with no mappings; `2026-04-05 02:30` must be `ambiguous` with AEDT/+11:00 and AEST/+10:00.
- `2023-10-28 23:30` America/Nuuk must be `unique` at `2023-10-29 01:30:00` under the bundled tzdata.
- A sub-minute offset must report its seconds.
- `EST` and `Etc/GMT+10` must be refused.
- An explicit zero-tools (NONE) agent must not receive this tool.

## Known limits

- Offsets before a zone kept a whole-minute offset are local mean time and approximate.
- `nonexistent` and `ambiguous` can also arise from a dateline move (`Pacific/Apia` 2011) or a standard-offset change (`Asia/Pyongyang` 2015, where both readings are `KST`), which the description currently attributes to daylight saving alone.
- `return_type()` is not serialized into the LLM tool schema, so the result-shape guidance the model receives is what the tool description carries.
