### PR TITLE
feat(memory): add safe admission and fallback primitives (toby)

### DIFF
--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -702,6 +702,73 @@ class LanceDBMemoryStore(MemoryStore):
         filters: Optional[dict[str, Any]] = None,
         similarity_threshold: Optional[float] = None,
     ) -> list[MemoryNote]:
+        return self._search(
+            query,
+            k=k,
+            filters=filters,
+            similarity_threshold=similarity_threshold,
+            include_null_vector_fallback=False,
+        )
+
+    def search_with_null_vector_fallback(
+        self,
+        query: str,
+        k: int = 5,
+        filters: Optional[dict[str, Any]] = None,
+        similarity_threshold: Optional[float] = None,
+    ) -> list[MemoryNote]:
+        """Dormant admission primitive that safely supplements ANN results."""
+        return self._search(
+            query,
+            k=k,
+            filters=filters,
+            similarity_threshold=similarity_threshold,
+            include_null_vector_fallback=True,
+        )
+
+    def _lexical_candidates(
+        self,
+        table: Any,
+        query: str,
+        filters: Optional[dict[str, Any]],
+        *,
+        null_vectors_only: bool,
+    ) -> list[MemoryNote]:
+        scan = table.search()
+        if null_vectors_only:
+            scan = scan.where("vector IS NULL")
+        rows = scan.limit(None).to_arrow().to_pylist()
+        other_filters = self._flat_other_filters(filters)
+        needle = query.casefold()
+        ranked: list[tuple[tuple[int, int, str], MemoryNote]] = []
+        for row in rows:
+            text = row.get("text") or ""
+            folded = text.casefold()
+            if needle and needle not in folded:
+                continue
+            try:
+                note = self._dict_to_memory_note(row)
+            except Exception as row_error:
+                logger.warning("Skipping malformed lexical memory row: %s", row_error)
+                continue
+            if filters and not self._matches_filters(note, filters, other_filters):
+                continue
+            match_kind = (
+                0 if folded == needle else 1 if folded.startswith(needle) else 2
+            )
+            ranked.append(((match_kind, -folded.count(needle), str(note.id)), note))
+        ranked.sort(key=lambda item: item[0])
+        return [note for _rank, note in ranked]
+
+    def _search(
+        self,
+        query: str,
+        k: int = 5,
+        filters: Optional[dict[str, Any]] = None,
+        similarity_threshold: Optional[float] = None,
+        *,
+        include_null_vector_fallback: bool,
+    ) -> list[MemoryNote]:
         """Search memory notes by query text with optional filters.
 
         Known limitation (#916): on the vector path, residual filters —
@@ -725,6 +792,7 @@ class LanceDBMemoryStore(MemoryStore):
                 self._collection_name
             )
             results = []
+            ann_search_completed = False
 
             # #822: push user_id + scope-dimension filters into a `where`
             # prefilter so the ANN returns k already-scoped neighbours; the rest
@@ -753,6 +821,7 @@ class LanceDBMemoryStore(MemoryStore):
                                     where_sql, prefilter=True
                                 )
                             vector_df = vector_query.limit(k).to_pandas()
+                            ann_search_completed = True
 
                             for _, row in vector_df.iterrows():
                                 # Check similarity threshold
@@ -827,6 +896,34 @@ class LanceDBMemoryStore(MemoryStore):
                 logger.warning(
                     f"Embedding generation failed, using text search: {embedding_error}"
                 )
+
+            if include_null_vector_fallback:
+                seen_ids: set[str] = set()
+                deduplicated: list[MemoryNote] = []
+                for note in results:
+                    identity = str(note.id)
+                    if identity not in seen_ids:
+                        seen_ids.add(identity)
+                        deduplicated.append(note)
+                results = deduplicated
+                candidates = (
+                    self._lexical_candidates(
+                        table,
+                        query,
+                        filters,
+                        null_vectors_only=ann_search_completed,
+                    )
+                    if len(results) < k
+                    else []
+                )
+                for note in candidates:
+                    identity = str(note.id)
+                    if identity not in seen_ids:
+                        seen_ids.add(identity)
+                        results.append(note)
+                    if len(results) >= k:
+                        break
+                return results[:k]
 
             # Fallback to text search if no vector results or vector search failed
             if not results:

--- a/src/xagent/core/memory/vector_compatibility.py
+++ b/src/xagent/core/memory/vector_compatibility.py
@@ -11,6 +11,7 @@ import pyarrow as pa  # type: ignore
 
 from ..model.model import EmbeddingModelConfig
 from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+from .scope_columns import SCOPE_DIMS_COLUMN, USER_ID_COLUMN, derive_scope_columns
 
 VECTOR_IDENTITY_METADATA_KEY = b"xagent.memory.vector_space"
 DASHSCOPE_DEFAULT_ENDPOINT = (
@@ -176,3 +177,99 @@ def inspect_lancedb_vector_compatibility(
         return classify_vector_compatibility(table.schema, expected_identity)
     finally:
         _safe_close_table(table)
+
+
+def _vector_capable_data(
+    identity: EmbeddingIdentity, existing: Any | None = None
+) -> pa.Table:
+    """Build typed memory data carrying one authoritative vector identity."""
+    if existing is None:
+        data = pa.table(
+            {
+                "id": pa.array(["__xagent_schema_seed__"], pa.string()),
+                "text": pa.array([""], pa.string()),
+                "metadata": pa.array(["{}"], pa.string()),
+                "vector": pa.array(
+                    [[0.0] * identity.dimension],
+                    pa.list_(pa.float32(), identity.dimension),
+                ),
+                USER_ID_COLUMN: pa.array([None], pa.int64()),
+                SCOPE_DIMS_COLUMN: pa.array([[]], pa.list_(pa.string())),
+            }
+        )
+    else:
+        names = set(existing.schema.names)
+        missing = {"id", "text", "metadata"} - names
+        if missing:
+            raise ValueError(
+                "vectorless memory table is missing required columns: "
+                + ", ".join(sorted(missing))
+            )
+        columns = {name: existing[name] for name in existing.schema.names}
+        for name in ("id", "text", "metadata"):
+            columns[name] = columns[name].cast(pa.string())
+        columns["vector"] = pa.nulls(
+            existing.num_rows, pa.list_(pa.float32(), identity.dimension)
+        )
+        derived = [
+            derive_scope_columns(value) for value in columns["metadata"].to_pylist()
+        ]
+        columns[USER_ID_COLUMN] = pa.array(
+            [user_id for user_id, _dims in derived], pa.int64()
+        )
+        columns[SCOPE_DIMS_COLUMN] = pa.array(
+            [dims for _user_id, dims in derived], pa.list_(pa.string())
+        )
+        data = pa.table(columns)
+    metadata = dict(
+        (existing.schema.metadata if existing is not None else data.schema.metadata)
+        or {}
+    )
+    metadata[VECTOR_IDENTITY_METADATA_KEY] = json.dumps(
+        identity.as_dict(), sort_keys=True, separators=(",", ":")
+    ).encode()
+    return data.replace_schema_metadata(metadata)
+
+
+def create_or_recreate_vector_capable_table(
+    connection: Any,
+    table_name: str,
+    expected_identity: EmbeddingIdentity | EmbeddingModelConfig | Mapping[str, Any],
+) -> VectorCompatibility:
+    """Create a missing table or overwrite a vectorless table with typed data.
+
+    This explicit lifecycle primitive is intentionally not called by request-time
+    store acquisition. Its future lifecycle caller must serialize it before writers
+    start. Open/create failures propagate unchanged.
+    """
+    identity = canonical_embedding_identity(expected_identity)
+    existing = None
+    table = None
+    try:
+        try:
+            table = connection.open_table(table_name)
+        except ValueError as error:
+            if "was not found" not in str(error):
+                raise
+        if table is not None:
+            if "vector" in table.schema.names:
+                return classify_vector_compatibility(table.schema, identity)
+            existing = table.to_arrow()
+        data = _vector_capable_data(identity, existing)
+    finally:
+        _safe_close_table(table)
+
+    created = connection.create_table(
+        table_name,
+        data=data,
+        mode="overwrite" if existing is not None else "create",
+    )
+    try:
+        if existing is None:
+            created.delete("id = '__xagent_schema_seed__'")
+        outcome = classify_vector_compatibility(created.schema, identity)
+        if outcome is not VectorCompatibility.MATCHING:
+            raise RuntimeError("created memory table failed vector compatibility")
+        return outcome
+    finally:
+        _safe_close_table(created)

--- a/src/xagent/core/memory/vector_compatibility.py
+++ b/src/xagent/core/memory/vector_compatibility.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Any, Mapping, Protocol
+from typing import Any, Mapping, Protocol, cast
 
 import pyarrow as pa  # type: ignore
 
@@ -53,6 +53,13 @@ class _ArrowSchema(Protocol):
     def metadata(self) -> Mapping[bytes, bytes] | None: ...
 
     def field(self, name: str) -> _ArrowField: ...
+
+
+class _ArrowTable(Protocol):
+    """Typed boundary for the Arrow table returned to LanceDB."""
+
+    @property
+    def schema(self) -> _ArrowSchema: ...
 
 
 class VectorCompatibility(str, Enum):
@@ -181,7 +188,7 @@ def inspect_lancedb_vector_compatibility(
 
 def _vector_capable_data(
     identity: EmbeddingIdentity, existing: Any | None = None
-) -> pa.Table:
+) -> _ArrowTable:
     """Build typed memory data carrying one authoritative vector identity."""
     if existing is None:
         data = pa.table(
@@ -228,7 +235,7 @@ def _vector_capable_data(
     metadata[VECTOR_IDENTITY_METADATA_KEY] = json.dumps(
         identity.as_dict(), sort_keys=True, separators=(",", ":")
     ).encode()
-    return data.replace_schema_metadata(metadata)
+    return cast(_ArrowTable, data.replace_schema_metadata(metadata))
 
 
 def create_or_recreate_vector_capable_table(

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -149,46 +149,34 @@ class DynamicMemoryStoreManager:
         self, embedding_model: DBModel
     ) -> UserIsolatedMemoryStore:
         """Create LanceDB store with the given embedding model."""
-        try:
-            # Check legacy location (project root) first for backward compatibility
-            legacy_dir = os.path.join(
-                os.path.dirname(
-                    os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-                ),
-                "memory_store",
-            )
-            if os.path.exists(legacy_dir) and os.listdir(legacy_dir):
-                logger.info(f"Using legacy memory store location: {legacy_dir}")
-                db_dir = legacy_dir
-            else:
-                # Use new default location
-                new_dir = get_storage_root() / "memory_store"
-                os.makedirs(new_dir, exist_ok=True)
-                db_dir = str(new_dir)
+        legacy_dir = os.path.join(
+            os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+            ),
+            "memory_store",
+        )
+        if os.path.exists(legacy_dir) and os.listdir(legacy_dir):
+            logger.info(f"Using legacy memory store location: {legacy_dir}")
+            db_dir = legacy_dir
+        else:
+            new_dir = get_storage_root() / "memory_store"
+            os.makedirs(new_dir, exist_ok=True)
+            db_dir = str(new_dir)
 
-            if embedding_model.model_provider == "dashscope":
-                lancedb_store = LanceDBMemoryStore(
-                    db_dir=db_dir,
-                    embedding_model=DashScopeEmbedding(
-                        api_key=str(embedding_model.api_key),
-                        dimension=int(embedding_model.dimension or 1024),
-                    ),
-                    similarity_threshold=self._similarity_threshold or 1.5,
-                )
-                logger.info("Created LanceDB store with DashScope embedding model")
-                return UserIsolatedMemoryStore(lancedb_store)
-            else:
-                # Fallback to in-memory if embedding type not supported
-                logger.warning(
-                    f"Unsupported embedding model type: {embedding_model.model_provider}"
-                )
-                self._initialize_in_memory_store()
-                return self._memory_store  # type: ignore[return-value]
-        except Exception as e:
-            logger.error(f"Error creating LanceDB store: {e}")
-            # Fallback to in-memory store
-            self._initialize_in_memory_store()
-            return self._memory_store  # type: ignore[return-value]
+        if embedding_model.model_provider != "dashscope":
+            raise ValueError(
+                f"Unsupported embedding model type: {embedding_model.model_provider}"
+            )
+        lancedb_store = LanceDBMemoryStore(
+            db_dir=db_dir,
+            embedding_model=DashScopeEmbedding(
+                api_key=str(embedding_model.api_key),
+                dimension=int(embedding_model.dimension or 1024),
+            ),
+            similarity_threshold=self._similarity_threshold or 1.5,
+        )
+        logger.info("Created LanceDB store with DashScope embedding model")
+        return UserIsolatedMemoryStore(lancedb_store)
 
     def _check_and_update_store(self) -> None:
         """Check if embedding model configuration has changed and update store accordingly."""
@@ -224,7 +212,12 @@ class DynamicMemoryStoreManager:
 
             if should_update:
                 if embedding_model:
-                    self._memory_store = self._create_lancedb_store(embedding_model)
+                    try:
+                        new_store = self._create_lancedb_store(embedding_model)
+                    except Exception as error:
+                        logger.error("Error creating LanceDB store: %s", error)
+                        return
+                    self._memory_store = new_store
                     self._is_lancedb = True
                     self._last_embedding_model_id = current_model_id  # type: ignore[assignment]
                     self._last_embedding_model_fingerprint = current_fingerprint

--- a/tests/core/memory/test_lancedb_admission.py
+++ b/tests/core/memory/test_lancedb_admission.py
@@ -1,0 +1,193 @@
+"""Real-LanceDB coverage for dormant memory admission primitives."""
+
+import json
+from types import SimpleNamespace
+
+import lancedb  # type: ignore
+import pyarrow as pa  # type: ignore
+import pytest
+
+from xagent.core.memory.core import MemoryNote
+from xagent.core.memory.lancedb import LanceDBMemoryStore
+from xagent.core.memory.scope_columns import SCOPE_DIMS_COLUMN, USER_ID_COLUMN
+from xagent.core.memory.vector_compatibility import (
+    VECTOR_IDENTITY_METADATA_KEY,
+    EmbeddingIdentity,
+    VectorCompatibility,
+    create_or_recreate_vector_capable_table,
+)
+from xagent.core.model.embedding import BaseEmbedding
+from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+from xagent.providers.vector_store.lancedb import clear_connection_cache
+from xagent.web.dynamic_memory_store import DynamicMemoryStoreManager
+
+
+IDENTITY = EmbeddingIdentity(
+    "openai", "text-embedding-3-small", "https://api.openai.com/v1/embeddings", 4, None
+)
+
+
+class ConstantEmbedding(BaseEmbedding):
+    def encode(self, text, dimension=None, instruct=None):
+        vector = [0.5] * 4
+        return vector if isinstance(text, str) else [vector for _ in text]
+
+    def get_dimension(self):
+        return 4
+
+    @property
+    def abilities(self):
+        return ["embed"]
+
+
+@pytest.fixture
+def store(tmp_path):
+    clear_connection_cache()
+    result = LanceDBMemoryStore(
+        str(tmp_path), collection_name="memories", embedding_model=ConstantEmbedding()
+    )
+    yield result
+    clear_connection_cache()
+
+
+def _raw_row(note_id, text, user_id, *, vector=None, priority="keep"):
+    return {
+        "id": note_id,
+        "text": text,
+        "metadata": json.dumps(
+            {"content": text or "", "user_id": user_id, "priority": priority}
+        ),
+        "vector": vector,
+        USER_ID_COLUMN: user_id,
+        SCOPE_DIMS_COLUMN: [],
+    }
+
+
+def test_ann_then_null_vector_fallback_is_filtered_deduplicated_and_stable(store):
+    assert store.add(
+        MemoryNote(
+            id="ann",
+            content="semantic winner",
+            metadata={"user_id": 7, "priority": "keep"},
+        )
+    ).success
+    table = store._vector_store.get_raw_connection().open_table("memories")
+    table.add(
+        [
+            _raw_row("z", "alpha alpha", 7),
+            _raw_row("a", "alpha", 7),
+            _raw_row("foreign", "alpha", 8),
+            _raw_row("filtered", "alpha", 7, priority="drop"),
+            _raw_row("ann", "alpha", 7),
+            _raw_row("null-text", None, 7),
+        ]
+    )
+    _safe_close_table(table)
+
+    filters = {"metadata": {"user_id": 7}, "priority": "keep"}
+    first = store.search_with_null_vector_fallback("alpha", k=3, filters=filters)
+    second = store.search_with_null_vector_fallback("alpha", k=3, filters=filters)
+    assert [note.id for note in first] == ["ann", "a", "z"]
+    assert [note.id for note in second] == ["ann", "a", "z"]
+
+    # Better ANN hits are never displaced merely to expose a lexical fallback.
+    assert [
+        note.id
+        for note in store.search_with_null_vector_fallback(
+            "alpha", k=1, filters=filters
+        )
+    ] == ["ann"]
+
+
+def test_standard_search_does_not_enable_null_vector_supplement(store):
+    assert store.add(MemoryNote(id="ann", content="winner")).success
+    table = store._vector_store.get_raw_connection().open_table("memories")
+    table.add([_raw_row("fallback", "alpha", None)])
+    _safe_close_table(table)
+    assert [note.id for note in store.search("alpha", k=2)] == ["ann"]
+
+
+def test_create_and_recreate_use_typed_vectors_and_canonical_identity(tmp_path):
+    connection = lancedb.connect(tmp_path)
+    assert (
+        create_or_recreate_vector_capable_table(connection, "new", IDENTITY)
+        is VectorCompatibility.MATCHING
+    )
+    table = connection.open_table("new")
+    assert table.count_rows() == 0
+    assert table.schema.field("vector").type == pa.list_(pa.float32(), 4)
+    assert VECTOR_IDENTITY_METADATA_KEY in (table.schema.metadata or {})
+    _safe_close_table(table)
+
+    vectorless = connection.create_table(
+        "legacy",
+        pa.table(
+            {
+                "id": ["kept"],
+                "text": pa.array([None], pa.string()),
+                "metadata": [json.dumps({"user_id": 9})],
+            }
+        ),
+    )
+    _safe_close_table(vectorless)
+    assert (
+        create_or_recreate_vector_capable_table(connection, "legacy", IDENTITY)
+        is VectorCompatibility.MATCHING
+    )
+    table = connection.open_table("legacy")
+    assert table.to_arrow().to_pylist() == [
+        {
+            "id": "kept",
+            "text": None,
+            "metadata": json.dumps({"user_id": 9}),
+            "vector": None,
+            USER_ID_COLUMN: 9,
+            SCOPE_DIMS_COLUMN: [],
+        }
+    ]
+    _safe_close_table(table)
+
+
+@pytest.mark.parametrize("failure_point", ["open", "create"])
+def test_recreation_propagates_real_io_errors(tmp_path, failure_point):
+    connection = lancedb.connect(tmp_path)
+    table = connection.create_table(
+        "memories", pa.table({"id": ["x"], "text": ["x"], "metadata": ["{}"]})
+    )
+    _safe_close_table(table)
+
+    class FailingConnection:
+        def open_table(self, name):
+            if failure_point == "open":
+                raise OSError("real open failure")
+            return connection.open_table(name)
+
+        def create_table(self, *args, **kwargs):
+            raise OSError("real create failure")
+
+    with pytest.raises(OSError, match=f"real {failure_point} failure"):
+        create_or_recreate_vector_capable_table(
+            FailingConnection(), "memories", IDENTITY
+        )
+
+
+def test_failed_manager_replacement_preserves_all_previous_state(monkeypatch):
+    manager = DynamicMemoryStoreManager()
+    previous_store = manager._memory_store
+    manager._is_lancedb = True
+    manager._last_embedding_model_id = 1
+    manager._last_embedding_model_fingerprint = (1, "old")
+    model = SimpleNamespace(id=2, updated_at="new")
+    monkeypatch.setattr(manager, "_get_embedding_model_from_db", lambda: model)
+    monkeypatch.setattr(
+        manager,
+        "_create_lancedb_store",
+        lambda _model: (_ for _ in ()).throw(OSError("construction failed")),
+    )
+
+    manager._check_and_update_store()
+
+    assert manager._memory_store is previous_store
+    assert manager._is_lancedb is True
+    assert manager._last_embedding_model_id == 1
+    assert manager._last_embedding_model_fingerprint == (1, "old")

--- a/tests/core/memory/test_lancedb_admission.py
+++ b/tests/core/memory/test_lancedb_admission.py
@@ -62,6 +62,10 @@ def _raw_row(note_id, text, user_id, *, vector=None, priority="keep"):
     }
 
 
+def _add_raw_rows(table, rows):
+    table.add(pa.Table.from_pylist(rows, schema=table.schema))
+
+
 def test_ann_then_null_vector_fallback_is_filtered_deduplicated_and_stable(store):
     assert store.add(
         MemoryNote(
@@ -71,7 +75,8 @@ def test_ann_then_null_vector_fallback_is_filtered_deduplicated_and_stable(store
         )
     ).success
     table = store._vector_store.get_raw_connection().open_table("memories")
-    table.add(
+    _add_raw_rows(
+        table,
         [
             _raw_row("z", "alpha alpha", 7),
             _raw_row("a", "alpha", 7),
@@ -79,7 +84,7 @@ def test_ann_then_null_vector_fallback_is_filtered_deduplicated_and_stable(store
             _raw_row("filtered", "alpha", 7, priority="drop"),
             _raw_row("ann", "alpha", 7),
             _raw_row("null-text", None, 7),
-        ]
+        ],
     )
     _safe_close_table(table)
 
@@ -101,7 +106,7 @@ def test_ann_then_null_vector_fallback_is_filtered_deduplicated_and_stable(store
 def test_standard_search_does_not_enable_null_vector_supplement(store):
     assert store.add(MemoryNote(id="ann", content="winner")).success
     table = store._vector_store.get_raw_connection().open_table("memories")
-    table.add([_raw_row("fallback", "alpha", None)])
+    _add_raw_rows(table, [_raw_row("fallback", "alpha", None)])
     _safe_close_table(table)
     assert [note.id for note in store.search("alpha", k=2)] == ["ann"]
 

--- a/tests/core/memory/test_lancedb_admission.py
+++ b/tests/core/memory/test_lancedb_admission.py
@@ -21,7 +21,6 @@ from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_
 from xagent.providers.vector_store.lancedb import clear_connection_cache
 from xagent.web.dynamic_memory_store import DynamicMemoryStoreManager
 
-
 IDENTITY = EmbeddingIdentity(
     "openai", "text-embedding-3-small", "https://api.openai.com/v1/embeddings", 4, None
 )


### PR DESCRIPTION
## Summary

- add an opt-in search primitive that preserves ANN ranking while deterministically filling remaining slots from eligible NULL-vector lexical matches
- add an explicit lifecycle primitive that creates or recreates vector-capable memory tables from typed Arrow data with canonical vector-space identity
- preserve the current store, embedding fingerprint, and LanceDB selection when replacement construction fails
- keep the new admission and fallback paths dormant with no startup or production caller

## Validation

- 75 focused real-LanceDB, compatibility, manager, and existing memory tests
- Ruff format and lint checks on all changed files
- Python bytecode compilation for all changed production modules
- mutation checks for disabled NULL-vector supplementation, missing canonical vector identity, and destructive manager fallback state

Closes #2212

Tracking: #2170
Depends on: #2214, #2227
Supersedes implementation evidence from: #2172