### PR TITLE
fix(agent): suppress same-turn duplicate write-tool calls in the ReAct loop

### DIFF
--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -185,6 +185,20 @@ class _AutoChildRuntime:
     def active_turn_id(self) -> str | None:
         return self.parent.active_turn_id
 
+    def _dag_turn_id(self, context: Any) -> str | None:
+        """Forward the parent's turn resolution for nested DAG steps.
+
+        ``_DAGStepRuntime.active_turn_id`` resolves per access by calling
+        ``parent._dag_turn_id(root_context)``, and under ``auto`` the DAG's
+        parent is this adapter rather than ``PatternRuntime``. Without this
+        forward that call raises ``AttributeError``, which the caller's
+        ``getattr(runtime, "active_turn_id", None)`` silently turns into an
+        unstamped tool call -- costing every auto->DAG step both its trace
+        turn attribution and the same-turn duplicate-write guard, which
+        only fires for calls carrying a turn_id.
+        """
+        return self.parent._dag_turn_id(context)
+
     async def should_interrupt(self) -> bool:
         return await self.parent.should_interrupt()
 

--- a/src/xagent/core/agent/pattern/react/duplicate_write_guard.py
+++ b/src/xagent/core/agent/pattern/react/duplicate_write_guard.py
@@ -1,0 +1,94 @@
+"""Same-turn duplicate-write guard for the ReAct tool-execution path.
+
+Defends against a model re-issuing a write-category tool call with
+byte-identical arguments after that call already succeeded in the same turn
+(xorbitsai/xagent#2217): the repeat is not executed; the model receives a
+structured envelope carrying the prior result instead.
+
+Scope is deliberately narrow:
+
+* Same turn only, enforced by turn_id equality on the ledger records: a
+  resume or injected user message continues the execution — and its
+  checkpointed ledger — under a fresh turn_id, so the guard holds across an
+  intra-turn resume but never across turns; creating two identical records
+  in different turns stays possible.
+* Identical execution arguments only, compared via the ledger's canonical
+  args hash.
+* Only tools that *explicitly* declare themselves as writes. An MCP tool
+  whose wire annotations classify as destructive, or an internal tool marked
+  ``non_idempotent = True``. Undeclared and read-only hints are exempt: an
+  unannotated MCP tool may be a legitimate identical-args poll loop, and
+  suppressing it would hand the model stale data.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Marker key stamped on every suppression envelope. Doubles as the signal
+# that a ledger record is an envelope rather than a genuine execution, so a
+# later duplicate always attaches the original result, never a suppression
+# of a suppression.
+DUPLICATE_WRITE_SUPPRESSED_KEY = "duplicate_write_suppressed"
+
+# Mirrors ``MCPWriteHint.DESTRUCTIVE.value`` without importing the MCP
+# adapter: this module sits under ``core.agent`` and duck-types the hint the
+# same way the common tool contract does (``_write_hint_value`` in
+# ``tools.adapters.vibe.base``). A pin test keeps the string aligned with
+# the enum.
+DESTRUCTIVE_WRITE_HINT_VALUE = "destructive"
+
+
+def tool_requires_duplicate_write_guard(tool: Any) -> bool:
+    """Whether ``tool`` explicitly declares itself a non-idempotent write.
+
+    True for exactly two declarations, both opt-in:
+
+    * ``tool.non_idempotent is True`` — an internal tool's own marker.
+      ``is True`` so a truthy non-boolean never enrolls a tool by accident.
+    * an MCP write hint whose value is ``destructive`` — the only
+      classification produced from an explicit ``destructiveHint: true`` on
+      the wire (see ``classify_write_hint``). UNDECLARED must stay exempt
+      here even though confirmation gating treats it as a write: the safe
+      direction inverts for deduplication, where suppressing an unannotated
+      poll loop would silently serve stale results.
+    """
+    if getattr(tool, "non_idempotent", None) is True:
+        return True
+
+    hint = getattr(tool, "write_hint", None)
+    if hint is None:
+        return False
+    value = getattr(hint, "value", None)
+    if not isinstance(value, str):
+        return False
+    return value == DESTRUCTIVE_WRITE_HINT_VALUE
+
+
+def build_suppression_envelope(
+    *,
+    tool_name: str,
+    prior_tool_call_id: str,
+    prior_result: Any,
+) -> dict[str, Any]:
+    """Build the model-facing envelope for a suppressed duplicate write.
+
+    ``success: True`` deliberately: the requested effect exists — it was
+    produced by the earlier call — so the loop's success accounting should
+    treat this observation like the write it stands in for.
+    """
+    return {
+        "success": True,
+        DUPLICATE_WRITE_SUPPRESSED_KEY: True,
+        "tool_name": tool_name,
+        "suppressed_duplicate_of": prior_tool_call_id,
+        "result": prior_result,
+        "message": (
+            f"Duplicate write suppressed: this exact {tool_name} call "
+            "already succeeded earlier in this turn "
+            f"(tool call {prior_tool_call_id}); it was not executed again. "
+            "The previous call's result is attached under 'result' — use it "
+            "instead of retrying. Repeating this write with identical "
+            "arguments is only possible in a later turn."
+        ),
+    }

--- a/src/xagent/core/agent/pattern/react/duplicate_write_guard.py
+++ b/src/xagent/core/agent/pattern/react/duplicate_write_guard.py
@@ -7,18 +7,39 @@ structured envelope carrying the prior result instead.
 
 Scope is deliberately narrow:
 
-* Same turn only, enforced by turn_id equality on the ledger records: a
-  resume or injected user message continues the execution — and its
-  checkpointed ledger — under a fresh turn_id, so the guard holds across an
-  intra-turn resume but never across turns; creating two identical records
-  in different turns stays possible.
+* Same turn only, enforced by turn_id equality on the ledger records. The
+  runner stamps a fresh turn_id on every user message (initial and
+  injected), and the pattern re-reads it at each pattern start, so a resume
+  that continues the execution — and its checkpointed ledger — under a new
+  user message compares unequal and executes, while an intra-turn resume
+  keeps suppressing the replay. A call with no turn_id (an embedding that
+  drives the pattern directly without stamping turns) is never guarded:
+  suppression must not outlive a turn, so an unknowable turn fails open.
 * Identical execution arguments only, compared via the ledger's canonical
   args hash.
-* Only tools that *explicitly* declare themselves as writes. An MCP tool
-  whose wire annotations classify as destructive, or an internal tool marked
-  ``non_idempotent = True``. Undeclared and read-only hints are exempt: an
-  unannotated MCP tool may be a legitimate identical-args poll loop, and
-  suppressing it would hand the model stale data.
+* Only tools that *explicitly* declare a non-idempotent write:
+
+  - an MCP tool whose wire annotations classify as a non-idempotent write
+    (``classify_non_idempotent_write`` in the MCP adapter: an exact
+    ``idempotentHint: false``, or an exact ``destructiveHint: true`` with no
+    idempotency promise, never a read-only tool), carried here as
+    ``ToolMetadata.mcp_non_idempotent_write``; or
+  - an internal tool that sets ``non_idempotent = True`` on itself, carried
+    as ``ToolMetadata.non_idempotent``.
+
+  Undeclared tools are exempt: an unannotated MCP tool may be a legitimate
+  identical-args poll loop, and suppressing it would hand the model stale
+  data. Deduplication therefore fails OPEN — the mirror image of a
+  confirmation-style consumer, for which ``MCPWriteHint``'s docstring
+  prescribes treating everything except an explicit read-only claim as a
+  write.
+
+Enrollment is read from ``tool.metadata`` rather than the concrete tool
+object: wrappers such as the sandbox tool wrapper forward only
+``.metadata``, so a declaration read off the adapter directly would vanish
+for every sandboxed MCP server. A bare ``non_idempotent = True`` attribute
+on the tool object is honored as well for tools that do not build their
+metadata through ``AbstractBaseTool``.
 """
 
 from __future__ import annotations
@@ -31,38 +52,27 @@ from typing import Any
 # of a suppression.
 DUPLICATE_WRITE_SUPPRESSED_KEY = "duplicate_write_suppressed"
 
-# Mirrors ``MCPWriteHint.DESTRUCTIVE.value`` without importing the MCP
-# adapter: this module sits under ``core.agent`` and duck-types the hint the
-# same way the common tool contract does (``_write_hint_value`` in
-# ``tools.adapters.vibe.base``). A pin test keeps the string aligned with
-# the enum.
-DESTRUCTIVE_WRITE_HINT_VALUE = "destructive"
-
 
 def tool_requires_duplicate_write_guard(tool: Any) -> bool:
     """Whether ``tool`` explicitly declares itself a non-idempotent write.
 
-    True for exactly two declarations, both opt-in:
-
-    * ``tool.non_idempotent is True`` — an internal tool's own marker.
-      ``is True`` so a truthy non-boolean never enrolls a tool by accident.
-    * an MCP write hint whose value is ``destructive`` — the only
-      classification produced from an explicit ``destructiveHint: true`` on
-      the wire (see ``classify_write_hint``). UNDECLARED must stay exempt
-      here even though confirmation gating treats it as a write: the safe
-      direction inverts for deduplication, where suppressing an unannotated
-      poll loop would silently serve stale results.
+    True for exactly three opt-in declarations — the tool object's own
+    ``non_idempotent is True`` marker, the same marker carried on its
+    metadata, or an MCP wire declaration carried as
+    ``metadata.mcp_non_idempotent_write is True``. ``is True`` throughout so
+    a truthy non-boolean never enrolls a tool by accident; everything
+    undeclared stays exempt (see the module docstring for why deduplication
+    fails open).
     """
     if getattr(tool, "non_idempotent", None) is True:
         return True
 
-    hint = getattr(tool, "write_hint", None)
-    if hint is None:
+    metadata = getattr(tool, "metadata", None)
+    if metadata is None:
         return False
-    value = getattr(hint, "value", None)
-    if not isinstance(value, str):
-        return False
-    return value == DESTRUCTIVE_WRITE_HINT_VALUE
+    if getattr(metadata, "non_idempotent", None) is True:
+        return True
+    return getattr(metadata, "mcp_non_idempotent_write", None) is True
 
 
 def build_suppression_envelope(

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -62,10 +62,7 @@ from datetime import timezone
 from enum import Enum
 from typing import Any, cast
 
-from ....context_ref import (
-    split_tool_result_context_references,
-    split_tool_result_supersedes_scope,
-)
+from ....context_ref import CONTEXT_REFS_KEY, SUPERSEDES_SCOPE_KEY
 from ....file_ref import (
     WORKSPACE_OUTPUT_FILES_TOOL_NAME,
     final_deliverable_file_reference_instructions,
@@ -3641,13 +3638,14 @@ class ReActPattern(AgentPattern):
         computed from the same post-transform ``tool_call`` that
         ``_record_tool_call`` hashes and ``_execute_tool`` executes — so two
         calls compare equal exactly when their executions would be identical.
-        The turn_id equality is what makes the guard strictly per-turn:
-        ``resume``/``inject_user_message`` continue this execution — and its
-        checkpointed ledger — under a fresh turn_id, so an explicit repeat
-        requested in a later turn always executes, while an intra-turn resume
-        keeps suppressing the replay. Where the embedding provides no turn
-        tracking, both sides are None and the scope degrades to the pattern
-        execution, which is a single turn in those embeddings.
+        The turn_id equality is what makes the guard strictly per-turn: the
+        runner stamps a fresh turn_id on every user message (initial and
+        injected), and ``active_turn_id`` is re-resolved from the latest user
+        message at each pattern start — so an explicit repeat requested in a
+        later turn always executes, while an intra-turn resume of the
+        checkpointed ledger keeps suppressing the replay. A call with no
+        stamped turn_id is never guarded: without a turn to scope to,
+        suppression could outlive a turn, so an unknowable turn fails open.
 
         Serial execution makes the check-then-record window safe for guarded
         tools: they are non-idempotent by declaration, so
@@ -3663,9 +3661,12 @@ class ReActPattern(AgentPattern):
         if not tool_requires_duplicate_write_guard(tool):
             return None
 
+        turn_id = self._tool_call_turn_id(tool_call)
+        if turn_id is None:
+            return None
+
         tool_name = str(tool_call["name"])
         args_hash = self._args_hash(self._tool_call_args_dict(tool_call))
-        turn_id = self._tool_call_turn_id(tool_call)
         # The caller runs this scan before recording anything for the current
         # call, so every ledger entry — including one under this call's own
         # id, which a provider may have reused — belongs to an earlier call.
@@ -3679,21 +3680,26 @@ class ReActPattern(AgentPattern):
             if isinstance(record.result, dict) and record.result.get(
                 DUPLICATE_WRITE_SUPPRESSED_KEY
             ):
-                # A prior suppression envelope; keep scanning so the model
-                # always gets the genuine execution's result attached.
+                # A prior suppression envelope: keep scanning so the model
+                # always gets the genuine execution's result attached. An
+                # envelope CAN precede its genuine record here — load_state
+                # rebuilds the ledger in the checkpoint's stored order, and
+                # _reorder_ledger_for_batch re-appends a batch's records at
+                # the tail, moving a genuine record behind an envelope when a
+                # provider reused its id inside a concurrent batch.
                 continue
             # The ledger stores the raw execution return, which may still
-            # carry reserved transport keys (_xagent_context_refs /
-            # _xagent_supersedes_scope). add_tool_result only splits those at
-            # the top level, so strip them here or they reach the model as
-            # noise nested inside the envelope.
-            prior_result, _ = split_tool_result_context_references(record.result)
-            try:
-                prior_result, _ = split_tool_result_supersedes_scope(prior_result)
-            except ValueError:
-                # An invalid nested scope value never blocks suppression; the
-                # original call already delivered its observation.
-                pass
+            # carry reserved transport keys. add_tool_result only splits
+            # those at the top level, so drop them here — unconditionally,
+            # not via the split helpers, whose scope validation could raise —
+            # or they reach the model as noise nested inside the envelope.
+            prior_result = record.result
+            if isinstance(prior_result, dict):
+                prior_result = {
+                    key: value
+                    for key, value in prior_result.items()
+                    if key not in (CONTEXT_REFS_KEY, SUPERSEDES_SCOPE_KEY)
+                }
             return build_suppression_envelope(
                 tool_name=tool_name,
                 prior_tool_call_id=record.tool_call_id,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -62,6 +62,10 @@ from datetime import timezone
 from enum import Enum
 from typing import Any, cast
 
+from ....context_ref import (
+    split_tool_result_context_references,
+    split_tool_result_supersedes_scope,
+)
 from ....file_ref import (
     WORKSPACE_OUTPUT_FILES_TOOL_NAME,
     final_deliverable_file_reference_instructions,
@@ -107,6 +111,11 @@ from ...runtime import (
 )
 from ..base import AgentPattern, PatternResult, truncate_prompt_preview
 from ..final_answer_stream import ReActFinalAnswerStreamer
+from .duplicate_write_guard import (
+    DUPLICATE_WRITE_SUPPRESSED_KEY,
+    build_suppression_envelope,
+    tool_requires_duplicate_write_guard,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +159,10 @@ class ToolCallRecord:
     status: str
     result: Any = None
     error: str | None = None
+    # The durable turn the call ran in (see _with_runtime_turn_id). None when
+    # the embedding provides no turn tracking, and for records restored from
+    # checkpoints written before the field existed.
+    turn_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -160,6 +173,7 @@ class ToolCallRecord:
             "status": self.status,
             "result": self.result,
             "error": self.error,
+            "turn_id": self.turn_id,
         }
 
     @classmethod
@@ -172,6 +186,7 @@ class ToolCallRecord:
             status=str(data.get("status", "pending")),
             result=data.get("result"),
             error=data.get("error"),
+            turn_id=str(data["turn_id"]) if data.get("turn_id") else None,
         )
 
 
@@ -3615,6 +3630,77 @@ class ReActPattern(AgentPattern):
             },
         ).to_dict()
 
+    def _suppressed_duplicate_write_result(
+        self,
+        tool_call: dict[str, Any],
+        tools: list[Any],
+    ) -> dict[str, Any] | None:
+        """Return the suppression envelope when this call repeats a completed write.
+
+        The comparison key is (turn_id, tool_name, args_hash), each side
+        computed from the same post-transform ``tool_call`` that
+        ``_record_tool_call`` hashes and ``_execute_tool`` executes — so two
+        calls compare equal exactly when their executions would be identical.
+        The turn_id equality is what makes the guard strictly per-turn:
+        ``resume``/``inject_user_message`` continue this execution — and its
+        checkpointed ledger — under a fresh turn_id, so an explicit repeat
+        requested in a later turn always executes, while an intra-turn resume
+        keeps suppressing the replay. Where the embedding provides no turn
+        tracking, both sides are None and the scope degrades to the pattern
+        execution, which is a single turn in those embeddings.
+
+        Serial execution makes the check-then-record window safe for guarded
+        tools: they are non-idempotent by declaration, so
+        ``_tool_is_concurrency_safe`` keeps them out of concurrent batches
+        unless configuration marks a non-idempotent tool concurrency-safe
+        (for MCP tools that flag is connection-level operator config), which
+        contradicts the flag's documented idempotency meaning.
+        """
+        try:
+            tool = self._find_tool(tool_call["name"], tools)
+        except Exception:  # noqa: BLE001 - unknown tool fails in _execute_tool
+            return None
+        if not tool_requires_duplicate_write_guard(tool):
+            return None
+
+        tool_name = str(tool_call["name"])
+        args_hash = self._args_hash(self._tool_call_args_dict(tool_call))
+        turn_id = self._tool_call_turn_id(tool_call)
+        # The caller runs this scan before recording anything for the current
+        # call, so every ledger entry — including one under this call's own
+        # id, which a provider may have reused — belongs to an earlier call.
+        for record in self.tool_ledger.values():
+            if record.status != "completed":
+                continue
+            if record.turn_id != turn_id:
+                continue
+            if record.tool_name != tool_name or record.args_hash != args_hash:
+                continue
+            if isinstance(record.result, dict) and record.result.get(
+                DUPLICATE_WRITE_SUPPRESSED_KEY
+            ):
+                # A prior suppression envelope; keep scanning so the model
+                # always gets the genuine execution's result attached.
+                continue
+            # The ledger stores the raw execution return, which may still
+            # carry reserved transport keys (_xagent_context_refs /
+            # _xagent_supersedes_scope). add_tool_result only splits those at
+            # the top level, so strip them here or they reach the model as
+            # noise nested inside the envelope.
+            prior_result, _ = split_tool_result_context_references(record.result)
+            try:
+                prior_result, _ = split_tool_result_supersedes_scope(prior_result)
+            except ValueError:
+                # An invalid nested scope value never blocks suppression; the
+                # original call already delivered its observation.
+                pass
+            return build_suppression_envelope(
+                tool_name=tool_name,
+                prior_tool_call_id=record.tool_call_id,
+                prior_result=prior_result,
+            )
+        return None
+
     async def _execute_tool_safely(
         self,
         tool_call: dict[str, Any],
@@ -3645,6 +3731,25 @@ class ReActPattern(AgentPattern):
         is_control = tool_call["name"] in CONTROL_TOOL_NAMES
         if not is_control:
             tool_call = self._with_trace_safe_tool_args(tool_call, tools)
+            # The duplicate-write scan runs before this call writes any ledger
+            # record: provider-supplied tool_call ids are not guaranteed
+            # unique (see _run_concurrent_batch), so recording "running" first
+            # would clobber the completed record that is the duplicate's own
+            # evidence when the model reuses the prior call's id. The scan and
+            # the envelope record are synchronous, preserving the
+            # distinct-fallback-id invariant for concurrent batch members.
+            suppressed = self._suppressed_duplicate_write_result(tool_call, tools)
+            if suppressed is not None:
+                # Never overwrite the matched genuine record with the
+                # envelope: on provider id reuse the genuine result must stay
+                # in the ledger so later duplicates still find it.
+                if str(tool_call["id"]) not in self.tool_ledger:
+                    self._record_tool_call(
+                        tool_call, status="completed", result=suppressed
+                    )
+                await runtime.on_tool_start(tool_call=tool_call)
+                await runtime.on_tool_end(tool_call=tool_call, result=suppressed)
+                return suppressed
         self._record_tool_call(tool_call, status="running")
         recorded_terminal = False
         try:
@@ -3857,7 +3962,13 @@ class ReActPattern(AgentPattern):
             status=status,
             result=result,
             error=error,
+            turn_id=self._tool_call_turn_id(tool_call),
         )
+
+    @staticmethod
+    def _tool_call_turn_id(tool_call: dict[str, Any]) -> str | None:
+        raw_turn_id = tool_call.get("turn_id")
+        return str(raw_turn_id) if raw_turn_id else None
 
     def _args_hash(self, args: dict[str, Any]) -> str:
         try:

--- a/src/xagent/core/tools/adapters/vibe/base.py
+++ b/src/xagent/core/tools/adapters/vibe/base.py
@@ -96,6 +96,20 @@ class ToolMetadata(BaseModel):
     # action must treat everything except an explicit read-only claim as a
     # write, and must not treat even that claim as a security fact.
     mcp_write_hint: Optional[str] = None
+    # Whether a *remote* MCP server's annotations explicitly declare this
+    # tool a non-idempotent write (see ``classify_non_idempotent_write`` in
+    # the MCP adapter), or None for any tool that is not an MCP tool.
+    # Consumed by the same-turn duplicate-write guard, which reads metadata
+    # rather than the concrete adapter so wrappers that forward only
+    # ``.metadata`` (e.g. the sandbox wrapper) keep the declaration.
+    mcp_non_idempotent_write: Optional[bool] = None
+    # A local tool author's own declaration that repeating this tool with
+    # identical arguments produces an additional external effect (a create,
+    # a send, a submission). Opt-in via a ``non_idempotent = True`` attribute
+    # on the tool; consumed by the same-turn duplicate-write guard. Distinct
+    # from ``mcp_non_idempotent_write``: this is a first-party guarantee,
+    # that is an untrusted remote hint.
+    non_idempotent: bool = False
 
 
 def _write_hint_value(tool: Any) -> Optional[str]:
@@ -113,6 +127,17 @@ def _write_hint_value(tool: Any) -> Optional[str]:
         return None
     value = getattr(hint, "value", None)
     return value if isinstance(value, str) else None
+
+
+def _non_idempotent_write_value(tool: Any) -> Optional[bool]:
+    """Read a tool's MCP non-idempotent-write declaration, if it has one.
+
+    Same duck-typing contract as ``_write_hint_value``: ``None`` means "not
+    an MCP declaration", distinct from an MCP tool whose annotations do not
+    declare a non-idempotent write, which reports ``False``.
+    """
+    declared = getattr(tool, "non_idempotent_write", None)
+    return declared if isinstance(declared, bool) else None
 
 
 @runtime_checkable
@@ -172,6 +197,10 @@ class AbstractBaseTool(ABC, Tool):
             # enum's value (a plain string) to keep this module free of a
             # dependency on the MCP adapter.
             mcp_write_hint=_write_hint_value(self),
+            mcp_non_idempotent_write=_non_idempotent_write_value(self),
+            # ``is True`` so a truthy non-boolean never enrolls a tool in the
+            # duplicate-write guard by accident.
+            non_idempotent=getattr(self, "non_idempotent", None) is True,
         )
 
     @abstractmethod

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -111,6 +111,7 @@ class MCPWriteHint(Enum):
 # spells them (camelCase is the protocol's, not this codebase's).
 _READ_ONLY_HINT = "readOnlyHint"
 _DESTRUCTIVE_HINT = "destructiveHint"
+_IDEMPOTENT_HINT = "idempotentHint"
 
 
 def classify_write_hint(raw_annotations: object) -> MCPWriteHint:
@@ -152,6 +153,52 @@ def classify_write_hint(raw_annotations: object) -> MCPWriteHint:
     if raw_annotations.get(_READ_ONLY_HINT) is True:
         return MCPWriteHint.READ_ONLY
     return MCPWriteHint.UNDECLARED
+
+
+def classify_non_idempotent_write(raw_annotations: object) -> bool:
+    """Whether a tool's *raw* wire annotations declare a non-idempotent write.
+
+    The consumer is the same-turn duplicate-write guard, whose enrollment
+    question is not "may this destroy data" but "does repeating this call
+    with identical arguments produce an additional effect". Per the MCP
+    schema that is ``idempotentHint`` (``false`` = repeats have additional
+    effect), not ``destructiveHint`` (``false`` = only additive updates) — a
+    well-annotated create tool is additive and non-idempotent, i.e.
+    ``destructiveHint: false, idempotentHint: false``.
+
+    Reads the wire mapping for the same reason ``classify_write_hint`` does:
+    only an exact boolean is a declaration. True exactly when
+    ``readOnlyHint`` is not exactly ``true`` and either
+
+    * ``idempotentHint`` is exactly ``false`` — the explicit declaration
+      that identical repeats compound, or
+    * ``destructiveHint`` is exactly ``true`` without an exact
+      ``idempotentHint: true`` — an explicit write whose idempotency the
+      server left unstated.
+
+    Everything else is False. An absent hint is never read through its
+    spec default: ``idempotentHint``'s default of false does not enroll an
+    unannotated tool, and ``destructiveHint``'s default of true does not
+    either, so enrollment always needs at least one exact boolean from the
+    server and legitimate identical-args poll loops stay unguarded. Within
+    an explicit ``destructiveHint: true``, though, a *missing*
+    ``idempotentHint`` does enroll: the server declared a write and said
+    nothing about repeats, which is the same reading the previous
+    destructive-only enrollment used. Unlike confirmation-style
+    consumers, deduplication fails OPEN: a contradictory or malformed claim
+    (e.g. read-only plus non-idempotent) reads as "do not enroll", because
+    the harmless failure mode here is executing, not suppressing.
+    """
+    if not isinstance(raw_annotations, Mapping):
+        return False
+    if raw_annotations.get(_READ_ONLY_HINT) is True:
+        return False
+    if raw_annotations.get(_IDEMPOTENT_HINT) is False:
+        return True
+    return (
+        raw_annotations.get(_DESTRUCTIVE_HINT) is True
+        and raw_annotations.get(_IDEMPOTENT_HINT) is not True
+    )
 
 
 @dataclass(frozen=True)
@@ -966,6 +1013,18 @@ class MCPToolAdapter(AbstractBaseTool):
         input never reads as the permissive answer.
         """
         return classify_write_hint(self._raw_annotations)
+
+    @property
+    def non_idempotent_write(self) -> bool:
+        """Whether the server's annotations declare a non-idempotent write.
+
+        Consumed (via ``ToolMetadata.mcp_non_idempotent_write``) by the
+        same-turn duplicate-write guard. Same wire-evidence discipline and
+        trust caveats as ``write_hint``; see
+        ``classify_non_idempotent_write`` for the enrollment predicate and
+        why it fails open.
+        """
+        return classify_non_idempotent_write(self._raw_annotations)
 
     @property
     def tags(self) -> List[str]:

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -27,6 +27,7 @@ from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_SOURCE_PLAN,
 )
 from xagent.core.agent.pattern.auto.auto import DECISION_TOOL_NAME, _AutoChildRuntime
+from xagent.core.agent.pattern.dag.dag import _DAGStepRuntime
 from xagent.core.model.chat.basic.router import RouterLLM
 from xagent.core.model.chat.exceptions import LLMToolProtocolError
 from xagent.core.model.chat.tool_protocol import (
@@ -2470,3 +2471,37 @@ async def test_auto_react_messages_preserve_user_turn_attribution(
     assert source["tool_call_id"] == "ask-1"
     assert source["tool_name"] == tool_name
     assert source["turn_id"] == "turn-42"
+
+
+def test_auto_child_runtime_forwards_dag_turn_resolution() -> None:
+    """A DAG step nested under ``auto`` must keep its turn identity.
+
+    ``_DAGStepRuntime.active_turn_id`` resolves the turn on every access by
+    calling ``parent._dag_turn_id(root_context)``. Under ``auto`` that
+    parent is ``_AutoChildRuntime``, so a missing forward raises
+    ``AttributeError`` from inside the property -- which every caller's
+    ``getattr(runtime, "active_turn_id", None)`` silently converts into an
+    unstamped tool call, costing the step both its trace turn attribution
+    and the same-turn duplicate-write guard (which only fires for calls
+    carrying a turn_id).
+    """
+    context = ExecutionContext()
+    context.add_user_message("Plan this", metadata={"turn_id": "turn-42"})
+    child_runtime = _AutoChildRuntime(
+        parent=PatternRuntime(),
+        auto_pattern=AutoPattern(),
+        root_context=context,
+    )
+    step_runtime = _DAGStepRuntime(
+        parent=child_runtime,
+        # Irrelevant to turn resolution, which reads only parent and
+        # root_context; kept real so the adapter is built as callers build it.
+        dag_pattern=DAGPattern(LLMPlanGenerator()),
+        root_context=context,
+        step_id="step-1",
+    )
+
+    # Read it the way react.py's _with_runtime_turn_id does: a plain getattr
+    # with a default is what hides a raising property, so the assertion has
+    # to go through the same access to catch a regression.
+    assert getattr(step_runtime, "active_turn_id", None) == "turn-42"

--- a/tests/core/agent/test_react_duplicate_write_guard.py
+++ b/tests/core/agent/test_react_duplicate_write_guard.py
@@ -1,0 +1,514 @@
+"""Same-turn duplicate-write guard on the ReAct tool-execution path.
+
+Covers xorbitsai/xagent#2217: a write-category tool call whose (tool,
+arguments) pair already succeeded earlier in the same turn must not execute
+again; the model receives a structured suppression envelope carrying the
+prior result instead. Only tools that explicitly declare themselves as
+writes are guarded — an MCP tool whose wire annotations classify as
+DESTRUCTIVE, or an internal tool marked ``non_idempotent = True``. Tools
+with an undeclared or read-only hint are exempt, so legitimate repeated
+reads (status polling with identical args) keep executing.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from xagent.core.agent import ExecutionContext, ReActPattern
+from xagent.core.agent.pattern.react.duplicate_write_guard import (
+    DESTRUCTIVE_WRITE_HINT_VALUE,
+    DUPLICATE_WRITE_SUPPRESSED_KEY,
+    build_suppression_envelope,
+    tool_requires_duplicate_write_guard,
+)
+from xagent.core.tools.adapters.vibe.mcp_adapter import MCPWriteHint
+
+
+class CreateRecordArgs(BaseModel):
+    title: str
+    amount: int = 0
+
+
+class FakeLLM:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+class FakeWriteTool:
+    """A create-style tool whose declared write hint is configurable."""
+
+    def __init__(
+        self,
+        *,
+        write_hint: Any = MCPWriteHint.DESTRUCTIVE,
+        fail_first: bool = False,
+        name: str = "create_record",
+    ) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._fail_first = fail_first
+        if write_hint is not None:
+            self.write_hint = write_hint
+
+        class Metadata:
+            description = "Create a record in the external system."
+
+        Metadata.name = name
+        self.metadata = Metadata()
+
+    def args_type(self) -> type[BaseModel]:
+        return CreateRecordArgs
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        self.calls.append(dict(args))
+        if self._fail_first and len(self.calls) == 1:
+            return {"success": False, "error": "transient provider error"}
+        return {"success": True, "record_id": f"rec-{len(self.calls)}"}
+
+
+class FakeNonIdempotentInternalTool(FakeWriteTool):
+    """Internal (non-MCP) tool explicitly marked non-idempotent."""
+
+    non_idempotent = True
+
+    def __init__(self) -> None:
+        super().__init__(write_hint=None, name="submit_form")
+
+
+def _tool_call_response(name: str, args: dict[str, Any], call_id: str) -> dict:
+    return {
+        "content": "",
+        "tool_calls": [
+            {
+                "id": call_id,
+                "function": {"name": name, "arguments": json.dumps(args)},
+            }
+        ],
+        "done": False,
+    }
+
+
+def _pattern() -> ReActPattern:
+    return ReActPattern(
+        max_iterations=8,
+        repeated_tool_decision_after_consecutive_tool_calls=None,
+        repeated_tool_decision_after_consecutive_work_tool_calls=None,
+    )
+
+
+def _run_twice_llm(
+    name: str,
+    first_args: dict[str, Any],
+    second_args: dict[str, Any],
+) -> FakeLLM:
+    return FakeLLM(
+        responses=[
+            _tool_call_response(name, first_args, "call_1"),
+            _tool_call_response(name, second_args, "call_2"),
+            {"content": "Done.", "done": True},
+        ]
+    )
+
+
+def _tool_results(context: ExecutionContext) -> list[Any]:
+    return [
+        message.metadata["raw_result"]
+        for message in context.messages
+        if message.role == "tool"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def test_destructive_hint_value_pins_the_mcp_enum() -> None:
+    # The guard module duck-types the hint instead of importing the MCP
+    # adapter; this pin keeps the string aligned with the enum it mirrors.
+    assert DESTRUCTIVE_WRITE_HINT_VALUE == MCPWriteHint.DESTRUCTIVE.value
+
+
+def test_only_explicit_writes_require_the_guard() -> None:
+    assert tool_requires_duplicate_write_guard(
+        FakeWriteTool(write_hint=MCPWriteHint.DESTRUCTIVE)
+    )
+    assert tool_requires_duplicate_write_guard(FakeNonIdempotentInternalTool())
+    # UNDECLARED and READ_ONLY are exempt by user decision on #2217: an
+    # unannotated MCP tool may be a legitimate identical-args poll loop.
+    assert not tool_requires_duplicate_write_guard(
+        FakeWriteTool(write_hint=MCPWriteHint.UNDECLARED)
+    )
+    assert not tool_requires_duplicate_write_guard(
+        FakeWriteTool(write_hint=MCPWriteHint.READ_ONLY)
+    )
+    assert not tool_requires_duplicate_write_guard(FakeWriteTool(write_hint=None))
+
+
+def test_non_boolean_non_idempotent_marker_does_not_guard() -> None:
+    tool = FakeWriteTool(write_hint=None)
+    tool.non_idempotent = "yes"  # type: ignore[attr-defined]
+    assert not tool_requires_duplicate_write_guard(tool)
+
+
+# ---------------------------------------------------------------------------
+# Suppression through the ReAct loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duplicate_destructive_call_is_suppressed() -> None:
+    args = {"title": "invoice", "amount": 7}
+    llm = _run_twice_llm("create_record", args, dict(args))
+    tool = FakeWriteTool()
+    context = ExecutionContext()
+    context.add_user_message("Create the invoice record")
+
+    result = await _pattern().run(context=context, tools=[tool], llm=llm)
+
+    assert result["success"] is True
+    assert tool.calls == [args]
+
+    tool_results = _tool_results(context)
+    assert len(tool_results) == 2
+    envelope = tool_results[1]
+    assert envelope[DUPLICATE_WRITE_SUPPRESSED_KEY] is True
+    assert envelope["success"] is True
+    assert envelope["suppressed_duplicate_of"] == "call_1"
+    assert envelope["result"] == {"success": True, "record_id": "rec-1"}
+
+
+@pytest.mark.asyncio
+async def test_key_order_does_not_defeat_the_guard() -> None:
+    # The args hash canonicalizes via json.dumps(sort_keys=True): the same
+    # arguments serialized in a different key order are still one write.
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "create_record",
+                            "arguments": '{"title": "invoice", "amount": 7}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "function": {
+                            "name": "create_record",
+                            "arguments": '{"amount": 7, "title": "invoice"}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {"content": "Done.", "done": True},
+        ]
+    )
+    tool = FakeWriteTool()
+    context = ExecutionContext()
+    context.add_user_message("Create the record")
+
+    await _pattern().run(context=context, tools=[tool], llm=llm)
+
+    assert len(tool.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_different_args_both_execute() -> None:
+    llm = _run_twice_llm(
+        "create_record",
+        {"title": "invoice", "amount": 7},
+        {"title": "invoice", "amount": 8},
+    )
+    tool = FakeWriteTool()
+    context = ExecutionContext()
+    context.add_user_message("Create both records")
+
+    await _pattern().run(context=context, tools=[tool], llm=llm)
+
+    assert len(tool.calls) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "write_hint",
+    [MCPWriteHint.UNDECLARED, MCPWriteHint.READ_ONLY, None],
+    ids=["undeclared", "read_only", "no_hint"],
+)
+async def test_unguarded_tools_repeat_identical_calls(write_hint: Any) -> None:
+    args = {"title": "status-poll"}
+    llm = _run_twice_llm("create_record", args, dict(args))
+    tool = FakeWriteTool(write_hint=write_hint)
+    context = ExecutionContext()
+    context.add_user_message("Poll twice")
+
+    await _pattern().run(context=context, tools=[tool], llm=llm)
+
+    assert len(tool.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_first_write_is_retried() -> None:
+    args = {"title": "invoice"}
+    llm = _run_twice_llm("create_record", args, dict(args))
+    tool = FakeWriteTool(fail_first=True)
+    context = ExecutionContext()
+    context.add_user_message("Create the record")
+
+    await _pattern().run(context=context, tools=[tool], llm=llm)
+
+    # Only a call that *succeeded* earlier in the turn suppresses a repeat.
+    assert len(tool.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_non_idempotent_internal_tool_is_guarded() -> None:
+    args = {"title": "form"}
+    llm = _run_twice_llm("submit_form", args, dict(args))
+    tool = FakeNonIdempotentInternalTool()
+    context = ExecutionContext()
+    context.add_user_message("Submit the form")
+
+    await _pattern().run(context=context, tools=[tool], llm=llm)
+
+    assert tool.calls == [args]
+
+
+@pytest.mark.asyncio
+async def test_provider_id_reuse_does_not_defeat_the_guard() -> None:
+    # Provider-supplied tool_call ids are not guaranteed unique. When the
+    # model reuses the completed call's id for the identical repeat, the
+    # guard must still find the completed record (the scan runs before the
+    # repeat writes any ledger entry) and must not overwrite the genuine
+    # result with the suppression envelope, so a third reuse still attaches
+    # the original result.
+    args = {"title": "invoice"}
+    llm = FakeLLM(
+        responses=[
+            _tool_call_response("create_record", args, "call_1"),
+            _tool_call_response("create_record", dict(args), "call_1"),
+            _tool_call_response("create_record", dict(args), "call_1"),
+            {"content": "Done.", "done": True},
+        ]
+    )
+    tool = FakeWriteTool()
+    context = ExecutionContext()
+    context.add_user_message("Create the record")
+
+    await _pattern().run(context=context, tools=[tool], llm=llm)
+
+    assert len(tool.calls) == 1
+    envelopes = _tool_results(context)[1:]
+    assert len(envelopes) == 2
+    for envelope in envelopes:
+        assert envelope[DUPLICATE_WRITE_SUPPRESSED_KEY] is True
+        assert envelope["suppressed_duplicate_of"] == "call_1"
+        assert envelope["result"] == {"success": True, "record_id": "rec-1"}
+
+
+@pytest.mark.asyncio
+async def test_third_call_attaches_the_original_result() -> None:
+    args = {"title": "invoice"}
+    llm = FakeLLM(
+        responses=[
+            _tool_call_response("create_record", args, "call_1"),
+            _tool_call_response("create_record", dict(args), "call_2"),
+            _tool_call_response("create_record", dict(args), "call_3"),
+            {"content": "Done.", "done": True},
+        ]
+    )
+    tool = FakeWriteTool()
+    context = ExecutionContext()
+    context.add_user_message("Create the record")
+
+    await _pattern().run(context=context, tools=[tool], llm=llm)
+
+    assert len(tool.calls) == 1
+    envelopes = _tool_results(context)[1:]
+    # Both suppressions must point at the genuine execution, never at a
+    # previous suppression envelope.
+    for envelope in envelopes:
+        assert envelope["suppressed_duplicate_of"] == "call_1"
+        assert envelope["result"] == {"success": True, "record_id": "rec-1"}
+
+
+@pytest.mark.asyncio
+async def test_guard_survives_checkpoint_state_round_trip() -> None:
+    args = {"title": "invoice"}
+    first_llm = FakeLLM(
+        responses=[
+            _tool_call_response("create_record", args, "call_1"),
+            {"content": "Created.", "done": True},
+        ]
+    )
+    first_tool = FakeWriteTool()
+    first_context = ExecutionContext()
+    first_context.add_user_message("Create the record")
+    first_pattern = _pattern()
+    await first_pattern.run(context=first_context, tools=[first_tool], llm=first_llm)
+    assert len(first_tool.calls) == 1
+
+    # Ledger state survives a checkpoint round-trip. Without turn tracking
+    # (no turn_id metadata anywhere, as in embeddings that never stamp one)
+    # the guard scope degrades to the pattern execution, so the restored
+    # ledger keeps suppressing the identical write. The stamped-turn variants
+    # of this scenario are covered by the two tests below.
+    resumed_pattern = _pattern()
+    resumed_pattern.load_state(json.loads(json.dumps(first_pattern.get_state())))
+    resumed_llm = FakeLLM(
+        responses=[
+            _tool_call_response("create_record", dict(args), "call_2"),
+            {"content": "Done.", "done": True},
+        ]
+    )
+    resumed_tool = FakeWriteTool()
+    resumed_context = ExecutionContext()
+    resumed_context.add_user_message("Create the record")
+
+    await resumed_pattern.run(
+        context=resumed_context, tools=[resumed_tool], llm=resumed_llm
+    )
+
+    assert resumed_tool.calls == []
+    envelope = _tool_results(resumed_context)[0]
+    assert envelope[DUPLICATE_WRITE_SUPPRESSED_KEY] is True
+    assert envelope["suppressed_duplicate_of"] == "call_1"
+
+
+@pytest.mark.asyncio
+async def test_intra_turn_resume_suppresses_under_the_same_turn_id() -> None:
+    args = {"title": "invoice"}
+    first_llm = FakeLLM(
+        responses=[
+            _tool_call_response("create_record", args, "call_1"),
+            {"content": "Created.", "done": True},
+        ]
+    )
+    first_tool = FakeWriteTool()
+    first_context = ExecutionContext()
+    first_context.add_user_message("Create the record", metadata={"turn_id": "turn-1"})
+    first_pattern = _pattern()
+    await first_pattern.run(context=first_context, tools=[first_tool], llm=first_llm)
+    assert len(first_tool.calls) == 1
+
+    resumed_pattern = _pattern()
+    resumed_pattern.load_state(json.loads(json.dumps(first_pattern.get_state())))
+    resumed_llm = FakeLLM(
+        responses=[
+            _tool_call_response("create_record", dict(args), "call_2"),
+            {"content": "Done.", "done": True},
+        ]
+    )
+    resumed_tool = FakeWriteTool()
+    resumed_context = ExecutionContext()
+    resumed_context.add_user_message(
+        "Create the record", metadata={"turn_id": "turn-1"}
+    )
+
+    await resumed_pattern.run(
+        context=resumed_context, tools=[resumed_tool], llm=resumed_llm
+    )
+
+    assert resumed_tool.calls == []
+
+
+@pytest.mark.asyncio
+async def test_identical_write_in_a_later_turn_executes() -> None:
+    # The guard must be strictly per-turn (#2217): an explicit user request
+    # in a later turn of the same execution repeats the identical write.
+    # resume/inject_user_message continue the execution with the ledger
+    # restored but a fresh turn_id on the new user message.
+    args = {"title": "invoice"}
+    pattern = _pattern()
+    tool = FakeWriteTool()
+    context = ExecutionContext()
+
+    context.add_user_message("Create the record", metadata={"turn_id": "turn-1"})
+    first_llm = FakeLLM(
+        responses=[
+            _tool_call_response("create_record", args, "call_1"),
+            {"content": "Created.", "done": True},
+        ]
+    )
+    await pattern.run(context=context, tools=[tool], llm=first_llm)
+    assert len(tool.calls) == 1
+
+    context.add_user_message(
+        "Create the exact same record again", metadata={"turn_id": "turn-2"}
+    )
+    second_llm = FakeLLM(
+        responses=[
+            _tool_call_response("create_record", dict(args), "call_2"),
+            {"content": "Created again.", "done": True},
+        ]
+    )
+    await pattern.run(context=context, tools=[tool], llm=second_llm)
+
+    assert len(tool.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Envelope shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_envelope_strips_reserved_transport_keys() -> None:
+    # The ledger stores the raw execution return; reserved transport keys
+    # must not reach the model nested inside the suppression envelope.
+    args = {"title": "invoice"}
+
+    class ReservedKeysTool(FakeWriteTool):
+        async def run_json_async(self, tool_args: dict[str, Any]) -> Any:
+            self.calls.append(dict(tool_args))
+            return {
+                "success": True,
+                "record_id": "rec-1",
+                "_xagent_context_refs": [],
+                "_xagent_supersedes_scope": "records",
+            }
+
+    llm = _run_twice_llm("create_record", args, dict(args))
+    tool = ReservedKeysTool()
+    context = ExecutionContext()
+    context.add_user_message("Create the record")
+
+    await _pattern().run(context=context, tools=[tool], llm=llm)
+
+    assert len(tool.calls) == 1
+    envelope = _tool_results(context)[1]
+    assert envelope[DUPLICATE_WRITE_SUPPRESSED_KEY] is True
+    assert "_xagent_context_refs" not in envelope["result"]
+    assert "_xagent_supersedes_scope" not in envelope["result"]
+    assert envelope["result"]["record_id"] == "rec-1"
+
+
+def test_suppression_envelope_shape() -> None:
+    envelope = build_suppression_envelope(
+        tool_name="create_record",
+        prior_tool_call_id="call_1",
+        prior_result={"success": True, "record_id": "rec-1"},
+    )
+    assert envelope["success"] is True
+    assert envelope[DUPLICATE_WRITE_SUPPRESSED_KEY] is True
+    assert envelope["tool_name"] == "create_record"
+    assert envelope["suppressed_duplicate_of"] == "call_1"
+    assert envelope["result"] == {"success": True, "record_id": "rec-1"}
+    assert "already succeeded earlier in this turn" in envelope["message"]

--- a/tests/core/agent/test_react_duplicate_write_guard.py
+++ b/tests/core/agent/test_react_duplicate_write_guard.py
@@ -3,11 +3,17 @@
 Covers xorbitsai/xagent#2217: a write-category tool call whose (tool,
 arguments) pair already succeeded earlier in the same turn must not execute
 again; the model receives a structured suppression envelope carrying the
-prior result instead. Only tools that explicitly declare themselves as
-writes are guarded — an MCP tool whose wire annotations classify as
-DESTRUCTIVE, or an internal tool marked ``non_idempotent = True``. Tools
-with an undeclared or read-only hint are exempt, so legitimate repeated
-reads (status polling with identical args) keep executing.
+prior result instead.
+
+Enrollment is explicit-only and read off ``tool.metadata`` (wrappers such as
+the sandbox tool wrapper forward only ``.metadata``): an MCP wire
+declaration carried as ``metadata.mcp_non_idempotent_write`` (classified by
+``classify_non_idempotent_write`` — covered by the wire-level tests in
+``tests/core/tools/adapters/vibe/test_mcp_adapter.py``), or an internal
+tool's ``non_idempotent = True`` marker. Undeclared tools stay exempt, so
+legitimate repeated reads (status polling with identical args) keep
+executing. The guard is strictly per-turn: it only fires for calls stamped
+with a turn_id, and only against records from the same turn.
 """
 
 from __future__ import annotations
@@ -20,12 +26,13 @@ from pydantic import BaseModel
 
 from xagent.core.agent import ExecutionContext, ReActPattern
 from xagent.core.agent.pattern.react.duplicate_write_guard import (
-    DESTRUCTIVE_WRITE_HINT_VALUE,
     DUPLICATE_WRITE_SUPPRESSED_KEY,
     build_suppression_envelope,
     tool_requires_duplicate_write_guard,
 )
-from xagent.core.tools.adapters.vibe.mcp_adapter import MCPWriteHint
+
+TURN_1 = {"turn_id": "turn-1"}
+TURN_2 = {"turn_id": "turn-2"}
 
 
 class CreateRecordArgs(BaseModel):
@@ -44,24 +51,26 @@ class FakeLLM:
 
 
 class FakeWriteTool:
-    """A create-style tool whose declared write hint is configurable."""
+    """A create-style tool whose metadata declaration is configurable."""
 
     def __init__(
         self,
         *,
-        write_hint: Any = MCPWriteHint.DESTRUCTIVE,
+        mcp_non_idempotent_write: Any = True,
         fail_first: bool = False,
         name: str = "create_record",
+        concurrency_safe: bool = False,
     ) -> None:
         self.calls: list[dict[str, Any]] = []
         self._fail_first = fail_first
-        if write_hint is not None:
-            self.write_hint = write_hint
 
         class Metadata:
             description = "Create a record in the external system."
+            non_idempotent = False
 
         Metadata.name = name
+        Metadata.mcp_non_idempotent_write = mcp_non_idempotent_write
+        Metadata.concurrency_safe = concurrency_safe
         self.metadata = Metadata()
 
     def args_type(self) -> type[BaseModel]:
@@ -80,7 +89,7 @@ class FakeNonIdempotentInternalTool(FakeWriteTool):
     non_idempotent = True
 
     def __init__(self) -> None:
-        super().__init__(write_hint=None, name="submit_form")
+        super().__init__(mcp_non_idempotent_write=None, name="submit_form")
 
 
 def _tool_call_response(name: str, args: dict[str, Any], call_id: str) -> dict:
@@ -96,12 +105,20 @@ def _tool_call_response(name: str, args: dict[str, Any], call_id: str) -> dict:
     }
 
 
-def _pattern() -> ReActPattern:
-    return ReActPattern(
-        max_iterations=8,
-        repeated_tool_decision_after_consecutive_tool_calls=None,
-        repeated_tool_decision_after_consecutive_work_tool_calls=None,
-    )
+def _pattern(**overrides: Any) -> ReActPattern:
+    kwargs: dict[str, Any] = {
+        "max_iterations": 8,
+        "repeated_tool_decision_after_consecutive_tool_calls": None,
+        "repeated_tool_decision_after_consecutive_work_tool_calls": None,
+    }
+    kwargs.update(overrides)
+    return ReActPattern(**kwargs)
+
+
+def _turn_context(message: str = "Create the record") -> ExecutionContext:
+    context = ExecutionContext()
+    context.add_user_message(message, metadata=dict(TURN_1))
+    return context
 
 
 def _run_twice_llm(
@@ -127,36 +144,49 @@ def _tool_results(context: ExecutionContext) -> list[Any]:
 
 
 # ---------------------------------------------------------------------------
-# Classification
+# Enrollment
 # ---------------------------------------------------------------------------
 
 
-def test_destructive_hint_value_pins_the_mcp_enum() -> None:
-    # The guard module duck-types the hint instead of importing the MCP
-    # adapter; this pin keeps the string aligned with the enum it mirrors.
-    assert DESTRUCTIVE_WRITE_HINT_VALUE == MCPWriteHint.DESTRUCTIVE.value
-
-
-def test_only_explicit_writes_require_the_guard() -> None:
+def test_only_explicit_declarations_require_the_guard() -> None:
     assert tool_requires_duplicate_write_guard(
-        FakeWriteTool(write_hint=MCPWriteHint.DESTRUCTIVE)
+        FakeWriteTool(mcp_non_idempotent_write=True)
     )
     assert tool_requires_duplicate_write_guard(FakeNonIdempotentInternalTool())
-    # UNDECLARED and READ_ONLY are exempt by user decision on #2217: an
-    # unannotated MCP tool may be a legitimate identical-args poll loop.
+    # Undeclared MCP tools (None) and explicitly-idempotent ones (False) are
+    # exempt: an unannotated tool may be a legitimate identical-args poll
+    # loop, and deduplication fails open.
     assert not tool_requires_duplicate_write_guard(
-        FakeWriteTool(write_hint=MCPWriteHint.UNDECLARED)
+        FakeWriteTool(mcp_non_idempotent_write=None)
     )
     assert not tool_requires_duplicate_write_guard(
-        FakeWriteTool(write_hint=MCPWriteHint.READ_ONLY)
+        FakeWriteTool(mcp_non_idempotent_write=False)
     )
-    assert not tool_requires_duplicate_write_guard(FakeWriteTool(write_hint=None))
 
 
-def test_non_boolean_non_idempotent_marker_does_not_guard() -> None:
-    tool = FakeWriteTool(write_hint=None)
+def test_metadata_level_internal_marker_enrolls() -> None:
+    # AbstractBaseTool.metadata carries the tool's non_idempotent marker, and
+    # wrappers forward metadata — the guard must honor it there too.
+    tool = FakeWriteTool(mcp_non_idempotent_write=None)
+    tool.metadata.non_idempotent = True
+    assert tool_requires_duplicate_write_guard(tool)
+
+
+def test_non_boolean_marker_on_the_tool_does_not_enroll() -> None:
+    # A tool author writing a truthy non-boolean must not be enrolled by
+    # accident. Only the tool-object attribute is checked here: the metadata
+    # fields are typed on a pydantic model, which coerces a truthy value to
+    # True before the guard ever sees it, so there is no such shape to pin.
+    tool = FakeWriteTool(mcp_non_idempotent_write=None)
     tool.non_idempotent = "yes"  # type: ignore[attr-defined]
     assert not tool_requires_duplicate_write_guard(tool)
+
+
+def test_tool_without_metadata_is_exempt() -> None:
+    class Bare:
+        pass
+
+    assert not tool_requires_duplicate_write_guard(Bare())
 
 
 # ---------------------------------------------------------------------------
@@ -165,12 +195,11 @@ def test_non_boolean_non_idempotent_marker_does_not_guard() -> None:
 
 
 @pytest.mark.asyncio
-async def test_duplicate_destructive_call_is_suppressed() -> None:
+async def test_duplicate_write_is_suppressed() -> None:
     args = {"title": "invoice", "amount": 7}
     llm = _run_twice_llm("create_record", args, dict(args))
     tool = FakeWriteTool()
-    context = ExecutionContext()
-    context.add_user_message("Create the invoice record")
+    context = _turn_context("Create the invoice record")
 
     result = await _pattern().run(context=context, tools=[tool], llm=llm)
 
@@ -222,8 +251,7 @@ async def test_key_order_does_not_defeat_the_guard() -> None:
         ]
     )
     tool = FakeWriteTool()
-    context = ExecutionContext()
-    context.add_user_message("Create the record")
+    context = _turn_context()
 
     await _pattern().run(context=context, tools=[tool], llm=llm)
 
@@ -238,8 +266,7 @@ async def test_different_args_both_execute() -> None:
         {"title": "invoice", "amount": 8},
     )
     tool = FakeWriteTool()
-    context = ExecutionContext()
-    context.add_user_message("Create both records")
+    context = _turn_context("Create both records")
 
     await _pattern().run(context=context, tools=[tool], llm=llm)
 
@@ -248,16 +275,15 @@ async def test_different_args_both_execute() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "write_hint",
-    [MCPWriteHint.UNDECLARED, MCPWriteHint.READ_ONLY, None],
-    ids=["undeclared", "read_only", "no_hint"],
+    "declaration",
+    [None, False],
+    ids=["undeclared", "explicitly_idempotent"],
 )
-async def test_unguarded_tools_repeat_identical_calls(write_hint: Any) -> None:
+async def test_unenrolled_tools_repeat_identical_calls(declaration: Any) -> None:
     args = {"title": "status-poll"}
     llm = _run_twice_llm("create_record", args, dict(args))
-    tool = FakeWriteTool(write_hint=write_hint)
-    context = ExecutionContext()
-    context.add_user_message("Poll twice")
+    tool = FakeWriteTool(mcp_non_idempotent_write=declaration)
+    context = _turn_context("Poll twice")
 
     await _pattern().run(context=context, tools=[tool], llm=llm)
 
@@ -269,8 +295,7 @@ async def test_failed_first_write_is_retried() -> None:
     args = {"title": "invoice"}
     llm = _run_twice_llm("create_record", args, dict(args))
     tool = FakeWriteTool(fail_first=True)
-    context = ExecutionContext()
-    context.add_user_message("Create the record")
+    context = _turn_context()
 
     await _pattern().run(context=context, tools=[tool], llm=llm)
 
@@ -283,8 +308,7 @@ async def test_non_idempotent_internal_tool_is_guarded() -> None:
     args = {"title": "form"}
     llm = _run_twice_llm("submit_form", args, dict(args))
     tool = FakeNonIdempotentInternalTool()
-    context = ExecutionContext()
-    context.add_user_message("Submit the form")
+    context = _turn_context("Submit the form")
 
     await _pattern().run(context=context, tools=[tool], llm=llm)
 
@@ -309,8 +333,7 @@ async def test_provider_id_reuse_does_not_defeat_the_guard() -> None:
         ]
     )
     tool = FakeWriteTool()
-    context = ExecutionContext()
-    context.add_user_message("Create the record")
+    context = _turn_context()
 
     await _pattern().run(context=context, tools=[tool], llm=llm)
 
@@ -335,8 +358,7 @@ async def test_third_call_attaches_the_original_result() -> None:
         ]
     )
     tool = FakeWriteTool()
-    context = ExecutionContext()
-    context.add_user_message("Create the record")
+    context = _turn_context()
 
     await _pattern().run(context=context, tools=[tool], llm=llm)
 
@@ -350,46 +372,44 @@ async def test_third_call_attaches_the_original_result() -> None:
 
 
 @pytest.mark.asyncio
-async def test_guard_survives_checkpoint_state_round_trip() -> None:
-    args = {"title": "invoice"}
-    first_llm = FakeLLM(
+async def test_unknown_tool_bypasses_the_guard_gracefully() -> None:
+    # A call naming a tool that is not mounted must not trip the guard's
+    # lookup; it flows to the normal not-found error path.
+    llm = FakeLLM(
         responses=[
-            _tool_call_response("create_record", args, "call_1"),
-            {"content": "Created.", "done": True},
-        ]
-    )
-    first_tool = FakeWriteTool()
-    first_context = ExecutionContext()
-    first_context.add_user_message("Create the record")
-    first_pattern = _pattern()
-    await first_pattern.run(context=first_context, tools=[first_tool], llm=first_llm)
-    assert len(first_tool.calls) == 1
-
-    # Ledger state survives a checkpoint round-trip. Without turn tracking
-    # (no turn_id metadata anywhere, as in embeddings that never stamp one)
-    # the guard scope degrades to the pattern execution, so the restored
-    # ledger keeps suppressing the identical write. The stamped-turn variants
-    # of this scenario are covered by the two tests below.
-    resumed_pattern = _pattern()
-    resumed_pattern.load_state(json.loads(json.dumps(first_pattern.get_state())))
-    resumed_llm = FakeLLM(
-        responses=[
-            _tool_call_response("create_record", dict(args), "call_2"),
+            _tool_call_response("missing_tool", {"title": "x"}, "call_1"),
             {"content": "Done.", "done": True},
         ]
     )
-    resumed_tool = FakeWriteTool()
-    resumed_context = ExecutionContext()
-    resumed_context.add_user_message("Create the record")
+    tool = FakeWriteTool()
+    context = _turn_context("Use a missing tool")
 
-    await resumed_pattern.run(
-        context=resumed_context, tools=[resumed_tool], llm=resumed_llm
-    )
+    result = await _pattern().run(context=context, tools=[tool], llm=llm)
 
-    assert resumed_tool.calls == []
-    envelope = _tool_results(resumed_context)[0]
-    assert envelope[DUPLICATE_WRITE_SUPPRESSED_KEY] is True
-    assert envelope["suppressed_duplicate_of"] == "call_1"
+    assert result["success"] is True
+    assert tool.calls == []
+    first_result = _tool_results(context)[0]
+    assert first_result.get("success") is False
+
+
+# ---------------------------------------------------------------------------
+# Turn scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unstamped_turns_are_never_guarded() -> None:
+    # Fail-closed on turn identity: without a stamped turn_id the guard
+    # cannot bound suppression to one turn, so it does not fire at all.
+    args = {"title": "invoice"}
+    llm = _run_twice_llm("create_record", args, dict(args))
+    tool = FakeWriteTool()
+    context = ExecutionContext()
+    context.add_user_message("Create the record")  # no turn metadata
+
+    await _pattern().run(context=context, tools=[tool], llm=llm)
+
+    assert len(tool.calls) == 2
 
 
 @pytest.mark.asyncio
@@ -402,8 +422,7 @@ async def test_intra_turn_resume_suppresses_under_the_same_turn_id() -> None:
         ]
     )
     first_tool = FakeWriteTool()
-    first_context = ExecutionContext()
-    first_context.add_user_message("Create the record", metadata={"turn_id": "turn-1"})
+    first_context = _turn_context()
     first_pattern = _pattern()
     await first_pattern.run(context=first_context, tools=[first_tool], llm=first_llm)
     assert len(first_tool.calls) == 1
@@ -417,30 +436,30 @@ async def test_intra_turn_resume_suppresses_under_the_same_turn_id() -> None:
         ]
     )
     resumed_tool = FakeWriteTool()
-    resumed_context = ExecutionContext()
-    resumed_context.add_user_message(
-        "Create the record", metadata={"turn_id": "turn-1"}
-    )
+    resumed_context = _turn_context()
 
     await resumed_pattern.run(
         context=resumed_context, tools=[resumed_tool], llm=resumed_llm
     )
 
     assert resumed_tool.calls == []
+    envelope = _tool_results(resumed_context)[0]
+    assert envelope[DUPLICATE_WRITE_SUPPRESSED_KEY] is True
+    assert envelope["suppressed_duplicate_of"] == "call_1"
 
 
 @pytest.mark.asyncio
 async def test_identical_write_in_a_later_turn_executes() -> None:
     # The guard must be strictly per-turn (#2217): an explicit user request
     # in a later turn of the same execution repeats the identical write.
-    # resume/inject_user_message continue the execution with the ledger
-    # restored but a fresh turn_id on the new user message.
+    # The runner stamps a fresh turn_id on every user message; the pattern
+    # re-resolves it at each pattern start.
     args = {"title": "invoice"}
     pattern = _pattern()
     tool = FakeWriteTool()
     context = ExecutionContext()
 
-    context.add_user_message("Create the record", metadata={"turn_id": "turn-1"})
+    context.add_user_message("Create the record", metadata=dict(TURN_1))
     first_llm = FakeLLM(
         responses=[
             _tool_call_response("create_record", args, "call_1"),
@@ -451,7 +470,7 @@ async def test_identical_write_in_a_later_turn_executes() -> None:
     assert len(tool.calls) == 1
 
     context.add_user_message(
-        "Create the exact same record again", metadata={"turn_id": "turn-2"}
+        "Create the exact same record again", metadata=dict(TURN_2)
     )
     second_llm = FakeLLM(
         responses=[
@@ -460,6 +479,162 @@ async def test_identical_write_in_a_later_turn_executes() -> None:
         ]
     )
     await pattern.run(context=context, tools=[tool], llm=second_llm)
+
+    assert len(tool.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_pre_upgrade_checkpoint_records_never_match_a_stamped_turn() -> None:
+    # Checkpoints written before ToolCallRecord.turn_id existed restore with
+    # turn_id=None; against a stamped turn they must fail the equality check
+    # and err toward executing.
+    args = {"title": "invoice"}
+    seed_pattern = _pattern()
+    seed_llm = FakeLLM(
+        responses=[
+            _tool_call_response("create_record", args, "call_1"),
+            {"content": "Created.", "done": True},
+        ]
+    )
+    seed_tool = FakeWriteTool()
+    await seed_pattern.run(context=_turn_context(), tools=[seed_tool], llm=seed_llm)
+
+    state = json.loads(json.dumps(seed_pattern.get_state()))
+    for record in state["tool_ledger"].values():
+        record.pop("turn_id", None)  # simulate the pre-upgrade shape
+
+    resumed_pattern = _pattern()
+    resumed_pattern.load_state(state)
+    resumed_tool = FakeWriteTool()
+    resumed_llm = FakeLLM(
+        responses=[
+            _tool_call_response("create_record", dict(args), "call_2"),
+            {"content": "Done.", "done": True},
+        ]
+    )
+
+    await resumed_pattern.run(
+        context=_turn_context(), tools=[resumed_tool], llm=resumed_llm
+    )
+
+    assert len(resumed_tool.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Ledger-order and concurrency edges
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_envelope_first_ledger_order_still_attaches_the_genuine_result() -> None:
+    # load_state rebuilds the ledger in the checkpoint's stored order, so an
+    # envelope record can precede its genuine record. The scan must skip the
+    # envelope and attach the genuine execution's result.
+    genuine_result = {"success": True, "record_id": "rec-1"}
+    envelope_record = {
+        "tool_call_id": "call_2",
+        "tool_name": "create_record",
+        "args": {"title": "invoice", "amount": 0},
+        "args_hash": "",
+        "status": "completed",
+        "result": build_suppression_envelope(
+            tool_name="create_record",
+            prior_tool_call_id="call_1",
+            prior_result=genuine_result,
+        ),
+        "error": None,
+        "turn_id": "turn-1",
+    }
+    genuine_record = {
+        "tool_call_id": "call_1",
+        "tool_name": "create_record",
+        "args": {"title": "invoice", "amount": 0},
+        "args_hash": "",
+        "status": "completed",
+        "result": genuine_result,
+        "error": None,
+        "turn_id": "turn-1",
+    }
+
+    seed_pattern = _pattern()
+    seed_llm = FakeLLM(
+        responses=[
+            _tool_call_response(
+                "create_record", {"title": "invoice", "amount": 0}, "call_1"
+            ),
+            {"content": "Created.", "done": True},
+        ]
+    )
+    await seed_pattern.run(
+        context=_turn_context(), tools=[FakeWriteTool()], llm=seed_llm
+    )
+    state = json.loads(json.dumps(seed_pattern.get_state()))
+    real_hash = state["tool_ledger"]["call_1"]["args_hash"]
+    envelope_record["args_hash"] = real_hash
+    genuine_record["args_hash"] = real_hash
+    state["tool_ledger"] = {"call_2": envelope_record, "call_1": genuine_record}
+
+    pattern = _pattern()
+    pattern.load_state(state)
+    tool = FakeWriteTool()
+    llm = FakeLLM(
+        responses=[
+            _tool_call_response(
+                "create_record", {"title": "invoice", "amount": 0}, "call_3"
+            ),
+            {"content": "Done.", "done": True},
+        ]
+    )
+    context = _turn_context()
+
+    await pattern.run(context=context, tools=[tool], llm=llm)
+
+    assert tool.calls == []
+    envelope = _tool_results(context)[0]
+    assert envelope["suppressed_duplicate_of"] == "call_1"
+    assert envelope["result"] == genuine_result
+
+
+@pytest.mark.asyncio
+async def test_concurrent_identical_writes_are_a_disclosed_boundary() -> None:
+    # Documents the disclosed check-then-record window: when an operator
+    # marks a non-idempotent tool concurrency_safe (contradicting that
+    # flag's idempotency meaning), two identical calls in one concurrent
+    # batch are invisible to each other (neither is "completed" during the
+    # other's scan) and both execute. If this test ever fails because only
+    # one call ran, the window was closed — update the guard's docstring and
+    # the PR-facing disclosure.
+    args = {"title": "invoice"}
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "create_record",
+                            "arguments": json.dumps(args),
+                        },
+                    },
+                    {
+                        "id": "call_2",
+                        "function": {
+                            "name": "create_record",
+                            "arguments": json.dumps(args),
+                        },
+                    },
+                ],
+                "done": False,
+            },
+            {"content": "Done.", "done": True},
+        ]
+    )
+    tool = FakeWriteTool(concurrency_safe=True)
+    context = _turn_context()
+    pattern = _pattern(tool_parallel_enabled=True, tool_max_concurrency=2)
+
+    await pattern.run(context=context, tools=[tool], llm=llm)
 
     assert len(tool.calls) == 2
 
@@ -473,6 +648,12 @@ async def test_identical_write_in_a_later_turn_executes() -> None:
 async def test_envelope_strips_reserved_transport_keys() -> None:
     # The ledger stores the raw execution return; reserved transport keys
     # must not reach the model nested inside the suppression envelope.
+    #
+    # Only a *valid* scope is exercised, deliberately: a value the scope
+    # parser rejects cannot reach this code at all, because the genuine
+    # call's own add_tool_result raises ValueError on the same value
+    # (context_ref.py) and nothing on the ReAct loop's backfill path catches
+    # it, so the turn ends before any duplicate can be issued.
     args = {"title": "invoice"}
 
     class ReservedKeysTool(FakeWriteTool):
@@ -487,8 +668,7 @@ async def test_envelope_strips_reserved_transport_keys() -> None:
 
     llm = _run_twice_llm("create_record", args, dict(args))
     tool = ReservedKeysTool()
-    context = ExecutionContext()
-    context.add_user_message("Create the record")
+    context = _turn_context()
 
     await _pattern().run(context=context, tools=[tool], llm=llm)
 

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -28,6 +28,7 @@ from xagent.core.tools.adapters.vibe.mcp_adapter import (
     _compact_json,
     _exception_indicates_http_401,
     _mcp_return_value_as_string,
+    classify_non_idempotent_write,
     classify_write_hint,
     load_mcp_tools_as_agent_tools,
 )
@@ -3219,6 +3220,78 @@ def test_annotations_reach_the_common_metadata_contract():
     # The scheduler's own read-only flag is a different, local guarantee and
     # must not be moved by an untrusted remote claim.
     assert read_only.metadata.read_only is False
+
+
+def _non_idempotent_flags_from_wire(*annotations: object) -> list[bool]:
+    """Classify through the same wire path the write-hint tests use."""
+    tools = _tools_with_raw_annotations(_listing(*annotations))
+    return [
+        _build_mcp_tool_adapter("srv", SimpleNamespace(), tool).non_idempotent_write
+        for tool in tools
+    ]
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # The #2217 incident shape: a well-annotated create tool. Additive
+        # (destructive false), explicitly non-idempotent -- must enroll.
+        (
+            {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False},
+            True,
+        ),
+        ({"idempotentHint": False}, True),
+        # Destructive with no idempotency declaration keeps enrolling.
+        ({"destructiveHint": True}, True),
+        ({"readOnlyHint": False, "destructiveHint": True}, True),
+        # An explicit idempotency promise wins over destructive: repeats are
+        # declared to have no additional effect, so there is nothing to guard.
+        ({"destructiveHint": True, "idempotentHint": True}, False),
+        ({"idempotentHint": True}, False),
+        # Read-only tools never enroll, even against a contradictory
+        # idempotency claim -- deduplication fails open on contradictions.
+        ({"readOnlyHint": True, "idempotentHint": False}, False),
+        ({"readOnlyHint": True, "destructiveHint": True}, False),
+        # Coercible non-booleans are not declarations.
+        ({"idempotentHint": "false"}, False),
+        ({"idempotentHint": 0}, False),
+        ({"destructiveHint": "true"}, False),
+        ({"destructiveHint": 1}, False),
+        # Nothing declared at all stays exempt (UNDECLARED poll loops).
+        ({"readOnlyHint": False}, False),
+        ({"idempotentHint": None, "destructiveHint": None}, False),
+        ({"title": "Echo"}, False),
+        ({}, False),
+        (None, False),
+    ],
+)
+def test_non_idempotent_write_classifies_wire_annotations(raw, expected):
+    """Enrollment needs an explicit non-idempotent-write declaration."""
+    assert _non_idempotent_flags_from_wire(raw) == [expected]
+
+
+@pytest.mark.parametrize("malformed", ["idempotent", 1, [], "false"])
+def test_non_mapping_annotations_are_not_non_idempotent(malformed):
+    assert classify_non_idempotent_write(malformed) is False
+
+
+def test_non_idempotent_write_reaches_the_common_metadata_contract():
+    """The duplicate-write guard reads this off ``metadata`` because tool
+    wrappers (e.g. the sandbox wrapper) forward only ``.metadata``."""
+    tools = _tools_with_raw_annotations(
+        _listing(
+            {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False},
+            {"destructiveHint": True, "idempotentHint": True},
+            None,
+        )
+    )
+    create_tool, idempotent_destructive, undeclared = (
+        _build_mcp_tool_adapter("srv", SimpleNamespace(), tool) for tool in tools
+    )
+
+    assert create_tool.metadata.mcp_non_idempotent_write is True
+    assert idempotent_destructive.metadata.mcp_non_idempotent_write is False
+    assert undeclared.metadata.mcp_non_idempotent_write is False
 
 
 def test_misaligned_listing_yields_no_declarations(monkeypatch):

--- a/tests/core/tools/adapters/vibe/test_tool_metadata_concurrency.py
+++ b/tests/core/tools/adapters/vibe/test_tool_metadata_concurrency.py
@@ -132,3 +132,50 @@ def test_abstract_base_tool_metadata_exposes_concurrency_fields() -> None:
     # scheduler can read them uniformly across every tool.
     assert "read_only" in PythonExecutorTool().metadata.model_dump()
     assert "concurrency_safe" in PythonExecutorTool().metadata.model_dump()
+
+
+def test_non_idempotent_marker_reaches_metadata_on_a_real_base_tool() -> None:
+    # The duplicate-write guard (#2217) reads its enrollment off metadata, so
+    # a first-party tool's class-level marker has to survive the base
+    # property's construction.
+    class SubmitFormTool(FakeBaseTool):
+        non_idempotent = True
+
+        @property
+        def name(self) -> str:
+            return "submit_form"
+
+    assert SubmitFormTool().metadata.non_idempotent is True
+    assert FunctionTool(_noop, name="plain").metadata.non_idempotent is False
+
+
+def test_sandboxed_wrapper_forwards_the_non_idempotent_marker() -> None:
+    # Sandboxed npx/uvx MCP tools reach the ReAct loop as wrappers that
+    # forward only .metadata; an enrollment signal read off the concrete tool
+    # object would vanish for every one of them.
+    @sandbox_config()
+    class SandboxSubmitTool(FakeBaseTool):
+        non_idempotent = True
+
+        def args_type(self) -> Type[BaseModel]:
+            return BaseModel
+
+        def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+            return {}
+
+        async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+            return {}
+
+        @property
+        def name(self) -> str:
+            return "sandbox_submit"
+
+    wrapped = SandboxedToolWrapper(SandboxSubmitTool(), MagicMock())
+
+    assert wrapped.metadata.non_idempotent is True
+    # And the guard enrolls it through that forwarded metadata alone.
+    from xagent.core.agent.pattern.react.duplicate_write_guard import (
+        tool_requires_duplicate_write_guard,
+    )
+
+    assert tool_requires_duplicate_write_guard(wrapped) is True


### PR DESCRIPTION
## Summary

Fixes #2217: within one turn the model can re-issue a write tool call with byte-identical arguments after the first call already succeeded, creating duplicate records in the external system (observed in production: three identical MCP create calls in one turn).

This adds a same-turn duplicate-write guard to the ReAct tool-execution path:

- Before executing a tool call whose tool **explicitly declares a non-idempotent write**, the loop scans the turn's tool ledger for a completed call with the same `(turn_id, tool_name, args_hash)`.
- On a hit, the call is **not executed**; the model receives a structured suppression envelope (`duplicate_write_suppressed: true`, `suppressed_duplicate_of: <tool_call_id>`, prior result attached) through the normal `on_tool_start`/`on_tool_end` events, so suppressions are visible in traces and transcripts.
- `ToolCallRecord` records the durable `turn_id` stamped on each call, and the guard requires turn equality. The ledger is checkpointed pattern state, so the guard **survives an intra-turn resume** (the incident's deferred-replay case) and **resets across turns**: the runner stamps a fresh `turn_id` on every user message and the pattern re-resolves it at each pattern start, so an explicit repeat requested in a later turn always executes, per the issue's "strictly per-turn / overridable in a later turn" requirement.

## Enrollment

Enrollment is explicit-only and read off `ToolMetadata`, never off the concrete tool object — wrappers such as `SandboxedToolWrapper` (every sandboxed npx/uvx MCP server) forward only `.metadata`, so an attribute read there would silently enroll nothing.

- **MCP tools**: `classify_non_idempotent_write` reads the raw wire annotations and enrolls when `readOnlyHint` is not exactly `true` and either `idempotentHint` is exactly `false`, or `destructiveHint` is exactly `true` with no `idempotentHint: true` promise. Per the MCP schema this is the right question — `destructiveHint: false` means "only additive updates", so a well-annotated create tool (the #2217 shape) is additive *and* non-idempotent. Carried as `ToolMetadata.mcp_non_idempotent_write`.
- **Internal tools**: an opt-in `non_idempotent = True` marker, carried as `ToolMetadata.non_idempotent`. The mechanism ships here; which internal tools opt in is a per-tool product decision left to follow-ups.
- **Never enrolled**: read-only tools, tools with no exact wire boolean (an absent hint is never read through its spec default), and anything contradictory. Deduplication deliberately fails **open** — the mirror image of a confirmation-style consumer — because suppressing an unannotated identical-args poll loop would serve the model stale data.

The optional client-side idempotency key from the issue is not implemented (the issue marks it optional).

## Also fixed

`_AutoChildRuntime` defined no `_dag_turn_id`, which `_DAGStepRuntime.active_turn_id` calls on every access; the resulting `AttributeError` was swallowed by the caller's `getattr(runtime, "active_turn_id", None)`, leaving every `auto` → DAG step's tool call unstamped. That already cost those steps their trace turn attribution, and it would have disabled this guard for the whole `auto` mode. One forwarding method, pinned by a test that returns `None` with the forward removed.

## Edge cases covered

- **Provider tool_call id reuse**: ids are not guaranteed unique. The scan runs before the repeat writes any ledger record, and a suppression never overwrites the matched genuine record, so a repeat that reuses the completed call's id is still suppressed and later repeats still attach the original result.
- **Argument canonicalization**: the args hash uses `json.dumps(sort_keys=True)`, so key order cannot defeat the guard.
- **Ledger order**: an envelope record can precede its genuine record (`load_state` rebuilds in stored order; batch reorder re-appends at the tail), so the scan skips envelopes and always attaches the genuine result.
- **Reserved transport keys** (`_xagent_context_refs` / `_xagent_supersedes_scope`) are dropped from the prior result before it is nested in the envelope; they are split only at top level by `add_tool_result` and would otherwise leak into model-visible content.
- **Turn identity fails closed**: a call with no stamped `turn_id` is never guarded, so suppression cannot outlive a turn. Pre-upgrade checkpoint records carry no `turn_id` and never match a stamped turn, erring toward executing.
- Failed and `waiting_for_user` calls never suppress (only `completed` records match).

## Known boundaries (deliberate, non-blocking)

- **Concurrent batches**: enrolled tools are serial by default (`concurrency_safe` defaults to `False` and is the author's idempotency contract). An operator who sets connection-level `concurrency_safe: true` on a non-idempotent MCP tool contradicts that contract and reopens a check-then-record window for two identical calls inside one batch. Documented in the guard's docstring and pinned by a characterization test so it cannot close silently.
- **DAG cross-step**: each DAG step runs its own ReAct pattern with a per-step ledger, so an identical write across two DAG steps in one turn is not suppressed. Tracked in #2236.

## Out of scope (pre-existing, declared)

- #2231 — a suppressed duplicate still meters one billable tool action via `on_tool_start`.
- #2236 — duplicate writes across DAG steps within one turn.
- #2238 — an invalid `_xagent_supersedes_scope` on a tool result kills the turn with an unhandled `ValueError` (surfaced while reviewing the envelope stripping on this path).
- #2216 — companion zero-iteration-resume defect from the same incident (separate fix).

## Tests

- `tests/core/agent/test_react_duplicate_write_guard.py` — 22 tests driving `ReActPattern.run` through the real execution path: suppression, arg differences, key-order canonicalization, the enrollment matrix, failed-first retry, internal marker, third-call original-result attachment, provider id reuse, unknown-tool early exit, checkpoint round-trip, same-turn resume, later-turn execution, unstamped turns, pre-upgrade checkpoints, envelope-first ledger order, the concurrent-batch boundary, and envelope key stripping.
- `tests/core/tools/adapters/vibe/test_mcp_adapter.py` — 17 wire-annotation cases through the same raw-annotation loader the neighbouring write-hint tests use, so coercible values never read as declarations.
- `tests/core/tools/adapters/vibe/test_tool_metadata_concurrency.py` — the marker on a real `AbstractBaseTool` subclass, and enrollment through a `SandboxedToolWrapper`-wrapped tool.
- `tests/core/agent/test_auto.py` — `auto` → DAG turn stamping.

`tests/core/agent` and `tests/core/tools/adapters` pass in full, plus `mypy` and `ruff` on every touched file; the full suite is left to CI.
