### PR TITLE
fix(frontend): reconcile user turns by identity, not by matching text

### DIFF
--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -488,19 +488,25 @@ function SeedExistingTask() {
   return null
 }
 
-function SendMessageProbe() {
+function SendMessageProbe({
+  label = "Send message",
+  message = "Optimistic round trip",
+  clientMessageId = "turn-optimistic",
+}: {
+  label?: string
+  message?: string
+  clientMessageId?: string
+}) {
   const { sendMessage } = useApp()
 
   return (
     <button
       type="button"
       onClick={() => {
-        void sendMessage("Optimistic round trip", {
-          clientMessageId: "turn-optimistic",
-        })
+        void sendMessage(message, { clientMessageId })
       }}
     >
-      Send message
+      {label}
     </button>
   )
 }
@@ -844,6 +850,365 @@ describe("AppProvider websocket message routing", () => {
           content: "Optimistic round trip",
           isOptimistic: false,
         }),
+      ])
+    })
+  })
+
+  it("keeps a second user turn whose text repeats an unreconciled optimistic turn", async () => {
+    // Two replies to the same fixed-string form: same text, different turns.
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <SendMessageProbe
+          label="Send repeated turn"
+          message="Confirmed"
+          clientMessageId="turn-first"
+        />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    // The first turn's live user_message never arrives - a run refused before
+    // it starts emits none (see sendMessage's own note on the quota gate) -
+    // so its bubble stays optimistic and remains a merge candidate.
+    fireEvent.click(screen.getByRole("button", { name: "Send repeated turn" }))
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ content: string; isOptimistic?: boolean }>
+      expect(messages).toEqual([
+        expect.objectContaining({ content: "Confirmed", isOptimistic: true }),
+      ])
+    })
+
+    // Inside USER_MESSAGE_REPLACE_WINDOW_MS of the optimistic bubble, which
+    // is what makes the two turns candidates for a content merge at all.
+    act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "trace_event",
+        timestamp: new Date().toISOString(),
+        data: {
+          event_id: "user-event-second",
+          event_type: "user_message",
+          data: { message: "Confirmed", turn_id: "turn-second" },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ id: string; content: string; isOptimistic?: boolean }>
+      expect(messages).toEqual([
+        expect.objectContaining({
+          id: "msg-user-turn-turn-first",
+          content: "Confirmed",
+          isOptimistic: true,
+        }),
+        expect.objectContaining({
+          id: "msg-user-turn-turn-second",
+          content: "Confirmed",
+          isOptimistic: false,
+        }),
+      ])
+    })
+  })
+
+  it("keeps two optimistic sends that repeat the same text", async () => {
+    // Both ids come from a client_message_id, so neither has been near the wire.
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <SendMessageProbe
+          label="Send first"
+          message="Confirmed"
+          clientMessageId="turn-first"
+        />
+        <SendMessageProbe
+          label="Send second"
+          message="Confirmed"
+          clientMessageId="turn-second"
+        />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Send first" }))
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<unknown>
+      expect(messages).toHaveLength(1)
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Send second" }))
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ id: string; isOptimistic?: boolean }>
+      expect(messages).toEqual([
+        expect.objectContaining({
+          id: "msg-user-turn-turn-first",
+          content: "Confirmed",
+          isOptimistic: true,
+        }),
+        expect.objectContaining({
+          id: "msg-user-turn-turn-second",
+          content: "Confirmed",
+          isOptimistic: true,
+        }),
+      ])
+    })
+  })
+
+  it("renders both repeated clarification replies on a Session transport", async () => {
+    // The incident surface: history is "none", so a collapsed turn never returns.
+    const transport = makeSessionTransport()
+    render(
+      <AppProvider token="token" transport={transport}>
+        <SessionControlsProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    act(() => webSocketOptions.current?.onConnect?.())
+    act(() => {
+      webSocketOptions.current?.onMessage?.(taskInfoMessage(1))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-id").textContent).toBe("1")
+    })
+
+    // First reply: its live user_message never arrives, so the bubble stays
+    // optimistic and remains a merge candidate.
+    await act(async () => {
+      await getSessionControls().sendMessage("Confirmed", {
+        clientMessageId: "session-turn-1",
+      })
+    })
+
+    act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "trace_event",
+        timestamp: new Date().toISOString(),
+        task_id: 1,
+        data: {
+          event_id: "session-user-event-2",
+          event_type: "user_message",
+          data: { message: "Confirmed", turn_id: "session-turn-2" },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ id: string; content: string; isOptimistic?: boolean }>
+      expect(messages).toEqual([
+        expect.objectContaining({
+          id: "msg-user-turn-session-turn-1",
+          content: "Confirmed",
+          isOptimistic: true,
+        }),
+        expect.objectContaining({
+          id: "msg-user-turn-session-turn-2",
+          content: "Confirmed",
+          isOptimistic: false,
+        }),
+      ])
+    })
+  })
+
+  it("shows one turn twice when its persisted id disagrees with the sender's", async () => {
+    // The accepted cost of reconciling by identity alone; see the commit.
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <SendMessageProbe
+          label="Send repeated turn"
+          message="Confirmed"
+          clientMessageId="turn-first"
+        />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Send repeated turn" }))
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<unknown>
+      expect(messages).toHaveLength(1)
+    })
+
+    // Same turn, server-minted id.
+    act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "trace_event",
+        timestamp: new Date().toISOString(),
+        data: {
+          event_id: "user-event-server-minted",
+          event_type: "user_message",
+          data: { message: "Confirmed", turn_id: "server-minted-uuid" },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ id: string }>
+      expect(messages).toEqual([
+        expect.objectContaining({ id: "msg-user-turn-turn-first" }),
+        expect.objectContaining({ id: "msg-user-turn-server-minted-uuid" }),
+      ])
+    })
+  })
+
+  it("keeps a repeated turn identified only by event_id", async () => {
+    // The msg-user-event- half of the identity test: a row whose turn_id is
+    // NULL replays carrying only an event_id, and is still its own turn.
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <SendMessageProbe
+          label="Send repeated turn"
+          message="Confirmed"
+          clientMessageId="turn-first"
+        />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Send repeated turn" }))
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<unknown>
+      expect(messages).toHaveLength(1)
+    })
+
+    act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "trace_event",
+        timestamp: new Date().toISOString(),
+        data: {
+          event_id: "user-event-no-turn",
+          event_type: "user_message",
+          data: { message: "Confirmed" },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ id: string; isOptimistic?: boolean }>
+      expect(messages).toEqual([
+        expect.objectContaining({
+          id: "msg-user-turn-turn-first",
+          isOptimistic: true,
+        }),
+        expect.objectContaining({
+          id: "msg-user-event-user-event-no-turn",
+          isOptimistic: false,
+        }),
+      ])
+    })
+  })
+
+  it("does not let blank client message ids collide into one bubble", async () => {
+    // `config` is untyped, so a blank id would otherwise mint a bare
+    // `msg-user-turn-` that every other blank-id turn reconciles onto.
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <SendMessageProbe label="Send blank one" message="First" clientMessageId="  " />
+        <SendMessageProbe label="Send blank two" message="Second" clientMessageId="  " />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Send blank one" }))
+    fireEvent.click(screen.getByRole("button", { name: "Send blank two" }))
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ id: string; content: string }>
+      expect(messages.map((message) => message.content)).toEqual(["First", "Second"])
+      expect(messages[0].id).not.toBe(messages[1].id)
+      expect(messages.some((message) => message.id === "msg-user-turn-")).toBe(false)
+    })
+  })
+
+  it("still reconciles a repeated user turn that carries no stable identity", async () => {
+    // No turn_id and no event_id: text is the only reconciliation available.
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <SendMessageProbe
+          label="Send repeated turn"
+          message="Confirmed"
+          clientMessageId="turn-first"
+        />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Send repeated turn" }))
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ content: string; isOptimistic?: boolean }>
+      expect(messages).toEqual([
+        expect.objectContaining({ content: "Confirmed", isOptimistic: true }),
+      ])
+    })
+
+    act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "trace_event",
+        timestamp: new Date().toISOString(),
+        data: {
+          event_type: "user_message",
+          data: { message: "Confirmed" },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ content: string; isOptimistic?: boolean }>
+      expect(messages).toEqual([
+        expect.objectContaining({ content: "Confirmed", isOptimistic: false }),
       ])
     })
   })

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -440,7 +440,6 @@ const dispatchAutoOpenPreview = (
   })
 }
 
-const OPTIMISTIC_USER_MESSAGE_PREFIX = "msg-user-optimistic"
 const USER_TURN_MESSAGE_PREFIX = "msg-user-turn"
 const USER_EVENT_MESSAGE_PREFIX = "msg-user-event"
 const USER_MESSAGE_REPLACE_WINDOW_MS = 30000
@@ -487,11 +486,29 @@ const normalizeMessageContent = (content: string | React.ReactNode): string => {
   return ''
 }
 
+// A user message id minted from a stable per-turn identity: the wire's
+// `turn_id` / `event_id` (stableUserMessageId) or the sender's own
+// client_message_id (userTurnMessageId), which the backend echoes back as
+// that turn's id.
+const hasStableUserTurnIdentity = (id: string): boolean =>
+  id.startsWith(`${USER_TURN_MESSAGE_PREFIX}-`) ||
+  id.startsWith(`${USER_EVENT_MESSAGE_PREFIX}-`)
+
 const findOptimisticUserMessageIndex = (
   messages: Message[],
   incomingMessage: Message,
 ): number => {
   if (incomingMessage.role !== "user") {
+    return -1
+  }
+
+  // Identity beats text: a message carrying one is reconciled by
+  // ADD_MESSAGE's id branch alone. Merging by text instead can drop a turn
+  // from the transcript with no error, and repeated text is routine here -
+  // a clarification form with no free-text field serializes to a fixed
+  // string. Only identity-less legacy events still need text. See the commit
+  // for which same-turn pairs this gives up on, and why they are unreachable.
+  if (hasStableUserTurnIdentity(incomingMessage.id)) {
     return -1
   }
 
@@ -504,14 +521,7 @@ const findOptimisticUserMessageIndex = (
 
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const existingMessage = messages[index]
-    if (
-      existingMessage.role !== "user" ||
-      typeof existingMessage.id !== "string" ||
-      (
-        !existingMessage.isOptimistic &&
-        !existingMessage.id.startsWith(OPTIMISTIC_USER_MESSAGE_PREFIX)
-      )
-    ) {
+    if (existingMessage.role !== "user" || !existingMessage.isOptimistic) {
       continue
     }
 
@@ -6133,9 +6143,14 @@ export function AppProvider({
       )
     }
 
-    const clientMessageId = typeof config?.clientMessageId === 'string'
-      ? config.clientMessageId
-      : generateClientMessageId()
+    // Mirrors stableUserMessageId's trim guard. `config` is untyped, so a
+    // blank id would reach userTurnMessageId and mint a bare
+    // `msg-user-turn-` that every other blank-id turn collides on.
+    const requestedClientMessageId =
+      typeof config?.clientMessageId === 'string'
+        ? config.clientMessageId.trim()
+        : ''
+    const clientMessageId = requestedClientMessageId || generateClientMessageId()
     const requestId = typeof config?.metadata?.request_id === 'string'
       ? config.metadata.request_id
       : undefined


### PR DESCRIPTION
Fixes the collapse described in #2250. Does **not** close #2218 — see "Relation to #2218".

## What was wrong

`ADD_MESSAGE` fell through to a content-based merge for every user message whose id did not already match one in the transcript. That merge (`findOptimisticUserMessageIndex`) matched on normalized text plus a 30s window and ignored `turn_id` entirely, so a second turn repeating an earlier still-optimistic turn's text **overwrote** it instead of appending. Two submissions, one bubble, no error.

Clarification replies make the collision routine rather than exceptional: a form with no free-text field serializes to a fixed string (`Confirmed`, the uploaded-files label, the connect-apps skip line, Yes/No). Three routes reach it:

- **Two rapid same-text sends.** Needs no unreconciled precondition at all — a bubble is optimistic until its own trace event lands.
- **A run refused before it starts** emits no `user_message` trace, so the bubble stays optimistic for the life of the page. `sendMessage`'s own pre-existing comment (`app-context-chat.tsx:6151-6157`) already documents this for the quota gate.
- **Transient socket loss between the delivery ack and the broadcast.** ~~On the widget session page (`history: "none"`) nothing replays it.~~ — see the post-merge correction below.

> **Correction (round 1).** An earlier revision of this description claimed the precondition came from the server suppressing a live `user_message` whose `turn_id` is already persisted. That is wrong, and thanks to @rogercloud for catching it. `DatabaseTraceHandler` is registered before `WebSocketTraceHandler` (`web/tracing.py:70-71`) and they are awaited in order (`trace.py:1278`), so by the time the guard runs, this event's own row is persisted — and `_has_prior_user_message_turn` excludes it via `event_id != event_id` (`ws_trace_handlers.py:487-516`). The original always broadcasts; only a re-emission is suppressed. Both producers I originally named collapse with it, and the three routes above replace them.

## The change

29 production lines. Skip the content match when the incoming message carries a stable turn identity; only identity-less legacy events still reconcile by text. Also removes `OPTIMISTIC_USER_MESSAGE_PREFIX` and the clause reading it — nothing in `frontend/src` has ever minted that prefix, so the clause reduced to `!isOptimistic`.

**Wider than the issue's wording, deliberately.** #2250 frames the predicate as "`stableUserMessageId()` would return null", which describes only messages built from the wire. An optimistic bubble is minted from the sender's own `client_message_id` and never goes through that function, so under a literal reading two rapid replies of the same text would still collapse before either trace event landed — the same defect, one producer over. Keying on the minted id covers both.

## What this gives up

Reconciling by identity alone means a pair that is really one turn, but whose two ids disagree, renders twice instead of being rescued by text. Three routes were enumerated and none is reachable with a bubble on screen:

- `turn_id = client_message_id or str(uuid.uuid4())` (`websocket.py:6327`) needs a client id this frontend cannot mint; `generateClientMessageId` always satisfies `COMMAND_ID_PATTERN`.
- `_ensure_user_message_turn_id` (`runner.py:963`) mints a uuid4, but only when no turn id was requested; the chat and clarification-resume paths both thread `:6327`'s value through, so it fires only for programmatic injections, which have no optimistic bubble.
- A replayed row with a NULL `turn_id` (the `20260710` migration NULLs duplicates; pre-`turn_id` rows have none) replays as `msg-user-event-chat_message_N` and cannot id-match a preserved optimistic bubble — but such rows are historical, so their `created_at` sits far outside the 30s window and the text merge already skipped them. **There was no merge to lose.**

Pinned anyway by `shows one turn twice when its persisted id disagrees with the sender's`. Failure mode is a visible duplicate, never a lost turn.

## Tests

Seven added. **Six fail without their guard** — verified by disabling each and re-running (five without the identity check, one without the trim guard):

- `keeps a second user turn whose text repeats an unreconciled optimistic turn` — the core defect
- `keeps two optimistic sends that repeat the same text` — the wider case above
- `renders both repeated clarification replies on a Session transport` — the incident surface, routed through `handleSessionMessage` with `history: "none"`
- `shows one turn twice when its persisted id disagrees with the sender's` — the accepted trade-off
- `keeps a repeated turn identified only by event_id` — the `msg-user-event-` half of the predicate
- `does not let blank client message ids collide into one bubble` — the trim guard below

The seventh, `still reconciles a repeated user turn that carries no stable identity`, passes with the guard reverted: it is a **non-regression guard on the legacy path, not a pin on the fix**, and should not be counted as coverage.

Full frontend suite `2925/2926`, widget config `1167/1167`, `tsc --noEmit` clean, no eslint findings in the changed lines.

## Also in round 1

Mirrors `stableUserMessageId`'s trim guard onto the optimistic minter. `sendMessage`'s `config` is untyped, so a blank `clientMessageId` reached `userTurnMessageId` and minted a bare `msg-user-turn-` that every other blank-id turn reconciled onto — a collision through the **id** branch rather than the content one, so it merges turns whose text differs. Unreachable from the only non-test caller, which always uses `generateClientMessageId`, but the asymmetry was real.

## Out of scope (pre-existing, registered)

- #2173 — `PROVIDER_DISPLAY_NAMES` is missing the `salesforce` builtin provider. `connect-apps-field.test.tsx` is the one failing test in the suite above; **it fails identically on clean `main`**, verified in a separate worktree at `d539da5a`. Untouched by this diff.
- #2252 — the two dead user-message frame handlers (`case "chat"`, `case "chat_message"`) that could still collapse distinct turns. Neither has any producer: both backend `"type": "chat"` occurrences are inbound/LLM-context, and `"chat_message"` has no producer at all. Unreachable, so not hardened here.
- #2253 — the mirror-image duplicate when the persisted id disagrees and arrives first. Latent per the analysis above; the honest fix is a protocol change (carry `client_message_id` on the persisted event), which should not ride along on a bug fix.

## Size and shape

+397 / −17, of which **375 lines are tests**; 39 lines land in production code. The whole diff sits in pre-existing files, so the footprint ratio is 100% — a 29-line behavioural fix inside `app-context-chat.tsx` (6974 lines, 24 non-test importers) cannot be relocated to a new module. Flagged rather than glossed: the change is confined to one pure function plus the two id minters it now shares a spelling with, and touches no other reducer branch.

## Post-merge correction (2026-09-10)

A browser verification run against local `main` at this commit falsified one premise stated above, and withdrew this PR's connection to #2218. Recording both here since the commit message cannot be amended.

**`history: "none"` does not mean nothing replays.** The run captured `historical_data_complete` twice and a replayed `event_id: chat_message_9` transcript row on the widget session page. The server pushes history on reconnect regardless; the setting only stops the client requesting it. The third route listed above rests on that premise and is struck through accordingly. The other two routes are unaffected, and the fix itself is unaffected — the run confirmed user turns reconciling correctly across two forced reconnects, including one turn delivered three times that collapsed into a single bubble.

**#2218 has been reopened.** Its own capture has the `user_message` arriving before `message_accepted`, and in that order no optimistic bubble is ever created for the turn (the trace builds it first as non-optimistic; the later optimistic copy is dropped by id). #2250's collapse needs an optimistic bubble to overwrite, so it cannot be that incident's cause. Every one of the 8 sends in the run also received its matching `user_message`, so the fallback explanation — an earlier turn left unreconciled — did not hold either.

What did reproduce is half of #2218's symptom through an unrelated mechanism: reconnect replays each assistant question twice and the form re-prints, filed as #2292. That is the mirror of the defect this PR fixed, one role over — assistant messages still take a fresh `generateMessageId("msg-agent")` on every arrival and have no identity to reconcile on.

None of this changes what merged here. #2250 was a real defect and stays closed.

## Relation to #2218

#2218's triage ruled out every wire-level cause. Reproducing that exact configuration with a single send renders correctly, so the remaining variable was cross-turn state — and its capture records three chat sends. This is that variable, reproduced.

It closes #2218 only if two of those three sends carried identical text within 30s of each other. That is checkable in the existing capture and is **not assumed here**, so this PR carries no `Closes #2218`; that issue stays open pending its own per-frame socket-id confirmation.

