### PR TITLE
fix(agent): drop malformed supersedes scope instead of killing the turn

### DIFF
--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -12,7 +12,6 @@ from uuid import uuid4
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import tiktoken
-logger = logging.getLogger(__name__)
 
 from ...context_ref import (
     CONTEXT_REFS_KEY,
@@ -64,6 +63,8 @@ from .skill_tool import (
     LOADED_SKILLS_METADATA_KEY,
     SKILL_INDEX_METADATA_KEY,
 )
+
+logger = logging.getLogger(__name__)
 
 READ_FILE_CONTEXT_LIMIT = 12_000
 # Set by the web layer into ``ExecutionContext.metadata`` at turn start: the

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections import Counter
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
@@ -11,9 +12,11 @@ from uuid import uuid4
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import tiktoken
+logger = logging.getLogger(__name__)
 
 from ...context_ref import (
     CONTEXT_REFS_KEY,
+    SUPERSEDES_SCOPE_KEY,
     ContextReference,
     normalize_context_references,
     split_tool_result_context_references,
@@ -322,7 +325,26 @@ class ExecutionContext:
         *,
         context_refs: Any = (),
     ) -> Message:
-        public_result, supersedes_scope = split_tool_result_supersedes_scope(result)
+        public_result = result
+        supersedes_scope: str | None = None
+        try:
+            public_result, supersedes_scope = split_tool_result_supersedes_scope(result)
+        except ValueError as exc:
+            # A malformed supersedes scope is internal bookkeeping for
+            # compacting superseded observations; losing it must degrade
+            # compaction, not the execution. Drop the key, log once with the
+            # tool name, and keep the turn alive (xorbitsai/xagent#2238).
+            # split_tool_result_supersedes_scope validates after popping from
+            # a private copy, so strip the key here before the model sees it.
+            if isinstance(public_result, dict):
+                public_result = dict(public_result)
+                public_result.pop(SUPERSEDES_SCOPE_KEY, None)
+            logger.warning(
+                "Dropping invalid %s from tool '%s' result: %s",
+                SUPERSEDES_SCOPE_KEY,
+                tool_name,
+                exc,
+            )
         public_result, embedded_refs = split_tool_result_context_references(
             public_result
         )

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import replace
 from datetime import datetime, timezone
 
@@ -2649,3 +2650,88 @@ def test_oversized_content_is_replaced_whole_not_sliced() -> None:
     # Byte-identical across builds: nothing in the notice comes from the
     # clock or a request id.
     assert transcript == second["messages"][-1]["content"]
+# ---------------------------------------------------------------------------
+# Supersedes-scope resilience (xorbitsai/xagent#2238)
+# ---------------------------------------------------------------------------
+
+
+def _tool_result_message(
+    ctx: ExecutionContext, payload: dict, call_id: str = "call-1"
+) -> Message:
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": call_id, "type": "function", "function": {"name": "computer"}}
+        ],
+    )
+    return ctx.add_tool_result("computer", payload, call_id)
+
+
+def test_malformed_supersedes_scope_is_dropped_not_fatal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A too-long scope must not kill the turn.
+
+    The scope is internal bookkeeping for compacting superseded
+    observations; losing it degrades compaction, not the execution. The
+    reserved key must also be stripped from the model-facing result, and a
+    warning is logged once with the tool name.
+    """
+    ctx = ExecutionContext()
+    oversized = "x" * 513
+
+    with caplog.at_level(logging.WARNING, logger="xagent.core.agent.context.execution"):
+        message = _tool_result_message(
+            ctx, {"success": True, "output": "ok", SUPERSEDES_SCOPE_KEY: oversized}
+        )
+
+    # The turn continues: a tool message is recorded as usual.
+    assert message.role == "tool"
+    assert "success" in message.metadata["raw_result"]
+    # The malformed scope key never reaches the model-facing result.
+    assert SUPERSEDES_SCOPE_KEY not in message.metadata["raw_result"]
+    # No compacting metadata was attached.
+    assert "supersedes_scope" not in message.metadata
+    # A warning mentions the tool name.
+    assert any(
+        "computer" in r.message and "Dropping invalid" in r.message
+        for r in caplog.records
+    )
+
+
+def test_control_char_supersedes_scope_is_dropped_not_fatal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A scope containing a control character must also degrade to none."""
+    ctx = ExecutionContext()
+    control_scope = "computer:task-\x01"
+
+    with caplog.at_level(logging.WARNING, logger="xagent.core.agent.context.execution"):
+        message = _tool_result_message(
+            ctx, {"success": True, "output": "ok", SUPERSEDES_SCOPE_KEY: control_scope}
+        )
+
+    assert message.role == "tool"
+    assert SUPERSEDES_SCOPE_KEY not in message.metadata["raw_result"]
+    assert "supersedes_scope" not in message.metadata
+
+
+def test_well_formed_supersedes_scope_still_compacts() -> None:
+    """A valid scope keeps its existing behavior: bookkeeping attached and
+    earlier same-scope observations superseded.
+    """
+    ctx = ExecutionContext()
+    _tool_result_message(
+        ctx,
+        {"success": True, "output": "old", SUPERSEDES_SCOPE_KEY: "computer:task-1"},
+        "call-1",
+    )
+    _tool_result_message(
+        ctx,
+        {"success": True, "output": "new", SUPERSEDES_SCOPE_KEY: "computer:task-1"},
+        "call-2",
+    )
+
+    superseded = [m for m in ctx.messages if (m.metadata or {}).get("superseded")]
+    assert len(superseded) == 1
+    assert "superseded" in superseded[0].content

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -2650,6 +2650,8 @@ def test_oversized_content_is_replaced_whole_not_sliced() -> None:
     # Byte-identical across builds: nothing in the notice comes from the
     # clock or a request id.
     assert transcript == second["messages"][-1]["content"]
+
+
 # ---------------------------------------------------------------------------
 # Supersedes-scope resilience (xorbitsai/xagent#2238)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`ExecutionContext.add_tool_result` splits the reserved `_xagent_supersedes_scope` key via `split_tool_result_supersedes_scope` (`src/xagent/core/context_ref.py`), which raises `ValueError("tool result supersedes scope is invalid")` for a scope longer than 512 chars or containing a control character. Nothing on the ReAct loop's backfill path caught it, so a malformed scope propagated out of the tool loop and **ended the turn** — even though the scope is internal bookkeeping for compacting superseded observations.

## Why

A first-party regression or future emitter producing a malformed scope currently takes down the whole execution instead of losing just its supersedes bookkeeping. Reachability today is low (only the first-party `computer` tool emits scopes), but the failure mode is a crash on what should be a no-op.

## How

Treat a malformed scope as **"no scope"**: catch the `ValueError` where the tool result is recorded (`ExecutionContext.add_tool_result`), strip the key from the model-facing result (the splitter validates after popping from a private copy, so the raw dict still carries it), log once with the tool name, and continue the turn. Compaction degrades; execution proceeds.

## Tests

- `test_malformed_supersedes_scope_is_dropped_not_fatal`: a 513-char scope records the tool message, strips the key from `raw_result`, attaches no `supersedes_scope` metadata, and emits a warning naming the tool.
- `test_control_char_supersedes_scope_is_dropped_not_fatal`: same behavior for a control-character scope.
- `test_well_formed_supersedes_scope_still_compacts`: a valid scope keeps the existing compaction behavior (earlier same-scope observations superseded).
- Mutation-checked: reverting the fix makes the two malformed-scope tests fail with the original `ValueError`.
- Full `tests/core/agent/` + `tests/core/test_context_ref.py` suites pass.

Fixes #2238