### PR TITLE
fix(agents): fill the main model slot for template-created agents

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -547,9 +547,11 @@ jobs:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
       - name: Test agent general-model backfill migration (Postgres-only)
-        # Its fixture drops and recreates the four tables it touches, by name,
-        # so this step neither depends on nor preserves state from its
-        # neighbours -- it can be reordered freely.
+        # Keep last. Its fixture DROPs agents/users/models/user_models with
+        # CASCADE and rebuilds them from ORM metadata, which also takes out
+        # ~40 foreign keys on tables it does not own and leaves
+        # alembic_version pointing at head over a schema no migration built.
+        # Anything Postgres-based that runs after it sees that schema.
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pytest tests/migrations/test_20260908_backfill_agent_general_model.py -m postgresql -q

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -547,6 +547,9 @@ jobs:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
       - name: Test agent general-model backfill migration (Postgres-only)
+        # Its fixture drops and recreates the four tables it touches, by name,
+        # so this step neither depends on nor preserves state from its
+        # neighbours -- it can be reordered freely.
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pytest tests/migrations/test_20260908_backfill_agent_general_model.py -m postgresql -q

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -546,6 +546,13 @@ jobs:
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
+      - name: Test agent general-model backfill migration (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/migrations/test_20260908_backfill_agent_general_model.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
   migrations-summary:
     name: Migrations Summary
     runs-on: ubuntu-latest

--- a/src/xagent/migration/loaders.py
+++ b/src/xagent/migration/loaders.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 from ..web.models.agent import Agent
 from ..web.models.skill import UserSkill
 from ..web.models.user import User
+from ..web.services.agent_store import with_default_general_model
 from .bundle import ArchivedItem, MigrationBundle
 
 # xagent's scheduled triggers currently fire on a fixed interval only; standard
@@ -138,7 +139,10 @@ class MigrationLoader:
             description=f"Imported from {bundle.source}.",
             instructions=instructions,
             execution_mode="balanced",
-            models={},
+            # Built here rather than through AgentStore.add_agent (this path
+            # owns its own commit), so the default-model fallback is applied
+            # explicitly instead of being inherited.
+            models=with_default_general_model(self.db, {}, user_id=self.user_id),
             knowledge_bases=[],
             skills=[],
             tool_categories=[],

--- a/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
+++ b/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
@@ -6,7 +6,6 @@ Create Date: 2026-09-08 00:00:00.000000
 
 """
 
-import json
 import logging
 from typing import Sequence, Union
 
@@ -15,7 +14,8 @@ from alembic import op
 
 logger = logging.getLogger(__name__)
 
-_CHUNK_SIZE = 1000
+# Hidden from every user-facing read path; see the scope note in upgrade().
+WORKFORCE_MANAGER_ORIGIN = "workforce_generated_manager"
 
 revision: str = "20260908_backfill_agent_general_model"
 down_revision: Union[str, tuple[str, str], None] = "20260901_seed_zendesk_mcp_app"
@@ -27,15 +27,32 @@ def upgrade() -> None:
     """Fill an unset `general` slot from the owner's default model.
 
     Server-side agent creation passed no model config at all, so those agents
-    persisted an empty config: the builder rendered "--" for Main Model and
-    refused to save until the owner picked one by hand. Runtime already fell
-    back to the owner's default (`get_default_model`), so this only writes
-    down what execution was resolving anyway.
+    persisted an unset config: the builder rendered "--" for Main Model and
+    refused to save until the owner picked one by hand.
 
-    Note that `Agent.models` is `Column(JSON)` with SQLAlchemy's default
-    `none_as_null=False`, so an unset config is stored as the JSON text
-    `null`, not SQL NULL. `WHERE models IS NULL` matches none of these rows,
-    which is why each payload is read back and inspected in Python.
+    `Agent.models` is `Column(JSON)` with SQLAlchemy's default
+    `none_as_null=False`, so an unset config is the JSON text `null`, **not**
+    SQL NULL -- `WHERE models IS NULL` matches none of these rows.
+
+    Scope, and why it is this narrow:
+
+    * Only `models` = JSON `null`. A config object that merely omits
+      `general` would need a read-modify-write to preserve its other slots;
+      production holds no such row (every row is either JSON `null` or an
+      object with `general` set), so that machinery would be dead code.
+    * Only private agents (`team_id IS NULL AND NOT share_enabled`). An
+      unset config is resolved per runner at execution time against *that
+      user's* default (`llm_utils.resolve_llms_from_names` ->
+      `get_configured_defaults(user_id)`), so filling it on a shared agent
+      would silently switch every other runner onto the owner's model.
+      Private agents have exactly one runner, so there is no such change.
+    * Not `workforce_generated_manager`, which `list_agent_items` and
+      `get_owned_agent` filter out of every user-facing read: no UI ever
+      showed "--" for these, so filling them buys nothing.
+
+    One UPDATE per owner, so the row's state is re-tested by the database at
+    write time. A read-then-write would let a `PUT /api/agents/{id}` from an
+    old replica during a rolling deploy land in between and be clobbered.
     """
     bind = op.get_bind()
     inspector = sa.inspect(bind)
@@ -44,24 +61,17 @@ def upgrade() -> None:
         return
 
     agent_columns = {col["name"] for col in inspector.get_columns("agents")}
-    if not {"models", "user_id"} <= agent_columns:
+    required = {"models", "user_id", "team_id", "share_enabled", "origin"}
+    if not required <= agent_columns:
         return
 
-    # Read `models` as text and deserialize per row: binding it as sa.JSON
-    # would decode during result iteration, where one malformed payload
-    # aborts the whole run instead of just its own row. On PostgreSQL the
-    # driver still hands back a decoded object for a json column, so the
-    # loop below accepts either shape. Writes go through the JSON-typed
-    # table so the value is encoded the same way the ORM encodes it.
-    agents_read = sa.table(
+    agents = sa.table(
         "agents",
         sa.column("id", sa.Integer),
         sa.column("user_id", sa.Integer),
-        sa.column("models", sa.Text),
-    )
-    agents_write = sa.table(
-        "agents",
-        sa.column("id", sa.Integer),
+        sa.column("team_id", sa.Integer),
+        sa.column("share_enabled", sa.Boolean),
+        sa.column("origin", sa.String),
         sa.column("models", sa.JSON),
     )
     user_defaults = sa.table(
@@ -76,9 +86,9 @@ def upgrade() -> None:
         sa.column("is_active", sa.Boolean),
     )
 
-    # Only the owner's own default is used. Resolving the shared-default
-    # fallback that ModelStore applies would mean replicating its
-    # visibility rules here, which drift as that code changes.
+    # Only the owner's own default, matching AgentStore's create-time
+    # fallback exactly. Neither side consults ModelStore's shared-default
+    # layer, so an agent's slot never depends on when it was created.
     default_by_user = {
         int(row["user_id"]): int(row["model_id"])
         for row in bind.execute(
@@ -97,60 +107,34 @@ def upgrade() -> None:
         )
         return
 
-    # Ids first, payloads a chunk at a time: `models` is small but the row
-    # count is unbounded, and Connection.execute buffers a whole result set.
-    # Reading ids to exhaustion also keeps the updates below off an open
-    # cursor over the same table. Chunks are contiguous slices of the sorted
-    # id list, so they are addressed by range rather than by an IN list --
-    # SQLite caps bound parameters at 999 before 3.32.0.
-    agent_ids = list(
-        bind.execute(sa.select(agents_read.c.id).order_by(agents_read.c.id)).scalars()
+    # JSON null compares as its text form on both backends: SQLite stores the
+    # column as TEXT, and PostgreSQL's json has no equality operator to use
+    # instead. Casting is what keeps this one statement dialect-agnostic.
+    unset = sa.cast(agents.c.models, sa.Text) == "null"
+    eligible = sa.and_(
+        agents.c.team_id.is_(None),
+        agents.c.share_enabled.is_(False),
+        agents.c.origin != WORKFORCE_MANAGER_ORIGIN,
+        unset,
     )
 
     filled = 0
-    skipped = 0
-    malformed = 0
-    for start in range(0, len(agent_ids), _CHUNK_SIZE):
-        chunk = agent_ids[start : start + _CHUNK_SIZE]
-        rows = bind.execute(
-            sa.select(
-                agents_read.c.id, agents_read.c.user_id, agents_read.c.models
-            ).where(agents_read.c.id.between(chunk[0], chunk[-1]))
+    for user_id, model_id in default_by_user.items():
+        result = bind.execute(
+            agents.update()
+            .where(agents.c.user_id == user_id, eligible)
+            .values(models={"general": model_id})
         )
-        for row in rows.mappings():
-            raw = row["models"]
-            if isinstance(raw, (str, bytes)):
-                try:
-                    config = json.loads(raw)
-                except ValueError:
-                    malformed += 1
-                    continue
-            else:
-                config = raw
-            if config is not None and not isinstance(config, dict):
-                malformed += 1
-                continue
-            # An explicit null is a deliberate "no main model" and is left
-            # alone, matching AgentManagementService's model validation.
-            if config and "general" in config:
-                continue
-            model_id = default_by_user.get(int(row["user_id"]))
-            if model_id is None:
-                skipped += 1
-                continue
-            bind.execute(
-                agents_write.update()
-                .where(agents_write.c.id == row["id"])
-                .values(models={**(config or {}), "general": model_id})
-            )
-            filled += 1
+        filled += result.rowcount if result.rowcount is not None else 0
 
+    remaining = bind.execute(
+        sa.select(sa.func.count()).select_from(agents).where(eligible)
+    ).scalar_one()
     logger.info(
-        "Backfilled general model for %s agent(s); %s left empty (owner has "
-        "no active general default), %s skipped as unreadable config",
+        "Backfilled general model for %s agent(s); %s left unset (owner has "
+        "no active general default)",
         filled,
-        skipped,
-        malformed,
+        remaining,
     )
 
 

--- a/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
+++ b/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
@@ -1,7 +1,7 @@
 """backfill the general model slot for agents created without one
 
 Revision ID: 20260908_backfill_agent_general_model
-Revises: 20260901_seed_zendesk_mcp_app
+Revises: 370740d9125a
 Create Date: 2026-09-08 00:00:00.000000
 
 """
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 WORKFORCE_MANAGER_ORIGIN = "workforce_generated_manager"
 
 revision: str = "20260908_backfill_agent_general_model"
-down_revision: Union[str, tuple[str, str], None] = "20260901_seed_zendesk_mcp_app"
+down_revision: Union[str, tuple[str, str], None] = "370740d9125a"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
+++ b/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
@@ -1,7 +1,7 @@
 """backfill the general model slot for agents created without one
 
 Revision ID: 20260908_backfill_agent_general_model
-Revises: 20260904_add_auto_model_config
+Revises: 20260901_seed_zendesk_mcp_app
 Create Date: 2026-09-08 00:00:00.000000
 
 """
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 _CHUNK_SIZE = 1000
 
 revision: str = "20260908_backfill_agent_general_model"
-down_revision: Union[str, tuple[str, str], None] = "20260904_add_auto_model_config"
+down_revision: Union[str, tuple[str, str], None] = "20260901_seed_zendesk_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
+++ b/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
@@ -6,6 +6,7 @@ Create Date: 2026-09-08 00:00:00.000000
 
 """
 
+import json
 import logging
 from typing import Sequence, Union
 
@@ -23,13 +24,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    """Fill an empty `general` slot from the owner's default model.
+    """Fill an unset `general` slot from the owner's default model.
 
-    Server-side template creation passed no model config at all, so those
-    agents persisted `models = NULL`: the builder rendered "--" for Main
-    Model and refused to save until the owner picked one by hand. Runtime
-    already fell back to the owner's default (`get_default_model`), so this
-    only writes down what execution was resolving anyway.
+    Server-side agent creation passed no model config at all, so those agents
+    persisted an empty config: the builder rendered "--" for Main Model and
+    refused to save until the owner picked one by hand. Runtime already fell
+    back to the owner's default (`get_default_model`), so this only writes
+    down what execution was resolving anyway.
+
+    Note that `Agent.models` is `Column(JSON)` with SQLAlchemy's default
+    `none_as_null=False`, so an unset config is stored as the JSON text
+    `null`, not SQL NULL. `WHERE models IS NULL` matches none of these rows,
+    which is why each payload is read back and inspected in Python.
     """
     bind = op.get_bind()
     inspector = sa.inspect(bind)
@@ -41,10 +47,21 @@ def upgrade() -> None:
     if not {"models", "user_id"} <= agent_columns:
         return
 
-    agents = sa.table(
+    # Read `models` as text and deserialize per row: binding it as sa.JSON
+    # would decode during result iteration, where one malformed payload
+    # aborts the whole run instead of just its own row. On PostgreSQL the
+    # driver still hands back a decoded object for a json column, so the
+    # loop below accepts either shape. Writes go through the JSON-typed
+    # table so the value is encoded the same way the ORM encodes it.
+    agents_read = sa.table(
         "agents",
         sa.column("id", sa.Integer),
         sa.column("user_id", sa.Integer),
+        sa.column("models", sa.Text),
+    )
+    agents_write = sa.table(
+        "agents",
+        sa.column("id", sa.Integer),
         sa.column("models", sa.JSON),
     )
     user_defaults = sa.table(
@@ -74,49 +91,67 @@ def upgrade() -> None:
         ).mappings()
     }
     if not default_by_user:
+        logger.info(
+            "No user has an active general default model; "
+            "no agent model config was backfilled"
+        )
         return
 
     # Ids first, payloads a chunk at a time: `models` is small but the row
     # count is unbounded, and Connection.execute buffers a whole result set.
     # Reading ids to exhaustion also keeps the updates below off an open
-    # cursor over the same table.
+    # cursor over the same table. Chunks are contiguous slices of the sorted
+    # id list, so they are addressed by range rather than by an IN list --
+    # SQLite caps bound parameters at 999 before 3.32.0.
     agent_ids = list(
-        bind.execute(sa.select(agents.c.id).order_by(agents.c.id)).scalars()
+        bind.execute(sa.select(agents_read.c.id).order_by(agents_read.c.id)).scalars()
     )
 
     filled = 0
     skipped = 0
+    malformed = 0
     for start in range(0, len(agent_ids), _CHUNK_SIZE):
         chunk = agent_ids[start : start + _CHUNK_SIZE]
         rows = bind.execute(
-            sa.select(agents.c.id, agents.c.user_id, agents.c.models).where(
-                agents.c.id.in_(chunk)
-            )
+            sa.select(
+                agents_read.c.id, agents_read.c.user_id, agents_read.c.models
+            ).where(agents_read.c.id.between(chunk[0], chunk[-1]))
         )
         for row in rows.mappings():
-            config = row["models"]
+            raw = row["models"]
+            if isinstance(raw, (str, bytes)):
+                try:
+                    config = json.loads(raw)
+                except ValueError:
+                    malformed += 1
+                    continue
+            else:
+                config = raw
             if config is not None and not isinstance(config, dict):
+                malformed += 1
                 continue
-            if config and config.get("general") is not None:
+            # An explicit null is a deliberate "no main model" and is left
+            # alone, matching AgentManagementService's model validation.
+            if config and "general" in config:
                 continue
             model_id = default_by_user.get(int(row["user_id"]))
             if model_id is None:
                 skipped += 1
                 continue
             bind.execute(
-                agents.update()
-                .where(agents.c.id == row["id"])
+                agents_write.update()
+                .where(agents_write.c.id == row["id"])
                 .values(models={**(config or {}), "general": model_id})
             )
             filled += 1
 
-    if filled or skipped:
-        logger.info(
-            "Backfilled general model for %s agent(s); %s left empty "
-            "(owner has no active general default)",
-            filled,
-            skipped,
-        )
+    logger.info(
+        "Backfilled general model for %s agent(s); %s left empty (owner has "
+        "no active general default), %s skipped as unreadable config",
+        filled,
+        skipped,
+        malformed,
+    )
 
 
 def downgrade() -> None:

--- a/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
+++ b/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
@@ -1,0 +1,110 @@
+"""backfill the general model slot for agents created without one
+
+Revision ID: 20260908_backfill_agent_general_model
+Revises: 20260904_add_auto_model_config
+Create Date: 2026-09-08 00:00:00.000000
+
+"""
+
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+logger = logging.getLogger(__name__)
+
+revision: str = "20260908_backfill_agent_general_model"
+down_revision: Union[str, tuple[str, str], None] = "20260904_add_auto_model_config"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Fill an empty `general` slot from the owner's default model.
+
+    Server-side template creation passed no model config at all, so those
+    agents persisted `models = NULL`: the builder rendered "--" for Main
+    Model and refused to save until the owner picked one by hand. Runtime
+    already fell back to the owner's default (`get_default_model`), so this
+    only writes down what execution was resolving anyway.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_names = set(inspector.get_table_names())
+    if not {"agents", "user_default_models", "models"} <= table_names:
+        return
+
+    agent_columns = {col["name"] for col in inspector.get_columns("agents")}
+    if not {"models", "user_id"} <= agent_columns:
+        return
+
+    agents = sa.table(
+        "agents",
+        sa.column("id", sa.Integer),
+        sa.column("user_id", sa.Integer),
+        sa.column("models", sa.JSON),
+    )
+    user_defaults = sa.table(
+        "user_default_models",
+        sa.column("user_id", sa.Integer),
+        sa.column("model_id", sa.Integer),
+        sa.column("config_type", sa.String),
+    )
+    db_models = sa.table(
+        "models",
+        sa.column("id", sa.Integer),
+        sa.column("is_active", sa.Boolean),
+    )
+
+    # Only the owner's own default is used. Resolving the shared-default
+    # fallback that ModelStore applies would mean replicating its
+    # visibility rules here, which drift as that code changes.
+    default_by_user = {
+        int(row["user_id"]): int(row["model_id"])
+        for row in bind.execute(
+            sa.select(user_defaults.c.user_id, user_defaults.c.model_id)
+            .join(db_models, user_defaults.c.model_id == db_models.c.id)
+            .where(
+                user_defaults.c.config_type == "general",
+                db_models.c.is_active.is_(True),
+            )
+        ).mappings()
+    }
+    if not default_by_user:
+        return
+
+    filled = 0
+    skipped = 0
+    rows = bind.execute(sa.select(agents.c.id, agents.c.user_id, agents.c.models))
+    for row in rows.mappings():
+        config = row["models"]
+        if config is not None and not isinstance(config, dict):
+            continue
+        if config and config.get("general") is not None:
+            continue
+        model_id = default_by_user.get(int(row["user_id"]))
+        if model_id is None:
+            skipped += 1
+            continue
+        bind.execute(
+            agents.update()
+            .where(agents.c.id == row["id"])
+            .values(models={**(config or {}), "general": model_id})
+        )
+        filled += 1
+
+    if filled or skipped:
+        logger.info(
+            "Backfilled general model for %s agent(s); %s left empty "
+            "(owner has no active general default)",
+            filled,
+            skipped,
+        )
+
+
+def downgrade() -> None:
+    # Not reversed: a filled slot is indistinguishable from one the owner
+    # picked themselves after upgrading, so clearing it would discard a
+    # real choice.
+    pass

--- a/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
+++ b/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
@@ -14,6 +14,8 @@ from alembic import op
 
 logger = logging.getLogger(__name__)
 
+_CHUNK_SIZE = 1000
+
 revision: str = "20260908_backfill_agent_general_model"
 down_revision: Union[str, tuple[str, str], None] = "20260904_add_auto_model_config"
 branch_labels: Union[str, Sequence[str], None] = None
@@ -74,25 +76,39 @@ def upgrade() -> None:
     if not default_by_user:
         return
 
+    # Ids first, payloads a chunk at a time: `models` is small but the row
+    # count is unbounded, and Connection.execute buffers a whole result set.
+    # Reading ids to exhaustion also keeps the updates below off an open
+    # cursor over the same table.
+    agent_ids = list(
+        bind.execute(sa.select(agents.c.id).order_by(agents.c.id)).scalars()
+    )
+
     filled = 0
     skipped = 0
-    rows = bind.execute(sa.select(agents.c.id, agents.c.user_id, agents.c.models))
-    for row in rows.mappings():
-        config = row["models"]
-        if config is not None and not isinstance(config, dict):
-            continue
-        if config and config.get("general") is not None:
-            continue
-        model_id = default_by_user.get(int(row["user_id"]))
-        if model_id is None:
-            skipped += 1
-            continue
-        bind.execute(
-            agents.update()
-            .where(agents.c.id == row["id"])
-            .values(models={**(config or {}), "general": model_id})
+    for start in range(0, len(agent_ids), _CHUNK_SIZE):
+        chunk = agent_ids[start : start + _CHUNK_SIZE]
+        rows = bind.execute(
+            sa.select(agents.c.id, agents.c.user_id, agents.c.models).where(
+                agents.c.id.in_(chunk)
+            )
         )
-        filled += 1
+        for row in rows.mappings():
+            config = row["models"]
+            if config is not None and not isinstance(config, dict):
+                continue
+            if config and config.get("general") is not None:
+                continue
+            model_id = default_by_user.get(int(row["user_id"]))
+            if model_id is None:
+                skipped += 1
+                continue
+            bind.execute(
+                agents.update()
+                .where(agents.c.id == row["id"])
+                .values(models={**(config or {}), "general": model_id})
+            )
+            filled += 1
 
     if filled or skipped:
         logger.info(

--- a/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
+++ b/src/xagent/migrations/versions/20260908_backfill_agent_general_model.py
@@ -36,10 +36,12 @@ def upgrade() -> None:
 
     Scope, and why it is this narrow:
 
-    * Only `models` = JSON `null`. A config object that merely omits
-      `general` would need a read-modify-write to preserve its other slots;
-      production holds no such row (every row is either JSON `null` or an
-      object with `general` set), so that machinery would be dead code.
+    * Only an empty config: JSON `null` (what every server-side creation
+      path left) or `{}` (what `migration/loaders.py` wrote for imported
+      agents before this change). Both render as "--". A *non-empty* object
+      that merely omits `general` is left alone -- preserving its other
+      slots would need a read-modify-write, and no creation path produces
+      that shape.
     * Only private agents (`team_id IS NULL AND NOT share_enabled`). An
       unset config is resolved per runner at execution time against *that
       user's* default (`llm_utils.resolve_llms_from_names` ->
@@ -57,7 +59,7 @@ def upgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     table_names = set(inspector.get_table_names())
-    if not {"agents", "user_default_models", "models"} <= table_names:
+    if not {"agents", "user_default_models", "models", "user_models"} <= table_names:
         return
 
     agent_columns = {col["name"] for col in inspector.get_columns("agents")}
@@ -85,10 +87,34 @@ def upgrade() -> None:
         sa.column("id", sa.Integer),
         sa.column("is_active", sa.Boolean),
     )
+    user_models = sa.table(
+        "user_models",
+        sa.column("model_id", sa.Integer),
+        sa.column("user_id", sa.Integer),
+        sa.column("is_shared", sa.Boolean),
+    )
 
     # Only the owner's own default, matching AgentStore's create-time
-    # fallback exactly. Neither side consults ModelStore's shared-default
-    # layer, so an agent's slot never depends on when it was created.
+    # fallback. Neither side consults ModelStore's shared-default layer, so
+    # an agent's slot never depends on when it was created.
+    #
+    # The reachability test is deliberately weaker than the application's:
+    # `_is_model_visible_to_user` resolves visibility through the current
+    # team graph, and freezing a copy of those rules into a historical
+    # revision would leave this statement asserting something that stops
+    # being true. Requiring a `user_models` row that the owner either holds
+    # or that someone shares is stable, and it still keeps an orphaned
+    # default -- one whose model rows are all gone -- from being written
+    # into an agent where the builder would render it blank.
+    reachable = sa.exists().where(
+        sa.and_(
+            user_models.c.model_id == user_defaults.c.model_id,
+            sa.or_(
+                user_models.c.user_id == user_defaults.c.user_id,
+                user_models.c.is_shared.is_(True),
+            ),
+        )
+    )
     default_by_user = {
         int(row["user_id"]): int(row["model_id"])
         for row in bind.execute(
@@ -97,6 +123,7 @@ def upgrade() -> None:
             .where(
                 user_defaults.c.config_type == "general",
                 db_models.c.is_active.is_(True),
+                reachable,
             )
         ).mappings()
     }
@@ -107,10 +134,12 @@ def upgrade() -> None:
         )
         return
 
-    # JSON null compares as its text form on both backends: SQLite stores the
-    # column as TEXT, and PostgreSQL's json has no equality operator to use
-    # instead. Casting is what keeps this one statement dialect-agnostic.
-    unset = sa.cast(agents.c.models, sa.Text) == "null"
+    # An empty config compares as its text form on both backends: SQLite
+    # stores the column as TEXT, and PostgreSQL's json has no equality
+    # operator to use instead. Casting is what keeps this one statement
+    # dialect-agnostic. Both spellings are what json.dumps emits, so no
+    # whitespace variant can hide from this.
+    unset = sa.cast(agents.c.models, sa.Text).in_(("null", "{}"))
     eligible = sa.and_(
         agents.c.team_id.is_(None),
         agents.c.share_enabled.is_(False),
@@ -125,7 +154,7 @@ def upgrade() -> None:
             .where(agents.c.user_id == user_id, eligible)
             .values(models={"general": model_id})
         )
-        filled += result.rowcount if result.rowcount is not None else 0
+        filled += max(result.rowcount or 0, 0)
 
     remaining = bind.execute(
         sa.select(sa.func.count()).select_from(agents).where(eligible)

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -678,10 +678,7 @@ class AgentManagementService:
         if self.store.agent_name_exists(user_id, name):
             raise DuplicateAgentNameError(name)
 
-        models = self._validate_models(
-            self._with_default_general_model(models, user_id=user_id),
-            user_id=user_id,
-        )
+        models = self._validate_models(models, user_id=user_id)
 
         try:
             agent = self.store.add_agent(  # flush, no commit
@@ -853,37 +850,6 @@ class AgentManagementService:
         )
         self.runtime_key_receipt = self.key_service.runtime_key_receipt
         return response
-
-    def _with_default_general_model(
-        self, models: dict[str, Any] | None, *, user_id: int
-    ) -> dict[str, Any] | None:
-        """Fill an unset `general` slot with the owner's default model.
-
-        Template creates pass no model config at all (no built-in template's
-        agent_config sets `models`), so without this the agent lands with a
-        NULL config: the builder shows "--" for Main Model and refuses to save
-        until the owner picks one by hand. Runs before _validate_models so the
-        filled id goes through the same visibility check.
-        """
-        if models and models.get("general") is not None:
-            return models
-
-        from .model_store import ModelStore
-
-        user = self.db.query(User).filter(User.id == user_id).first()
-        if user is None:
-            return models
-        general = next(
-            (
-                default
-                for default in ModelStore(self.db).get_user_default_models(user)
-                if default.get("config_type") == "general"
-            ),
-            None,
-        )
-        if general is None or general.get("model_id") is None:
-            return models
-        return {**(models or {}), "general": int(general["model_id"])}
 
     def _validate_models(
         self, models: dict[str, Any] | None, *, user_id: int

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -678,7 +678,10 @@ class AgentManagementService:
         if self.store.agent_name_exists(user_id, name):
             raise DuplicateAgentNameError(name)
 
-        models = self._validate_models(models, user_id=user_id)
+        models = self._validate_models(
+            self._with_default_general_model(models, user_id=user_id),
+            user_id=user_id,
+        )
 
         try:
             agent = self.store.add_agent(  # flush, no commit
@@ -850,6 +853,37 @@ class AgentManagementService:
         )
         self.runtime_key_receipt = self.key_service.runtime_key_receipt
         return response
+
+    def _with_default_general_model(
+        self, models: dict[str, Any] | None, *, user_id: int
+    ) -> dict[str, Any] | None:
+        """Fill an unset `general` slot with the owner's default model.
+
+        Template creates pass no model config at all (no built-in template's
+        agent_config sets `models`), so without this the agent lands with a
+        NULL config: the builder shows "--" for Main Model and refuses to save
+        until the owner picks one by hand. Runs before _validate_models so the
+        filled id goes through the same visibility check.
+        """
+        if models and models.get("general") is not None:
+            return models
+
+        from .model_store import ModelStore
+
+        user = self.db.query(User).filter(User.id == user_id).first()
+        if user is None:
+            return models
+        general = next(
+            (
+                default
+                for default in ModelStore(self.db).get_user_default_models(user)
+                if default.get("config_type") == "general"
+            ),
+            None,
+        )
+        if general is None or general.get("model_id") is None:
+            return models
+        return {**(models or {}), "general": int(general["model_id"])}
 
     def _validate_models(
         self, models: dict[str, Any] | None, *, user_id: int

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -160,7 +160,15 @@ def with_default_general_model(
     that would consult the shared/admin-default layer, which the backfill
     migration deliberately does not, so an agent's slot would depend on when
     it was created -- and it would put a synchronous Redis round-trip inside
-    this write transaction (see the issue #889 note in ``list_agent_items``).
+    this write transaction (the pattern issue #889 is about; see the note in
+    ``workforce_runs.create_preview_workforce_run``).
+
+    The id is still visibility-checked. Nothing prunes a
+    ``user_default_models`` row when the model stops being visible -- a team
+    move or a demotion leaves it pointing at something the owner can no
+    longer see -- and injecting such an id would slip past
+    ``_validate_models`` on the create path, leaving the builder's Main Model
+    blank while its save guard sees a value and lets the agent through.
     """
     if models is not None and not isinstance(models, dict):
         return models
@@ -178,6 +186,11 @@ def with_default_general_model(
         .scalar()
     )
     if default_model_id is None:
+        return models
+
+    from .model_service import _is_model_visible_to_user
+
+    if not _is_model_visible_to_user(db, int(default_model_id), user_id):
         return models
     return {**(models or {}), "general": int(default_model_id)}
 

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -138,6 +138,45 @@ def clean_tool_categories(categories: Any) -> list[str]:
     return normalize_tool_categories(categories) or []
 
 
+def _with_default_general_model(
+    db: Session, models: dict[str, Any] | None, *, user_id: int
+) -> dict[str, Any] | None:
+    """Fill an omitted `general` slot with the owner's default model.
+
+    Every agent-creation path funnels through ``add_agent``, and several of
+    them pass no model config at all (template creates, workforce members,
+    the vibe agent tool). Those used to persist an empty config, which the
+    builder renders as "--" and refuses to save until the owner picks a model
+    by hand. An explicit ``{"general": None}`` is left alone: callers that
+    mean "no main model" are honoured, matching AgentManagementService's
+    model validation.
+
+    The filled id comes from ModelStore, which already restricts itself to
+    models visible to this user, so it needs no separate visibility check
+    here -- unlike caller-supplied ids, which are validated upstream.
+    """
+    if models is not None and "general" in models:
+        return models
+
+    from ..models.user import User
+    from .model_store import ModelStore
+
+    user = db.query(User).filter(User.id == user_id).first()
+    if user is None:
+        return models
+    general = next(
+        (
+            default
+            for default in ModelStore(db).get_user_default_models(user)
+            if default.get("config_type") == "general"
+        ),
+        None,
+    )
+    if general is None or general.get("model_id") is None:
+        return models
+    return {**(models or {}), "general": int(general["model_id"])}
+
+
 class AgentStore:
     """Owns Agent reads/writes that participate in hot-path cache policy."""
 
@@ -392,6 +431,7 @@ class AgentStore:
         if visibility is not None and visibility not in _VALID_VISIBILITIES:
             raise ValueError(f"Unsupported agent visibility: {visibility}")
         widget_key = new_widget_key() if widget_enabled else None
+        models = _with_default_general_model(self.db, models, user_id=user_id)
         # Agents are created personal (team_id NULL). Team ownership is granted
         # only by an explicit promote (see ``promote_agent_to_team``); a create
         # never stamps the caller's team. ``visibility`` is stored but only

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -12,7 +12,9 @@ from ...core.utils.type_check import ensure_list
 from ..models.agent import Agent, AgentOrigin, AgentStatus
 from ..models.agent_api_key import AgentApiKey
 from ..models.database import release_db_connection_if_clean
+from ..models.model import Model as DBModel
 from ..models.task import Task
+from ..models.user import UserDefaultModel
 from .agent_team_scope import (
     get_agent_team_scope,
     owned_agent_clause,
@@ -138,43 +140,46 @@ def clean_tool_categories(categories: Any) -> list[str]:
     return normalize_tool_categories(categories) or []
 
 
-def _with_default_general_model(
+def with_default_general_model(
     db: Session, models: dict[str, Any] | None, *, user_id: int
 ) -> dict[str, Any] | None:
     """Fill an omitted `general` slot with the owner's default model.
 
-    Every agent-creation path funnels through ``add_agent``, and several of
-    them pass no model config at all (template creates, workforce members,
-    the vibe agent tool). Those used to persist an empty config, which the
-    builder renders as "--" and refuses to save until the owner picks a model
-    by hand. An explicit ``{"general": None}`` is left alone: callers that
-    mean "no main model" are honoured, matching AgentManagementService's
-    model validation.
+    Most agent-creation paths reach ``add_agent`` -- template creates,
+    workforce members, the vibe agent tool, plain ``POST /api/agents`` -- and
+    several pass no model config, which used to persist as an unset config
+    the builder renders as "--" and refuses to save until the owner picks a
+    model by hand. (``migration/loaders.py`` builds its ``Agent`` directly
+    and calls this itself.)
 
-    The filled id comes from ModelStore, which already restricts itself to
-    models visible to this user, so it needs no separate visibility check
-    here -- unlike caller-supplied ids, which are validated upstream.
+    Left untouched: an explicit ``{"general": None}``, which means "no main
+    model" and is honoured by AgentManagementService's validation, and a
+    non-dict payload, which is template data this layer does not validate.
+
+    Reads ``user_default_models`` directly rather than through ``ModelStore``:
+    that would consult the shared/admin-default layer, which the backfill
+    migration deliberately does not, so an agent's slot would depend on when
+    it was created -- and it would put a synchronous Redis round-trip inside
+    this write transaction (see the issue #889 note in ``list_agent_items``).
     """
+    if models is not None and not isinstance(models, dict):
+        return models
     if models is not None and "general" in models:
         return models
 
-    from ..models.user import User
-    from .model_store import ModelStore
-
-    user = db.query(User).filter(User.id == user_id).first()
-    if user is None:
-        return models
-    general = next(
-        (
-            default
-            for default in ModelStore(db).get_user_default_models(user)
-            if default.get("config_type") == "general"
-        ),
-        None,
+    default_model_id = (
+        db.query(UserDefaultModel.model_id)
+        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+        .filter(
+            UserDefaultModel.user_id == user_id,
+            UserDefaultModel.config_type == "general",
+            DBModel.is_active.is_(True),
+        )
+        .scalar()
     )
-    if general is None or general.get("model_id") is None:
+    if default_model_id is None:
         return models
-    return {**(models or {}), "general": int(general["model_id"])}
+    return {**(models or {}), "general": int(default_model_id)}
 
 
 class AgentStore:
@@ -431,7 +436,7 @@ class AgentStore:
         if visibility is not None and visibility not in _VALID_VISIBILITIES:
             raise ValueError(f"Unsupported agent visibility: {visibility}")
         widget_key = new_widget_key() if widget_enabled else None
-        models = _with_default_general_model(self.db, models, user_id=user_id)
+        models = with_default_general_model(self.db, models, user_id=user_id)
         # Agents are created personal (team_id NULL). Team ownership is granted
         # only by an explicit promote (see ``promote_agent_to_team``); a create
         # never stamps the caller's team. ``visibility`` is stored but only

--- a/tests/migration/test_platform_migration.py
+++ b/tests/migration/test_platform_migration.py
@@ -259,7 +259,7 @@ def test_loader_fills_the_general_model_from_the_owner_default(
     (rogercloud review on #2229, finding 1)."""
     from xagent.web.models.agent import Agent
     from xagent.web.models.model import Model as DBModel
-    from xagent.web.models.user import UserDefaultModel
+    from xagent.web.models.user import UserDefaultModel, UserModel
 
     user = _make_user(db_session)
     model = DBModel(
@@ -273,6 +273,7 @@ def test_loader_fills_the_general_model_from_the_owner_default(
     )
     db_session.add(model)
     db_session.flush()
+    db_session.add(UserModel(user_id=user.id, model_id=model.id, is_owner=True))
     db_session.add(
         UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general")
     )

--- a/tests/migration/test_platform_migration.py
+++ b/tests/migration/test_platform_migration.py
@@ -250,6 +250,42 @@ def _make_user(db) -> object:
     return user
 
 
+def test_loader_fills_the_general_model_from_the_owner_default(
+    db_session, openclaw_home: Path
+) -> None:
+    """This loader builds its Agent outside AgentStore and owns its own
+    commit, so it applies the default-model fallback explicitly; without it,
+    imported agents land with an unset config the builder shows as "--"
+    (rogercloud review on #2229, finding 1)."""
+    from xagent.web.models.agent import Agent
+    from xagent.web.models.model import Model as DBModel
+    from xagent.web.models.user import UserDefaultModel
+
+    user = _make_user(db_session)
+    model = DBModel(
+        model_id="imported-default",
+        category="llm",
+        model_provider="openai",
+        model_name="gpt-4o",
+        api_key="test-api-key",
+        base_url="https://api.openai.com/v1",
+        is_active=True,
+    )
+    db_session.add(model)
+    db_session.flush()
+    db_session.add(
+        UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general")
+    )
+    db_session.commit()
+
+    MigrationLoader(db_session, user=user).load(
+        OpenClawAdapter(root=openclaw_home).parse()
+    )
+
+    agent = db_session.query(Agent).filter(Agent.user_id == user.id).one()
+    assert agent.models == {"general": int(model.id)}
+
+
 def test_loader_imports_agent_skills_and_interval_schedule(
     db_session, openclaw_home: Path
 ) -> None:

--- a/tests/migrations/test_20260908_backfill_agent_general_model.py
+++ b/tests/migrations/test_20260908_backfill_agent_general_model.py
@@ -1,4 +1,10 @@
-"""Tests for the agents.models general-slot backfill migration."""
+"""Tests for the agents.models general-slot backfill migration.
+
+Run against SQLite and PostgreSQL both: the eligibility predicate compares
+`models` cast to text (`Column(JSON)` with `none_as_null=False` stores an
+unset config as the JSON text `null`, so `IS NULL` matches nothing), and that
+cast is the one part of the statement whose behaviour differs per backend.
+"""
 
 from __future__ import annotations
 
@@ -11,7 +17,7 @@ import sqlalchemy as sa
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
-from xagent.web.models.agent import Agent
+from xagent.web.models.agent import Agent, AgentOrigin
 from xagent.web.models.database import Base
 from xagent.web.models.model import Model as DBModel
 from xagent.web.models.user import User, UserDefaultModel
@@ -19,7 +25,6 @@ from xagent.web.models.user import User, UserDefaultModel
 MIGRATION = importlib.import_module(
     "xagent.migrations.versions.20260908_backfill_agent_general_model"
 )
-
 
 # Tables this test touches, in dependency order.
 _TABLE_NAMES = ("users", "models", "user_default_models", "agents")
@@ -47,12 +52,6 @@ def _postgres_url() -> str | None:
     ]
 )
 def db(request: pytest.FixtureRequest) -> Session:
-    """Both backends, because the payload arrives in different shapes.
-
-    SQLite stores `models` as text, so the migration receives a JSON string
-    and decodes it. PostgreSQL's json column is decoded by the driver, so the
-    migration receives an object -- a branch no SQLite run can reach.
-    """
     if request.param == "postgresql":
         url = _postgres_url()
         if not url:
@@ -98,17 +97,25 @@ def _user(db: Session, username: str) -> User:
     return user
 
 
-def _agent(db: Session, user: User, name: str, models: dict | None) -> Agent:
+def _agent(db: Session, user: User, name: str, models: dict | None, **kwargs) -> Agent:
     agent = Agent(
         user_id=user.id,
         name=name,
         instructions="Be useful.",
         execution_mode="balanced",
         models=models,
+        **kwargs,
     )
     db.add(agent)
     db.flush()
     return agent
+
+
+def _owner_with_default(db: Session, username: str) -> tuple[User, int]:
+    user = _user(db, username)
+    model = _model(db, f"{username}-default")
+    db.add(UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general"))
+    return user, int(model.id)
 
 
 def _run_upgrade(db: Session) -> None:
@@ -122,134 +129,120 @@ def _models_of(db: Session, agent_id: int) -> dict | None:
     return db.execute(sa.select(Agent.models).where(Agent.id == agent_id)).scalar_one()
 
 
-def test_backfills_null_config_from_owner_default(db: Session) -> None:
-    user = _user(db, "owner")
-    model = _model(db, "gpt-4o")
-    db.add(UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general"))
-    agent = _agent(db, user, "Template agent", None)
-    agent_id, model_id = int(agent.id), int(model.id)
+def test_backfills_an_unset_config_from_the_owner_default(db: Session) -> None:
+    """`None` reaches the column as the JSON text `null`, which is the shape
+    every server-side creation path left behind."""
+    user, model_id = _owner_with_default(db, "owner")
+    agent_id = int(_agent(db, user, "Template agent", None).id)
 
     _run_upgrade(db)
 
     assert _models_of(db, agent_id) == {"general": model_id}
 
 
-def test_preserves_other_slots_and_respects_an_explicit_general(db: Session) -> None:
-    """An omitted `general` is filled while other slots survive; a value the
-    owner already chose, including an explicit null, is left alone."""
-    user = _user(db, "owner")
-    default_model = _model(db, "gpt-4o")
-    chosen = _model(db, "gpt-4o-mini")
-    db.add(
-        UserDefaultModel(
-            user_id=user.id, model_id=default_model.id, config_type="general"
-        )
-    )
-    partial = _agent(db, user, "Partial", {"small_fast": 7})
-    already_set = _agent(db, user, "Already set", {"general": chosen.id})
-    explicit_null = _agent(db, user, "Explicit null", {"general": None})
-    partial_id, already_id = int(partial.id), int(already_set.id)
-    null_id = int(explicit_null.id)
-    default_id, chosen_id = int(default_model.id), int(chosen.id)
+def test_leaves_a_config_that_already_has_a_value_alone(db: Session) -> None:
+    user, _ = _owner_with_default(db, "owner")
+    chosen = _model(db, "chosen")
+    already_set = int(_agent(db, user, "Already set", {"general": chosen.id}).id)
+    explicit_null = int(_agent(db, user, "Explicit null", {"general": None}).id)
+    partial = int(_agent(db, user, "Partial", {"small_fast": 7}).id)
+    chosen_id = int(chosen.id)
 
     _run_upgrade(db)
 
-    assert _models_of(db, partial_id) == {"small_fast": 7, "general": default_id}
-    assert _models_of(db, already_id) == {"general": chosen_id}
-    assert _models_of(db, null_id) == {"general": None}
+    assert _models_of(db, already_set) == {"general": chosen_id}
+    assert _models_of(db, explicit_null) == {"general": None}
+    # Out of scope by design: preserving sibling slots would need a
+    # read-modify-write, and production holds no row of this shape.
+    assert _models_of(db, partial) == {"small_fast": 7}
 
 
-def test_malformed_payload_does_not_abort_the_run(db: Session) -> None:
-    """Nothing deserializes a payload up front, so a row holding invalid JSON
-    cannot take the whole backfill down with it (rogercloud review, finding 2).
+def test_skips_shared_and_team_agents(db: Session) -> None:
+    """An unset config is resolved per runner against that user's own
+    default, so filling it on a shared agent would switch everyone else onto
+    the owner's model."""
+    user, model_id = _owner_with_default(db, "owner")
+    private = int(_agent(db, user, "Private", None).id)
+    shared = int(_agent(db, user, "Shared", None, share_enabled=True).id)
+    team = int(_agent(db, user, "Team", None, team_id=4242).id)
 
-    SQLite-only by construction: `models` is TEXT there and accepts anything,
-    while PostgreSQL's json column rejects invalid JSON at write time, so the
-    bad row cannot exist to begin with.
-    """
-    if db.bind.dialect.name != "sqlite":
-        pytest.skip("a json column rejects invalid JSON at write time")
-    user = _user(db, "owner")
-    model = _model(db, "gpt-4o")
-    db.add(UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general"))
-    target = _agent(db, user, "Needs backfill", None)
-    broken = _agent(db, user, "Broken payload", None)
-    target_id, broken_id, model_id = int(target.id), int(broken.id), int(model.id)
-    db.commit()
-    db.execute(
-        sa.text("UPDATE agents SET models = :junk WHERE id = :id"),
-        {"junk": "{not json", "id": broken_id},
+    _run_upgrade(db)
+
+    assert _models_of(db, private) == {"general": model_id}
+    assert _models_of(db, shared) is None
+    assert _models_of(db, team) is None
+
+
+def test_skips_the_hidden_workforce_manager_agent(db: Session) -> None:
+    """Filtered out of every user-facing read path, so no UI ever showed
+    "--" for one."""
+    user, model_id = _owner_with_default(db, "owner")
+    visible = int(_agent(db, user, "Visible", None).id)
+    hidden = int(
+        _agent(
+            db,
+            user,
+            "Generated manager",
+            None,
+            origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+        ).id
     )
 
     _run_upgrade(db)
 
-    assert _models_of(db, target_id) == {"general": model_id}
-    assert (
-        db.execute(
-            sa.text("SELECT models FROM agents WHERE id = :id"), {"id": broken_id}
-        ).scalar_one()
-        == "{not json"
-    )
+    assert _models_of(db, visible) == {"general": model_id}
+    assert _models_of(db, hidden) is None
 
 
-def test_leaves_agent_untouched_without_usable_owner_default(db: Session) -> None:
-    """No default at all, and an inactive one, both leave the slot empty
-    rather than writing an id the app would reject as unusable."""
+def test_leaves_agents_whose_owner_has_no_usable_default(db: Session) -> None:
+    """No default at all, and an inactive one, both leave the slot unset
+    rather than writing an id the app would reject."""
     no_default = _user(db, "no-default")
-    inactive_default = _user(db, "inactive-default")
-    inactive = _model(db, "retired-model", is_active=False)
+    inactive_owner = _user(db, "inactive-default")
+    retired = _model(db, "retired", is_active=False)
     db.add(
         UserDefaultModel(
-            user_id=inactive_default.id, model_id=inactive.id, config_type="general"
+            user_id=inactive_owner.id, model_id=retired.id, config_type="general"
         )
     )
-    a = _agent(db, no_default, "No default", None)
-    b = _agent(db, inactive_default, "Inactive default", None)
-    a_id, b_id = int(a.id), int(b.id)
+    a = int(_agent(db, no_default, "No default", None).id)
+    b = int(_agent(db, inactive_owner, "Inactive default", None).id)
 
     _run_upgrade(db)
 
-    assert _models_of(db, a_id) is None
-    assert _models_of(db, b_id) is None
+    assert _models_of(db, a) is None
+    assert _models_of(db, b) is None
 
 
 def test_ignores_non_general_defaults(db: Session) -> None:
     user = _user(db, "owner")
-    model = _model(db, "gpt-4o-mini")
+    model = _model(db, "fast-only")
     db.add(
         UserDefaultModel(user_id=user.id, model_id=model.id, config_type="small_fast")
     )
-    agent = _agent(db, user, "Fast only", None)
-    agent_id = int(agent.id)
+    agent_id = int(_agent(db, user, "Fast only", None).id)
 
     _run_upgrade(db)
 
     assert _models_of(db, agent_id) is None
 
 
-def test_processes_agents_past_the_first_chunk(db: Session) -> None:
-    """Payloads are read a chunk at a time, addressed by id range rather than
-    an IN list (SQLite caps bound parameters at 999 before 3.32.0), so a row
-    in a later chunk must be backfilled too."""
-    user = _user(db, "owner")
-    model = _model(db, "gpt-4o")
-    db.add(UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general"))
-    agents = [_agent(db, user, f"Agent {i}", None) for i in range(5)]
-    agent_ids = [int(a.id) for a in agents]
-    model_id = int(model.id)
+def test_fills_each_owner_from_their_own_default(db: Session) -> None:
+    """One UPDATE per owner: nobody inherits another user's model."""
+    first, first_model = _owner_with_default(db, "first")
+    second, second_model = _owner_with_default(db, "second")
+    a = int(_agent(db, first, "First agent", None).id)
+    b = int(_agent(db, second, "Second agent", None).id)
 
-    with patch.object(MIGRATION, "_CHUNK_SIZE", 2):
-        _run_upgrade(db)
+    _run_upgrade(db)
 
-    assert [_models_of(db, i) for i in agent_ids] == [{"general": model_id}] * 5
+    assert _models_of(db, a) == {"general": first_model}
+    assert _models_of(db, b) == {"general": second_model}
 
 
 def test_is_idempotent(db: Session) -> None:
-    user = _user(db, "owner")
-    model = _model(db, "gpt-4o")
-    db.add(UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general"))
-    agent = _agent(db, user, "Template agent", None)
-    agent_id, model_id = int(agent.id), int(model.id)
+    user, model_id = _owner_with_default(db, "owner")
+    agent_id = int(_agent(db, user, "Template agent", None).id)
 
     _run_upgrade(db)
     _run_upgrade(db)

--- a/tests/migrations/test_20260908_backfill_agent_general_model.py
+++ b/tests/migrations/test_20260908_backfill_agent_general_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 from unittest.mock import patch
 
 import pytest
@@ -20,15 +21,58 @@ MIGRATION = importlib.import_module(
 )
 
 
-@pytest.fixture
-def db() -> Session:
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
+# Tables this test touches, in dependency order.
+_TABLE_NAMES = ("users", "models", "user_default_models", "agents")
+_METADATA_TABLES = sa.MetaData()
+for _name in _TABLE_NAMES:
+    Base.metadata.tables[_name].to_metadata(_METADATA_TABLES)
+
+
+def _drop_tables(engine) -> None:
+    with engine.begin() as conn:
+        for name in reversed(_TABLE_NAMES):
+            conn.execute(sa.text(f"DROP TABLE IF EXISTS {name} CASCADE"))
+
+
+def _postgres_url() -> str | None:
+    return os.getenv("XAGENT_TEST_POSTGRES_URL") or os.getenv(
+        "POSTGRES_TEST_DATABASE_URL"
+    )
+
+
+@pytest.fixture(
+    params=[
+        "sqlite",
+        pytest.param("postgresql", marks=pytest.mark.postgresql),
+    ]
+)
+def db(request: pytest.FixtureRequest) -> Session:
+    """Both backends, because the payload arrives in different shapes.
+
+    SQLite stores `models` as text, so the migration receives a JSON string
+    and decodes it. PostgreSQL's json column is decoded by the driver, so the
+    migration receives an object -- a branch no SQLite run can reach.
+    """
+    if request.param == "postgresql":
+        url = _postgres_url()
+        if not url:
+            pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+        engine = create_engine(url)
+        # Only this test's own tables, dropped by name: the Postgres URL is a
+        # shared test database, so create_all/drop_all over the full metadata
+        # would tear down whatever else is using it.
+        _drop_tables(engine)
+        _METADATA_TABLES.create_all(bind=engine)
+    else:
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(bind=engine)
     session = sessionmaker(bind=engine)()
     try:
         yield session
     finally:
         session.close()
+        if request.param == "postgresql":
+            _drop_tables(engine)
         engine.dispose()
 
 
@@ -90,7 +134,9 @@ def test_backfills_null_config_from_owner_default(db: Session) -> None:
     assert _models_of(db, agent_id) == {"general": model_id}
 
 
-def test_preserves_other_slots_and_existing_general(db: Session) -> None:
+def test_preserves_other_slots_and_respects_an_explicit_general(db: Session) -> None:
+    """An omitted `general` is filled while other slots survive; a value the
+    owner already chose, including an explicit null, is left alone."""
     user = _user(db, "owner")
     default_model = _model(db, "gpt-4o")
     chosen = _model(db, "gpt-4o-mini")
@@ -101,13 +147,49 @@ def test_preserves_other_slots_and_existing_general(db: Session) -> None:
     )
     partial = _agent(db, user, "Partial", {"small_fast": 7})
     already_set = _agent(db, user, "Already set", {"general": chosen.id})
+    explicit_null = _agent(db, user, "Explicit null", {"general": None})
     partial_id, already_id = int(partial.id), int(already_set.id)
+    null_id = int(explicit_null.id)
     default_id, chosen_id = int(default_model.id), int(chosen.id)
 
     _run_upgrade(db)
 
     assert _models_of(db, partial_id) == {"small_fast": 7, "general": default_id}
     assert _models_of(db, already_id) == {"general": chosen_id}
+    assert _models_of(db, null_id) == {"general": None}
+
+
+def test_malformed_payload_does_not_abort_the_run(db: Session) -> None:
+    """Nothing deserializes a payload up front, so a row holding invalid JSON
+    cannot take the whole backfill down with it (rogercloud review, finding 2).
+
+    SQLite-only by construction: `models` is TEXT there and accepts anything,
+    while PostgreSQL's json column rejects invalid JSON at write time, so the
+    bad row cannot exist to begin with.
+    """
+    if db.bind.dialect.name != "sqlite":
+        pytest.skip("a json column rejects invalid JSON at write time")
+    user = _user(db, "owner")
+    model = _model(db, "gpt-4o")
+    db.add(UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general"))
+    target = _agent(db, user, "Needs backfill", None)
+    broken = _agent(db, user, "Broken payload", None)
+    target_id, broken_id, model_id = int(target.id), int(broken.id), int(model.id)
+    db.commit()
+    db.execute(
+        sa.text("UPDATE agents SET models = :junk WHERE id = :id"),
+        {"junk": "{not json", "id": broken_id},
+    )
+
+    _run_upgrade(db)
+
+    assert _models_of(db, target_id) == {"general": model_id}
+    assert (
+        db.execute(
+            sa.text("SELECT models FROM agents WHERE id = :id"), {"id": broken_id}
+        ).scalar_one()
+        == "{not json"
+    )
 
 
 def test_leaves_agent_untouched_without_usable_owner_default(db: Session) -> None:
@@ -146,8 +228,9 @@ def test_ignores_non_general_defaults(db: Session) -> None:
 
 
 def test_processes_agents_past_the_first_chunk(db: Session) -> None:
-    """Payloads are fetched a chunk at a time, so a row in a later chunk
-    must be backfilled too."""
+    """Payloads are read a chunk at a time, addressed by id range rather than
+    an IN list (SQLite caps bound parameters at 999 before 3.32.0), so a row
+    in a later chunk must be backfilled too."""
     user = _user(db, "owner")
     model = _model(db, "gpt-4o")
     db.add(UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general"))

--- a/tests/migrations/test_20260908_backfill_agent_general_model.py
+++ b/tests/migrations/test_20260908_backfill_agent_general_model.py
@@ -1,0 +1,158 @@
+"""Tests for the agents.models general-slot backfill migration."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from xagent.web.models.agent import Agent
+from xagent.web.models.database import Base
+from xagent.web.models.model import Model as DBModel
+from xagent.web.models.user import User, UserDefaultModel
+
+MIGRATION = importlib.import_module(
+    "xagent.migrations.versions.20260908_backfill_agent_general_model"
+)
+
+
+@pytest.fixture
+def db() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _model(db: Session, model_id: str, *, is_active: bool = True) -> DBModel:
+    model = DBModel(
+        model_id=model_id,
+        category="llm",
+        model_provider="openai",
+        model_name=model_id,
+        api_key="test-api-key",
+        base_url="https://api.openai.com/v1",
+        is_active=is_active,
+    )
+    db.add(model)
+    db.flush()
+    return model
+
+
+def _user(db: Session, username: str) -> User:
+    user = User(username=username, password_hash="hash")
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _agent(db: Session, user: User, name: str, models: dict | None) -> Agent:
+    agent = Agent(
+        user_id=user.id,
+        name=name,
+        instructions="Be useful.",
+        execution_mode="balanced",
+        models=models,
+    )
+    db.add(agent)
+    db.flush()
+    return agent
+
+
+def _run_upgrade(db: Session) -> None:
+    db.commit()
+    with patch.object(MIGRATION.op, "get_bind", return_value=db.connection()):
+        MIGRATION.upgrade()
+    db.commit()
+
+
+def _models_of(db: Session, agent_id: int) -> dict | None:
+    return db.execute(sa.select(Agent.models).where(Agent.id == agent_id)).scalar_one()
+
+
+def test_backfills_null_config_from_owner_default(db: Session) -> None:
+    user = _user(db, "owner")
+    model = _model(db, "gpt-4o")
+    db.add(UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general"))
+    agent = _agent(db, user, "Template agent", None)
+    agent_id, model_id = int(agent.id), int(model.id)
+
+    _run_upgrade(db)
+
+    assert _models_of(db, agent_id) == {"general": model_id}
+
+
+def test_preserves_other_slots_and_existing_general(db: Session) -> None:
+    user = _user(db, "owner")
+    default_model = _model(db, "gpt-4o")
+    chosen = _model(db, "gpt-4o-mini")
+    db.add(
+        UserDefaultModel(
+            user_id=user.id, model_id=default_model.id, config_type="general"
+        )
+    )
+    partial = _agent(db, user, "Partial", {"small_fast": 7})
+    already_set = _agent(db, user, "Already set", {"general": chosen.id})
+    partial_id, already_id = int(partial.id), int(already_set.id)
+    default_id, chosen_id = int(default_model.id), int(chosen.id)
+
+    _run_upgrade(db)
+
+    assert _models_of(db, partial_id) == {"small_fast": 7, "general": default_id}
+    assert _models_of(db, already_id) == {"general": chosen_id}
+
+
+def test_leaves_agent_untouched_without_usable_owner_default(db: Session) -> None:
+    """No default at all, and an inactive one, both leave the slot empty
+    rather than writing an id the app would reject as unusable."""
+    no_default = _user(db, "no-default")
+    inactive_default = _user(db, "inactive-default")
+    inactive = _model(db, "retired-model", is_active=False)
+    db.add(
+        UserDefaultModel(
+            user_id=inactive_default.id, model_id=inactive.id, config_type="general"
+        )
+    )
+    a = _agent(db, no_default, "No default", None)
+    b = _agent(db, inactive_default, "Inactive default", None)
+    a_id, b_id = int(a.id), int(b.id)
+
+    _run_upgrade(db)
+
+    assert _models_of(db, a_id) is None
+    assert _models_of(db, b_id) is None
+
+
+def test_ignores_non_general_defaults(db: Session) -> None:
+    user = _user(db, "owner")
+    model = _model(db, "gpt-4o-mini")
+    db.add(
+        UserDefaultModel(user_id=user.id, model_id=model.id, config_type="small_fast")
+    )
+    agent = _agent(db, user, "Fast only", None)
+    agent_id = int(agent.id)
+
+    _run_upgrade(db)
+
+    assert _models_of(db, agent_id) is None
+
+
+def test_is_idempotent(db: Session) -> None:
+    user = _user(db, "owner")
+    model = _model(db, "gpt-4o")
+    db.add(UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general"))
+    agent = _agent(db, user, "Template agent", None)
+    agent_id, model_id = int(agent.id), int(model.id)
+
+    _run_upgrade(db)
+    _run_upgrade(db)
+
+    assert _models_of(db, agent_id) == {"general": model_id}

--- a/tests/migrations/test_20260908_backfill_agent_general_model.py
+++ b/tests/migrations/test_20260908_backfill_agent_general_model.py
@@ -145,6 +145,22 @@ def test_ignores_non_general_defaults(db: Session) -> None:
     assert _models_of(db, agent_id) is None
 
 
+def test_processes_agents_past_the_first_chunk(db: Session) -> None:
+    """Payloads are fetched a chunk at a time, so a row in a later chunk
+    must be backfilled too."""
+    user = _user(db, "owner")
+    model = _model(db, "gpt-4o")
+    db.add(UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general"))
+    agents = [_agent(db, user, f"Agent {i}", None) for i in range(5)]
+    agent_ids = [int(a.id) for a in agents]
+    model_id = int(model.id)
+
+    with patch.object(MIGRATION, "_CHUNK_SIZE", 2):
+        _run_upgrade(db)
+
+    assert [_models_of(db, i) for i in agent_ids] == [{"general": model_id}] * 5
+
+
 def test_is_idempotent(db: Session) -> None:
     user = _user(db, "owner")
     model = _model(db, "gpt-4o")

--- a/tests/migrations/test_20260908_backfill_agent_general_model.py
+++ b/tests/migrations/test_20260908_backfill_agent_general_model.py
@@ -20,14 +20,14 @@ from sqlalchemy.orm import Session, sessionmaker
 from xagent.web.models.agent import Agent, AgentOrigin
 from xagent.web.models.database import Base
 from xagent.web.models.model import Model as DBModel
-from xagent.web.models.user import User, UserDefaultModel
+from xagent.web.models.user import User, UserDefaultModel, UserModel
 
 MIGRATION = importlib.import_module(
     "xagent.migrations.versions.20260908_backfill_agent_general_model"
 )
 
 # Tables this test touches, in dependency order.
-_TABLE_NAMES = ("users", "models", "user_default_models", "agents")
+_TABLE_NAMES = ("users", "models", "user_models", "user_default_models", "agents")
 _METADATA_TABLES = sa.MetaData()
 for _name in _TABLE_NAMES:
     Base.metadata.tables[_name].to_metadata(_METADATA_TABLES)
@@ -114,6 +114,7 @@ def _agent(db: Session, user: User, name: str, models: dict | None, **kwargs) ->
 def _owner_with_default(db: Session, username: str) -> tuple[User, int]:
     user = _user(db, username)
     model = _model(db, f"{username}-default")
+    db.add(UserModel(user_id=user.id, model_id=model.id, is_owner=True))
     db.add(UserDefaultModel(user_id=user.id, model_id=model.id, config_type="general"))
     return user, int(model.id)
 
@@ -192,6 +193,44 @@ def test_skips_the_hidden_workforce_manager_agent(db: Session) -> None:
 
     assert _models_of(db, visible) == {"general": model_id}
     assert _models_of(db, hidden) is None
+
+
+def test_backfills_an_empty_object_config(db: Session) -> None:
+    """`migration/loaders.py` wrote `models={}` for imported agents, which
+    the builder renders as "--" exactly like JSON null does."""
+    user, model_id = _owner_with_default(db, "owner")
+    agent_id = int(_agent(db, user, "Imported agent", {}).id)
+
+    _run_upgrade(db)
+
+    assert _models_of(db, agent_id) == {"general": model_id}
+
+
+def test_leaves_agents_whose_default_points_at_an_unreachable_model(
+    db: Session,
+) -> None:
+    """Nothing prunes a `user_default_models` row when its model stops being
+    reachable, and writing such an id in would leave the builder's Main Model
+    blank while its save guard sees a value."""
+    user = _user(db, "owner")
+    orphaned = _model(db, "orphaned")
+    db.add(
+        UserDefaultModel(user_id=user.id, model_id=orphaned.id, config_type="general")
+    )
+    private = _model(db, "someone-elses-private")
+    other = _user(db, "other")
+    db.add(UserModel(user_id=other.id, model_id=private.id, is_owner=True))
+    second = _user(db, "second")
+    db.add(
+        UserDefaultModel(user_id=second.id, model_id=private.id, config_type="general")
+    )
+    a = int(_agent(db, user, "Orphaned default", None).id)
+    b = int(_agent(db, second, "Unshared default", None).id)
+
+    _run_upgrade(db)
+
+    assert _models_of(db, a) is None
+    assert _models_of(db, b) is None
 
 
 def test_leaves_agents_whose_owner_has_no_usable_default(db: Session) -> None:

--- a/tests/web/api/v1/test_management.py
+++ b/tests/web/api/v1/test_management.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from xagent.templates.manager import TemplateManager
 from xagent.web.models.agent import Agent
 from xagent.web.models.model import Model as DBModel
-from xagent.web.models.user import User, UserModel
+from xagent.web.models.user import User, UserDefaultModel, UserModel
 
 from ..conftest import _admin_headers, _direct_db_session, app_for_tests, client
 
@@ -397,6 +397,47 @@ def test_from_template_creates_agent(template_manager):
     assert body["agent"]["knowledge_bases"] == []
     assert body["agent"]["suggested_prompts"] == ["Ask anything"]
     assert body["api_key"]["full_key"].startswith("xag_")
+
+
+def test_from_template_inherits_owner_default_general_model(template_manager):
+    """No template's agent_config sets `models`, so without the server-side
+    fallback the agent lands with a NULL config and the builder shows "--"."""
+    from xagent.web.services.hot_path_cache import invalidate_model_cache
+
+    key = _personal_key()
+    db = _direct_db_session()
+    try:
+        admin = db.query(User).filter(User.username == "admin").first()
+        assert admin is not None
+        model = DBModel(
+            model_id="own-default-model",
+            category="llm",
+            model_provider="openai",
+            model_name="gpt-4o",
+            api_key="test-api-key",
+            base_url="https://api.openai.com/v1",
+            is_active=True,
+        )
+        db.add(model)
+        db.flush()
+        db.add(UserModel(user_id=admin.id, model_id=model.id, is_owner=True))
+        db.add(
+            UserDefaultModel(user_id=admin.id, model_id=model.id, config_type="general")
+        )
+        db.commit()
+        model_id = int(model.id)
+        admin_id = int(admin.id)
+    finally:
+        db.close()
+    invalidate_model_cache(admin_id)
+
+    resp = client.post(
+        "/v1/agents/from-template",
+        headers=_bearer(key),
+        json={"template_id": "qa", "name": "Template agent with model"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent"]["models"]["general"] == model_id
 
 
 def test_from_template_strips_agent_tool_category(template_manager):

--- a/tests/web/services/test_agent_store_default_general_model.py
+++ b/tests/web/services/test_agent_store_default_general_model.py
@@ -1,0 +1,140 @@
+"""The `general` model slot is filled at the one chokepoint every
+agent-creation path funnels through (rogercloud review on #2229, finding 1).
+
+`AgentStore.add_agent` is reached by `create_agent` (plain `POST /api/agents`,
+the vibe agent tool), by `AgentManagementService.create_agent_with_optional_key`
+(template creates, `/v1/agents`), and directly by `workforce_creator`. Filling
+the slot in any one caller leaves the others persisting an empty config, which
+the builder renders as "--".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from xagent.web.models.database import Base
+from xagent.web.models.model import Model as DBModel
+from xagent.web.models.user import User, UserDefaultModel, UserModel
+from xagent.web.services.agent_store import AgentStore
+
+
+@pytest.fixture()
+def db() -> Iterator[Session]:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _model(db: Session, model_id: str, *, is_active: bool = True) -> DBModel:
+    model = DBModel(
+        model_id=model_id,
+        category="llm",
+        model_provider="openai",
+        model_name=model_id,
+        api_key="test-api-key",
+        base_url="https://api.openai.com/v1",
+        is_active=is_active,
+    )
+    db.add(model)
+    db.flush()
+    return model
+
+
+@pytest.fixture()
+def owner(db: Session) -> User:
+    user = User(username="owner", password_hash="x", is_admin=False)
+    db.add(user)
+    db.flush()
+    return user
+
+
+@pytest.fixture()
+def default_model(db: Session, owner: User) -> DBModel:
+    model = _model(db, "gpt-4o")
+    db.add(UserModel(user_id=owner.id, model_id=model.id, is_owner=True))
+    db.add(UserDefaultModel(user_id=owner.id, model_id=model.id, config_type="general"))
+    db.commit()
+    return model
+
+
+def _add(db: Session, owner: User, name: str, models: dict | None) -> dict | None:
+    agent = AgentStore(db).add_agent(
+        user_id=int(owner.id),
+        name=name,
+        description=None,
+        instructions="Be useful.",
+        models=models,
+    )
+    db.commit()
+    return agent.models
+
+
+def test_omitted_config_is_filled_from_the_owner_default(
+    db: Session, owner: User, default_model: DBModel
+) -> None:
+    assert _add(db, owner, "No config", None) == {"general": int(default_model.id)}
+
+
+def test_empty_config_is_filled_from_the_owner_default(
+    db: Session, owner: User, default_model: DBModel
+) -> None:
+    assert _add(db, owner, "Empty config", {}) == {"general": int(default_model.id)}
+
+
+def test_an_explicit_choice_survives_unmodified(
+    db: Session, owner: User, default_model: DBModel
+) -> None:
+    """Blocking criterion #3 of the PR: a caller-supplied payload is not
+    rewritten by the fallback."""
+    chosen = _model(db, "gpt-4o-mini")
+    db.add(UserModel(user_id=owner.id, model_id=chosen.id, is_owner=True))
+    db.commit()
+    payload = {"general": int(chosen.id), "small_fast": int(default_model.id)}
+
+    assert _add(db, owner, "Explicit", dict(payload)) == payload
+
+
+def test_an_explicit_null_general_is_left_alone(
+    db: Session, owner: User, default_model: DBModel
+) -> None:
+    """`_validate_models` honours an explicit null, so the fallback must not
+    overwrite it into a model id."""
+    assert _add(db, owner, "Explicit null", {"general": None}) == {"general": None}
+
+
+def test_other_slots_are_preserved_while_general_is_filled(
+    db: Session, owner: User, default_model: DBModel
+) -> None:
+    assert _add(db, owner, "Partial", {"small_fast": 7}) == {
+        "small_fast": 7,
+        "general": int(default_model.id),
+    }
+
+
+def test_no_usable_owner_default_leaves_the_config_untouched(db: Session) -> None:
+    """No default at all, and an inactive one, both leave the slot unset
+    rather than writing an id the app would reject."""
+    no_default = User(username="no-default", password_hash="x", is_admin=False)
+    inactive_owner = User(username="inactive", password_hash="x", is_admin=False)
+    db.add_all([no_default, inactive_owner])
+    db.flush()
+    retired = _model(db, "retired", is_active=False)
+    db.add(UserModel(user_id=inactive_owner.id, model_id=retired.id, is_owner=True))
+    db.add(
+        UserDefaultModel(
+            user_id=inactive_owner.id, model_id=retired.id, config_type="general"
+        )
+    )
+    db.commit()
+
+    assert _add(db, no_default, "No default", None) is None
+    assert _add(db, inactive_owner, "Inactive default", None) is None

--- a/tests/web/services/test_agent_store_default_general_model.py
+++ b/tests/web/services/test_agent_store_default_general_model.py
@@ -1,12 +1,14 @@
 """The `general` model slot is filled where the creation paths converge
 (rogercloud review on #2229, finding 1).
 
-`AgentStore.add_agent` is reached by `create_agent` (plain `POST /api/agents`,
-the vibe agent tool), by `AgentManagementService.create_agent_with_optional_key`
-(template creates, `/v1/agents`), and directly by `workforce_creator`. Filling
-the slot in any one caller leaves the others persisting an unset config, which
-the builder renders as "--". `migration/loaders.py` builds its `Agent` outside
-the store and calls the helper itself; `test_platform_migration` covers it.
+`AgentStore.add_agent` is reached by `create_agent` (plain `POST /api/agents`),
+by `AgentManagementService.create_agent_with_optional_key` (template creates,
+`/v1/agents`), and directly by `workforce_creator` -- the callers that pass no
+model config, leaving one the builder renders as "--". Filling the slot in any
+single caller would leave the rest behind. (The vibe agent tool also lands
+here, but assembles its own `models` first, so it only reaches the fallback
+when nothing resolves. `migration/loaders.py` builds its `Agent` outside the
+store and calls the helper directly; `test_platform_migration` covers it.)
 """
 
 from __future__ import annotations
@@ -129,6 +131,26 @@ def test_a_non_dict_payload_passes_through_untouched(
     typos into a 500; it is stored as-is, exactly as before this fallback
     existed."""
     assert _add(db, owner, "Malformed", ["not", "a", "dict"]) == ["not", "a", "dict"]
+
+
+def test_a_default_pointing_at_an_invisible_model_is_not_used(
+    db: Session, owner: User
+) -> None:
+    """Nothing prunes a `user_default_models` row when its model stops being
+    visible (a team move, a demotion). Injecting that id would slip past
+    `_validate_models` on the create path and leave the builder's Main Model
+    blank while its save guard sees a value and lets the agent through."""
+    other = User(username="stranger", password_hash="x", is_admin=False)
+    db.add(other)
+    db.flush()
+    private = _model(db, "someone-elses-private")
+    db.add(UserModel(user_id=other.id, model_id=private.id, is_owner=True))
+    db.add(
+        UserDefaultModel(user_id=owner.id, model_id=private.id, config_type="general")
+    )
+    db.commit()
+
+    assert _add(db, owner, "Invisible default", None) is None
 
 
 def test_no_usable_owner_default_leaves_the_config_untouched(db: Session) -> None:

--- a/tests/web/services/test_agent_store_default_general_model.py
+++ b/tests/web/services/test_agent_store_default_general_model.py
@@ -1,11 +1,12 @@
-"""The `general` model slot is filled at the one chokepoint every
-agent-creation path funnels through (rogercloud review on #2229, finding 1).
+"""The `general` model slot is filled where the creation paths converge
+(rogercloud review on #2229, finding 1).
 
 `AgentStore.add_agent` is reached by `create_agent` (plain `POST /api/agents`,
 the vibe agent tool), by `AgentManagementService.create_agent_with_optional_key`
 (template creates, `/v1/agents`), and directly by `workforce_creator`. Filling
-the slot in any one caller leaves the others persisting an empty config, which
-the builder renders as "--".
+the slot in any one caller leaves the others persisting an unset config, which
+the builder renders as "--". `migration/loaders.py` builds its `Agent` outside
+the store and calls the helper itself; `test_platform_migration` covers it.
 """
 
 from __future__ import annotations
@@ -66,7 +67,7 @@ def default_model(db: Session, owner: User) -> DBModel:
     return model
 
 
-def _add(db: Session, owner: User, name: str, models: dict | None) -> dict | None:
+def _add(db: Session, owner: User, name: str, models: object) -> object:
     agent = AgentStore(db).add_agent(
         user_id=int(owner.id),
         name=name,
@@ -120,6 +121,16 @@ def test_other_slots_are_preserved_while_general_is_filled(
     }
 
 
+def test_a_non_dict_payload_passes_through_untouched(
+    db: Session, owner: User, default_model: DBModel
+) -> None:
+    """`workforce_creator` forwards `agent_config["models"]` straight from
+    unvalidated template YAML. Rejecting the shape here would turn authoring
+    typos into a 500; it is stored as-is, exactly as before this fallback
+    existed."""
+    assert _add(db, owner, "Malformed", ["not", "a", "dict"]) == ["not", "a", "dict"]
+
+
 def test_no_usable_owner_default_leaves_the_config_untouched(db: Session) -> None:
     """No default at all, and an inactive one, both leave the slot unset
     rather than writing an id the app would reject."""
@@ -138,3 +149,23 @@ def test_no_usable_owner_default_leaves_the_config_untouched(db: Session) -> Non
 
     assert _add(db, no_default, "No default", None) is None
     assert _add(db, inactive_owner, "Inactive default", None) is None
+
+
+def test_a_shared_default_is_not_consulted(db: Session, owner: User) -> None:
+    """Deliberately unlike ModelStore.get_user_default_models: the backfill
+    migration cannot replicate that shared/admin-default layer without
+    freezing its visibility rules into a historical revision, so neither
+    side uses it and an agent's slot never depends on when it was created."""
+    other = User(username="sharer", password_hash="x", is_admin=True)
+    db.add(other)
+    db.flush()
+    shared = _model(db, "shared-model")
+    db.add(
+        UserModel(user_id=other.id, model_id=shared.id, is_owner=True, is_shared=True)
+    )
+    db.add(
+        UserDefaultModel(user_id=other.id, model_id=shared.id, config_type="general")
+    )
+    db.commit()
+
+    assert _add(db, owner, "No personal default", None) is None


### PR DESCRIPTION
## Invariant

When an agent is persisted, `agents.models.general` holds a usable value whenever its owner has one to inherit and the caller stated no choice of its own. Existing private agents that violate this are backfilled by a migration.

## Root cause

The server-side agent-creation paths never set `models`. `_spec_from_template` reads `agent_config.get("models")`, but no built-in template's YAML carries a `models` key, and `resolve_agent_from_template` passes `models=None`. `_validate_models` returns `None` untouched, so the row persists with an empty config: the builder renders `--` for Main Model (`agent-builder.tsx:1893`), and its `!modelConfig.general` required-field check (`:1460`) means the owner cannot save the agent without picking a model by hand first.

Contrast the builder path: the frontend seeds `general` from `/api/models/user-default`. The server had no equivalent layer.

`Agent.models` is `Column(JSON)` with SQLAlchemy's default `none_as_null=False`, so an unset config is stored as the JSON text `null`, **not** SQL NULL — `WHERE models IS NULL` matches none of these rows.

## Where the fix lives

`AgentStore.add_agent` is the chokepoint the creation paths cross, so the fallback lives there:

- `create_agent_with_optional_key` → template creates (`/api/agents/from-template`, `/api/agents/from-template/resolve`, `/v1/agents/from-template`)
- `create_agent` → plain `POST /api/agents`
- `add_agent` directly → `workforce_creator.py` (workforce members and the generated manager)

Two callers are not covered by that alone and are handled explicitly:

- `migration/loaders.py` builds its `Agent` outside the store and owns its own commit, so it calls the helper directly. Before this change it wrote `models={}` (since #869), which renders as `--` exactly like JSON `null`.
- The vibe agent tool assembles its own `models` first, so it only reaches the fallback when nothing resolves.

An earlier revision placed the fallback in `create_agent_with_optional_key` alone, which covered only the template paths.

## Changes

**`agent_store.py`** — `with_default_general_model` fills an omitted `general` slot from the owner's `user_default_models` row, called from `add_agent`.

It reads that table directly rather than through `ModelStore.get_user_default_models`, for two reasons: that method consults a shared/admin-default layer the backfill migration cannot replicate, so an agent's slot would depend on when it was created; and its first statement is a `cache_get`, which would put a synchronous Redis round-trip inside this write transaction (the pattern issue #889 is about).

The id is still visibility-checked with `_is_model_visible_to_user` (a plain DB query, no cache). Nothing prunes a `user_default_models` row when its model stops being visible — a team move or a demotion leaves it dangling — and injecting such an id would slip past `_validate_models` on the create path, leaving Main Model blank while the save guard sees a value and lets the agent through.

Left untouched: an explicit `{"general": None}` (which means "no main model" and is honoured by `_validate_models`), and a non-dict payload, which `workforce_creator` forwards straight from unvalidated template YAML — rejecting the shape here would turn an authoring typo into a 500.

**`20260908_backfill_agent_general_model.py`** — one UPDATE per owner, so the row's state is re-tested by the database at write time. A read-then-write would let a `PUT /api/agents/{id}` from an old replica during a rolling deploy land in between and be clobbered.

Scope, and why it is this narrow:

- **Only an empty config** — JSON `null` or `{}`. Both compare as their text form, which is dialect-agnostic and is exactly what `json.dumps` emits. A non-empty object that merely omits `general` is left alone: preserving its other slots would need a read-modify-write, and no creation path produces that shape.
- **Only private agents** (`team_id IS NULL AND NOT share_enabled`). An empty config is resolved *per runner* at execution time against **that user's** default (`llm_utils.resolve_llms_from_names` → `get_configured_defaults(user_id)`), so filling it on a shared agent would silently switch every other runner onto the owner's model. Private agents have one runner, so there is no such change.
- **Not `workforce_generated_manager`**, which `list_agent_items` and `get_owned_agent` filter out of every user-facing read: no UI ever showed `--` for these.
- **Reachability is tested more weakly than the application does.** `_is_model_visible_to_user` resolves visibility through the current team graph; freezing a copy of those rules into a historical revision would leave the statement asserting something that stops being true. Requiring a `user_models` row the owner holds or that someone shares is stable, and still keeps an orphaned default out of an agent where the builder would render it blank.
- `downgrade` is a no-op: a backfilled slot is indistinguishable from one the owner picked after upgrading.

## Consequence worth stating

Both sides write a **static** model id, whereas an empty config was previously re-resolved on every run. After this change, later changes to an owner's default no longer propagate to agents created or backfilled before it — the same as agents whose owner picked a model by hand, which is what the builder has always produced.

The cross-user half of that is why shared and team agents are excluded above. It is not fully gone: an agent created private and later promoted to a team carries its filled slot in, so its teammates get the owner's model where they would previously have got their own. On this deployment every existing team agent already has an explicit `general`, which suggests owners set one before promoting; there is no provenance flag distinguishing a filled slot from a chosen one, so this is not reversible per-row.

## Not included

- **The frontend's "pick the first available LLM" fallback is not ported to the server.** An owner with no usable default still sees `--`.
- No frontend changes.
- Only the `general` slot. An empty `small_fast` / `visual` / `compact` is a legitimate state with its own runtime fallback.
- The pre-existing failures in `tests/migration/test_platform_migration.py` (which does not isolate `Path.home()`) and the two `test_upgrade_does_not_log_when_no_grants_exist` tests (whose `assert caplog.records == []` is wider than intended once `env.py`'s `fileConfig` raises the `alembic` logger to INFO process-wide). Both are unrelated and green in CI.

## Verification

`tests/web/services/test_agent_store_default_general_model.py` — 9 cases on the chokepoint: omitted and empty configs are filled; a caller's explicit choice survives byte-for-byte; an explicit null is preserved; other slots survive; a non-dict payload passes through; no usable default leaves the slot unset; a default pointing at an invisible model is not used; a shared default is deliberately not consulted.

`tests/migrations/test_20260908_backfill_agent_general_model.py` — 10 cases, parametrized over SQLite **and** PostgreSQL (`@pytest.mark.postgresql`; the matching step is wired into `test-migrations.yml`, and both backends were run locally against a real server). Covers JSON `null` and `{}`, every scope exclusion, per-owner isolation, unreachable defaults, inactive defaults, non-general defaults, and idempotency.

`test_loader_fills_the_general_model_from_the_owner_default` covers the CLI import path; `test_from_template_inherits_owner_default_general_model` covers the original report end to end.

Mutation matrix, 15/15 caught — including the one that matters most: swapping the empty-config predicate back to `IS NULL` fails 10 tests at once, which is the bug an earlier revision of this PR actually shipped into review.

| Mutation | Caught by |
|---|---|
| Predicate back to `models IS NULL` | 10 tests |
| Only `null`, not `{}` | `test_backfills_an_empty_object_config` |
| Drop each of the 4 eligibility clauses | scope tests (4 mutations) |
| Drop reachability / widen it to any `user_models` row | `test_leaves_agents_whose_default_points_at_an_unreachable_model` |
| Drop the helper's visibility check | `test_a_default_pointing_at_an_invisible_model_is_not_used` |
| Drop `is_active` (either side) | inactive-default tests (2 mutations) |
| Drop the per-owner `WHERE` | `test_fills_each_owner_from_their_own_default` |
| Treat an explicit null as unset (either side) | explicit-null tests (2 mutations) |
| Drop the non-dict guard | `test_a_non_dict_payload_passes_through_untouched` |
| Drop the `add_agent` call / the `loaders.py` call | 3 tests / `test_loader_fills_...` |

`alembic heads` reports a single head, chained onto `20260901_seed_zendesk_mcp_app`.

## Blocking criteria

Do not merge if any of these hold: `alembic heads` reports more than one head; the backfill modifies any existing `general` value, including an explicit null; the backfill touches a shared, team, or hidden-manager agent; or the fallback rewrites a caller-supplied `models` payload.
