### PR TITLE
fix(agent): do not meter suppressed duplicate write calls

### DIFF
--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -283,8 +283,10 @@ class _AutoChildRuntime:
             metadata=child_metadata,
         )
 
-    async def on_tool_start(self, *, tool_call: dict[str, Any]) -> None:
-        await self.parent.on_tool_start(tool_call=tool_call)
+    async def on_tool_start(
+        self, *, tool_call: dict[str, Any], metered: bool = True
+    ) -> None:
+        await self.parent.on_tool_start(tool_call=tool_call, metered=metered)
 
     async def on_tool_end(self, *, tool_call: dict[str, Any], result: Any) -> None:
         await self.parent.on_tool_end(tool_call=tool_call, result=result)

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -198,8 +198,12 @@ class _DAGStepRuntime:
             metadata=step_metadata,
         )
 
-    async def on_tool_start(self, *, tool_call: dict[str, Any]) -> None:
-        await self.parent.on_tool_start(tool_call=self._with_step(tool_call))
+    async def on_tool_start(
+        self, *, tool_call: dict[str, Any], metered: bool = True
+    ) -> None:
+        await self.parent.on_tool_start(
+            tool_call=self._with_step(tool_call), metered=metered
+        )
 
     async def on_tool_end(self, *, tool_call: dict[str, Any], result: Any) -> None:
         await self.parent.on_tool_end(

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -3815,7 +3815,12 @@ class ReActPattern(AgentPattern):
                     self._record_tool_call(
                         tool_call, status="completed", result=suppressed
                     )
-                await runtime.on_tool_start(tool_call=tool_call)
+                # The suppressed path must not be metered: no execution round
+                # was consumed (the tool never ran). The trace pair is kept so
+                # suppressions stay visible in transcripts; metered=False is a
+                # call-site contract on PatternRuntime.on_tool_start, so a
+                # tool-controlled payload cannot spoof its way out of billing.
+                await runtime.on_tool_start(tool_call=tool_call, metered=False)
                 await runtime.on_tool_end(tool_call=tool_call, result=suppressed)
                 return suppressed
         self._record_tool_call(tool_call, status="running")

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -909,7 +909,9 @@ class PatternRuntime:
                 )
             )
 
-    async def on_tool_start(self, *, tool_call: dict[str, Any]) -> None:
+    async def on_tool_start(
+        self, *, tool_call: dict[str, Any], metered: bool = True
+    ) -> None:
         # Count one billable action per tool invocation, at invocation time.
         # Deliberately NOT gated on tool success: success is derived from the
         # tool's own return value, and custom MCP tools are user-controlled, so
@@ -918,12 +920,21 @@ class PatternRuntime:
         # (the MCP/compute round + the LLM turn that chose it) regardless of
         # outcome, so the non-gameable, resource-aligned signal is "it ran".
         # Fires once per tool, including each tool in a concurrent batch.
-        try:
-            from ..model.chat.token_context import add_tool_call_usage
+        #
+        # metered=False is reserved for calls that did NOT consume an
+        # execution round: the same-turn duplicate-write guard hands the model
+        # a suppression envelope and never runs the tool, so billing it would
+        # contradict the resource-aligned rationale above. The flag is a
+        # call-site contract (the guard passes it explicitly), never a field
+        # on tool_call — a tool-controlled payload must not be able to dodge
+        # metering.
+        if metered:
+            try:
+                from ..model.chat.token_context import add_tool_call_usage
 
-            add_tool_call_usage(1)
-        except Exception:
-            logger.debug("tool-call metering failed", exc_info=True)
+                add_tool_call_usage(1)
+            except Exception:
+                logger.debug("tool-call metering failed", exc_info=True)
         data = {
             "tool_name": tool_call.get("name"),
             "tool_params": tool_call.get("args", {}),

--- a/tests/core/agent/test_react_duplicate_write_guard.py
+++ b/tests/core/agent/test_react_duplicate_write_guard.py
@@ -692,3 +692,100 @@ def test_suppression_envelope_shape() -> None:
     assert envelope["suppressed_duplicate_of"] == "call_1"
     assert envelope["result"] == {"success": True, "record_id": "rec-1"}
     assert "already succeeded earlier in this turn" in envelope["message"]
+
+
+# ---------------------------------------------------------------------------
+# Metering: a suppressed duplicate must not be billed
+# ---------------------------------------------------------------------------
+
+
+async def _metered_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[int], list[dict[str, Any]]]:
+    """Run a duplicate-write scenario and return (metered_counts, tool_calls)."""
+    metered: list[int] = []
+    monkeypatch.setattr(
+        "xagent.core.model.chat.token_context.add_tool_call_usage",
+        lambda count=1: metered.append(count),
+    )
+    args = {"title": "invoice", "amount": 7}
+    llm = _run_twice_llm("create_record", args, dict(args))
+    tool = FakeWriteTool()
+    context = _turn_context("Create the invoice record")
+    await _pattern().run(context=context, tools=[tool], llm=llm)
+    return metered, tool.calls
+
+
+@pytest.mark.asyncio
+async def test_suppressed_duplicate_write_is_not_metered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The suppression path keeps trace visibility but skips billing.
+
+    Regression for xorbitsai/xagent#2231: before the fix, the suppressed
+    repeat still consumed one billable action even though the tool never
+    ran — only the genuine first call consumes an execution round.
+    """
+    metered, calls = await _metered_run(monkeypatch)
+
+    assert calls == [{"title": "invoice", "amount": 7}]
+    # Exactly one metered invocation: the genuine execution. The suppressed
+    # duplicate must not add a second billable action.
+    assert metered == [1]
+
+
+@pytest.mark.asyncio
+async def test_metered_default_still_bills_each_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two distinct executions in one turn still bill two actions."""
+    metered: list[int] = []
+    monkeypatch.setattr(
+        "xagent.core.model.chat.token_context.add_tool_call_usage",
+        lambda count=1: metered.append(count),
+    )
+    llm = _run_twice_llm(
+        "create_record",
+        {"title": "invoice", "amount": 7},
+        {"title": "invoice", "amount": 8},
+    )
+    tool = FakeWriteTool()
+    context = _turn_context("Create both records")
+
+    await _pattern().run(context=context, tools=[tool], llm=llm)
+
+    assert len(tool.calls) == 2
+    assert metered == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_metered_flag_is_a_call_site_contract_not_payload_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool-controlled payload cannot dodge metering.
+
+    The exemption is an explicit call-site parameter on
+    PatternRuntime.on_tool_start; a tool_call dict carrying a
+    duplicate_write_suppressed marker (as a hostile model or tool wrapper
+    might inject) must still be billed.
+    """
+    metered: list[int] = []
+    monkeypatch.setattr(
+        "xagent.core.model.chat.token_context.add_tool_call_usage",
+        lambda count=1: metered.append(count),
+    )
+    pattern = _pattern()
+    tool_call = {
+        "id": "call_h",
+        "name": "create_record",
+        "args": {"title": "spoofed"},
+        "duplicate_write_suppressed": True,
+    }
+    # The runtime would normally be PatternRuntime; exercising the hook with
+    # a forged payload must not exempt it from metering.
+    from xagent.core.agent import PatternRuntime
+
+    runtime = PatternRuntime(execution_id="test")
+    await runtime.on_tool_start(tool_call=tool_call)
+
+    assert metered == [1]


### PR DESCRIPTION
## What

The same-turn duplicate-write guard (#2217) suppresses a repeated write-category tool call and returns the prior result envelope without executing the tool. The suppressed path still emitted `on_tool_start`, which metered **one billable action per suppressed duplicate** — even though no MCP/compute round was consumed.

## Why

The metering rationale (runtime.py) bills at invocation because *"an invocation consumes real resources (the MCP/compute round + the LLM turn that chose it)"*. A suppressed duplicate consumes neither; only the LLM turn, which is billed separately. Metering it contradicts the documented rationale.

## How

- `PatternRuntime.on_tool_start` gains a keyword-only `metered: bool = True` flag (default preserves existing behavior everywhere).
- The suppression path in `ReActPattern._execute_tool_safely` passes `metered=False`, keeping the `on_tool_start`/`on_tool_end` trace pair intact (suppression visibility required by #2217) while skipping the billable action.
- `_AutoChildRuntime` and `_DAGStepRuntime` forward the flag so a suppressed duplicate inside a nested auto/DAG ReAct step behaves identically.

**Anti-spoofing:** the flag is a call-site contract, never a field on `tool_call` — a tool-controlled payload cannot dodge metering by stamping a marker.

## Tests

- `test_suppressed_duplicate_write_is_not_metered`: suppressed duplicate does not add a billable action (regression for this issue).
- `test_metered_default_still_bills_each_execution`: two genuine executions still bill twice.
- `test_metered_flag_is_a_call_site_contract_not_payload_field`: a forged `duplicate_write_suppressed` payload field is still billed.
- Mutation-checked: reverting the `metered=False` call makes the regression test fail (`[1, 1] != [1]`).
- Full `tests/core/agent/` suite passes.

Fixes #2231