### PR TITLE
fix: aggregate tool usage from persisted trace events

### DIFF
--- a/src/xagent/web/api/tools.py
+++ b/src/xagent/web/api/tools.py
@@ -8,14 +8,16 @@ from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy.orm import Session
+from sqlalchemy import case, func
+from sqlalchemy.orm import Query, Session
 
 from ...config import get_uploads_dir
 from ...core.tools.adapters.vibe.config import run_with_tool_runtime_cleanup
 from ..auth_dependencies import get_current_user
 from ..init_tool_configs import get_default_tool_configs
 from ..models.database import get_db
-from ..models.tool_config import ToolConfig, ToolUsage
+from ..models.task import TraceEvent
+from ..models.tool_config import ToolConfig
 from ..models.user import User
 from ..services.tool_credentials import (
     TOOL_CREDENTIAL_SPECS,
@@ -30,6 +32,24 @@ from ..services.tool_credentials import (
 from ..tools.config import WebToolConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _tool_usage_query(db: Session) -> Query[Any]:
+    """Count persisted completion events, shared by the list and usage endpoints."""
+    tool_name = TraceEvent.data["tool_name"].as_string()
+    query: Query[Any] = (
+        db.query(
+            tool_name.label("tool_name"),
+            func.count(TraceEvent.id).label("usage_count"),
+        )
+        .filter(
+            TraceEvent.event_type == "tool_execution_end",
+            tool_name.isnot(None),
+            tool_name != "",
+        )
+        .group_by(tool_name)
+    )
+    return query
 
 
 def _require_user_id(current_user: User) -> int:
@@ -394,7 +414,7 @@ async def get_available_tools(
 
         usage_map: defaultdict[str, int] = defaultdict(int)
         try:
-            usage_stats: list[Any] = db.query(ToolUsage).all()
+            usage_stats = await asyncio.to_thread(lambda: _tool_usage_query(db).all())
             for stat in usage_stats:
                 usage_map[stat.tool_name] = stat.usage_count
         except Exception as e:
@@ -647,7 +667,17 @@ async def get_tool_usage(db: Session = Depends(get_db)) -> list[dict[str, Any]]:
     try:
         # Run synchronous database queries in thread pool to avoid blocking event loop
         def _get_tool_usage_sync() -> list[dict[str, Any]]:
-            usage_stats = db.query(ToolUsage).all()
+            # Completion payloads carry a boolean; older events omit it on success.
+            success = func.coalesce(TraceEvent.data["success"].as_boolean(), True)
+            usage_stats = (
+                _tool_usage_query(db)
+                .add_columns(
+                    func.sum(case((success, 1), else_=0)).label("success_count"),
+                    func.sum(case((success, 0), else_=1)).label("error_count"),
+                    func.max(TraceEvent.timestamp).label("last_used_at"),
+                )
+                .all()
+            )
 
             result = []
             for stat in usage_stats:

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -29,7 +29,6 @@ from ...web.models.database import get_db
 from ...web.models.task import Task, TaskStatus
 from ...web.models.task import TraceEvent as DatabaseTraceEvent
 from ...web.models.task_interaction import TaskInteractionRequest
-from ...web.models.tool_config import ToolUsage
 from ...web.services.interaction_rollout import (
     COUNTER_CHECKPOINT_READ_PARTITION_WIDENED,
     increment_counter,
@@ -1104,38 +1103,6 @@ class DatabaseTraceHandler(BaseTraceHandler):
                         f"Task {self.task_id} lease changed before checkpoint "
                         f"{event.id} could be persisted"
                     )
-
-            # Update tool usage statistics if this is a tool execution event
-            if event_type_str == "tool_execution_end":
-                tool_name = data.get("tool_name") if isinstance(data, dict) else None
-                if tool_name:
-                    try:
-                        tool_usage: Any = (
-                            db.query(ToolUsage)
-                            .filter(ToolUsage.tool_name == tool_name)
-                            .first()
-                        )
-                        if not tool_usage:
-                            tool_usage = ToolUsage(
-                                tool_name=tool_name,
-                                usage_count=0,
-                                success_count=0,
-                                error_count=0,
-                            )
-                            db.add(tool_usage)
-
-                        tool_usage.usage_count += 1
-                        # We assume success for tool_execution_end events as errors are typically handled separately
-                        # and react pattern emits this event on success
-                        if isinstance(data, dict) and data.get("success", True):
-                            tool_usage.success_count += 1
-                        else:
-                            tool_usage.error_count += 1
-
-                        tool_usage.last_used_at = timestamp
-                        logger.debug(f"Updated usage stats for tool {tool_name}")
-                    except Exception as e:
-                        logger.error(f"Failed to update tool usage stats: {e}")
 
             db.commit()
 

--- a/tests/web/api/test_tool_usage_stats.py
+++ b/tests/web/api/test_tool_usage_stats.py
@@ -1,0 +1,111 @@
+"""Tool statistics come from completion events rather than shared counters."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.orm import Session
+
+from tests.web.services.test_task_execution_event_store import engine as engine_fixture
+from tests.web.services.test_task_execution_event_store import (
+    task_id as task_id_fixture,
+)
+from xagent.core.agent.trace import ACTION_END_TOOL
+from xagent.core.agent.trace import TraceEvent as CoreTraceEvent
+from xagent.web.api.tools import _tool_usage_query, get_tool_usage
+from xagent.web.api.trace_handlers import DatabaseTraceHandler
+from xagent.web.models.task import Task, TraceEvent
+from xagent.web.models.tool_config import ToolUsage
+from xagent.web.services import task_lease_service
+
+engine = engine_fixture
+task_id = task_id_fixture
+
+
+@pytest.mark.asyncio
+async def test_usage_aggregates_completed_events_across_tasks(engine, task_id):
+    start = datetime(2026, 9, 8, tzinfo=timezone.utc)
+    with Session(engine) as db:
+        assert await get_tool_usage(db) == []
+        task = db.get(Task, task_id)
+        other = Task(user_id=task.user_id, title="Other task")
+        db.add(other)
+        db.flush()
+        payloads = [
+            (task_id, "tool_execution_start", {"tool_name": "search"}),
+            (task_id, "tool_execution_end", {"tool_name": "search", "success": True}),
+            (other.id, "tool_execution_end", {"tool_name": "search", "success": False}),
+            (other.id, "tool_execution_end", {"tool_name": "search"}),
+            (other.id, "tool_execution_failed", {"tool_name": "search"}),
+            (
+                task_id,
+                "tool_execution_end",
+                {"tool_name": "计算器🔎", "success": False},
+            ),
+            (task_id, "tool_execution_end", {}),
+            (task_id, "tool_execution_end", {"tool_name": ""}),
+            (task_id, "tool_execution_end", {"tool_name": None}),
+        ]
+        for index, (tid, kind, data) in enumerate(payloads):
+            db.add(
+                TraceEvent(
+                    task_id=tid,
+                    event_id=str(index),
+                    event_type=kind,
+                    timestamp=start + timedelta(seconds=index),
+                    data=data,
+                )
+            )
+        # Legacy totals must not be added to the same events a second time.
+        db.add(ToolUsage(tool_name="search", usage_count=999))
+        db.commit()
+        counts = {row.tool_name: row.usage_count for row in _tool_usage_query(db).all()}
+        assert counts == {"search": 3, "计算器🔎": 1}
+        response = {row["tool_name"]: row for row in await get_tool_usage(db)}
+        assert {name: row["usage_count"] for name, row in response.items()} == counts
+        assert response["search"]["success_count"] == 2
+        assert response["search"]["error_count"] == 1
+        assert response["search"]["success_rate"] == pytest.approx(200 / 3)
+        last_used = datetime.fromisoformat(response["search"]["last_used_at"])
+        if last_used.tzinfo is None:  # SQLite stores UTC without an offset.
+            last_used = last_used.replace(tzinfo=timezone.utc)
+        assert last_used == start + timedelta(seconds=3)
+        assert response["计算器🔎"]["success_count"] == 0
+        assert response["计算器🔎"]["error_count"] == 1
+
+
+def test_tool_trace_persists_without_accessing_shared_counters(engine, task_id):
+    with Session(engine) as db:
+        lease = task_lease_service.acquire_task_lease_no_commit(
+            db, task_id, runner_id="tool-stats-test", new_run=True
+        )
+        db.commit()
+    assert lease is not None
+    statements = []
+
+    def record(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement.lower())
+
+    event.listen(engine, "before_cursor_execute", record)
+    try:
+        with Session(engine) as db:
+            trace = CoreTraceEvent(
+                ACTION_END_TOOL,
+                task_id=str(task_id),
+                step_id="tool-step",
+                data={"tool_name": "search", "success": True},
+                require_persisted=True,
+            )
+            with task_lease_service.bind_task_lease_context(lease):
+                DatabaseTraceHandler(task_id)._save_trace_event(db, trace)
+        with Session(engine) as db:
+            assert (
+                db.query(TraceEvent)
+                .filter(TraceEvent.event_id == str(trace.id))
+                .count()
+                == 1
+            )
+            assert _tool_usage_query(db).one().usage_count == 1
+        assert not any("tool_usage" in statement for statement in statements)
+    finally:
+        event.remove(engine, "before_cursor_execute", record)

--- a/tests/web/api/test_tools_api.py
+++ b/tests/web/api/test_tools_api.py
@@ -7,6 +7,7 @@ which lists all tools that can be used by agents.
 
 import logging
 import tempfile
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -19,7 +20,9 @@ from xagent.core.tools.adapters.vibe.config import (
 from xagent.web.api.auth import auth_router
 from xagent.web.api.tools import _create_tool_info, tools_router
 from xagent.web.models.database import Base, get_db, get_engine, init_db
-from xagent.web.models.tool_config import ToolConfig, ToolUsage
+from xagent.web.models.task import Task, TraceEvent
+from xagent.web.models.tool_config import ToolConfig
+from xagent.web.models.user import User
 
 
 def override_get_db():
@@ -243,6 +246,10 @@ class _AvailableToolsRouteHarness:
             def query(self, model: object) -> Query:
                 return Query(model)
 
+        monkeypatch.setattr(
+            "xagent.web.api.tools._tool_usage_query", lambda _db: Query("tool_usage")
+        )
+
         class SandboxManager:
             async def get_or_create_lease_provider(
                 self, _scope: str, _user_id: str
@@ -334,7 +341,7 @@ async def test_available_tools_cleanup_failure_follows_complete_route_body(
         "sound_effect",
         "music",
         "response_shape",
-        ToolUsage.__name__,
+        "tool_usage",
         ToolConfig.__name__,
         "user_overrides",
         "close",
@@ -563,6 +570,32 @@ class TestToolsAvailableAPI:
 
         data = response.json()
         tools = data["tools"]
+
+        counted_tool = tools[0]["name"]
+        with next(get_db()) as db:
+            user = db.query(User).filter(User.username == "admin").one()
+            task = Task(user_id=user.id, title="Tool usage")
+            db.add(task)
+            db.flush()
+            db.add(
+                TraceEvent(
+                    task_id=task.id,
+                    event_id="tool-usage-list-event",
+                    event_type="tool_execution_end",
+                    timestamp=datetime.now(timezone.utc),
+                    data={"tool_name": counted_tool, "success": True},
+                )
+            )
+            db.commit()
+        response = client.get(
+            "/api/tools/available", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert response.status_code == 200
+        tools = response.json()["tools"]
+        assert (
+            next(tool for tool in tools if tool["name"] == counted_tool)["usage_count"]
+            == 1
+        )
 
         # Each tool should have usage_count field
         for tool in tools:


### PR DESCRIPTION
Tool completion traces currently update a shared `ToolUsage` row while holding the task lease fence. Concurrent tasks using the same tool can therefore contend on the counter and extend task-lock hold times.

Remove counter maintenance from trace persistence and aggregate persisted `trace_events` in the two tools API readers instead. Both queries run off the event loop; the tool list computes counts only. Preserve the existing completion-event scope and boolean success/default-success semantics, and derive last use with `MAX(timestamp)`. Start and failure notifications are not counted separately. Keep the legacy table without reading or updating it; no schema migration is needed. Totals now reflect retained traces, so deleting tasks or missing historical traces can reduce the displayed totals.

Validation:
- 136 related SQLite/PostgreSQL, tools API, trace staging, and lease regression tests passed. After the self-review fix moving list aggregation off the event loop, the 41 API tests passed again.
- Tests cover cross-task counts, default success, failures, last-use time, Unicode tool names, empty data, ignoring legacy counters, list response counts, and lease-fenced trace persistence without any counter-table access.
- One unrelated authentication test was excluded: this local FastAPI environment returns 401 where it expects 403. Reproduced with the unchanged base implementation.
- All applicable pre-commit checks passed, including full-project mypy.
- A local PostgreSQL experiment with 200,000 synthetic traces (10,000 tool completions) took about 11 ms; adding an event-type index did not improve that measurement. No speculative index is included; this is not a production latency guarantee.

Self-review completed; the event-loop query placement issue was fixed before committing.
