### PR TITLE
fix(react): give every waiting_for_user message an answerable field

### DIFF
--- a/src/xagent/core/agent/clarification.py
+++ b/src/xagent/core/agent/clarification.py
@@ -237,9 +237,9 @@ def draft_from_waiting_request(
     - otherwise ``request["tool_name"] == "ask_user_question"`` ->
       ``"ask_user_question"``. Keyed on the tool name rather than on the
       presence of an ``"interactions"`` key, because every waiting path now
-      carries that key: the engine substitutes a default free-text field
-      when the model supplied none, so key presence no longer tells the two
-      control tools apart. ``tool_name`` has always been written here, so
+      carries that key: the engine appends a default free-text field
+      whenever nothing the model supplied is answerable, so key presence no
+      longer tells the two control tools apart. ``tool_name`` has always been written here, so
       checkpoints from before that substitution classify the same way.
     - otherwise -> ``"send_message"``.
 
@@ -251,8 +251,8 @@ def draft_from_waiting_request(
     - ``request`` is a dict but carries neither a non-empty message nor an
       ``"interactions"`` key nor a non-empty ``"requests"`` list. No
       ReAct waiting path produces that shape any more -- every one of them
-      now writes an ``"interactions"`` key, defaulted to a free-text field
-      when the model supplied none. What remains is resuming a checkpoint
+      now writes an ``"interactions"`` key, carrying an appended free-text
+      field whenever nothing the model supplied is answerable. What remains is resuming a checkpoint
       written by an older schema, which degrades to "no draft" instead of
       raising and blocking resume.
     """

--- a/src/xagent/core/agent/clarification.py
+++ b/src/xagent/core/agent/clarification.py
@@ -234,9 +234,13 @@ def draft_from_waiting_request(
 
     - ``request["kind"] == "tool_waiting_for_user"`` -> ``"tool_waiting"``,
       one :class:`ClarificationRequestItem` per entry in ``request["requests"]``.
-    - otherwise ``request["message_type"] == "question"`` *and* ``request``
-      has an ``"interactions"`` key (key presence, not truthiness -- an
-      empty-form ``ask_user_question`` still has the key) -> ``"ask_user_question"``.
+    - otherwise ``request["tool_name"] == "ask_user_question"`` ->
+      ``"ask_user_question"``. Keyed on the tool name rather than on the
+      presence of an ``"interactions"`` key, because every waiting path now
+      carries that key: the engine substitutes a default free-text field
+      when the model supplied none, so key presence no longer tells the two
+      control tools apart. ``tool_name`` has always been written here, so
+      checkpoints from before that substitution classify the same way.
     - otherwise -> ``"send_message"``.
 
     Returns ``None`` in two cases, both meaning "no typed draft could be
@@ -245,14 +249,12 @@ def draft_from_waiting_request(
     - ``request`` is not a dict (``None``, a stray ``str``, a ``list``,
       ...) -- a type mismatch from the caller.
     - ``request`` is a dict but carries neither a non-empty message nor an
-      ``"interactions"`` key nor a non-empty ``"requests"`` list. This is
-      reachable in production today: a ``send_message`` call with an empty
-      ``message`` and ``expect_response=True`` reaches ``waiting_for_user``
-      with no message, no ``"interactions"`` key, and no ``"requests"``
-      list (see the ``send_message`` branch of
-      ``ReActPattern._handle_control_tool`` in ``react.py``). It also
-      covers resuming a checkpoint written by an older schema, which
-      degrades to "no draft" instead of raising and blocking resume.
+      ``"interactions"`` key nor a non-empty ``"requests"`` list. No
+      ReAct waiting path produces that shape any more -- every one of them
+      now writes an ``"interactions"`` key, defaulted to a free-text field
+      when the model supplied none. What remains is resuming a checkpoint
+      written by an older schema, which degrades to "no draft" instead of
+      raising and blocking resume.
     """
 
     if not isinstance(request, dict):
@@ -300,7 +302,7 @@ def draft_from_waiting_request(
                     )
                 )
         requests = tuple(items)
-    elif request.get("message_type") == "question" and has_interactions_key:
+    elif request.get("tool_name") == "ask_user_question":
         source = "ask_user_question"
         tool_call_id = str(request.get("tool_call_id") or "")
         requests = (

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -70,8 +70,8 @@ from ....model.chat.exceptions import LLMToolProtocolError
 from ....model.chat.tool_protocol import get_tool_protocol_error
 from ....tools.adapters.vibe.interaction_types import (
     DEFAULT_WAITING_INTERACTION,
+    INTERACTION_TYPE_ALIASES,
     INTERACTION_TYPES,
-    RENDERABLE_INTERACTION_TYPES,
     TYPES_REQUIRING_OPTIONS,
 )
 from ....tools.user_interaction import (
@@ -291,6 +291,9 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
             continue
 
         item = dict(interaction)
+        item_type = item.get("type")
+        if isinstance(item_type, str) and item_type in INTERACTION_TYPE_ALIASES:
+            item["type"] = INTERACTION_TYPE_ALIASES[item_type]
         field = item.get("field") or item.get("id") or item.get("name")
         normalized_field = (
             _normalize_interaction_text(field) if isinstance(field, str) else ""
@@ -407,15 +410,17 @@ _DEFAULT_WAITING_ANSWER_PREFIX = f"{DEFAULT_WAITING_INTERACTION['label']}: "
 def _is_answerable(interaction: Any) -> bool:
     """Whether a user handed this control could produce an answer with it.
 
-    Two ways to fail. A type outside ``RENDERABLE_INTERACTION_TYPES`` --
-    including a ``type`` the model did not even send as a string -- is dropped
-    by the frontend's ``normalizeInteractions``
-    (``frontend/src/contexts/app-context-chat.tsx``), and a list it empties
-    renders no form at all, which is the dead end this check exists to
-    prevent. And a pick-from-a-list type with nothing to pick survives
-    ``_normalize_ask_user_interactions`` (which drops the blank options, not
-    the interaction) as a control with no choices. Every other type renders
-    an input that stands on its own.
+    Two ways to fail. A type outside ``INTERACTION_TYPES`` -- including a
+    ``type`` the model did not even send as a string, and ``connect_apps``,
+    whose OAuth-button widget ``ClarificationForm`` renders without a Submit
+    button at all (``isConnectAppsOnly``, clarification-form.tsx) -- is
+    dropped by the frontend's ``normalizeInteractions`` or lands in a form
+    with nothing to submit, which is the dead end this check exists to
+    prevent. Aliases are not a third case: ``_normalize_ask_user_interactions``
+    has already mapped them onto these seven by the time this runs. And a
+    pick-from-a-list type with nothing to pick survives that normalization
+    (which drops the blank options, not the interaction) as a control with no
+    choices. Every other type renders an input that stands on its own.
 
     Nothing upstream refuses either shape: the tool schema's ``enum`` is a
     prompt, not a runtime constraint, and the write-side admissibility rules
@@ -429,7 +434,7 @@ def _is_answerable(interaction: Any) -> bool:
     # is free to send a list) would raise there and kill the whole run.
     if not isinstance(interaction_type, str):
         return False
-    if interaction_type not in RENDERABLE_INTERACTION_TYPES:
+    if interaction_type not in INTERACTION_TYPES:
         return False
     if interaction_type in TYPES_REQUIRING_OPTIONS:
         options = interaction.get("options")
@@ -2611,9 +2616,10 @@ class ReActPattern(AgentPattern):
         keeps the substituted field the only one, so its base name cannot
         collide with a caller's ``_2``/``_3`` dedup suffixes.
 
-        Both branches return fresh dicts: the published list is stored on the
-        waiting request, the tool-call record and the result dict, so it must
-        not alias items the caller still holds.
+        Both branches return a fresh list of fresh dicts: the published list
+        is stored on the waiting request and the result dict, so it must not
+        alias items the caller still holds. Shallow -- ``options`` and its
+        entries stay shared, and no reader rewrites those.
         """
 
         published = (

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -131,6 +131,9 @@ UNGROUPED_TOOL_DECISION_CATEGORIES = frozenset({"basic", "other"})
 # module's untrusted-input logging: bounded length, escaped, never raw.
 STRIP_LOG_MAX_TOOL_NAMES = 8
 STRIP_LOG_MAX_TOOL_NAME_CHARS = 64
+# Only ever injected into an otherwise empty interaction list, so this base
+# name can never collide with the callers' _2/_3 dedup suffixes.
+DEFAULT_WAITING_INTERACTION_FIELD = "response"
 REACT_RESPONSE_LANGUAGE_DESCRIPTION = (
     "Target natural language for user-facing prose in this ReAct response, "
     "for example English, Simplified Chinese, Traditional Chinese, or Spanish. "
@@ -394,6 +397,24 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
         )
 
     return normalized
+
+
+def _default_waiting_interaction() -> dict[str, Any]:
+    """The free-text field a suspended run falls back to.
+
+    Honours xagent#1528's "no controls means answer in free text" contract on
+    the write side, so no reader has to infer it. Carried by both surfaces a
+    reader can use: the outbound message's metadata and the waiting request
+    the structured interaction row is built from.
+    """
+
+    return {
+        "type": "text_input",
+        "field": DEFAULT_WAITING_INTERACTION_FIELD,
+        "label": "Your response",
+        "placeholder": "Type your answer",
+        "multiline": True,
+    }
 
 
 class ReActPattern(AgentPattern):
@@ -2159,7 +2180,12 @@ class ReActPattern(AgentPattern):
                 "type": "function",
                 "function": {
                     "name": "send_message",
-                    "description": "Send a message to the user, optionally waiting for a response.",
+                    "description": (
+                        "Send a message to the user, optionally waiting for a "
+                        "response. Do not use it to narrate a plan you are about "
+                        "to carry out, and do not use it to ask a question; ask "
+                        "with ask_user_question instead."
+                    ),
                     "parameters": {
                         "type": "object",
                         "properties": {
@@ -2379,13 +2405,24 @@ class ReActPattern(AgentPattern):
             expect_response = bool(args.get("expect_response", False))
             message_type = str(args.get("message_type", "info"))
             visible = bool(args.get("visible", True))
-            outbound_message = await runtime.send_message(
-                message=message,
-                message_type=message_type,
-                expect_response=expect_response,
-                visible=visible,
-                metadata=source,
-            )
+            interactions: list[dict[str, Any]] = []
+            if expect_response:
+                outbound_message, interactions = await self._send_waiting_message(
+                    runtime=runtime,
+                    message=message,
+                    message_type=message_type,
+                    interactions=[],
+                    metadata=source,
+                    visible=visible,
+                )
+            else:
+                outbound_message = await runtime.send_message(
+                    message=message,
+                    message_type=message_type,
+                    expect_response=False,
+                    visible=visible,
+                    metadata=source,
+                )
             self._record_tool_call(
                 tool_call,
                 status="completed",
@@ -2403,6 +2440,7 @@ class ReActPattern(AgentPattern):
                         "status": "waiting_for_user",
                         "message": message,
                         "message_type": message_type,
+                        "interactions": interactions,
                     },
                     tool_call_id=tool_call.get("id"),
                 )
@@ -2412,6 +2450,7 @@ class ReActPattern(AgentPattern):
                     "tool_name": name,
                     "message": message,
                     "message_type": message_type,
+                    "interactions": interactions,
                     "task_text": self.task_text,
                     "message_count": len(getattr(context, "messages", [])),
                 }
@@ -2420,6 +2459,7 @@ class ReActPattern(AgentPattern):
                     "status": self.status,
                     "message": message,
                     "message_type": message_type,
+                    "interactions": interactions,
                     "context": context,
                     "clarification_draft": draft_from_waiting_request(
                         self.waiting_for_user_request,
@@ -2464,16 +2504,12 @@ class ReActPattern(AgentPattern):
                 item["field"] = field
                 used_fields.add(field)
                 deduplicated_interactions.append(item)
-            interactions = deduplicated_interactions
-            outbound_message = await runtime.send_message(
+            outbound_message, interactions = await self._send_waiting_message(
+                runtime=runtime,
                 message=message,
                 message_type="question",
-                expect_response=True,
-                visible=True,
-                metadata={
-                    **source,
-                    "interactions": interactions,
-                },
+                interactions=deduplicated_interactions,
+                metadata=source,
             )
             self._record_tool_call(
                 tool_call,
@@ -2520,6 +2556,36 @@ class ReActPattern(AgentPattern):
             }
 
         return None
+
+    async def _send_waiting_message(
+        self,
+        *,
+        runtime: PatternRuntime,
+        message: str,
+        message_type: str,
+        interactions: list[dict[str, Any]],
+        metadata: dict[str, Any],
+        visible: bool = True,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Publish a message that suspends the run, and return what it carried.
+
+        Every path that publishes a suspending message goes through here, so
+        the "at least one answerable field" guarantee is made once. It is not
+        pushed down into ``runtime.send_message``: that call also serves
+        non-suspending messages, which must stay field-free, and the callers
+        need the published list back to store on the waiting request -- which
+        is also what the structured interaction row is built from.
+        """
+
+        published = interactions or [_default_waiting_interaction()]
+        outbound_message = await runtime.send_message(
+            message=message,
+            message_type=message_type,
+            expect_response=True,
+            visible=visible,
+            metadata={**metadata, "interactions": published},
+        )
+        return outbound_message, published
 
     def _reject_empty_final_answer(
         self, tool_call: dict[str, Any], context: Any
@@ -2789,13 +2855,12 @@ class ReActPattern(AgentPattern):
             )
             message_type = "question"
 
-        outbound_message = await runtime.send_message(
+        outbound_message, interactions = await self._send_waiting_message(
+            runtime=runtime,
             message=message,
             message_type=message_type,
-            expect_response=True,
-            visible=True,
+            interactions=interactions,
             metadata={
-                "interactions": interactions,
                 "tool_calls": [
                     self._tool_message_source(
                         self._with_runtime_turn_id(

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -250,8 +250,9 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
     treated the same as missing: the option is dropped. A field name that is
     blank after normalization falls back to ``response_{index}``; a
     well-formed field name is normalized and written back so the frontend's
-    own ``trim()`` is a no-op on it. Survivors are otherwise kept verbatim --
-    only blankness is judged here, not content.
+    own ``trim()`` is a no-op on it. An off-contract ``type`` is rewritten to
+    the canonical name the frontend maps it to (``INTERACTION_TYPE_ALIASES``).
+    Survivors are otherwise kept verbatim.
 
     The alias chain ``field or id or name`` intentionally keeps its raw
     truthiness check; it is not normalization-aware. The frontend's own
@@ -1855,15 +1856,16 @@ class ReActPattern(AgentPattern):
             return
         # The form submits "<label>: <value>"; for the substituted field the
         # label carries nothing, so a resume callback would get a prefixed value.
+        # Not keyed on the field being alone: it is appended to entries the form
+        # renders but cannot submit, which contribute no line of their own.
         published = waiting_request.get("interactions")
-        if (
-            isinstance(published, list)
-            and len(published) == 1
-            and is_default_waiting_interaction(published[0])
-        ):
-            prefix = f"{published[0]['label']}: "
+        for item in published if isinstance(published, list) else []:
+            if not is_default_waiting_interaction(item):
+                continue
+            prefix = f"{item['label']}: "
             if response.startswith(prefix):
                 response = response[len(prefix) :]
+            break
         raw_requests = waiting_request.get("requests")
         requests = raw_requests if isinstance(raw_requests, list) else [waiting_request]
         for request in requests:

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -71,6 +71,7 @@ from ....model.chat.tool_protocol import get_tool_protocol_error
 from ....tools.adapters.vibe.interaction_types import (
     DEFAULT_WAITING_INTERACTION,
     INTERACTION_TYPES,
+    RENDERABLE_INTERACTION_TYPES,
     TYPES_REQUIRING_OPTIONS,
 )
 from ....tools.user_interaction import (
@@ -400,22 +401,37 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
     return normalized
 
 
+_DEFAULT_WAITING_ANSWER_PREFIX = f"{DEFAULT_WAITING_INTERACTION['label']}: "
+
+
 def _is_answerable(interaction: Any) -> bool:
     """Whether a user handed this control could produce an answer with it.
 
-    Only the pick-from-a-list types can fail: emptied options survive
-    ``_normalize_ask_user_interactions`` as an entry with nothing to select
-    (that function drops the blank options, not the interaction), and a
-    malformed non-list ``options`` survives it untouched, which the render
-    surface cannot iterate either. Every other type renders an input that
-    stands on its own, and an unrecognized type is treated as answerable
-    rather than silently replaced -- the write-side admissibility rules are
-    what refuse those.
+    Two ways to fail. A type outside ``RENDERABLE_INTERACTION_TYPES`` --
+    including a ``type`` the model did not even send as a string -- is dropped
+    by the frontend's ``normalizeInteractions``
+    (``frontend/src/contexts/app-context-chat.tsx``), and a list it empties
+    renders no form at all, which is the dead end this check exists to
+    prevent. And a pick-from-a-list type with nothing to pick survives
+    ``_normalize_ask_user_interactions`` (which drops the blank options, not
+    the interaction) as a control with no choices. Every other type renders
+    an input that stands on its own.
+
+    Nothing upstream refuses either shape: the tool schema's ``enum`` is a
+    prompt, not a runtime constraint, and the write-side admissibility rules
+    in ``validate_v1_write_payload`` have no production caller.
     """
 
     if not isinstance(interaction, dict):
         return False
-    if interaction.get("type") in TYPES_REQUIRING_OPTIONS:
+    interaction_type = interaction.get("type")
+    # Before the frozenset lookup below: an unhashable ``type`` (the model
+    # is free to send a list) would raise there and kill the whole run.
+    if not isinstance(interaction_type, str):
+        return False
+    if interaction_type not in RENDERABLE_INTERACTION_TYPES:
+        return False
+    if interaction_type in TYPES_REQUIRING_OPTIONS:
         options = interaction.get("options")
         return isinstance(options, list) and bool(options)
     return True
@@ -1819,6 +1835,12 @@ class ReActPattern(AgentPattern):
             or waiting_request.get("kind") != "tool_waiting_for_user"
         ):
             return
+        # The form submits "<label>: <value>"; for the substituted field the
+        # label carries nothing, so a resume callback would get a prefixed value.
+        if waiting_request.get("interactions") == [
+            DEFAULT_WAITING_INTERACTION
+        ] and response.startswith(_DEFAULT_WAITING_ANSWER_PREFIX):
+            response = response[len(_DEFAULT_WAITING_ANSWER_PREFIX) :]
         raw_requests = waiting_request.get("requests")
         requests = raw_requests if isinstance(raw_requests, list) else [waiting_request]
         for request in requests:
@@ -2185,10 +2207,14 @@ class ReActPattern(AgentPattern):
                 "function": {
                     "name": "send_message",
                     "description": (
-                        "Send a message to the user, optionally waiting for a "
-                        "response. Do not use it to narrate a plan you are about "
-                        "to carry out, and do not use it to ask a question; ask "
-                        "with ask_user_question instead."
+                        "Send a prose message to the user. Set message_type to "
+                        "what the message is: use progress to report work "
+                        "already underway, not to announce a plan you have not "
+                        "started. Set expect_response=true only when the task "
+                        "cannot continue until the user replies, and only for a "
+                        "reply you can read as free text; when the answer should "
+                        "come from options or from named fields, call "
+                        "ask_user_question instead."
                     ),
                     "parameters": {
                         "type": "object",
@@ -2584,10 +2610,14 @@ class ReActPattern(AgentPattern):
         every entry in it is a control the user cannot use, and replacing
         keeps the substituted field the only one, so its base name cannot
         collide with a caller's ``_2``/``_3`` dedup suffixes.
+
+        Both branches return fresh dicts: the published list is stored on the
+        waiting request, the tool-call record and the result dict, so it must
+        not alias items the caller still holds.
         """
 
         published = (
-            interactions
+            [dict(item) if isinstance(item, dict) else item for item in interactions]
             if any(_is_answerable(item) for item in interactions)
             else [dict(DEFAULT_WAITING_INTERACTION)]
         )

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -68,7 +68,11 @@ from ....file_ref import (
 )
 from ....model.chat.exceptions import LLMToolProtocolError
 from ....model.chat.tool_protocol import get_tool_protocol_error
-from ....tools.adapters.vibe.interaction_types import INTERACTION_TYPES
+from ....tools.adapters.vibe.interaction_types import (
+    DEFAULT_WAITING_INTERACTION,
+    INTERACTION_TYPES,
+    TYPES_REQUIRING_OPTIONS,
+)
 from ....tools.user_interaction import (
     tool_result_waits_for_user,
     user_interaction_resume_callable,
@@ -131,9 +135,6 @@ UNGROUPED_TOOL_DECISION_CATEGORIES = frozenset({"basic", "other"})
 # module's untrusted-input logging: bounded length, escaped, never raw.
 STRIP_LOG_MAX_TOOL_NAMES = 8
 STRIP_LOG_MAX_TOOL_NAME_CHARS = 64
-# Only ever injected into an otherwise empty interaction list, so this base
-# name can never collide with the callers' _2/_3 dedup suffixes.
-DEFAULT_WAITING_INTERACTION_FIELD = "response"
 REACT_RESPONSE_LANGUAGE_DESCRIPTION = (
     "Target natural language for user-facing prose in this ReAct response, "
     "for example English, Simplified Chinese, Traditional Chinese, or Spanish. "
@@ -399,22 +400,25 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
     return normalized
 
 
-def _default_waiting_interaction() -> dict[str, Any]:
-    """The free-text field a suspended run falls back to.
+def _is_answerable(interaction: Any) -> bool:
+    """Whether a user handed this control could produce an answer with it.
 
-    Honours xagent#1528's "no controls means answer in free text" contract on
-    the write side, so no reader has to infer it. Carried by both surfaces a
-    reader can use: the outbound message's metadata and the waiting request
-    the structured interaction row is built from.
+    Only the pick-from-a-list types can fail: emptied options survive
+    ``_normalize_ask_user_interactions`` as an entry with nothing to select
+    (that function drops the blank options, not the interaction), and a
+    malformed non-list ``options`` survives it untouched, which the render
+    surface cannot iterate either. Every other type renders an input that
+    stands on its own, and an unrecognized type is treated as answerable
+    rather than silently replaced -- the write-side admissibility rules are
+    what refuse those.
     """
 
-    return {
-        "type": "text_input",
-        "field": DEFAULT_WAITING_INTERACTION_FIELD,
-        "label": "Your response",
-        "placeholder": "Type your answer",
-        "multiline": True,
-    }
+    if not isinstance(interaction, dict):
+        return False
+    if interaction.get("type") in TYPES_REQUIRING_OPTIONS:
+        options = interaction.get("options")
+        return isinstance(options, list) and bool(options)
+    return True
 
 
 class ReActPattern(AgentPattern):
@@ -2575,9 +2579,18 @@ class ReActPattern(AgentPattern):
         non-suspending messages, which must stay field-free, and the callers
         need the published list back to store on the waiting request -- which
         is also what the structured interaction row is built from.
+
+        A list with nothing answerable in it is replaced, not appended to:
+        every entry in it is a control the user cannot use, and replacing
+        keeps the substituted field the only one, so its base name cannot
+        collide with a caller's ``_2``/``_3`` dedup suffixes.
         """
 
-        published = interactions or [_default_waiting_interaction()]
+        published = (
+            interactions
+            if any(_is_answerable(item) for item in interactions)
+            else [dict(DEFAULT_WAITING_INTERACTION)]
+        )
         outbound_message = await runtime.send_message(
             message=message,
             message_type=message_type,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -405,6 +405,18 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
     return normalized
 
 
+def _unique_field(base_field: str, used_fields: set[str]) -> str:
+    """Suffix ``_2``/``_3``... until unused, record it, and return it."""
+
+    field = base_field
+    suffix = 2
+    while field in used_fields:
+        field = f"{base_field}_{suffix}"
+        suffix += 1
+    used_fields.add(field)
+    return field
+
+
 def _is_answerable(interaction: Any) -> bool:
     """Whether a user handed this control could produce an answer with it.
 
@@ -2218,13 +2230,11 @@ class ReActPattern(AgentPattern):
                 "function": {
                     "name": "send_message",
                     "description": (
-                        "Send a prose message to the user. Set message_type to "
-                        "what the message is: use progress to report work "
-                        "already underway, not to announce a plan you have not "
-                        "started. Set expect_response=true only when the task "
-                        "cannot continue until the user replies, and only for a "
-                        "reply you can read as free text; when the answer should "
-                        "come from options or from named fields, call "
+                        "Send a prose message to the user. Set "
+                        "expect_response=true only when the task cannot "
+                        "continue until the user replies, and only for a reply "
+                        "you can read as free text; when the answer should come "
+                        "from options or from named fields, call "
                         "ask_user_question instead."
                     ),
                     "parameters": {
@@ -2465,24 +2475,25 @@ class ReActPattern(AgentPattern):
                     visible=visible,
                     metadata=source,
                 )
-            self._record_tool_call(
-                tool_call,
-                status="completed",
-                result={
-                    "message": message,
-                    "expect_response": expect_response,
-                    "visible": visible,
-                },
-            )
+            ledger_result: dict[str, Any] = {
+                "message": message,
+                "expect_response": expect_response,
+                "visible": visible,
+            }
+            if expect_response:
+                ledger_result["interactions"] = interactions
+            self._record_tool_call(tool_call, status="completed", result=ledger_result)
             if expect_response:
                 self.status = "waiting_for_user"
+                # No ``interactions`` here: the model called a tool that has
+                # no such parameter, and echoing a form back would read as one
+                # it produced.
                 context.add_tool_result(
                     tool_name=name,
                     result={
                         "status": "waiting_for_user",
                         "message": message,
                         "message_type": message_type,
-                        "interactions": interactions,
                     },
                     tool_call_id=tool_call.get("id"),
                 )
@@ -2537,14 +2548,9 @@ class ReActPattern(AgentPattern):
             deduplicated_interactions: list[dict[str, Any]] = []
             for interaction in interactions:
                 item = dict(interaction)
-                base_field = str(item.get("field") or "response")
-                field = base_field
-                suffix = 2
-                while field in used_fields:
-                    field = f"{base_field}_{suffix}"
-                    suffix += 1
-                item["field"] = field
-                used_fields.add(field)
+                item["field"] = _unique_field(
+                    str(item.get("field") or "response"), used_fields
+                )
                 deduplicated_interactions.append(item)
             outbound_message, interactions = await self._send_waiting_message(
                 context=context,
@@ -2620,26 +2626,33 @@ class ReActPattern(AgentPattern):
         need the published list back to store on the waiting request -- which
         is also what the structured interaction row is built from.
 
-        A list with nothing answerable in it is replaced, not appended to:
-        every entry in it is a control the user cannot use, and replacing
-        keeps the substituted field the only one, so its base name cannot
-        collide with a caller's ``_2``/``_3`` dedup suffixes.
+        A list with nothing answerable in it is appended to, not replaced:
+        the entries the user cannot act on still carry the question text --
+        an options-less ``select_one``'s ``label`` is the question -- and
+        replacing them leaves a bare input box asking nothing. The appended
+        field takes its name through the same ``_unique_field`` dedup the
+        model-supplied fields do, so it cannot collide with one of them.
 
         The substituted field is localized to the run's pinned output language
         when there is one, and is English otherwise; ``context`` is taken for
         that alone.
 
-        Both branches return a fresh list of fresh dicts: the published list
-        is stored on the waiting request and the result dict, so it must not
-        alias items the caller still holds. Shallow -- ``options`` and its
-        entries stay shared, and no reader rewrites those.
+        The published list is a fresh list of fresh dicts: it is stored on the
+        waiting request and the result dict, so it must not alias items the
+        caller still holds. Shallow -- ``options`` and its entries stay
+        shared, and no reader rewrites those.
         """
 
-        published = (
-            [dict(item) if isinstance(item, dict) else item for item in interactions]
-            if any(_is_answerable(item) for item in interactions)
-            else [default_waiting_interaction(effective_output_language(context))]
-        )
+        published = [dict(item) for item in interactions]
+        if not any(_is_answerable(item) for item in published):
+            substituted = default_waiting_interaction(
+                effective_output_language(context)
+            )
+            substituted["field"] = _unique_field(
+                str(substituted["field"]),
+                {str(item.get("field") or "") for item in published},
+            )
+            published.append(substituted)
         outbound_message = await runtime.send_message(
             message=message,
             message_type=message_type,
@@ -2878,14 +2891,9 @@ class ReActPattern(AgentPattern):
             deduplicated_request_interactions: list[dict[str, Any]] = []
             for interaction in request_interactions:
                 item = dict(interaction)
-                base_field = str(item.get("field") or "response")
-                field = base_field
-                suffix = 2
-                while field in used_fields:
-                    field = f"{base_field}_{suffix}"
-                    suffix += 1
-                item["field"] = field
-                used_fields.add(field)
+                item["field"] = _unique_field(
+                    str(item.get("field") or "response"), used_fields
+                )
                 interactions.append(item)
                 deduplicated_request_interactions.append(item)
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -69,10 +69,11 @@ from ....file_ref import (
 from ....model.chat.exceptions import LLMToolProtocolError
 from ....model.chat.tool_protocol import get_tool_protocol_error
 from ....tools.adapters.vibe.interaction_types import (
-    DEFAULT_WAITING_INTERACTION,
     INTERACTION_TYPE_ALIASES,
     INTERACTION_TYPES,
     TYPES_REQUIRING_OPTIONS,
+    default_waiting_interaction,
+    is_default_waiting_interaction,
 )
 from ....tools.user_interaction import (
     tool_result_waits_for_user,
@@ -89,7 +90,7 @@ from ...context.enrichment import (
 from ...context.memory_tool import build_memory_tools
 from ...context.skill_tool import build_load_skill_tool
 from ...grounding import grounding_rule
-from ...language import final_answer_language_rule
+from ...language import effective_output_language, final_answer_language_rule
 from ...result import (
     CONTROL_TOOL_NAMES,
     tool_result_succeeded,
@@ -404,9 +405,6 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
     return normalized
 
 
-_DEFAULT_WAITING_ANSWER_PREFIX = f"{DEFAULT_WAITING_INTERACTION['label']}: "
-
-
 def _is_answerable(interaction: Any) -> bool:
     """Whether a user handed this control could produce an answer with it.
 
@@ -420,7 +418,10 @@ def _is_answerable(interaction: Any) -> bool:
     has already mapped them onto these seven by the time this runs. And a
     pick-from-a-list type with nothing to pick survives that normalization
     (which drops the blank options, not the interaction) as a control with no
-    choices. Every other type renders an input that stands on its own.
+    choices. Every other type renders an input that stands on its own, with
+    one gap this check does not close: ``file_upload`` renders nothing and
+    contributes no submitted line while ``filesDisabled`` is set, which it is
+    by default (``clarification-form.tsx``).
 
     Nothing upstream refuses either shape: the tool schema's ``enum`` is a
     prompt, not a runtime constraint, and the write-side admissibility rules
@@ -1842,10 +1843,15 @@ class ReActPattern(AgentPattern):
             return
         # The form submits "<label>: <value>"; for the substituted field the
         # label carries nothing, so a resume callback would get a prefixed value.
-        if waiting_request.get("interactions") == [
-            DEFAULT_WAITING_INTERACTION
-        ] and response.startswith(_DEFAULT_WAITING_ANSWER_PREFIX):
-            response = response[len(_DEFAULT_WAITING_ANSWER_PREFIX) :]
+        published = waiting_request.get("interactions")
+        if (
+            isinstance(published, list)
+            and len(published) == 1
+            and is_default_waiting_interaction(published[0])
+        ):
+            prefix = f"{published[0]['label']}: "
+            if response.startswith(prefix):
+                response = response[len(prefix) :]
         raw_requests = waiting_request.get("requests")
         requests = raw_requests if isinstance(raw_requests, list) else [waiting_request]
         for request in requests:
@@ -2443,6 +2449,7 @@ class ReActPattern(AgentPattern):
             interactions: list[dict[str, Any]] = []
             if expect_response:
                 outbound_message, interactions = await self._send_waiting_message(
+                    context=context,
                     runtime=runtime,
                     message=message,
                     message_type=message_type,
@@ -2540,6 +2547,7 @@ class ReActPattern(AgentPattern):
                 used_fields.add(field)
                 deduplicated_interactions.append(item)
             outbound_message, interactions = await self._send_waiting_message(
+                context=context,
                 runtime=runtime,
                 message=message,
                 message_type="question",
@@ -2595,6 +2603,7 @@ class ReActPattern(AgentPattern):
     async def _send_waiting_message(
         self,
         *,
+        context: Any,
         runtime: PatternRuntime,
         message: str,
         message_type: str,
@@ -2616,6 +2625,10 @@ class ReActPattern(AgentPattern):
         keeps the substituted field the only one, so its base name cannot
         collide with a caller's ``_2``/``_3`` dedup suffixes.
 
+        The substituted field is localized to the run's pinned output language
+        when there is one, and is English otherwise; ``context`` is taken for
+        that alone.
+
         Both branches return a fresh list of fresh dicts: the published list
         is stored on the waiting request and the result dict, so it must not
         alias items the caller still holds. Shallow -- ``options`` and its
@@ -2625,7 +2638,7 @@ class ReActPattern(AgentPattern):
         published = (
             [dict(item) if isinstance(item, dict) else item for item in interactions]
             if any(_is_answerable(item) for item in interactions)
-            else [dict(DEFAULT_WAITING_INTERACTION)]
+            else [default_waiting_interaction(effective_output_language(context))]
         )
         outbound_message = await runtime.send_message(
             message=message,
@@ -2905,6 +2918,7 @@ class ReActPattern(AgentPattern):
             message_type = "question"
 
         outbound_message, interactions = await self._send_waiting_message(
+            context=context,
             runtime=runtime,
             message=message,
             message_type=message_type,

--- a/src/xagent/core/agent/transcript.py
+++ b/src/xagent/core/agent/transcript.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from ..context_ref import CONTEXT_REFS_KEY, normalize_context_references
-from ..tools.adapters.vibe.interaction_types import DEFAULT_WAITING_INTERACTION
+from ..tools.adapters.vibe.interaction_types import is_default_waiting_interaction
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ def build_assistant_transcript_content(
             # The engine substitutes this field wherever a suspending message
             # would carry no control at all; it says nothing the prose does
             # not, and every waiting turn would otherwise replay it.
-            if interaction == DEFAULT_WAITING_INTERACTION:
+            if is_default_waiting_interaction(interaction):
                 continue
             interaction_type = _get_interaction_attr(interaction, "type")
             options = _get_interaction_attr(interaction, "options") or []

--- a/src/xagent/core/agent/transcript.py
+++ b/src/xagent/core/agent/transcript.py
@@ -20,8 +20,8 @@ def build_assistant_transcript_content(
     if interactions:
         interaction_lines: List[str] = []
         for interaction in interactions:
-            # The engine substitutes this field wherever a suspending message
-            # would carry no control at all; it says nothing the prose does
+            # The engine appends this field wherever a suspending message
+            # would carry nothing answerable; it says nothing the prose does
             # not, and every waiting turn would otherwise replay it.
             if is_default_waiting_interaction(interaction):
                 continue

--- a/src/xagent/core/agent/transcript.py
+++ b/src/xagent/core/agent/transcript.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from ..context_ref import CONTEXT_REFS_KEY, normalize_context_references
+from ..tools.adapters.vibe.interaction_types import DEFAULT_WAITING_INTERACTION
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,11 @@ def build_assistant_transcript_content(
     if interactions:
         interaction_lines: List[str] = []
         for interaction in interactions:
+            # The engine substitutes this field wherever a suspending message
+            # would carry no control at all; it says nothing the prose does
+            # not, and every waiting turn would otherwise replay it.
+            if interaction == DEFAULT_WAITING_INTERACTION:
+                continue
             interaction_type = _get_interaction_attr(interaction, "type")
             options = _get_interaction_attr(interaction, "options") or []
             label = _get_interaction_attr(interaction, "label")

--- a/src/xagent/core/tools/adapters/vibe/interaction_types.py
+++ b/src/xagent/core/tools/adapters/vibe/interaction_types.py
@@ -1,7 +1,8 @@
 """The interaction types the ask_user_question render surface implements,
-plus three more names about that surface -- the off-contract aliases it
-accepts, one subset of these types, and one literal field -- that the engine,
-the transcript builder and the web layer all have to agree on.
+plus three more things about that surface -- the off-contract aliases it
+accepts, one subset of these types, and the free-text field the engine
+substitutes (with its translations and the check that recognizes it) -- that
+the engine, the transcript builder and the web layer all have to agree on.
 
 Kept in a module of its own rather than beside ``InteractionArg`` in
 ``ask_user_tool``, which is where the model that carries the field lives:
@@ -61,8 +62,9 @@ TYPES_REQUIRING_OPTIONS: frozenset[str] = frozenset(
 )
 
 # The free-text field the engine substitutes when a suspending message would
-# otherwise carry nothing answerable. Copy before publishing -- readers keep
-# what they are handed, and this dict is shared.
+# otherwise carry nothing answerable, in English -- the copy used whenever no
+# output language is pinned. Copy before publishing; readers keep what they
+# are handed.
 DEFAULT_WAITING_INTERACTION: dict[str, object] = {
     "type": "text_input",
     "field": "response",
@@ -71,14 +73,54 @@ DEFAULT_WAITING_INTERACTION: dict[str, object] = {
     "multiline": True,
 }
 
+# Translations of that label and placeholder, keyed by the canonical language
+# labels ``effective_output_language`` returns (``language.py``). Only Chinese:
+# English and Chinese are the two locales the product ships UI copy in
+# (``frontend/src/i18n/locales``), and Simplified and Traditional are kept apart
+# because ``language.py`` treats them as different output languages. Any
+# language absent here keeps the English copy above.
+_DEFAULT_WAITING_TRANSLATIONS: dict[str, tuple[str, str]] = {
+    "Chinese": ("您的回复", "请输入您的回答"),
+    "Simplified Chinese": ("您的回复", "请输入您的回答"),
+    "Mandarin Chinese": ("您的回复", "请输入您的回答"),
+    "Traditional Chinese": ("您的回覆", "請輸入您的回答"),
+    "Cantonese": ("您的回覆", "請輸入您的回答"),
+}
+
+
+def default_waiting_interaction(output_language: str = "") -> dict[str, object]:
+    """Return a fresh substituted field, localized to a pinned output language."""
+
+    translated = _DEFAULT_WAITING_TRANSLATIONS.get(output_language)
+    if translated is None:
+        return dict(DEFAULT_WAITING_INTERACTION)
+    label, placeholder = translated
+    return {**DEFAULT_WAITING_INTERACTION, "label": label, "placeholder": placeholder}
+
+
+_DEFAULT_WAITING_VARIANTS: tuple[dict[str, object], ...] = (
+    DEFAULT_WAITING_INTERACTION,
+    *(
+        default_waiting_interaction(language)
+        for language in _DEFAULT_WAITING_TRANSLATIONS
+    ),
+)
+
 
 def is_default_waiting_interaction(interaction: object) -> bool:
     """Whether this published item is the substituted field, not a real one.
 
-    Equality against the literal above, so it only recognizes the shape the
-    engine itself publishes: an interaction that has been round-tripped
-    through a model dump or arrives from a client carries other keys and is
-    rendered like any other field.
+    Equality against every localized variant the substitution can publish,
+    generated from the same table it publishes from, so the two cannot drift
+    and a run resumed under a different pinned language still recognizes the
+    field it published earlier.
+
+    Equality is a heuristic, not proof of origin: a model-supplied free-text
+    field that happens to carry these exact five keys and this exact copy is
+    indistinguishable from the substituted one and is skipped too. The cost is
+    bounded to the two readers that call this -- one transcript line and one
+    channel bullet -- and neither the published form nor the resumed answer
+    changes.
     """
 
-    return interaction == DEFAULT_WAITING_INTERACTION
+    return any(interaction == variant for variant in _DEFAULT_WAITING_VARIANTS)

--- a/src/xagent/core/tools/adapters/vibe/interaction_types.py
+++ b/src/xagent/core/tools/adapters/vibe/interaction_types.py
@@ -35,6 +35,25 @@ INTERACTION_TYPES: tuple[str, ...] = (
     "action_cards",
 )
 
+# Every ``type`` the frontend's ``normalizeInteractions`` keeps
+# (``frontend/src/contexts/app-context-chat.tsx``): the seven above, the
+# ``connect_apps`` live widget it renders but the tool schema does not offer,
+# and the aliases it maps onto the canonical names. It drops anything else,
+# and a list it empties renders no form at all -- so this set, not
+# ``INTERACTION_TYPES``, is what the engine's answerability check reads.
+RENDERABLE_INTERACTION_TYPES: frozenset[str] = frozenset(INTERACTION_TYPES) | {
+    "connect_apps",
+    "input",
+    "text",
+    "textarea",
+    "string",
+    "file",
+    "upload",
+    "number",
+    "integer",
+    "boolean",
+}
+
 # The subset whose whole purpose is picking from a supplied list, so one of
 # them carrying no options is a control nobody can answer. Shared so the
 # write-side admissibility rule and the engine's answerability check cannot
@@ -53,3 +72,15 @@ DEFAULT_WAITING_INTERACTION: dict[str, object] = {
     "placeholder": "Type your answer",
     "multiline": True,
 }
+
+
+def is_default_waiting_interaction(interaction: object) -> bool:
+    """Whether this published item is the substituted field, not a real one.
+
+    Equality against the literal above, so it only recognizes the shape the
+    engine itself publishes: an interaction that has been round-tripped
+    through a model dump or arrives from a client carries other keys and is
+    rendered like any other field.
+    """
+
+    return interaction == DEFAULT_WAITING_INTERACTION

--- a/src/xagent/core/tools/adapters/vibe/interaction_types.py
+++ b/src/xagent/core/tools/adapters/vibe/interaction_types.py
@@ -1,4 +1,7 @@
-"""The interaction types the ask_user_question render surface implements.
+"""The interaction types the ask_user_question render surface implements,
+plus two more constants about that surface -- one subset of these types, one
+literal field -- that the engine, the transcript builder and the web layer
+all have to agree on.
 
 Kept in a module of its own rather than beside ``InteractionArg`` in
 ``ask_user_tool``, which is where the model that carries the field lives:
@@ -31,3 +34,22 @@ INTERACTION_TYPES: tuple[str, ...] = (
     "number_input",
     "action_cards",
 )
+
+# The subset whose whole purpose is picking from a supplied list, so one of
+# them carrying no options is a control nobody can answer. Shared so the
+# write-side admissibility rule and the engine's answerability check cannot
+# drift apart.
+TYPES_REQUIRING_OPTIONS: frozenset[str] = frozenset(
+    {"select_one", "select_multiple", "action_cards"}
+)
+
+# The free-text field the engine substitutes when a suspending message would
+# otherwise carry nothing answerable. Copy before publishing -- readers keep
+# what they are handed, and this dict is shared.
+DEFAULT_WAITING_INTERACTION: dict[str, object] = {
+    "type": "text_input",
+    "field": "response",
+    "label": "Your response",
+    "placeholder": "Type your answer",
+    "multiline": True,
+}

--- a/src/xagent/core/tools/adapters/vibe/interaction_types.py
+++ b/src/xagent/core/tools/adapters/vibe/interaction_types.py
@@ -10,7 +10,7 @@ importing ``ask_user_tool`` pulls in the whole tool-registration chain and
 with it 61 ``xagent.web`` modules, and one of this list's three consumers
 (``core/agent/pattern/react/react.py``) imports nothing from ``xagent.web``
 today. A list of seven strings must not be what changes that. This module
-imports nothing, so any consumer can take it.
+imports only the standard library, so any consumer can take it.
 
 Ordered, not a set: two of the three consumers render it into text a model
 reads -- the ``ask_user_question`` JSON-Schema enum and
@@ -25,6 +25,9 @@ seven names:
 * the write side's admissibility set (``_V1_INTERACTION_TYPES``,
   ``web/services/task_interaction_service.py``)
 """
+
+from collections.abc import Mapping
+from types import MappingProxyType
 
 INTERACTION_TYPES: tuple[str, ...] = (
     "select_one",
@@ -63,15 +66,20 @@ TYPES_REQUIRING_OPTIONS: frozenset[str] = frozenset(
 
 # The free-text field the engine substitutes when a suspending message would
 # otherwise carry nothing answerable, in English -- the copy used whenever no
-# output language is pinned. Copy before publishing; readers keep what they
-# are handed.
-DEFAULT_WAITING_INTERACTION: dict[str, object] = {
-    "type": "text_input",
-    "field": "response",
-    "label": "Your response",
-    "placeholder": "Type your answer",
-    "multiline": True,
-}
+# output language is pinned. Read-only: publishers copy it, and an in-place
+# edit here would change every later substitution in the process.
+DEFAULT_WAITING_INTERACTION: Mapping[str, object] = MappingProxyType(
+    {
+        "type": "text_input",
+        "field": "response",
+        "label": "Your response",
+        "placeholder": "Type your answer",
+        "multiline": True,
+    }
+)
+
+_SIMPLIFIED = ("您的回复", "请输入您的回答")
+_TRADITIONAL = ("您的回覆", "請輸入您的回答")
 
 # Translations of that label and placeholder, keyed by the canonical language
 # labels ``effective_output_language`` returns (``language.py``). Only Chinese:
@@ -80,11 +88,11 @@ DEFAULT_WAITING_INTERACTION: dict[str, object] = {
 # because ``language.py`` treats them as different output languages. Any
 # language absent here keeps the English copy above.
 _DEFAULT_WAITING_TRANSLATIONS: dict[str, tuple[str, str]] = {
-    "Chinese": ("您的回复", "请输入您的回答"),
-    "Simplified Chinese": ("您的回复", "请输入您的回答"),
-    "Mandarin Chinese": ("您的回复", "请输入您的回答"),
-    "Traditional Chinese": ("您的回覆", "請輸入您的回答"),
-    "Cantonese": ("您的回覆", "請輸入您的回答"),
+    "Chinese": _SIMPLIFIED,
+    "Simplified Chinese": _SIMPLIFIED,
+    "Mandarin Chinese": _SIMPLIFIED,
+    "Traditional Chinese": _TRADITIONAL,
+    "Cantonese": _TRADITIONAL,
 }
 
 
@@ -98,12 +106,17 @@ def default_waiting_interaction(output_language: str = "") -> dict[str, object]:
     return {**DEFAULT_WAITING_INTERACTION, "label": label, "placeholder": placeholder}
 
 
-_DEFAULT_WAITING_VARIANTS: tuple[dict[str, object], ...] = (
-    DEFAULT_WAITING_INTERACTION,
-    *(
-        default_waiting_interaction(language)
-        for language in _DEFAULT_WAITING_TRANSLATIONS
-    ),
+# Compared without ``field``: the substituted field is deduplicated against
+# whatever fields are already in the list it joins, so its name is not fixed.
+_DEFAULT_WAITING_VARIANTS: tuple[dict[str, object], ...] = tuple(
+    {key: value for key, value in variant.items() if key != "field"}
+    for variant in (
+        dict(DEFAULT_WAITING_INTERACTION),
+        *(
+            default_waiting_interaction(language)
+            for language in _DEFAULT_WAITING_TRANSLATIONS
+        ),
+    )
 )
 
 
@@ -113,14 +126,19 @@ def is_default_waiting_interaction(interaction: object) -> bool:
     Equality against every localized variant the substitution can publish,
     generated from the same table it publishes from, so the two cannot drift
     and a run resumed under a different pinned language still recognizes the
-    field it published earlier.
+    field it published earlier. ``field`` is excluded from the comparison: the
+    substituted field is deduplicated against the fields already in the list
+    it joins, so it can be published as ``response_2``.
 
     Equality is a heuristic, not proof of origin: a model-supplied free-text
-    field that happens to carry these exact five keys and this exact copy is
-    indistinguishable from the substituted one and is skipped too. The cost is
-    bounded to the two readers that call this -- one transcript line and one
-    channel bullet -- and neither the published form nor the resumed answer
-    changes.
+    field that happens to carry this exact copy is indistinguishable from the
+    substituted one and is skipped too. The cost is bounded to the three
+    readers that call this -- one transcript line, one channel bullet and one
+    replayed history row -- and neither the published form nor the resumed
+    answer changes.
     """
 
-    return any(interaction == variant for variant in _DEFAULT_WAITING_VARIANTS)
+    if not isinstance(interaction, dict):
+        return False
+    without_field = {key: value for key, value in interaction.items() if key != "field"}
+    return any(without_field == variant for variant in _DEFAULT_WAITING_VARIANTS)

--- a/src/xagent/core/tools/adapters/vibe/interaction_types.py
+++ b/src/xagent/core/tools/adapters/vibe/interaction_types.py
@@ -132,10 +132,12 @@ def is_default_waiting_interaction(interaction: object) -> bool:
 
     Equality is a heuristic, not proof of origin: a model-supplied free-text
     field that happens to carry this exact copy is indistinguishable from the
-    substituted one and is skipped too. The cost is bounded to the three
-    readers that call this -- one transcript line, one channel bullet and one
-    replayed history row -- and neither the published form nor the resumed
-    answer changes.
+    substituted one. Three of the four callers only skip rendering it -- one
+    transcript line, one channel bullet, one replayed history row -- and the
+    published form is unaffected. The fourth (``_queue_tool_interaction_
+    responses``, ``react.py``) strips the ``"<label>: "`` prefix off the
+    answer handed to a tool's resume callback, so a false match there costs
+    that tool the label it chose.
     """
 
     if not isinstance(interaction, dict):

--- a/src/xagent/core/tools/adapters/vibe/interaction_types.py
+++ b/src/xagent/core/tools/adapters/vibe/interaction_types.py
@@ -1,7 +1,7 @@
 """The interaction types the ask_user_question render surface implements,
-plus two more constants about that surface -- one subset of these types, one
-literal field -- that the engine, the transcript builder and the web layer
-all have to agree on.
+plus three more names about that surface -- the off-contract aliases it
+accepts, one subset of these types, and one literal field -- that the engine,
+the transcript builder and the web layer all have to agree on.
 
 Kept in a module of its own rather than beside ``InteractionArg`` in
 ``ask_user_tool``, which is where the model that carries the field lives:
@@ -35,23 +35,21 @@ INTERACTION_TYPES: tuple[str, ...] = (
     "action_cards",
 )
 
-# Every ``type`` the frontend's ``normalizeInteractions`` keeps
-# (``frontend/src/contexts/app-context-chat.tsx``): the seven above, the
-# ``connect_apps`` live widget it renders but the tool schema does not offer,
-# and the aliases it maps onto the canonical names. It drops anything else,
-# and a list it empties renders no form at all -- so this set, not
-# ``INTERACTION_TYPES``, is what the engine's answerability check reads.
-RENDERABLE_INTERACTION_TYPES: frozenset[str] = frozenset(INTERACTION_TYPES) | {
-    "connect_apps",
-    "input",
-    "text",
-    "textarea",
-    "string",
-    "file",
-    "upload",
-    "number",
-    "integer",
-    "boolean",
+# The off-contract type names the frontend's ``normalizeInteractions``
+# (``frontend/src/contexts/app-context-chat.tsx``) maps onto the seven above.
+# Applied engine-side too, so one alias cannot mean a rendered field to the
+# frontend and an unsupported type to the write-side validator, the transcript
+# builder, or the answerability check -- each of which knows only the seven.
+INTERACTION_TYPE_ALIASES: dict[str, str] = {
+    "input": "text_input",
+    "text": "text_input",
+    "textarea": "text_input",
+    "string": "text_input",
+    "file": "file_upload",
+    "upload": "file_upload",
+    "number": "number_input",
+    "integer": "number_input",
+    "boolean": "confirm",
 }
 
 # The subset whose whole purpose is picking from a supplied list, so one of

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -64,6 +64,9 @@ from ...core.execution_scope import (
     resolve_execution_scope_off_turn,
 )
 from ...core.file_ref import FILE_REF_MODEL_INSTRUCTIONS, build_file_ref
+from ...core.tools.adapters.vibe.interaction_types import (
+    is_default_waiting_interaction,
+)
 from ..models.chat_message import TaskChatMessage
 from ..models.database import (
     get_db,
@@ -8107,7 +8110,18 @@ def _load_historical_stream_snapshot_sync(
                         "visible": True,
                     }
                     if isinstance(interactions, list):
-                        data["metadata"] = {"interactions": interactions}
+                        # Replay only. The substituted free-text field exists to
+                        # make the current waiting turn answerable, and that turn
+                        # is reasserted separately below; replaying it here would
+                        # grow a clarification form on every past send_message
+                        # pause that never had one.
+                        data["metadata"] = {
+                            "interactions": [
+                                item
+                                for item in interactions
+                                if not is_default_waiting_interaction(item)
+                            ]
+                        }
                     event_type = "agent_message"
                 else:
                     continue

--- a/src/xagent/web/services/execution_result_projection.py
+++ b/src/xagent/web/services/execution_result_projection.py
@@ -50,6 +50,9 @@ def project_execution_result_for_channel(
         diagnostic_error = (
             str(result.get("error") or "").strip() or base_text.strip() or None
         )
+    # Keyed on what would actually be rendered: the engine's substituted field
+    # is skipped below, so a non-empty list can still render nothing.
+    visible_text = _append_interactions(base_text, interactions)
     if status == "interrupted":
         # An interruption is control state, not an assistant answer. Show a
         # friendly status in every chat channel without adding it to the
@@ -57,17 +60,16 @@ def project_execution_result_for_channel(
         base_text = INTERRUPTED_USER_MESSAGE
         transcript_content = ""
         interactions = []
+        visible_text = base_text
     elif task_status == TaskStatus.FAILED:
         base_text = CLIENT_SAFE_TASK_FAILURE
         transcript_content = base_text
         interactions = []
-    elif not _append_interactions(base_text, interactions).strip():
-        # Keyed on what would actually be rendered: the engine's substituted
-        # field is skipped below, so a non-empty list can still render nothing.
+        visible_text = base_text
+    elif not visible_text.strip():
         base_text = EMPTY_CHANNEL_OUTPUT_FALLBACK
         transcript_content = base_text
-
-    visible_text = _append_interactions(base_text, interactions)
+        visible_text = base_text
 
     return ChannelExecutionProjection(
         task_status=task_status,

--- a/src/xagent/web/services/execution_result_projection.py
+++ b/src/xagent/web/services/execution_result_projection.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass
 from typing import Any
 
 from ...core.agent.execution_adapter import INTERRUPTED_USER_MESSAGE
+from ...core.tools.adapters.vibe.interaction_types import (
+    is_default_waiting_interaction,
+)
 from ..models.task import TaskStatus
 from .assistant_history_safety import ASSISTANT_RESPONSE_MESSAGE_TYPE
 from .client_error_messages import CLIENT_SAFE_TASK_FAILURE
@@ -90,6 +93,10 @@ def _append_interactions(base_text: str, interactions: list[dict[str, Any]]) -> 
 
     interaction_texts: list[str] = []
     for interaction in interactions:
+        # Same reason the transcript builder skips it: the substituted field
+        # says nothing the prose does not, and this renders as a bullet.
+        if is_default_waiting_interaction(interaction):
+            continue
         label = interaction.get("label") or interaction.get("field", "Input")
         options = interaction.get("options", [])
         if options:
@@ -103,4 +110,6 @@ def _append_interactions(base_text: str, interactions: list[dict[str, Any]]) -> 
         else:
             interaction_texts.append(f"• {label}")
 
+    if not interaction_texts:
+        return base_text
     return base_text + "\n\n" + "\n".join(interaction_texts)

--- a/src/xagent/web/services/execution_result_projection.py
+++ b/src/xagent/web/services/execution_result_projection.py
@@ -61,7 +61,9 @@ def project_execution_result_for_channel(
         base_text = CLIENT_SAFE_TASK_FAILURE
         transcript_content = base_text
         interactions = []
-    elif not base_text.strip() and not interactions:
+    elif not _append_interactions(base_text, interactions).strip():
+        # Keyed on what would actually be rendered: the engine's substituted
+        # field is skipped below, so a non-empty list can still render nothing.
         base_text = EMPTY_CHANNEL_OUTPUT_FALLBACK
         transcript_content = base_text
 

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -410,14 +410,13 @@ def parse_clarification_payload(
     ``interactions`` comes back ``None``, not ``[]``, whenever the payload
     carries no interaction items. ``get_latest_waiting_question`` itself is
     not this consistent: it returns ``None`` for a persisted row whose
-    ``interactions`` column is ``NULL`` (the shape a ``send_message``-
-    sourced draft always produces, since that source's payload never has
-    any interactions to carry), but it returns ``[]`` for a row whose
-    column holds an actual empty list -- the shape an empty-form
-    ``ask_user_question`` call produces (a legal call: ``ask_user_question``
-    is classified by whether its request carries an ``interactions`` key at
-    all, not by whether that key's value is non-empty; see
-    ``draft_from_waiting_request``). That ``NULL``-vs-``[]`` split on the
+    ``interactions`` column is ``NULL`` but ``[]`` for a row whose column
+    holds an actual empty list. No ReAct run writes either shape any more --
+    every suspending path publishes at least one answerable field, and
+    ``draft_from_waiting_request`` classifies ``ask_user_question`` by
+    ``tool_name`` rather than by the presence of an ``interactions`` key --
+    so both are now reachable only from rows an older schema wrote. That
+    ``NULL``-vs-``[]`` split on the
     legacy side is a known, un-reconciled divergence, not something this
     function reproduces: every empty case collapses to ``None`` here,
     deliberately, so a caller checking "did this turn have interactions"

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -411,11 +411,12 @@ def parse_clarification_payload(
     carries no interaction items. ``get_latest_waiting_question`` itself is
     not this consistent: it returns ``None`` for a persisted row whose
     ``interactions`` column is ``NULL`` but ``[]`` for a row whose column
-    holds an actual empty list. No ReAct run writes either shape any more --
-    every suspending path publishes at least one answerable field, and
-    ``draft_from_waiting_request`` classifies ``ask_user_question`` by
-    ``tool_name`` rather than by the presence of an ``interactions`` key --
-    so both are now reachable only from rows an older schema wrote. That
+    holds an actual empty list. No newly suspended ReAct run produces either
+    shape any more -- every suspending path publishes at least one answerable
+    field, and ``draft_from_waiting_request`` classifies ``ask_user_question``
+    by ``tool_name`` rather than by the presence of an ``interactions`` key.
+    A run resuming a checkpoint written before that still can: the stored
+    request has no ``interactions`` key and the resume path re-emits it. That
     ``NULL``-vs-``[]`` split on the
     legacy side is a known, un-reconciled divergence, not something this
     function reproduces: every empty case collapses to ``None`` here,

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1313,7 +1313,8 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
         # rule cannot drift from itself. interaction.type is provably in
         # _V1_INTERACTION_TYPES by here -- the unsupported_type check
         # above rejects anything else. Shared with the engine, which
-        # replaces rather than refuses an unanswerable control.
+        # appends a usable field beside an unanswerable control rather than
+        # refusing it.
         requires_options = interaction.type in TYPES_REQUIRING_OPTIONS
         if requires_options and not interaction.options:
             raise InteractionWritePayloadRejected(

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -120,7 +120,10 @@ from ...core.agent.checkpoint import (
 )
 from ...core.agent.pattern.react.react import _normalize_interaction_text
 from ...core.tools.adapters.vibe.ask_user_tool import AskUserQuestionArgs
-from ...core.tools.adapters.vibe.interaction_types import INTERACTION_TYPES
+from ...core.tools.adapters.vibe.interaction_types import (
+    INTERACTION_TYPES,
+    TYPES_REQUIRING_OPTIONS,
+)
 from ..models.task import Task, TaskStatus, TaskStatusPredicate, TraceEvent
 from ..models.task_command import TaskExecutionCommand
 from ..models.task_interaction import (
@@ -1078,9 +1081,10 @@ _V1_INTERACTION_TYPES = frozenset(INTERACTION_TYPES)
 # (``frontend/src/components/chat/clarification-form.tsx``), while
 # ``confirm`` renders a switch, ``text_input`` a field, ``number_input`` a
 # spinner, and ``file_upload`` a picker -- none of which read ``options``.
-_V1_TYPES_REQUIRING_OPTIONS = frozenset(
-    {"select_one", "select_multiple", "action_cards"}
-)
+# Shared with the engine, which replaces -- rather than refuses, as this side
+# does -- a suspending message whose only controls are these with nothing to
+# select.
+_V1_TYPES_REQUIRING_OPTIONS = TYPES_REQUIRING_OPTIONS
 
 
 @dataclass(frozen=True)
@@ -1205,12 +1209,12 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
     ``build_clarification_payload`` (``task_clarification_draft.py``) is a
     second producer of this same shape and its output has to keep passing
     here, pinned by a test that feeds this function that builder's real
-    output. Two of that builder's shapes are the reason for the boundaries
-    drawn below. An empty ``interactions`` list is accepted: a
-    ``send_message``-sourced draft never carries interactions, and an
-    over-size form is deliberately dropped to ``[]`` rather than truncated
-    to half a form -- both are questions with prose and no form, which the
-    read surface renders. A blank ``message`` is rejected, and that costs
+    output. An empty ``interactions`` list is accepted: an over-size form is
+    deliberately dropped to ``[]`` rather than truncated to half a form, and
+    that is a question with prose and no form, which the read surface
+    renders. (A ``send_message``-sourced draft used to be the other such
+    shape; it now carries the engine's substituted free-text field, so its
+    list is never empty.) A blank ``message`` is rejected, and that costs
     the builder nothing: ``resolve_publishable_clarification`` already
     classifies a payload whose message is blank after filtering as
     ``NotApplicable("empty_question")`` and never offers it for writing.

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1072,20 +1072,6 @@ def build_v1_request_payload(parsed: AskUserQuestionArgs) -> dict[str, Any]:
 # is what keeps either surface from having to.
 _V1_INTERACTION_TYPES = frozenset(INTERACTION_TYPES)
 
-# The types whose whole purpose is picking from a supplied list -- one set,
-# per #1314 item 2 ("key rules by interaction type, rather than one flat
-# list"), read below as a total function of membership rather than the two
-# independent flat sets this replaces. The split is the render surface's,
-# not this module's: ``select_one``, ``select_multiple``, and
-# ``action_cards`` iterate ``interaction.options``
-# (``frontend/src/components/chat/clarification-form.tsx``), while
-# ``confirm`` renders a switch, ``text_input`` a field, ``number_input`` a
-# spinner, and ``file_upload`` a picker -- none of which read ``options``.
-# Shared with the engine, which replaces -- rather than refuses, as this side
-# does -- a suspending message whose only controls are these with nothing to
-# select.
-_V1_TYPES_REQUIRING_OPTIONS = TYPES_REQUIRING_OPTIONS
-
 
 @dataclass(frozen=True)
 class InteractionWriteRefusal:
@@ -1185,7 +1171,7 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
     identifier and the position it fired at, never producer-supplied text
     (``#1314`` item 3) -- describing the first violation found; returns
     ``None`` when the payload may be written. Each rule below is scoped by
-    ``interaction.type`` through ``_V1_TYPES_REQUIRING_OPTIONS`` where a
+    ``interaction.type`` through ``TYPES_REQUIRING_OPTIONS`` where a
     rule is type-specific at all (``#1314`` item 2); the rules that apply
     to every
     type (blank/duplicate field, blank/duplicate option) are not, because
@@ -1326,8 +1312,9 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
         # flat sets that could drift apart; a single set with a derived
         # rule cannot drift from itself. interaction.type is provably in
         # _V1_INTERACTION_TYPES by here -- the unsupported_type check
-        # above rejects anything else.
-        requires_options = interaction.type in _V1_TYPES_REQUIRING_OPTIONS
+        # above rejects anything else. Shared with the engine, which
+        # replaces rather than refuses an unanswerable control.
+        requires_options = interaction.type in TYPES_REQUIRING_OPTIONS
         if requires_options and not interaction.options:
             raise InteractionWritePayloadRejected(
                 InteractionWriteRefusal(

--- a/tests/core/agent/test_clarification_draft.py
+++ b/tests/core/agent/test_clarification_draft.py
@@ -14,6 +14,9 @@ from xagent.core.agent.clarification import (
     draft_from_waiting_request,
 )
 from xagent.core.agent.pattern.react.react import _normalize_ask_user_interactions
+from xagent.core.tools.adapters.vibe.interaction_types import (
+    DEFAULT_WAITING_INTERACTION,
+)
 from xagent.web.api.trace_handlers import DatabaseTraceHandler
 from xagent.web.services.task_clarification_draft import clarification_idempotency_key
 
@@ -199,9 +202,10 @@ def test_tool_waiting_draft_classifies_and_shapes_requests() -> None:
 def test_empty_form_ask_user_question_still_classifies_as_ask_user_question() -> None:
     """An empty-form ask_user_question is still ``ask_user_question``, not send_message.
 
-    The classifier reads key presence (``"interactions" in request``), not
-    truthiness -- an empty ``interactions`` list must not fall through to the
-    ``send_message`` branch.
+    The classifier reads ``tool_name``, so an empty ``interactions`` list
+    must not fall through to the ``send_message`` branch. It used to read
+    key presence, which gave the same answer here but no longer distinguishes
+    the two: every waiting path now writes the key.
     """
 
     request = _ask_user_question_request(message="", interactions=[])
@@ -211,6 +215,28 @@ def test_empty_form_ask_user_question_still_classifies_as_ask_user_question() ->
     assert draft is not None
     assert draft.source == "ask_user_question"
     assert draft.interactions == ()
+
+
+def test_send_message_carrying_interactions_still_classifies_as_send_message() -> None:
+    """The shape every ``send_message`` pause now has: a populated
+    ``"interactions"`` key holding the engine's substituted free-text field.
+
+    This is the cell the ``tool_name`` rule exists for. Mutation (measured):
+    restoring the old ``message_type == "question" and has_interactions_key``
+    rule turns this red -- the request below is a ``question`` and does carry
+    the key, so it would be misclassified as ``ask_user_question`` and the
+    draft would advertise a tool the model never called.
+    """
+
+    request = _send_message_request()
+    request["interactions"] = [dict(DEFAULT_WAITING_INTERACTION)]
+
+    draft = draft_from_waiting_request(request, execution_id="exec-1", step_id=None)
+
+    assert draft is not None
+    assert draft.source == "send_message"
+    assert draft.requests[0].tool_name == "send_message"
+    assert list(draft.interactions) == [DEFAULT_WAITING_INTERACTION]
 
 
 def test_tool_waiting_multi_tool_requests_and_interaction_id_fallback() -> None:

--- a/tests/core/agent/test_clarification_draft.py
+++ b/tests/core/agent/test_clarification_draft.py
@@ -240,7 +240,7 @@ def test_send_message_carrying_interactions_still_classifies_as_send_message() -
 
 
 def test_a_request_with_no_tool_name_classifies_as_send_message() -> None:
-    """The only shape the old and new rules disagree on, and the one the
+    """The second shape the old and new rules disagree on, and the one the
     docstring's "``tool_name`` has always been written here" claim rests on.
 
     ``message_type == "question"`` plus a non-empty ``interactions`` and no

--- a/tests/core/agent/test_clarification_draft.py
+++ b/tests/core/agent/test_clarification_draft.py
@@ -239,6 +239,34 @@ def test_send_message_carrying_interactions_still_classifies_as_send_message() -
     assert list(draft.interactions) == [DEFAULT_WAITING_INTERACTION]
 
 
+def test_a_request_with_no_tool_name_classifies_as_send_message() -> None:
+    """The only shape the old and new rules disagree on, and the one the
+    docstring's "``tool_name`` has always been written here" claim rests on.
+
+    ``message_type == "question"`` plus a non-empty ``interactions`` and no
+    ``tool_name`` classified as ``ask_user_question`` under the old rule and
+    as ``send_message`` under the new one. No ReAct path produces it -- both
+    control-tool branches and ``_pause_for_tool_results`` write ``tool_name``
+    or ``kind`` -- so this is only reachable from a hand-built or foreign
+    checkpoint, where degrading to ``send_message`` names no tool the model
+    never called. Pinned because nothing else pins the divergence.
+    """
+
+    request = {
+        "event_id": "evt-1",
+        "message": "Which city?",
+        "message_type": "question",
+        "interactions": [dict(DEFAULT_WAITING_INTERACTION)],
+        "message_count": 5,
+    }
+
+    draft = draft_from_waiting_request(request, execution_id="exec-1", step_id=None)
+
+    assert draft is not None
+    assert draft.source == "send_message"
+    assert draft.requests[0].tool_name == ""
+
+
 def test_tool_waiting_multi_tool_requests_and_interaction_id_fallback() -> None:
     """Multiple waiting tools produce multiple requests; a missing
     ``interaction_id`` falls back to ``tool_call_id``, mirroring react.py's

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -2409,6 +2409,7 @@ async def test_dag_pattern_single_waiting_regression_unchanged() -> None:
         "status",
         "message",
         "message_type",
+        "interactions",
         "context",
         "clarification_draft",
         "execution_id",

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4653,8 +4653,8 @@ async def test_react_pattern_ask_user_question_pauses_with_structured_payload() 
     assert outbound_message["expect_response"] is True
     assert outbound_message["visible"] is True
     assert outbound_message["step_id"] == outbound_message["metadata"]["step_id"]
-    # Carries real options: a picker with nothing to select is replaced by the
-    # engine's free-text field, which would make this a test of that instead.
+    # Carries real options: a picker with nothing to select gets the engine's
+    # free-text field appended, which would make this a test of that instead.
     assert outbound_message["metadata"]["interactions"] == [
         {
             "type": "select_one",
@@ -5194,7 +5194,7 @@ async def test_pause_for_tool_results_deduplicates_normalized_fields() -> None:
         "message": "Pick one",
         "message_type": "question",
         # Options are what keep these answerable, so the published list is the
-        # deduplicated one rather than the engine's free-text substitute.
+        # deduplicated one with no free-text field appended.
         "interactions": [
             {
                 "type": "select_one",

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4625,7 +4625,8 @@ async def test_react_pattern_ask_user_question_pauses_with_structured_payload() 
                             "name": "ask_user_question",
                             "arguments": (
                                 '{"message":"Pick one","interactions":'
-                                '[{"type":"select_one","field":"choice","label":"Choice"}]}'
+                                '[{"type":"select_one","field":"choice","label":"Choice",'
+                                '"options":[{"label":"A","value":"a"}]}]}'
                             ),
                         },
                     }
@@ -4652,11 +4653,14 @@ async def test_react_pattern_ask_user_question_pauses_with_structured_payload() 
     assert outbound_message["expect_response"] is True
     assert outbound_message["visible"] is True
     assert outbound_message["step_id"] == outbound_message["metadata"]["step_id"]
+    # Carries real options: a picker with nothing to select is replaced by the
+    # engine's free-text field, which would make this a test of that instead.
     assert outbound_message["metadata"]["interactions"] == [
         {
             "type": "select_one",
             "field": "choice",
             "label": "Choice",
+            "options": [{"label": "A", "value": "a"}],
         }
     ]
     assert pattern.tool_ledger["call_question_form"].status == "completed"
@@ -5189,13 +5193,27 @@ async def test_pause_for_tool_results_deduplicates_normalized_fields() -> None:
         "status": "waiting_for_user",
         "message": "Pick one",
         "message_type": "question",
-        "interactions": [{"type": "select_one", "field": "\ufeffchoice"}],
+        # Options are what keep these answerable, so the published list is the
+        # deduplicated one rather than the engine's free-text substitute.
+        "interactions": [
+            {
+                "type": "select_one",
+                "field": "\ufeffchoice",
+                "options": [{"label": "A", "value": "a"}],
+            }
+        ],
     }
     result_b = {
         "status": "waiting_for_user",
         "message": "Pick another",
         "message_type": "question",
-        "interactions": [{"type": "select_one", "field": "choice"}],
+        "interactions": [
+            {
+                "type": "select_one",
+                "field": "choice",
+                "options": [{"label": "B", "value": "b"}],
+            }
+        ],
     }
 
     outcome = await pattern._pause_for_tool_results(

--- a/tests/core/agent/test_react_ask_user_question_dedup.py
+++ b/tests/core/agent/test_react_ask_user_question_dedup.py
@@ -205,12 +205,11 @@ async def test_dedup_cell_7_deduplicated_output_passes_the_write_side_validator(
 
 
 @pytest.mark.asyncio
-async def test_dedup_cell_8_an_empty_interactions_list_survives_untouched() -> None:
-    """The degenerate input. The dedup loop must be a no-op on an empty
-    list, not a short-circuit that skips the surrounding waiting path:
-    ``_run_ask_user_question`` already asserts status == "waiting_for_user"
-    internally, so reaching its return at all proves that; this test
-    additionally pins the empty interactions list itself.
+async def test_dedup_cell_8_an_empty_interactions_list_gets_the_default_field() -> None:
+    """The degenerate input. The dedup loop is a no-op on an empty list,
+    and ``_send_waiting_message`` then substitutes the default free-text
+    field so the suspended run still renders a control. The default's base
+    name is not suffixed, because the dedup loop claimed nothing.
 
     Mutation (measured): an early `if not interactions: ...` short-circuit
     before the waiting path turns this red -- not on the status assertion
@@ -219,7 +218,7 @@ async def test_dedup_cell_8_an_empty_interactions_list_survives_untouched() -> N
     given, an IndexError on the test double's own canned-response list."""
 
     out = await _run_ask_user_question([])
-    assert out == []
+    assert [item["field"] for item in out] == ["response"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/agent/test_react_clarification_draft.py
+++ b/tests/core/agent/test_react_clarification_draft.py
@@ -202,16 +202,17 @@ async def test_waiting_return_via_tool_carries_tool_waiting_draft() -> None:
 
 
 @pytest.mark.asyncio
-async def test_empty_message_send_message_reaches_waiting_with_no_draft() -> None:
+async def test_empty_message_send_message_still_yields_an_answerable_draft() -> None:
     """A ``send_message`` call with an empty ``message`` and
     ``expect_response=True`` is schema-valid (the tool only requires the
     ``message`` key to be present, not non-empty) and reaches
-    ``waiting_for_user`` with no derivable draft.
+    ``waiting_for_user``.
 
-    This is the reachable production case documented on
-    ``draft_from_waiting_request``: the waiting request carries no message,
-    no ``"interactions"`` key, and no ``"requests"`` list, so
-    ``clarification_draft`` is ``None`` rather than a typed draft.
+    It used to derive no draft at all -- no message, no ``"interactions"``
+    key, no ``"requests"`` list -- which is the worst version of the bug the
+    default free-text field exists for: nothing to read and nothing to answer
+    with. The substituted field now supplies the ``"interactions"`` key, so a
+    draft is derivable and the structured interaction row can be written.
     """
 
     llm = FakeLLM(
@@ -239,7 +240,11 @@ async def test_empty_message_send_message_reaches_waiting_with_no_draft() -> Non
     result = await pattern.run(context=context, tools=[], llm=llm)
 
     assert result["status"] == "waiting_for_user"
-    assert result["clarification_draft"] is None
+    draft = result["clarification_draft"]
+    assert draft is not None
+    assert draft.source == "send_message"
+    assert draft.message == ""
+    assert [item["field"] for item in draft.interactions] == ["response"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react_clarification_draft.py
+++ b/tests/core/agent/test_react_clarification_draft.py
@@ -212,7 +212,11 @@ async def test_empty_message_send_message_still_yields_an_answerable_draft() -> 
     key, no ``"requests"`` list -- which is the worst version of the bug the
     default free-text field exists for: nothing to read and nothing to answer
     with. The substituted field now supplies the ``"interactions"`` key, so a
-    draft is derivable and the structured interaction row can be written.
+    draft is derivable. Only the draft: a blank message is still refused
+    downstream (``resolve_publishable_clarification`` returns
+    ``NotApplicable("empty_question")``, and ``websocket.py`` persists no chat
+    row for an empty message), so this case ends the turn with an answerable
+    field published and nothing durable holding it.
     """
 
     llm = FakeLLM(

--- a/tests/core/agent/test_react_waiting_message_default_interaction.py
+++ b/tests/core/agent/test_react_waiting_message_default_interaction.py
@@ -9,9 +9,11 @@ message the frontend rendered as ordinary assistant prose, with nothing to
 answer it with.
 
 ``ReActPattern._send_waiting_message`` is the one place every suspending
-path publishes through, and it substitutes a ``text_input`` field when the
-list is empty. These cells pin that on all three paths and pin the reverse:
-a model that did supply interactions gets exactly its own, untouched.
+path publishes through, and it substitutes a ``text_input`` field whenever
+nothing in the list is answerable -- an empty list, but equally a list whose
+every entry the render surface would drop or render with nothing to pick.
+These cells pin that on all three paths and pin the reverse: a model that
+did supply an answerable field gets exactly its own, untouched.
 """
 
 from __future__ import annotations
@@ -315,15 +317,14 @@ async def test_a_picker_whose_options_are_not_a_list_is_replaced() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "interaction",
+    ("interaction", "expected_type"),
     [
-        {"type": "confirm", "field": "ok", "label": "Proceed?"},
-        {"type": "file_upload", "field": "doc", "label": "Upload"},
-        {"type": "number_input", "field": "n", "label": "How many?"},
-        {"type": "text_input", "field": "note", "label": "Note"},
-        {"type": "text", "field": "note", "label": "Note"},
-        {"type": "boolean", "field": "ok", "label": "Proceed?"},
-        {"type": "connect_apps", "field": "apps", "label": "Connect"},
+        ({"type": "confirm", "field": "ok", "label": "Proceed?"}, "confirm"),
+        ({"type": "file_upload", "field": "doc", "label": "Upload"}, "file_upload"),
+        ({"type": "number_input", "field": "n", "label": "How many?"}, "number_input"),
+        ({"type": "text_input", "field": "note", "label": "Note"}, "text_input"),
+        ({"type": "text", "field": "note", "label": "Note"}, "text_input"),
+        ({"type": "boolean", "field": "ok", "label": "Proceed?"}, "confirm"),
     ],
     ids=[
         "confirm",
@@ -332,24 +333,28 @@ async def test_a_picker_whose_options_are_not_a_list_is_replaced() -> None:
         "text_input",
         "alias_text",
         "alias_boolean",
-        "connect_apps",
     ],
 )
 async def test_a_type_that_needs_no_options_is_left_alone(
     interaction: dict[str, Any],
+    expected_type: str,
 ) -> None:
     """The answerability test must not fire on the types that never render
     options -- replacing one of those would throw away the model's real
-    question. The last three are why the check reads the frontend's whitelist
-    and not the tool schema's ``enum``: ``normalizeInteractions`` maps
-    ``text``/``boolean`` onto canonical names and renders ``connect_apps``,
-    none of which the ``enum`` offers."""
+    question. The last two are aliases the schema ``enum`` never offers:
+    ``_normalize_ask_user_interactions`` maps them onto a canonical name, so
+    the answerability check, the transcript builder and the write-side
+    validator -- none of which know the aliases -- all see the same seven."""
 
     _, runtime = await _run(
         "ask_user_question", {"message": "Well?", "interactions": [interaction]}
     )
     published = _published_interactions(runtime)
-    assert [item["type"] for item in published] == [interaction["type"]]
+    # Field name too: a replaced alias would land on the default field, whose
+    # type is itself ``text_input`` and would satisfy the type check alone.
+    assert [(item["type"], item["field"]) for item in published] == [
+        (expected_type, interaction["field"])
+    ]
 
 
 @pytest.mark.asyncio
@@ -411,8 +416,16 @@ async def test_default_field_passes_the_write_side_validator() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "interaction_type",
-    ["something_new", "", ["select_one"], {"type": "select_one"}, None, 7],
-    ids=["unknown", "blank", "list", "dict", "none", "int"],
+    [
+        "something_new",
+        "",
+        "connect_apps",
+        ["select_one"],
+        {"type": "select_one"},
+        None,
+        7,
+    ],
+    ids=["unknown", "blank", "connect_apps", "list", "dict", "none", "int"],
 )
 async def test_a_type_the_render_surface_cannot_use_is_replaced(
     interaction_type: Any,
@@ -423,7 +436,13 @@ async def test_a_type_the_render_surface_cannot_use_is_replaced(
     schema ``enum`` is a prompt, the tool arguments are raw ``json.loads``, and
     ``validate_v1_write_payload`` has no production caller. A non-``str`` type
     additionally used to raise ``TypeError`` on the frozenset lookup and take
-    the whole run down with it."""
+    the whole run down with it.
+
+    ``connect_apps`` is the one the frontend does keep and still cannot answer:
+    a form whose fields are all live widgets renders no Submit button at all
+    (``isConnectAppsOnly``, ``clarification-form.tsx``). Replacing it costs
+    nothing -- a widget beside any real field keeps the whole list, because
+    one answerable entry is enough."""
 
     _, runtime = await _run(
         "ask_user_question",
@@ -510,3 +529,52 @@ def test_the_substituted_label_is_stripped_before_the_resume_callback(
     assert [
         item["response"] for item in pattern.pending_tool_interaction_responses
     ] == [expected]
+
+
+@pytest.mark.asyncio
+async def test_a_live_widget_survives_beside_an_answerable_field() -> None:
+    """Replacing an unanswerable list must not become "drop every widget".
+    ``connect_apps`` is unanswerable alone but is a real control the model may
+    want shown next to a question, and the substitution is all-or-nothing."""
+
+    _, runtime = await _run(
+        "ask_user_question",
+        {
+            "message": "Connect an app, then tell me which one.",
+            "interactions": [
+                {"type": "connect_apps", "field": "apps", "label": "Connect"},
+                {"type": "text_input", "field": "which", "label": "Which one?"},
+            ],
+        },
+    )
+    assert [item["type"] for item in _published_interactions(runtime)] == [
+        "connect_apps",
+        "text_input",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_normalized_alias_passes_the_write_side_validator() -> None:
+    """The alias mapping is what keeps the four readers of a published type
+    agreeing. Without it the engine would bless ``{"type": "text"}`` as
+    answerable while this validator rejected it as an unsupported type and
+    the transcript builder rendered no line for it at all."""
+
+    from xagent.core.tools.adapters.vibe.ask_user_tool import AskUserQuestionArgs
+    from xagent.web.services.task_interaction_service import validate_v1_write_payload
+
+    _, runtime = await _run(
+        "ask_user_question",
+        {
+            "message": "Note?",
+            "interactions": [{"type": "text", "field": "note", "label": "Note"}],
+        },
+    )
+    published = _published_interactions(runtime)
+    assert published[0]["type"] == "text_input"
+    assert published[0]["field"] == "note"
+    validate_v1_write_payload(
+        AskUserQuestionArgs.model_validate(
+            {"message": "Note?", "interactions": published}
+        )
+    )

--- a/tests/core/agent/test_react_waiting_message_default_interaction.py
+++ b/tests/core/agent/test_react_waiting_message_default_interaction.py
@@ -17,6 +17,7 @@ a model that did supply interactions gets exactly its own, untouched.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -320,17 +321,29 @@ async def test_a_picker_whose_options_are_not_a_list_is_replaced() -> None:
         {"type": "file_upload", "field": "doc", "label": "Upload"},
         {"type": "number_input", "field": "n", "label": "How many?"},
         {"type": "text_input", "field": "note", "label": "Note"},
-        {"type": "something_new", "field": "x", "label": "X"},
+        {"type": "text", "field": "note", "label": "Note"},
+        {"type": "boolean", "field": "ok", "label": "Proceed?"},
+        {"type": "connect_apps", "field": "apps", "label": "Connect"},
     ],
-    ids=["confirm", "file_upload", "number_input", "text_input", "unknown_type"],
+    ids=[
+        "confirm",
+        "file_upload",
+        "number_input",
+        "text_input",
+        "alias_text",
+        "alias_boolean",
+        "connect_apps",
+    ],
 )
 async def test_a_type_that_needs_no_options_is_left_alone(
     interaction: dict[str, Any],
 ) -> None:
     """The answerability test must not fire on the types that never render
     options -- replacing one of those would throw away the model's real
-    question. An unrecognized type counts as answerable too: refusing it is
-    the write side's job, not this substitution's."""
+    question. The last three are why the check reads the frontend's whitelist
+    and not the tool schema's ``enum``: ``normalizeInteractions`` maps
+    ``text``/``boolean`` onto canonical names and renders ``connect_apps``,
+    none of which the ``enum`` offers."""
 
     _, runtime = await _run(
         "ask_user_question", {"message": "Well?", "interactions": [interaction]}
@@ -393,3 +406,107 @@ async def test_default_field_passes_the_write_side_validator() -> None:
         {"message": "Which one?", "interactions": _published_interactions(runtime)}
     )
     validate_v1_write_payload(parsed)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "interaction_type",
+    ["something_new", "", ["select_one"], {"type": "select_one"}, None, 7],
+    ids=["unknown", "blank", "list", "dict", "none", "int"],
+)
+async def test_a_type_the_render_surface_cannot_use_is_replaced(
+    interaction_type: Any,
+) -> None:
+    """``normalizeInteractions`` drops anything outside its whitelist and a
+    list it empties renders no form, so an unrecognized type is the very dead
+    end this substitution exists to prevent. Nothing upstream refuses one: the
+    schema ``enum`` is a prompt, the tool arguments are raw ``json.loads``, and
+    ``validate_v1_write_payload`` has no production caller. A non-``str`` type
+    additionally used to raise ``TypeError`` on the frozenset lookup and take
+    the whole run down with it."""
+
+    _, runtime = await _run(
+        "ask_user_question",
+        {
+            "message": "Well?",
+            "interactions": [
+                {"type": interaction_type, "field": "x", "label": "X"},
+            ],
+        },
+    )
+    assert _published_interactions(runtime) == [DEFAULT_FIELD]
+
+
+@pytest.mark.asyncio
+async def test_a_model_supplied_list_is_published_as_copies() -> None:
+    """The published list is stored on the waiting request, the tool-call
+    record and the result dict. One policy for both branches: the pass-through
+    one must not alias items the caller still holds either, which is what
+    ``_pause_for_tool_results`` does -- it keeps the same items on each
+    per-tool request entry."""
+
+    pattern = ReActPattern(max_iterations=2)
+    runtime = PatternRuntime(execution_id="exec-waiting-copies")
+    supplied = [
+        {
+            "type": "select_one",
+            "field": "city",
+            "label": "City",
+            "options": [{"label": "Paris", "value": "paris"}],
+        }
+    ]
+    _, published = await pattern._send_waiting_message(
+        runtime=runtime,
+        message="Which city?",
+        message_type="question",
+        interactions=supplied,
+        metadata={},
+    )
+    assert published == supplied
+    assert published[0] is not supplied[0]
+
+
+class _ResumableTool:
+    def __init__(self) -> None:
+        self.metadata = SimpleNamespace(name="gate", description="gate")
+
+    def resume_user_interaction(self, *, interaction_id: str, response: str) -> None:
+        pass
+
+
+@pytest.mark.parametrize(
+    ("published", "expected"),
+    [
+        ([dict(DEFAULT_FIELD)], "hello"),
+        (
+            [{"type": "text_input", "field": "note", "label": "Your response"}],
+            "Your response: hello",
+        ),
+    ],
+    ids=["substituted", "model_supplied_same_label"],
+)
+def test_the_substituted_label_is_stripped_before_the_resume_callback(
+    published: list[dict[str, Any]], expected: str
+) -> None:
+    """``clarification-form.tsx`` submits "<label>: <value>". The substituted
+    field's label is engine-invented, so passing the prefixed string on would
+    hand a tool's ``resume_user_interaction`` something the user never typed.
+    A model-supplied field that happens to share the label keeps its prefix --
+    that label is the model's own words and the tool may rely on it."""
+
+    pattern = ReActPattern()
+    pattern._queue_tool_interaction_responses(
+        waiting_request={
+            "kind": "tool_waiting_for_user",
+            "interactions": published,
+            "requests": [
+                {"tool_name": "gate", "tool_call_id": "call_1"},
+            ],
+        },
+        response="Your response: hello",
+        tools=[_ResumableTool()],
+    )
+
+    assert [
+        item["response"] for item in pattern.pending_tool_interaction_responses
+    ] == [expected]

--- a/tests/core/agent/test_react_waiting_message_default_interaction.py
+++ b/tests/core/agent/test_react_waiting_message_default_interaction.py
@@ -9,11 +9,13 @@ message the frontend rendered as ordinary assistant prose, with nothing to
 answer it with.
 
 ``ReActPattern._send_waiting_message`` is the one place every suspending
-path publishes through, and it substitutes a ``text_input`` field whenever
-nothing in the list is answerable -- an empty list, but equally a list whose
-every entry the render surface would drop or render with nothing to pick.
-These cells pin that on all three paths and pin the reverse: a model that
-did supply an answerable field gets exactly its own, untouched.
+path publishes through, and it appends a ``text_input`` field whenever
+nothing already in the list is answerable -- an empty list, but equally a
+list whose every entry the render surface would drop or render with nothing
+to pick. Appended, not substituted for the list: an options-less picker's
+``label`` is the question text, and the run has no other copy of it. These
+cells pin that on all three paths and pin the reverse: a model that did
+supply an answerable field gets exactly its own, untouched.
 """
 
 from __future__ import annotations
@@ -27,6 +29,9 @@ import pytest
 from xagent.core.agent import ExecutionContext, PatternRuntime, ReActPattern
 from xagent.core.agent.language import OUTPUT_LANGUAGE_METADATA_KEY
 from xagent.core.agent.transcript import build_assistant_transcript_content
+from xagent.core.tools.adapters.vibe.interaction_types import (
+    is_default_waiting_interaction,
+)
 from xagent.web.services.execution_result_projection import (
     project_execution_result_for_channel,
 )
@@ -169,6 +174,62 @@ async def test_send_message_pause_carries_the_field_into_the_structured_row() ->
 
 
 @pytest.mark.asyncio
+async def test_send_message_records_the_field_without_echoing_it_to_the_model() -> None:
+    """Two audiences, two answers. The trace ledger has to show what the pause
+    actually published or a trace cannot be used to check this invariant at
+    all. The model's own tool result must not: ``send_message`` has no
+    ``interactions`` parameter, and handing one back reads as a structured form
+    it produced -- against the tool description, which points structured
+    questions at ``ask_user_question``."""
+
+    llm = FakeLLM(
+        responses=[
+            _control_call(
+                "send_message", {"message": "Shall I?", "expect_response": True}
+            )
+        ]
+    )
+    pattern = ReActPattern(max_iterations=2)
+    runtime = PatternRuntime(execution_id="exec-waiting-ledger")
+    context = ExecutionContext()
+    context.add_user_message("Do the thing")
+    await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert pattern.tool_ledger["call_1"].result["interactions"] == [DEFAULT_FIELD]
+    tool_messages = [
+        message.content
+        for message in context.messages
+        if getattr(message, "role", "") == "tool"
+    ]
+    assert tool_messages
+    assert "Your response" not in "".join(tool_messages)
+
+
+@pytest.mark.asyncio
+async def test_a_non_waiting_send_message_records_no_interactions() -> None:
+    """The ledger key is added on the suspending branch only: an ordinary
+    message publishes no field and must not claim to have published one."""
+
+    llm = FakeLLM(
+        responses=[
+            _control_call("send_message", {"message": "Working on it."}),
+            {"content": "done", "tool_calls": []},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext()
+    context.add_user_message("Do the thing")
+    await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        runtime=PatternRuntime(execution_id="exec-plain-send"),
+    )
+
+    assert "interactions" not in pattern.tool_ledger["call_1"].result
+
+
+@pytest.mark.asyncio
 async def test_a_hidden_waiting_message_keeps_its_visible_flag() -> None:
     """``visible`` is passed through, not overridden: the fallback adds a
     field, it does not decide whether the message is shown."""
@@ -271,7 +332,7 @@ async def test_model_supplied_interactions_are_not_augmented() -> None:
 @pytest.mark.parametrize(
     "picker_type", ["select_one", "select_multiple", "action_cards"]
 )
-async def test_a_picker_whose_options_were_all_blank_is_replaced(
+async def test_a_picker_whose_options_were_all_blank_keeps_its_label(
     picker_type: str,
 ) -> None:
     """The list is non-empty and still unanswerable.
@@ -280,7 +341,9 @@ async def test_a_picker_whose_options_were_all_blank_is_replaced(
     interaction itself, so a picker whose every option was blank arrives here
     as an entry with ``options == []`` -- a control with nothing to select,
     which is the same dead end an empty list is. An emptiness test lets it
-    through; the answerability test replaces it.
+    through; the answerability test appends a field to it. The picker itself
+    stays: its ``label`` is the question, and dropping it leaves a bare input
+    box asking nothing.
     """
 
     _, runtime = await _run(
@@ -291,17 +354,59 @@ async def test_a_picker_whose_options_were_all_blank_is_replaced(
                 {
                     "type": picker_type,
                     "field": "choice",
-                    "label": "Choice",
+                    "label": "Which region?",
                     "options": [{"label": "  ", "value": ""}],
                 }
             ],
         },
     )
-    assert _published_interactions(runtime) == [DEFAULT_FIELD]
+    assert _published_interactions(runtime) == [
+        {
+            "type": picker_type,
+            "field": "choice",
+            "label": "Which region?",
+            "options": [],
+        },
+        DEFAULT_FIELD,
+    ]
 
 
 @pytest.mark.asyncio
-async def test_a_picker_whose_options_are_not_a_list_is_replaced() -> None:
+async def test_the_kept_question_text_reaches_both_readers() -> None:
+    """What the label preservation is for. The two readers that skip the
+    substituted field must still render the entry it was appended to, or the
+    user sees an input box and no question."""
+
+    _, runtime = await _run(
+        "ask_user_question",
+        {
+            "message": "",
+            "interactions": [
+                {
+                    "type": "select_one",
+                    "field": "region",
+                    "label": "Which region?",
+                    "options": [],
+                }
+            ],
+        },
+    )
+    published = _published_interactions(runtime)
+
+    assert "Which region?" in build_assistant_transcript_content("", published)
+    projection = project_execution_result_for_channel(
+        {
+            "status": "waiting_for_user",
+            "success": False,
+            "output": "",
+            "chat_response": {"message": "", "interactions": published},
+        }
+    )
+    assert "Which region?" in projection.visible_text
+
+
+@pytest.mark.asyncio
+async def test_a_picker_whose_options_are_not_a_list_gets_a_field() -> None:
     """``_normalize_ask_user_interactions`` warns about a non-list ``options``
     and then leaves it exactly as the model wrote it. A truthy non-list is
     still nothing the render surface can iterate, so answerability has to test
@@ -321,7 +426,15 @@ async def test_a_picker_whose_options_are_not_a_list_is_replaced() -> None:
             ],
         },
     )
-    assert _published_interactions(runtime) == [DEFAULT_FIELD]
+    assert _published_interactions(runtime) == [
+        {
+            "type": "select_one",
+            "field": "choice",
+            "label": "Choice",
+            "options": "auto",
+        },
+        DEFAULT_FIELD,
+    ]
 
 
 @pytest.mark.asyncio
@@ -436,7 +549,7 @@ async def test_default_field_passes_the_write_side_validator() -> None:
     ],
     ids=["unknown", "blank", "connect_apps", "list", "dict", "none", "int"],
 )
-async def test_a_type_the_render_surface_cannot_use_is_replaced(
+async def test_a_type_the_render_surface_cannot_use_gets_a_field(
     interaction_type: Any,
 ) -> None:
     """``normalizeInteractions`` drops anything outside its whitelist and a
@@ -449,9 +562,9 @@ async def test_a_type_the_render_surface_cannot_use_is_replaced(
 
     ``connect_apps`` is the one the frontend does keep and still cannot answer:
     a form whose fields are all live widgets renders no Submit button at all
-    (``isConnectAppsOnly``, ``clarification-form.tsx``). Replacing it costs
-    nothing -- a widget beside any real field keeps the whole list, because
-    one answerable entry is enough."""
+    (``isConnectAppsOnly``, ``clarification-form.tsx``). The entry is kept and
+    the field is appended, so the widget still renders and the form gains
+    something to submit."""
 
     _, runtime = await _run(
         "ask_user_question",
@@ -462,7 +575,9 @@ async def test_a_type_the_render_surface_cannot_use_is_replaced(
             ],
         },
     )
-    assert _published_interactions(runtime) == [DEFAULT_FIELD]
+    published = _published_interactions(runtime)
+    assert published[0]["label"] == "X"
+    assert published[1:] == [DEFAULT_FIELD]
 
 
 @pytest.mark.asyncio
@@ -542,8 +657,38 @@ def test_the_substituted_label_is_stripped_before_the_resume_callback(
 
 
 @pytest.mark.asyncio
+async def test_the_substituted_field_is_deduplicated_against_the_kept_ones() -> None:
+    """The appended field goes through the same ``_unique_field`` dedup the
+    model-supplied fields do, so an unanswerable entry that already occupies
+    ``response`` does not end up sharing a name with it -- two fields under one
+    name lose one of the two submitted answers."""
+
+    _, runtime = await _run(
+        "ask_user_question",
+        {
+            "message": "Which one?",
+            "interactions": [
+                {
+                    "type": "select_one",
+                    "field": "response",
+                    "label": "Which region?",
+                    "options": [],
+                }
+            ],
+        },
+    )
+    published = _published_interactions(runtime)
+    assert [item["field"] for item in published] == ["response", "response_2"]
+    # Still recognized as the substituted field under its renamed field, or
+    # the transcript builder and the channel projection would start rendering
+    # it and the resume path would stop stripping its label.
+    assert published[1] == {**DEFAULT_FIELD, "field": "response_2"}
+    assert is_default_waiting_interaction(published[1])
+
+
+@pytest.mark.asyncio
 async def test_a_live_widget_survives_beside_an_answerable_field() -> None:
-    """Replacing an unanswerable list must not become "drop every widget".
+    """Appending to an unanswerable list must not become "drop every widget".
     ``connect_apps`` is unanswerable alone but is a real control the model may
     want shown next to a question, and the substitution is all-or-nothing."""
 

--- a/tests/core/agent/test_react_waiting_message_default_interaction.py
+++ b/tests/core/agent/test_react_waiting_message_default_interaction.py
@@ -5,8 +5,11 @@ left "no controls means answer in free text" to the reader. No reader
 implements it, so a model that emits ``ask_user_question`` with an empty or
 missing ``interactions`` -- or that suspends through ``send_message``, which
 has no ``interactions`` parameter at all -- produced a ``waiting_for_user``
-message the frontend rendered as ordinary assistant prose, with nothing to
-answer it with.
+turn the frontend rendered as ordinary assistant prose with no form. The
+composer stays open during a wait (``waiting_for_user`` is a stopped status,
+``ChatInput.tsx``), so a free-text reply was still possible there; what was
+missing is the form, and with it every surface built on the structured
+interaction row, which is built from this same list.
 
 ``ReActPattern._send_waiting_message`` is the one place every suspending
 path publishes through, and it appends a ``text_input`` field whenever
@@ -373,9 +376,9 @@ async def test_a_picker_whose_options_were_all_blank_keeps_its_label(
 
 @pytest.mark.asyncio
 async def test_the_kept_question_text_reaches_both_readers() -> None:
-    """What the label preservation is for. The two readers that skip the
-    substituted field must still render the entry it was appended to, or the
-    user sees an input box and no question."""
+    """What the label preservation is for. The readers that skip the appended
+    field must still render the entry it was appended to, or the user sees an
+    input box and no question."""
 
     _, runtime = await _run(
         "ask_user_question",
@@ -623,11 +626,29 @@ class _ResumableTool:
     [
         ([dict(DEFAULT_FIELD)], "hello"),
         (
+            [
+                {
+                    "type": "select_one",
+                    "field": "choice",
+                    "label": "Which region?",
+                    "options": [],
+                },
+                dict(DEFAULT_FIELD),
+            ],
+            "hello",
+        ),
+        ([{**DEFAULT_FIELD, "field": "response_2"}], "hello"),
+        (
             [{"type": "text_input", "field": "note", "label": "Your response"}],
             "Your response: hello",
         ),
     ],
-    ids=["substituted", "model_supplied_same_label"],
+    ids=[
+        "substituted",
+        "beside_the_entry_it_was_appended_to",
+        "renamed_by_dedup",
+        "model_supplied_same_label",
+    ],
 )
 def test_the_substituted_label_is_stripped_before_the_resume_callback(
     published: list[dict[str, Any]], expected: str
@@ -636,7 +657,12 @@ def test_the_substituted_label_is_stripped_before_the_resume_callback(
     field's label is engine-invented, so passing the prefixed string on would
     hand a tool's ``resume_user_interaction`` something the user never typed.
     A model-supplied field that happens to share the label keeps its prefix --
-    that label is the model's own words and the tool may rely on it."""
+    that label is the model's own words and the tool may rely on it.
+
+    The second case is the one appending created: the entry the field was
+    appended to renders but submits no line of its own (no value can be
+    selected from an empty options list), so the user's whole submission is
+    still the substituted field's one prefixed line."""
 
     pattern = ReActPattern()
     pattern._queue_tool_interaction_responses(

--- a/tests/core/agent/test_react_waiting_message_default_interaction.py
+++ b/tests/core/agent/test_react_waiting_message_default_interaction.py
@@ -25,6 +25,11 @@ from typing import Any
 import pytest
 
 from xagent.core.agent import ExecutionContext, PatternRuntime, ReActPattern
+from xagent.core.agent.language import OUTPUT_LANGUAGE_METADATA_KEY
+from xagent.core.agent.transcript import build_assistant_transcript_content
+from xagent.web.services.execution_result_projection import (
+    project_execution_result_for_channel,
+)
 
 
 class FakeLLM:
@@ -47,11 +52,15 @@ def _control_call(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-async def _run(name: str, arguments: dict[str, Any]) -> tuple[Any, PatternRuntime]:
+async def _run(
+    name: str, arguments: dict[str, Any], output_language: str = ""
+) -> tuple[Any, PatternRuntime]:
     llm = FakeLLM(responses=[_control_call(name, arguments)])
     pattern = ReActPattern(max_iterations=2)
     runtime = PatternRuntime(execution_id="exec-waiting-default")
     context = ExecutionContext()
+    if output_language:
+        context.metadata[OUTPUT_LANGUAGE_METADATA_KEY] = output_language
     context.add_user_message("Do the thing")
 
     result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
@@ -475,6 +484,7 @@ async def test_a_model_supplied_list_is_published_as_copies() -> None:
         }
     ]
     _, published = await pattern._send_waiting_message(
+        context=ExecutionContext(),
         runtime=runtime,
         message="Which city?",
         message_type="question",
@@ -578,3 +588,82 @@ async def test_a_normalized_alias_passes_the_write_side_validator() -> None:
             {"message": "Note?", "interactions": published}
         )
     )
+
+
+SIMPLIFIED_FIELD = {**DEFAULT_FIELD, "label": "您的回复", "placeholder": "请输入您的回答"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("output_language", "expected"),
+    [
+        ("Simplified Chinese", SIMPLIFIED_FIELD),
+        ("zh-cn", SIMPLIFIED_FIELD),
+        (
+            "Traditional Chinese",
+            {**DEFAULT_FIELD, "label": "您的回覆", "placeholder": "請輸入您的回答"},
+        ),
+        ("Japanese", DEFAULT_FIELD),
+        ("", DEFAULT_FIELD),
+    ],
+    ids=["simplified", "alias", "traditional", "untranslated", "unpinned"],
+)
+async def test_the_substituted_field_follows_the_pinned_output_language(
+    output_language: str, expected: dict[str, Any]
+) -> None:
+    """The field is the only thing a user can answer a substituted turn with, so
+    its label is user-facing prose and follows the same pinned language the rest
+    of the turn does. A language the copy table has no entry for stays English
+    rather than blocking the substitution."""
+
+    _, runtime = await _run(
+        "send_message",
+        {"message": "Shall I proceed?", "expect_response": True},
+        output_language=output_language,
+    )
+    assert _published_interactions(runtime) == [expected]
+
+
+@pytest.mark.asyncio
+async def test_a_localized_substituted_field_is_still_skipped_by_both_readers() -> None:
+    """The coupling localization introduces. The transcript builder and the
+    channel projection both recognize the substituted field so they can skip it;
+    both would start rendering it again the moment its label stopped matching
+    what they compare against."""
+
+    _, runtime = await _run(
+        "send_message",
+        {"message": "继续吗？", "expect_response": True},
+        output_language="Simplified Chinese",
+    )
+    published = _published_interactions(runtime)
+    assert published == [SIMPLIFIED_FIELD]
+
+    assert build_assistant_transcript_content("继续吗？", published) == "继续吗？"
+    projection = project_execution_result_for_channel(
+        {
+            "status": "waiting_for_user",
+            "success": False,
+            "output": "Need input.",
+            "chat_response": {"message": "继续吗？", "interactions": published},
+        }
+    )
+    assert projection.visible_text == "继续吗？"
+
+
+def test_a_localized_substituted_label_is_stripped_before_the_resume_callback() -> None:
+    """The third reader that used to compare against the English literal."""
+
+    pattern = ReActPattern(max_iterations=2)
+    pattern._queue_tool_interaction_responses(
+        waiting_request={
+            "kind": "tool_waiting_for_user",
+            "interactions": [dict(SIMPLIFIED_FIELD)],
+            "requests": [{"tool_name": "gate", "tool_call_id": "call_1"}],
+        },
+        response="您的回复: 好",
+        tools=[_ResumableTool()],
+    )
+    assert [
+        item["response"] for item in pattern.pending_tool_interaction_responses
+    ] == ["好"]

--- a/tests/core/agent/test_react_waiting_message_default_interaction.py
+++ b/tests/core/agent/test_react_waiting_message_default_interaction.py
@@ -1,0 +1,270 @@
+"""A suspended ReAct run always publishes at least one answerable field.
+
+xagent#1528 declared an empty ``interactions`` list a legitimate shape and
+left "no controls means answer in free text" to the reader. No reader
+implements it, so a model that emits ``ask_user_question`` with an empty or
+missing ``interactions`` -- or that suspends through ``send_message``, which
+has no ``interactions`` parameter at all -- produced a ``waiting_for_user``
+message the frontend rendered as ordinary assistant prose, with nothing to
+answer it with.
+
+``ReActPattern._send_waiting_message`` is the one place every suspending
+path publishes through, and it substitutes a ``text_input`` field when the
+list is empty. These cells pin that on all three paths and pin the reverse:
+a model that did supply interactions gets exactly its own, untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from xagent.core.agent import ExecutionContext, PatternRuntime, ReActPattern
+
+
+class FakeLLM:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+
+    async def chat(self, **kwargs: Any) -> Any:
+        return self.responses.pop(0)
+
+
+def _control_call(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "function": {"name": name, "arguments": json.dumps(arguments)},
+            }
+        ],
+    }
+
+
+async def _run(name: str, arguments: dict[str, Any]) -> tuple[Any, PatternRuntime]:
+    llm = FakeLLM(responses=[_control_call(name, arguments)])
+    pattern = ReActPattern(max_iterations=2)
+    runtime = PatternRuntime(execution_id="exec-waiting-default")
+    context = ExecutionContext()
+    context.add_user_message("Do the thing")
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+    assert result["status"] == "waiting_for_user"
+    return result, runtime
+
+
+def _published_interactions(runtime: PatternRuntime) -> list[dict[str, Any]]:
+    waiting = [
+        payload
+        for payload in runtime.outbound_messages
+        if payload.get("expect_response")
+    ]
+    assert len(waiting) == 1
+    return waiting[0]["metadata"]["interactions"]
+
+
+DEFAULT_FIELD = {
+    "type": "text_input",
+    "field": "response",
+    "label": "Your response",
+    "placeholder": "Type your answer",
+    "multiline": True,
+}
+
+
+@pytest.mark.asyncio
+async def test_ask_user_question_with_an_empty_interactions_list() -> None:
+    result, runtime = await _run(
+        "ask_user_question", {"message": "Which one?", "interactions": []}
+    )
+    assert _published_interactions(runtime) == [DEFAULT_FIELD]
+    assert result["interactions"] == [DEFAULT_FIELD]
+
+
+@pytest.mark.asyncio
+async def test_ask_user_question_with_the_interactions_key_omitted() -> None:
+    """The shape Kimi K2.5 was observed producing: ``interactions`` is in the
+    schema's ``required`` list and the model omits it anyway."""
+
+    result, runtime = await _run("ask_user_question", {"message": "Which one?"})
+    assert _published_interactions(runtime) == [DEFAULT_FIELD]
+    assert result["interactions"] == [DEFAULT_FIELD]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "interactions",
+    ["pick one", {"type": "text_input", "field": "city"}, 7],
+    ids=["string", "dict", "int"],
+)
+async def test_ask_user_question_with_a_non_list_interactions(
+    interactions: Any,
+) -> None:
+    """``_normalize_ask_user_interactions`` already flattens every non-list to
+    ``[]``; the default field is what keeps that from reaching the user as an
+    unanswerable message."""
+
+    _, runtime = await _run(
+        "ask_user_question", {"message": "Which one?", "interactions": interactions}
+    )
+    assert _published_interactions(runtime) == [DEFAULT_FIELD]
+
+
+@pytest.mark.asyncio
+async def test_send_message_that_expects_a_response() -> None:
+    """``send_message`` has no ``interactions`` parameter, so its suspending
+    branch had no ``interactions`` metadata key at all before this guard."""
+
+    result, runtime = await _run(
+        "send_message",
+        {
+            "message": "Here is my plan. Shall I proceed?",
+            "message_type": "question",
+            "expect_response": True,
+        },
+    )
+    assert _published_interactions(runtime) == [DEFAULT_FIELD]
+    assert result["interactions"] == [DEFAULT_FIELD]
+
+
+@pytest.mark.asyncio
+async def test_send_message_pause_carries_the_field_into_the_structured_row() -> None:
+    """A task with ``interaction_protocol_version`` set reads its controls off
+    the interaction row, which is built from ``clarification_draft`` -- not off
+    the chat message. Publishing the field only in the outbound metadata would
+    leave that surface empty, so the waiting request has to carry it too.
+
+    The draft must still attribute itself to ``send_message``: the field is
+    substituted by the engine, it does not turn the call into an
+    ``ask_user_question``.
+    """
+
+    result, _ = await _run(
+        "send_message",
+        {
+            "message": "Here is my plan. Shall I proceed?",
+            "message_type": "question",
+            "expect_response": True,
+        },
+    )
+    draft = result["clarification_draft"]
+    assert draft is not None
+    assert draft.source == "send_message"
+    assert list(draft.interactions) == [DEFAULT_FIELD]
+
+
+@pytest.mark.asyncio
+async def test_a_hidden_waiting_message_keeps_its_visible_flag() -> None:
+    """``visible`` is passed through, not overridden: the fallback adds a
+    field, it does not decide whether the message is shown."""
+
+    _, runtime = await _run(
+        "send_message",
+        {
+            "message": "Quiet question",
+            "expect_response": True,
+            "visible": False,
+        },
+    )
+    waiting = [p for p in runtime.outbound_messages if p.get("expect_response")]
+    assert len(waiting) == 1
+    assert waiting[0]["visible"] is False
+    assert waiting[0]["metadata"]["interactions"] == [DEFAULT_FIELD]
+
+
+@pytest.mark.asyncio
+async def test_tool_requested_pause_with_no_interactions() -> None:
+    """The third suspending path: a tool that reports ``waiting_for_user``
+    without offering any interaction of its own."""
+
+    pattern = ReActPattern(max_iterations=2)
+    runtime = PatternRuntime(execution_id="exec-tool-wait")
+    context = ExecutionContext()
+    context.add_user_message("Ask")
+
+    outcome = await pattern._pause_for_tool_results(
+        waiting_pairs=[
+            ({"id": "call_a", "name": "tool_a"}, {"message": "Need a value"})
+        ],
+        context=context,
+        runtime=runtime,
+    )
+
+    assert outcome["status"] == "waiting_for_user"
+    assert outcome["interactions"] == [DEFAULT_FIELD]
+    assert _published_interactions(runtime) == [DEFAULT_FIELD]
+    assert pattern.waiting_for_user_request is not None
+    assert pattern.waiting_for_user_request["interactions"] == [DEFAULT_FIELD]
+
+
+@pytest.mark.asyncio
+async def test_send_message_without_expect_response_stays_field_free() -> None:
+    """The fallback must not leak onto messages that do not suspend the run."""
+
+    llm = FakeLLM(
+        responses=[
+            _control_call(
+                "send_message",
+                {"message": "Working on it.", "message_type": "progress"},
+            ),
+            _control_call(
+                "final_answer",
+                {
+                    "response_language": "English",
+                    "answer": "Done.",
+                    "outcome": "completed",
+                },
+            ),
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    runtime = PatternRuntime(execution_id="exec-no-wait")
+    context = ExecutionContext()
+    context.add_user_message("Do the thing")
+
+    await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert runtime.outbound_messages
+    for payload in runtime.outbound_messages:
+        assert not payload.get("expect_response")
+        assert "interactions" not in payload["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_model_supplied_interactions_are_not_augmented() -> None:
+    """The reverse assertion: a well-formed question keeps exactly its own
+    fields, with no default appended."""
+
+    supplied = [
+        {
+            "type": "select_one",
+            "field": "city",
+            "label": "City",
+            "options": [{"label": "Paris", "value": "paris"}],
+        }
+    ]
+    result, runtime = await _run(
+        "ask_user_question", {"message": "Which city?", "interactions": supplied}
+    )
+    published = _published_interactions(runtime)
+    assert [item["field"] for item in published] == ["city"]
+    assert published[0]["type"] == "select_one"
+    assert result["interactions"] == published
+
+
+@pytest.mark.asyncio
+async def test_default_field_passes_the_write_side_validator() -> None:
+    """The injected field has to survive the same admissibility rules the
+    model-supplied ones do, or the substitution buys nothing."""
+
+    from xagent.core.tools.adapters.vibe.ask_user_tool import AskUserQuestionArgs
+    from xagent.web.services.task_interaction_service import validate_v1_write_payload
+
+    _, runtime = await _run("ask_user_question", {"message": "Which one?"})
+    parsed = AskUserQuestionArgs.model_validate(
+        {"message": "Which one?", "interactions": _published_interactions(runtime)}
+    )
+    validate_v1_write_payload(parsed)

--- a/tests/core/agent/test_react_waiting_message_default_interaction.py
+++ b/tests/core/agent/test_react_waiting_message_default_interaction.py
@@ -256,6 +256,131 @@ async def test_model_supplied_interactions_are_not_augmented() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "picker_type", ["select_one", "select_multiple", "action_cards"]
+)
+async def test_a_picker_whose_options_were_all_blank_is_replaced(
+    picker_type: str,
+) -> None:
+    """The list is non-empty and still unanswerable.
+
+    ``_normalize_ask_user_interactions`` drops blank options but keeps the
+    interaction itself, so a picker whose every option was blank arrives here
+    as an entry with ``options == []`` -- a control with nothing to select,
+    which is the same dead end an empty list is. An emptiness test lets it
+    through; the answerability test replaces it.
+    """
+
+    _, runtime = await _run(
+        "ask_user_question",
+        {
+            "message": "Which one?",
+            "interactions": [
+                {
+                    "type": picker_type,
+                    "field": "choice",
+                    "label": "Choice",
+                    "options": [{"label": "  ", "value": ""}],
+                }
+            ],
+        },
+    )
+    assert _published_interactions(runtime) == [DEFAULT_FIELD]
+
+
+@pytest.mark.asyncio
+async def test_a_picker_whose_options_are_not_a_list_is_replaced() -> None:
+    """``_normalize_ask_user_interactions`` warns about a non-list ``options``
+    and then leaves it exactly as the model wrote it. A truthy non-list is
+    still nothing the render surface can iterate, so answerability has to test
+    the type, not just truthiness."""
+
+    _, runtime = await _run(
+        "ask_user_question",
+        {
+            "message": "Which one?",
+            "interactions": [
+                {
+                    "type": "select_one",
+                    "field": "choice",
+                    "label": "Choice",
+                    "options": "auto",
+                }
+            ],
+        },
+    )
+    assert _published_interactions(runtime) == [DEFAULT_FIELD]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "interaction",
+    [
+        {"type": "confirm", "field": "ok", "label": "Proceed?"},
+        {"type": "file_upload", "field": "doc", "label": "Upload"},
+        {"type": "number_input", "field": "n", "label": "How many?"},
+        {"type": "text_input", "field": "note", "label": "Note"},
+        {"type": "something_new", "field": "x", "label": "X"},
+    ],
+    ids=["confirm", "file_upload", "number_input", "text_input", "unknown_type"],
+)
+async def test_a_type_that_needs_no_options_is_left_alone(
+    interaction: dict[str, Any],
+) -> None:
+    """The answerability test must not fire on the types that never render
+    options -- replacing one of those would throw away the model's real
+    question. An unrecognized type counts as answerable too: refusing it is
+    the write side's job, not this substitution's."""
+
+    _, runtime = await _run(
+        "ask_user_question", {"message": "Well?", "interactions": [interaction]}
+    )
+    published = _published_interactions(runtime)
+    assert [item["type"] for item in published] == [interaction["type"]]
+
+
+@pytest.mark.asyncio
+async def test_one_answerable_field_keeps_the_whole_list() -> None:
+    """The substitution is all-or-nothing: one usable control is enough, and
+    the unusable one beside it is published as the model wrote it rather than
+    being pruned. Pruning is the write side's decision, not this one's."""
+
+    _, runtime = await _run(
+        "ask_user_question",
+        {
+            "message": "Which city?",
+            "interactions": [
+                {"type": "select_one", "field": "empty", "label": "E", "options": []},
+                {
+                    "type": "select_one",
+                    "field": "city",
+                    "label": "City",
+                    "options": [{"label": "Paris", "value": "paris"}],
+                },
+            ],
+        },
+    )
+    assert [item["field"] for item in _published_interactions(runtime)] == [
+        "empty",
+        "city",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_each_substitution_publishes_its_own_copy() -> None:
+    """The default lives in a module-level dict. Publishing it by reference
+    would let any reader that edits what it was handed corrupt every later
+    waiting message in the process."""
+
+    _, first = await _run("ask_user_question", {"message": "One?"})
+    published = _published_interactions(first)
+    published[0]["field"] = "mutated"
+
+    _, second = await _run("ask_user_question", {"message": "Two?"})
+    assert _published_interactions(second) == [DEFAULT_FIELD]
+
+
+@pytest.mark.asyncio
 async def test_default_field_passes_the_write_side_validator() -> None:
     """The injected field has to survive the same admissibility rules the
     model-supplied ones do, or the substitution buys nothing."""

--- a/tests/core/agent/test_react_waiting_message_default_interaction.py
+++ b/tests/core/agent/test_react_waiting_message_default_interaction.py
@@ -590,7 +590,11 @@ async def test_a_normalized_alias_passes_the_write_side_validator() -> None:
     )
 
 
-SIMPLIFIED_FIELD = {**DEFAULT_FIELD, "label": "您的回复", "placeholder": "请输入您的回答"}
+SIMPLIFIED_FIELD = {
+    **DEFAULT_FIELD,
+    "label": "您的回复",
+    "placeholder": "请输入您的回答",
+}
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_transcript.py
+++ b/tests/core/agent/test_transcript.py
@@ -1,5 +1,42 @@
-from xagent.core.agent.transcript import normalize_transcript_messages
+from xagent.core.agent.transcript import (
+    build_assistant_transcript_content,
+    normalize_transcript_messages,
+)
 from xagent.core.context_ref import CONTEXT_REFS_KEY, ContextReference
+from xagent.core.tools.adapters.vibe.interaction_types import (
+    DEFAULT_WAITING_INTERACTION,
+)
+
+
+def test_the_engines_substituted_field_leaves_no_trace_in_the_transcript() -> None:
+    """Every ``waiting_for_user`` turn now carries at least one field, and a
+    ``send_message`` pause carries the substituted one. Rendering it would
+    append a form block to the persisted content of every such turn -- text
+    the user reads back on reload and the model replays as context -- saying
+    only what the prose already said.
+    """
+
+    assert (
+        build_assistant_transcript_content(
+            "Shall I proceed?", [dict(DEFAULT_WAITING_INTERACTION)]
+        )
+        == "Shall I proceed?"
+    )
+
+
+def test_a_model_supplied_field_beside_the_substituted_one_still_renders() -> None:
+    """Only the substituted field is skipped. Suppressing the whole block
+    whenever it appears would lose real questions."""
+
+    content = build_assistant_transcript_content(
+        "Pick one",
+        [
+            dict(DEFAULT_WAITING_INTERACTION),
+            {"type": "text_input", "field": "city", "label": "City"},
+        ],
+    )
+    assert "Your response" not in content
+    assert "- City: text input" in content
 
 
 def _image_reference() -> ContextReference:

--- a/tests/core/tools/adapters/vibe/test_interaction_type_aliases.py
+++ b/tests/core/tools/adapters/vibe/test_interaction_type_aliases.py
@@ -1,0 +1,61 @@
+"""``INTERACTION_TYPE_ALIASES`` is a hand-copy of a frontend table.
+
+``normalizeInteractions`` (``frontend/src/contexts/app-context-chat.tsx``) maps
+off-contract type names onto the seven the render surface implements, and the
+engine applies the same map before it decides whether an interaction is
+answerable. The two tables have to agree: an alias only the frontend knows
+reads as an unsupported type engine-side, and one only the engine knows gets
+published and then dropped on render. Nothing but this cell notices when one
+side is edited alone.
+
+The parse is deliberately literal. If the ternary chain is restructured this
+fails with "could not parse", which is the right outcome -- the map has to be
+re-read by a human either way.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.interaction_types import (
+    INTERACTION_TYPE_ALIASES,
+    INTERACTION_TYPES,
+)
+
+SOURCE = (
+    Path(__file__).resolve().parents[5]
+    / "frontend"
+    / "src"
+    / "contexts"
+    / "app-context-chat.tsx"
+)
+
+# One arm of the chain: the `rawType === "x" || rawType === "y"` test, then the
+# canonical name it resolves to. Matched against whitespace-collapsed source so
+# a reformat of the same expression still parses.
+_ARM = re.compile(r'((?:rawType === "\w+"(?: \|\| )?)+) \? "(\w+)"')
+_ALIAS = re.compile(r'rawType === "(\w+)"')
+
+
+def _frontend_aliases() -> dict[str, str]:
+    if not SOURCE.exists():
+        pytest.skip(f"frontend source not present: {SOURCE}")
+    flattened = re.sub(r"\s+", " ", SOURCE.read_text(encoding="utf-8"))
+    body = flattened.split("const rawType = item.type", 1)
+    assert len(body) == 2, "could not parse: normalizeInteractions moved"
+    region = body[1].split("const rawField", 1)[0]
+    arms = _ARM.findall(region)
+    assert arms, "could not parse: the alias ternary chain changed shape"
+    return {
+        alias: canonical for tests, canonical in arms for alias in _ALIAS.findall(tests)
+    }
+
+
+def test_the_engine_alias_table_matches_the_frontend_one() -> None:
+    assert _frontend_aliases() == INTERACTION_TYPE_ALIASES
+
+
+def test_every_alias_resolves_to_a_supported_type() -> None:
+    assert set(INTERACTION_TYPE_ALIASES.values()) <= set(INTERACTION_TYPES)
+    assert not set(INTERACTION_TYPE_ALIASES) & set(INTERACTION_TYPES)

--- a/tests/e2e/test_skill_runtime_session_postgres.py
+++ b/tests/e2e/test_skill_runtime_session_postgres.py
@@ -47,6 +47,15 @@ POSTGRES_DATABASE = "xagent_test"
 MIN_SERVER_VERSION_NUM = 170000
 SKILL_INDEX_SENTINEL = "Pool handoff regression fixture"
 QUESTION = "Which deployment target should I use?"
+# Mirrors react._default_waiting_interaction as a literal on purpose: a change
+# to the published shape must fail here rather than follow the source.
+DEFAULT_WAITING_FIELD = {
+    "type": "text_input",
+    "field": "response",
+    "label": "Your response",
+    "placeholder": "Type your answer",
+    "multiline": True,
+}
 EXPECTED_SKILL_INDEX_LINE = (
     "- session-safe: Pool handoff regression fixture "
     "When to use: Test authenticated Skill database reads"
@@ -651,10 +660,10 @@ async def test_retained_agent_services_wait_without_holding_postgres_pool(
             assert result["status"] == "waiting_for_user"
             assert result["message"] == QUESTION
             assert result["message_type"] == "question"
-            assert result["interactions"] == []
+            assert result["interactions"] == [DEFAULT_WAITING_FIELD]
             assert result["chat_response"] == {
                 "message": QUESTION,
-                "interactions": [],
+                "interactions": [DEFAULT_WAITING_FIELD],
             }
             assert (
                 service.get_execution_status(f"retained-skill-runtime-{index}")[

--- a/tests/e2e/test_skill_runtime_session_postgres.py
+++ b/tests/e2e/test_skill_runtime_session_postgres.py
@@ -47,8 +47,9 @@ POSTGRES_DATABASE = "xagent_test"
 MIN_SERVER_VERSION_NUM = 170000
 SKILL_INDEX_SENTINEL = "Pool handoff regression fixture"
 QUESTION = "Which deployment target should I use?"
-# Mirrors react._default_waiting_interaction as a literal on purpose: a change
-# to the published shape must fail here rather than follow the source.
+# Mirrors interaction_types.DEFAULT_WAITING_INTERACTION as a literal on
+# purpose: a change to the published shape must fail here, not follow the
+# source.
 DEFAULT_WAITING_FIELD = {
     "type": "text_input",
     "field": "response",

--- a/tests/web/api/test_waiting_field_history_replay.py
+++ b/tests/web/api/test_waiting_field_history_replay.py
@@ -1,0 +1,119 @@
+"""History replay does not turn a past pause into a clarification form.
+
+Every suspending ReAct turn now publishes at least one answerable field, and
+the field is persisted on the assistant history row so the *current* waiting
+turn still renders a form after a reload. Replay of the *earlier* turns reads
+the same rows: without this filter, every past ``send_message`` pause -- which
+carried no interactions before and rendered as ordinary prose -- would come
+back as a collapsed clarification form. The frontend is unchanged; what it is
+handed is what has to stay the same.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.web.api.conftest import _direct_db_session
+from xagent.core.tools.adapters.vibe.interaction_types import (
+    default_waiting_interaction,
+)
+from xagent.web.api import websocket as websocket_api
+from xagent.web.models.chat_message import TaskChatMessage
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+
+REAL_FIELD = {
+    "type": "select_one",
+    "field": "city",
+    "label": "City",
+    "options": [{"label": "Paris", "value": "paris"}],
+}
+
+
+def _waiting_history_row(*, username: str, interactions: list[dict]) -> tuple[int, int]:
+    db = _direct_db_session()
+    try:
+        user = User(username=username, password_hash="hash")
+        db.add(user)
+        db.flush()
+        task = Task(
+            user_id=int(user.id),
+            title="Replayed pause",
+            description="Replayed pause",
+            status=TaskStatus.WAITING_FOR_USER,
+        )
+        db.add(task)
+        db.flush()
+        db.add(
+            TaskChatMessage(
+                task_id=int(task.id),
+                user_id=int(user.id),
+                role="assistant",
+                content="Shall I proceed?",
+                message_type="question",
+                interactions=interactions,
+                turn_id=None,
+                attachments=None,
+            )
+        )
+        db.commit()
+        return int(task.id), int(user.id)
+    finally:
+        db.close()
+
+
+async def _replayed_interactions(
+    monkeypatch: pytest.MonkeyPatch, *, task_id: int, user_id: int
+) -> list[list[dict]]:
+    sent_events: list[dict] = []
+
+    async def send_personal_message(event: dict, _websocket: object) -> None:
+        sent_events.append(event)
+
+    monkeypatch.setattr(websocket_api, "cache_get", lambda _key: None)
+    monkeypatch.setattr(websocket_api, "cache_set", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        websocket_api.manager, "send_personal_message", send_personal_message
+    )
+
+    await websocket_api.send_historical_data_as_stream(
+        websocket=object(),
+        task_id=task_id,
+        user=SimpleNamespace(id=user_id, is_admin=False),
+    )
+    return [
+        event["data"]["metadata"]["interactions"]
+        for event in sent_events
+        if event.get("event_type") == "agent_message"
+        and "metadata" in event.get("data", {})
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("persisted", "expected"),
+    [
+        ([default_waiting_interaction()], []),
+        ([default_waiting_interaction("Simplified Chinese")], []),
+        ([{**default_waiting_interaction(), "field": "response_2"}], []),
+        ([REAL_FIELD, default_waiting_interaction()], [REAL_FIELD]),
+        ([REAL_FIELD], [REAL_FIELD]),
+    ],
+    ids=["substituted", "localized", "renamed", "beside_a_real_field", "real_only"],
+)
+async def test_replay_drops_only_the_substituted_field(
+    _test_db,
+    monkeypatch: pytest.MonkeyPatch,
+    persisted: list[dict],
+    expected: list[dict],
+) -> None:
+    task_id, user_id = _waiting_history_row(
+        username=f"replay-{len(persisted)}-{persisted[0]['field']}",
+        interactions=persisted,
+    )
+
+    replayed = await _replayed_interactions(
+        monkeypatch, task_id=task_id, user_id=user_id
+    )
+
+    assert replayed == [expected]

--- a/tests/web/services/test_task_clarification_draft.py
+++ b/tests/web/services/test_task_clarification_draft.py
@@ -470,17 +470,16 @@ def test_payload_round_trip_matches_the_legacy_reader_shape_for_a_send_message_d
     for the legacy transcript path -- checked against that real function,
     not against this module's own return-type promise.
 
-    ``send_message`` is the source that actually reaches this comparison
-    with no interactions: its waiting request never carries an
-    ``"interactions"`` key at all (see the ``send_message`` branch of
-    ``ReActPattern._handle_control_tool`` in ``react.py``), so
-    ``draft_from_waiting_request`` always builds it with an empty
-    ``interactions`` tuple, and the websocket outbound-message path that
-    persists the matching chat row (``websocket.py``, the
-    ``expect_response`` branch) never passes an ``interactions`` keyword
-    either, leaving the column ``NULL``. Both readers must call that "no
-    interactions", i.e. ``None`` -- never ``[]``, which would claim a form
-    existed when none did.
+    The keyless waiting request built below is the shape a ``send_message``
+    pause used to produce and the shape an older checkpoint still holds; a
+    live run now carries the engine's substituted free-text field instead
+    (see ``ReActPattern._send_waiting_message`` in ``react.py``). What is
+    pinned here is the no-interactions comparison itself, which that legacy
+    shape is what still reaches: ``draft_from_waiting_request`` builds an
+    empty ``interactions`` tuple from it, and the row persisted below passes
+    no ``interactions`` keyword, leaving the column ``NULL``. Both readers
+    must call that "no interactions", i.e. ``None`` -- never ``[]``, which
+    would claim a form existed when none did.
     """
 
     engine = _engine(tmp_path)

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -6279,10 +6279,7 @@ def _base_interaction_for_type(
     interaction_type: str, **overrides: Any
 ) -> dict[str, Any]:
     item = _interaction(type=interaction_type, **overrides)
-    if (
-        interaction_type in svc._V1_TYPES_REQUIRING_OPTIONS
-        and "options" not in overrides
-    ):
+    if interaction_type in svc.TYPES_REQUIRING_OPTIONS and "options" not in overrides:
         item["options"] = [{"label": "Option A", "value": "a"}]
     return item
 

--- a/tests/web/test_execution_result_projection.py
+++ b/tests/web/test_execution_result_projection.py
@@ -177,3 +177,23 @@ def test_project_execution_result_keeps_real_fields_beside_the_substituted_one()
     assert projection.visible_text == (
         "Which city?\n\n\u2022 Destination\n  Options: Tokyo"
     )
+
+
+def test_project_execution_result_falls_back_when_only_the_substituted_field_remains():
+    """The substituted field makes ``interactions`` non-empty on every waiting
+    turn, including one whose message is blank. Keying the empty-output fallback
+    on the list alone would then send a channel an empty body."""
+
+    projection = project_execution_result_for_channel(
+        {
+            "status": "waiting_for_user",
+            "success": False,
+            "output": "",
+            "chat_response": {
+                "message": "",
+                "interactions": [dict(DEFAULT_WAITING_INTERACTION)],
+            },
+        }
+    )
+
+    assert projection.visible_text == EMPTY_CHANNEL_OUTPUT_FALLBACK

--- a/tests/web/test_execution_result_projection.py
+++ b/tests/web/test_execution_result_projection.py
@@ -1,4 +1,7 @@
 from xagent.core.agent.execution_adapter import INTERRUPTED_USER_MESSAGE
+from xagent.core.tools.adapters.vibe.interaction_types import (
+    DEFAULT_WAITING_INTERACTION,
+)
 from xagent.web.models.task import TaskStatus
 from xagent.web.services.execution_result_projection import (
     EMPTY_CHANNEL_OUTPUT_FALLBACK,
@@ -131,3 +134,46 @@ def test_project_empty_failure_has_no_diagnostic_and_uses_safe_display() -> None
     assert projection.transcript_content == "Task execution failed."
     assert projection.diagnostic_error is None
     assert projection.interactions == []
+
+
+def test_project_execution_result_omits_the_substituted_waiting_field():
+    """Every waiting turn with no other answerable field now carries the
+    engine's substituted ``text_input``. Bulleting it would put a "Your
+    response" line under every question on Slack/Telegram/Lark, where the
+    channel reply box is already the answer box."""
+
+    projection = project_execution_result_for_channel(
+        {
+            "status": "waiting_for_user",
+            "success": False,
+            "output": "Need input.",
+            "chat_response": {
+                "message": "Which city?",
+                "interactions": [dict(DEFAULT_WAITING_INTERACTION)],
+            },
+        }
+    )
+
+    assert projection.visible_text == "Which city?"
+    assert projection.interactions == [DEFAULT_WAITING_INTERACTION]
+
+
+def test_project_execution_result_keeps_real_fields_beside_the_substituted_one():
+    projection = project_execution_result_for_channel(
+        {
+            "status": "waiting_for_user",
+            "success": False,
+            "output": "Need input.",
+            "chat_response": {
+                "message": "Which city?",
+                "interactions": [
+                    dict(DEFAULT_WAITING_INTERACTION),
+                    {"label": "Destination", "options": [{"label": "Tokyo"}]},
+                ],
+            },
+        }
+    )
+
+    assert projection.visible_text == (
+        "Which city?\n\n\u2022 Destination\n  Options: Tokyo"
+    )


### PR DESCRIPTION
## Background

An agent can narrate its plan as a *question* and suspend the run, while the
message carries no answerable field at all. The frontend has no control to
render, so the visitor sees an ordinary assistant paragraph and has no way to
know the turn is theirs. The conversation stays parked indefinitely.

Confirmed on a real parked task: the waiting message had a 214-character body,
`message_type=question`, `expect_response=True`, and an **empty**
`metadata.interactions` list. The task was still `WAITING_FOR_USER` six days
later.

xagent#1528 deliberately allows an empty `interactions` list and states that
"a reader should understand the absence of controls as an invitation to answer
in free text". No reader implements that contract today. This PR honours it on
the write side, once, so no reader has to infer it.

## Invariant

Every message that puts a run into `waiting_for_user` carries at least one
answerable field.

## Entry points

A new `ReActPattern._send_waiting_message` is the only site in the repository
that publishes with `expect_response=True`. All three suspending paths funnel
through it:

- `ask_user_question`
- `send_message(expect_response=True)`
- `_pause_for_tool_results`

When the interaction list is empty it injects a single `text_input`
(`field="response"`); a non-empty list passes through untouched. The published
list is returned to the caller so the waiting request — the source the
structured interaction row is built from — records what was actually sent.

`send_message`'s tool description gains one sentence telling the model not to
narrate a plan through it and to use `ask_user_question` to ask.

`clarification.py`'s draft classifier previously keyed on the *presence* of an
`interactions` key to recognise `ask_user_question`. This change makes that key
universal, so the classifier now reads `tool_name`, which the same dict has
always carried.

## Non-goals

- `final_answer` and its guard, and the `outcome` enum fallback
- Any frontend change
- A timeout or release mechanism for parked tasks
- Semantic validation: this guarantees an answerable field exists, not that the
  question is a sensible one
- `send_message(expect_response=True, visible=False)`, which suspends the run
  while neither broadcasting nor persisting the message. Pre-existing and
  separate; `visible` is forwarded faithfully here rather than hardcoded, so
  this PR neither fixes nor deepens it.

## Blocking criteria

- `tests/core/agent` green (~1100 tests)
- Four mutations killed: dropping the default injection (11 red), dropping
  `interactions` from the `send_message` waiting request (2 red), reverting the
  draft classifier to the old key check (6 red), hardcoding `visible=True`
  (1 red)
- Full `pre-commit run --files` and mypy pass; zero errors in `react.py` and
  `clarification.py`

## Size

77 net lines of source, 292 lines of tests (~79% tests).
