### PR TITLE
feat(mcp): add actor-scoped stdio connection storage (toby)

### DIFF
--- a/src/xagent/migrations/versions/20260909_add_actor_mcp_server_connections.py
+++ b/src/xagent/migrations/versions/20260909_add_actor_mcp_server_connections.py
@@ -114,7 +114,7 @@ def _check_expression_fingerprint(dialect: str, value: object) -> str:
         return "generation-nonempty"
     unwrapped = compact.replace("(", "").replace(")", "")
     if dialect == "postgresql" and re.fullmatch(
-        r"lifecycle_generation::(?:charactervarying|text)<>''::text",
+        r"lifecycle_generation::(?:charactervarying|text)(?:::text)?<>''::text",
         unwrapped,
     ):
         return "generation-nonempty"

--- a/src/xagent/migrations/versions/20260909_add_actor_mcp_server_connections.py
+++ b/src/xagent/migrations/versions/20260909_add_actor_mcp_server_connections.py
@@ -1,0 +1,85 @@
+"""add actor-scoped stdio MCP connection storage
+
+Revision ID: 20260909_actor_mcp_connections
+Revises: 20260901_seed_zendesk_mcp_app
+Create Date: 2026-09-09
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from xagent.web.models.generation import RandomUUID
+
+revision: str = "20260909_actor_mcp_connections"
+down_revision: Union[str, None] = "20260901_seed_zendesk_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "actor_mcp_server_connections"
+
+
+def upgrade() -> None:
+    op.create_table(
+        TABLE,
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "lifecycle_generation",
+            sa.Uuid(),
+            server_default=RandomUUID(),
+            nullable=False,
+        ),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("resource_owner_key", sa.String(length=512), nullable=False),
+        sa.Column("app_id", sa.String(length=100), nullable=False),
+        sa.Column("catalog_app_generation", sa.Uuid(), nullable=False),
+        sa.Column("encrypted_env", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "CAST(lifecycle_generation AS VARCHAR) <> ''",
+            name="ck_actor_mcp_server_connections_generation_nonempty",
+        ),
+        sa.ForeignKeyConstraint(
+            ["catalog_app_generation"],
+            ["public_mcp_apps.generation"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "lifecycle_generation",
+            name="uq_actor_mcp_server_connections_lifecycle_generation",
+        ),
+        sa.UniqueConstraint(
+            "user_id",
+            "resource_owner_key",
+            "app_id",
+            name="uq_actor_mcp_server_connections_actor_app",
+        ),
+        sa.UniqueConstraint(
+            "user_id",
+            "resource_owner_key",
+            "catalog_app_generation",
+            name="uq_actor_mcp_server_connections_actor_catalog_generation",
+        ),
+    )
+    op.create_index(op.f("ix_actor_mcp_server_connections_id"), TABLE, ["id"])
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_actor_mcp_server_connections_id"), table_name=TABLE)
+    op.drop_table(TABLE)

--- a/src/xagent/migrations/versions/20260909_add_actor_mcp_server_connections.py
+++ b/src/xagent/migrations/versions/20260909_add_actor_mcp_server_connections.py
@@ -7,7 +7,8 @@ Create Date: 2026-09-09
 
 from __future__ import annotations
 
-from typing import Sequence, Union
+import re
+from typing import Any, Mapping, Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
@@ -21,78 +22,277 @@ depends_on: Union[str, Sequence[str], None] = None
 
 TABLE = "actor_mcp_server_connections"
 
+_UNIQUE_CONSTRAINT_COLUMNS = {
+    (
+        "uq_actor_mcp_server_connections_lifecycle_generation",
+        ("lifecycle_generation",),
+    ),
+    (
+        "uq_actor_mcp_server_connections_actor_app",
+        ("user_id", "resource_owner_key", "app_id"),
+    ),
+    (
+        "uq_actor_mcp_server_connections_actor_catalog_generation",
+        ("user_id", "resource_owner_key", "catalog_app_generation"),
+    ),
+}
+
+
+def _compact_sql(value: object) -> str:
+    return re.sub(r"\s+", "", str(value or "").lower().replace('"', ""))
+
+
+def _column_type_fingerprint(
+    dialect: str, name: str, type_: sa.types.TypeEngine
+) -> str:
+    visit_name = type_.__visit_name__.lower()
+    if name in {"id", "user_id"} and visit_name == "integer":
+        return "integer"
+    if name in {"lifecycle_generation", "catalog_app_generation"}:
+        if (
+            dialect == "sqlite"
+            and visit_name == "char"
+            and getattr(type_, "length", None) == 32
+        ):
+            return "uuid"
+        if dialect == "postgresql" and visit_name == "uuid":
+            return "uuid"
+    if name == "resource_owner_key" and visit_name == "varchar":
+        return f"varchar:{getattr(type_, 'length', None)}"
+    if name == "app_id" and visit_name == "varchar":
+        return f"varchar:{getattr(type_, 'length', None)}"
+    if name == "encrypted_env" and visit_name == "json":
+        return "json"
+    if name in {"created_at", "updated_at"} and visit_name in {
+        "datetime",
+        "timestamp",
+    }:
+        # SQLite does not persist timezone metadata in its declared DATETIME type.
+        timezone = (
+            False if dialect == "sqlite" else bool(getattr(type_, "timezone", False))
+        )
+        return f"timestamp:timezone={timezone}"
+    return f"unsupported:{type_!r}"
+
+
+def _default_fingerprint(dialect: str, name: str, value: object) -> str:
+    compact = _compact_sql(value)
+    if name == "id":
+        if dialect == "sqlite" and not compact:
+            return "identity"
+        expected = "nextval('actor_mcp_server_connections_id_seq'::regclass)"
+        if dialect == "postgresql" and compact == expected:
+            return "identity"
+    if name == "lifecycle_generation":
+        if dialect == "postgresql" and compact in {
+            "gen_random_uuid()",
+            "(gen_random_uuid())",
+        }:
+            return "random-uuid"
+        sqlite_random_uuid = _compact_sql(
+            "lower(hex(randomblob(4))) || lower(hex(randomblob(2))) || "
+            "'4' || substr(lower(hex(randomblob(2))), 2) || "
+            "substr('89ab', (random() & 3) + 1, 1) || "
+            "substr(lower(hex(randomblob(2))), 2) || lower(hex(randomblob(6)))"
+        )
+        if dialect == "sqlite" and compact == sqlite_random_uuid:
+            return "random-uuid"
+    if name in {"created_at", "updated_at"}:
+        allowed = {"current_timestamp"} if dialect == "sqlite" else {"now()"}
+        if compact in allowed:
+            return "current-timestamp"
+    if value is None:
+        return "none"
+    return f"unsupported:{compact}"
+
+
+def _check_expression_fingerprint(dialect: str, value: object) -> str:
+    compact = _compact_sql(value)
+    if dialect == "sqlite" and re.fullmatch(
+        r"cast\(lifecycle_generationasvarchar(?:\(\d+\))?\)<>''", compact
+    ):
+        return "generation-nonempty"
+    unwrapped = compact.replace("(", "").replace(")", "")
+    if dialect == "postgresql" and re.fullmatch(
+        r"lifecycle_generation::(?:charactervarying|text)<>''::text",
+        unwrapped,
+    ):
+        return "generation-nonempty"
+    return f"unsupported:{compact}"
+
+
+def _index_fingerprint(index: Mapping[str, Any]) -> tuple[object, ...]:
+    options = dict(index.get("dialect_options") or {})
+    where = options.pop("postgresql_where", None)
+    include = tuple(index.get("include_columns") or ())
+    option_include = tuple(options.pop("postgresql_include", ()) or ())
+    nulls_not_distinct = options.pop("postgresql_nulls_not_distinct", False)
+    column_sorting = tuple(
+        sorted(
+            (name, tuple(values))
+            for name, values in dict(index.get("column_sorting") or {}).items()
+        )
+    )
+    return (
+        index.get("name"),
+        tuple(index.get("column_names") or ()),
+        tuple(index.get("expressions") or ()),
+        bool(index.get("unique")),
+        include,
+        option_include,
+        column_sorting,
+        _compact_sql(where),
+        bool(nulls_not_distinct),
+        tuple(sorted((str(key), str(value)) for key, value in options.items())),
+    )
+
+
+def _unique_fingerprint(
+    dialect: str, constraint: Mapping[str, Any]
+) -> tuple[object, ...]:
+    options = dict(constraint.get("dialect_options") or {})
+    include = tuple(options.pop("postgresql_include", ()) or ())
+    nulls_not_distinct = bool(options.pop("postgresql_nulls_not_distinct", False))
+    return (
+        constraint.get("name"),
+        tuple(constraint.get("column_names") or ()),
+        include if dialect == "postgresql" else (),
+        nulls_not_distinct,
+        tuple(sorted((str(key), str(value)) for key, value in options.items())),
+    )
+
+
+def _reflected_schema_fingerprint(inspector: sa.Inspector) -> dict[str, object]:
+    dialect = inspector.bind.dialect.name
+    columns = inspector.get_columns(TABLE)
+    column_fingerprint = tuple(
+        (
+            column["name"],
+            _column_type_fingerprint(dialect, column["name"], column["type"]),
+            bool(column["nullable"]),
+            _default_fingerprint(dialect, column["name"], column.get("default")),
+            column.get("computed"),
+            column.get("identity"),
+        )
+        for column in columns
+    )
+    uniques = {
+        _unique_fingerprint(dialect, constraint)
+        for constraint in inspector.get_unique_constraints(TABLE)
+    }
+    reflected_indexes = inspector.get_indexes(TABLE)
+    duplicate_constraints = {
+        index.get("duplicates_constraint")
+        for index in reflected_indexes
+        if index.get("duplicates_constraint") is not None
+    }
+    indexes = {
+        _index_fingerprint(index)
+        for index in reflected_indexes
+        if index.get("duplicates_constraint") is None
+    }
+    return {
+        "columns": column_fingerprint,
+        "primary_key": tuple(
+            inspector.get_pk_constraint(TABLE).get("constrained_columns") or ()
+        ),
+        "uniques": uniques,
+        "duplicate_constraints": duplicate_constraints,
+        "foreign_keys": {
+            (
+                tuple(foreign_key.get("constrained_columns") or ()),
+                foreign_key.get("referred_schema"),
+                foreign_key.get("referred_table"),
+                tuple(foreign_key.get("referred_columns") or ()),
+                tuple(
+                    sorted(
+                        (str(key), str(value).upper())
+                        for key, value in (foreign_key.get("options") or {}).items()
+                    )
+                ),
+            )
+            for foreign_key in inspector.get_foreign_keys(TABLE)
+        },
+        "checks": {
+            (
+                constraint.get("name"),
+                _check_expression_fingerprint(dialect, constraint.get("sqltext")),
+            )
+            for constraint in inspector.get_check_constraints(TABLE)
+        },
+        "indexes": indexes,
+    }
+
+
+def _expected_schema_fingerprint(dialect: str) -> dict[str, object]:
+    timestamp_type = (
+        "timestamp:timezone=False" if dialect == "sqlite" else "timestamp:timezone=True"
+    )
+    duplicate_constraints: set[str] = set()
+    if dialect == "postgresql":
+        duplicate_constraints = {name for name, _columns in _UNIQUE_CONSTRAINT_COLUMNS}
+    return {
+        "columns": (
+            ("id", "integer", False, "identity", None, None),
+            ("lifecycle_generation", "uuid", False, "random-uuid", None, None),
+            ("user_id", "integer", False, "none", None, None),
+            ("resource_owner_key", "varchar:512", False, "none", None, None),
+            ("app_id", "varchar:100", False, "none", None, None),
+            ("catalog_app_generation", "uuid", False, "none", None, None),
+            ("encrypted_env", "json", True, "none", None, None),
+            ("created_at", timestamp_type, False, "current-timestamp", None, None),
+            ("updated_at", timestamp_type, False, "current-timestamp", None, None),
+        ),
+        "primary_key": ("id",),
+        "uniques": {
+            (name, columns, (), False, ())
+            for name, columns in _UNIQUE_CONSTRAINT_COLUMNS
+        },
+        "duplicate_constraints": duplicate_constraints,
+        "foreign_keys": {
+            (("user_id",), None, "users", ("id",), (("ondelete", "CASCADE"),)),
+            (
+                ("catalog_app_generation",),
+                None,
+                "public_mcp_apps",
+                ("generation",),
+                (("ondelete", "CASCADE"),),
+            ),
+        },
+        "checks": {
+            (
+                "ck_actor_mcp_server_connections_generation_nonempty",
+                "generation-nonempty",
+            )
+        },
+        "indexes": {
+            (
+                "ix_actor_mcp_server_connections_id",
+                ("id",),
+                (),
+                False,
+                (),
+                (),
+                (),
+                "",
+                False,
+                (),
+            )
+        },
+    }
+
 
 def _adopt_current_metadata_table() -> bool:
-    """Adopt an exact metadata-created table, rejecting partial schema drift."""
+    """Adopt only a dialect-normalized, provably isomorphic metadata table."""
     inspector = sa.inspect(op.get_bind())
     if not inspector.has_table(TABLE):
         return False
-
-    columns = {column["name"]: column for column in inspector.get_columns(TABLE)}
-    expected_columns = {
-        "id",
-        "lifecycle_generation",
-        "user_id",
-        "resource_owner_key",
-        "app_id",
-        "catalog_app_generation",
-        "encrypted_env",
-        "created_at",
-        "updated_at",
-    }
-    nullable_columns = {name for name, column in columns.items() if column["nullable"]}
-    lengths = {
-        name: getattr(column["type"], "length", None)
-        for name, column in columns.items()
-    }
-    primary_key = tuple(inspector.get_pk_constraint(TABLE)["constrained_columns"])
-    unique_columns = {
-        tuple(constraint["column_names"])
-        for constraint in inspector.get_unique_constraints(TABLE)
-    }
-    foreign_keys = {
-        tuple(foreign_key["constrained_columns"]): (
-            foreign_key["referred_table"],
-            tuple(foreign_key["referred_columns"]),
-            str((foreign_key.get("options") or {}).get("ondelete")).upper(),
-        )
-        for foreign_key in inspector.get_foreign_keys(TABLE)
-    }
-    indexes = {
-        (index["name"], tuple(index["column_names"]))
-        for index in inspector.get_indexes(TABLE)
-    }
-    check_constraints = {
-        constraint["name"] for constraint in inspector.get_check_constraints(TABLE)
-    }
-    valid = (
-        set(columns) == expected_columns
-        and nullable_columns == {"encrypted_env"}
-        and lengths["resource_owner_key"] == 512
-        and lengths["app_id"] == 100
-        and columns["lifecycle_generation"]["default"] is not None
-        and columns["created_at"]["default"] is not None
-        and columns["updated_at"]["default"] is not None
-        and primary_key == ("id",)
-        and "ck_actor_mcp_server_connections_generation_nonempty" in check_constraints
-        and unique_columns
-        >= {
-            ("lifecycle_generation",),
-            ("user_id", "resource_owner_key", "app_id"),
-            ("user_id", "resource_owner_key", "catalog_app_generation"),
-        }
-        and foreign_keys
-        == {
-            ("user_id",): ("users", ("id",), "CASCADE"),
-            ("catalog_app_generation",): (
-                "public_mcp_apps",
-                ("generation",),
-                "CASCADE",
-            ),
-        }
-        and (op.f("ix_actor_mcp_server_connections_id"), ("id",)) in indexes
-    )
-    if not valid:
+    dialect = inspector.bind.dialect.name
+    if dialect not in {"sqlite", "postgresql"}:
+        raise RuntimeError(f"unsupported schema-adoption dialect: {dialect}")
+    if _reflected_schema_fingerprint(inspector) != _expected_schema_fingerprint(
+        dialect
+    ):
         raise RuntimeError(
             "actor_mcp_server_connections already exists with incompatible schema"
         )

--- a/src/xagent/migrations/versions/20260909_add_actor_mcp_server_connections.py
+++ b/src/xagent/migrations/versions/20260909_add_actor_mcp_server_connections.py
@@ -22,7 +22,86 @@ depends_on: Union[str, Sequence[str], None] = None
 TABLE = "actor_mcp_server_connections"
 
 
+def _adopt_current_metadata_table() -> bool:
+    """Adopt an exact metadata-created table, rejecting partial schema drift."""
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table(TABLE):
+        return False
+
+    columns = {column["name"]: column for column in inspector.get_columns(TABLE)}
+    expected_columns = {
+        "id",
+        "lifecycle_generation",
+        "user_id",
+        "resource_owner_key",
+        "app_id",
+        "catalog_app_generation",
+        "encrypted_env",
+        "created_at",
+        "updated_at",
+    }
+    nullable_columns = {name for name, column in columns.items() if column["nullable"]}
+    lengths = {
+        name: getattr(column["type"], "length", None)
+        for name, column in columns.items()
+    }
+    primary_key = tuple(inspector.get_pk_constraint(TABLE)["constrained_columns"])
+    unique_columns = {
+        tuple(constraint["column_names"])
+        for constraint in inspector.get_unique_constraints(TABLE)
+    }
+    foreign_keys = {
+        tuple(foreign_key["constrained_columns"]): (
+            foreign_key["referred_table"],
+            tuple(foreign_key["referred_columns"]),
+            str((foreign_key.get("options") or {}).get("ondelete")).upper(),
+        )
+        for foreign_key in inspector.get_foreign_keys(TABLE)
+    }
+    indexes = {
+        (index["name"], tuple(index["column_names"]))
+        for index in inspector.get_indexes(TABLE)
+    }
+    check_constraints = {
+        constraint["name"] for constraint in inspector.get_check_constraints(TABLE)
+    }
+    valid = (
+        set(columns) == expected_columns
+        and nullable_columns == {"encrypted_env"}
+        and lengths["resource_owner_key"] == 512
+        and lengths["app_id"] == 100
+        and columns["lifecycle_generation"]["default"] is not None
+        and columns["created_at"]["default"] is not None
+        and columns["updated_at"]["default"] is not None
+        and primary_key == ("id",)
+        and "ck_actor_mcp_server_connections_generation_nonempty" in check_constraints
+        and unique_columns
+        >= {
+            ("lifecycle_generation",),
+            ("user_id", "resource_owner_key", "app_id"),
+            ("user_id", "resource_owner_key", "catalog_app_generation"),
+        }
+        and foreign_keys
+        == {
+            ("user_id",): ("users", ("id",), "CASCADE"),
+            ("catalog_app_generation",): (
+                "public_mcp_apps",
+                ("generation",),
+                "CASCADE",
+            ),
+        }
+        and (op.f("ix_actor_mcp_server_connections_id"), ("id",)) in indexes
+    )
+    if not valid:
+        raise RuntimeError(
+            "actor_mcp_server_connections already exists with incompatible schema"
+        )
+    return True
+
+
 def upgrade() -> None:
+    if _adopt_current_metadata_table():
+        return
     op.create_table(
         TABLE,
         sa.Column("id", sa.Integer(), nullable=False),

--- a/src/xagent/web/models/__init__.py
+++ b/src/xagent/web/models/__init__.py
@@ -1,5 +1,5 @@
-from .actor_oauth_flow import ActorOAuthFlowState
 from .actor_mcp_connection import ActorMCPServerConnection
+from .actor_oauth_flow import ActorOAuthFlowState
 from .agent import Agent
 from .agent_api_key import AgentApiKey
 from .auto_model import AutoModelCandidate, AutoModelConfig

--- a/src/xagent/web/models/__init__.py
+++ b/src/xagent/web/models/__init__.py
@@ -1,4 +1,5 @@
 from .actor_oauth_flow import ActorOAuthFlowState
+from .actor_mcp_connection import ActorMCPServerConnection
 from .agent import Agent
 from .agent_api_key import AgentApiKey
 from .auto_model import AutoModelCandidate, AutoModelConfig
@@ -45,6 +46,7 @@ from .workforce import Workforce, WorkforceAgent, WorkforceBuilderMessage, Workf
 __all__ = [
     "Base",
     "ActorOAuthFlowState",
+    "ActorMCPServerConnection",
     "get_engine",
     "get_db",
     "get_session_local",

--- a/src/xagent/web/models/actor_mcp_connection.py
+++ b/src/xagent/web/models/actor_mcp_connection.py
@@ -31,6 +31,10 @@ class ActorMCPServerConnection(Base):  # type: ignore[no-any-unimported]
     actor connections are not ordinary xagent connector associations and are
     not visible to the existing runtime until a later integration explicitly
     opts into this storage.
+
+    Actor identity and catalog binding are immutable through supported ORM and
+    service writes. Database-owner operations, database Core statements, and
+    native SQL are trusted and outside this enforcement boundary.
     """
 
     __tablename__ = "actor_mcp_server_connections"
@@ -117,5 +121,6 @@ def _prevent_actor_mcp_connection_generation_update(
     ]
     if changed:
         raise ValueError(
-            "ActorMCPServerConnection identity and catalog binding are immutable"
+            "ActorMCPServerConnection identity and catalog binding are immutable "
+            "through supported ORM and service writes"
         )

--- a/src/xagent/web/models/actor_mcp_connection.py
+++ b/src/xagent/web/models/actor_mcp_connection.py
@@ -104,5 +104,18 @@ class ActorMCPServerConnection(Base):  # type: ignore[no-any-unimported]
 def _prevent_actor_mcp_connection_generation_update(
     _mapper: Any, _connection: Any, target: ActorMCPServerConnection
 ) -> None:
-    if inspect(target).attrs.lifecycle_generation.history.has_changes():
-        raise ValueError("ActorMCPServerConnection.lifecycle_generation is immutable")
+    state: Any = inspect(target)
+    immutable_fields = (
+        "lifecycle_generation",
+        "user_id",
+        "resource_owner_key",
+        "app_id",
+        "catalog_app_generation",
+    )
+    changed = [
+        field for field in immutable_fields if state.attrs[field].history.has_changes()
+    ]
+    if changed:
+        raise ValueError(
+            "ActorMCPServerConnection identity and catalog binding are immutable"
+        )

--- a/src/xagent/web/models/actor_mcp_connection.py
+++ b/src/xagent/web/models/actor_mcp_connection.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+    Uuid,
+    event,
+    inspect,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from .database import Base
+from .generation import RandomUUID
+
+ACTOR_MCP_RESOURCE_OWNER_KEY_MAX_LENGTH = 512
+
+
+class ActorMCPServerConnection(Base):  # type: ignore[no-any-unimported]
+    """One actor-owned personal connection to a canonical stdio MCP app.
+
+    The encrypted env is intentionally separate from ``UserMCPServer.env``:
+    actor connections are not ordinary xagent connector associations and are
+    not visible to the existing runtime until a later integration explicitly
+    opts into this storage.
+    """
+
+    __tablename__ = "actor_mcp_server_connections"
+    __table_args__ = (
+        UniqueConstraint(
+            "lifecycle_generation",
+            name="uq_actor_mcp_server_connections_lifecycle_generation",
+        ),
+        UniqueConstraint(
+            "user_id",
+            "resource_owner_key",
+            "app_id",
+            name="uq_actor_mcp_server_connections_actor_app",
+        ),
+        UniqueConstraint(
+            "user_id",
+            "resource_owner_key",
+            "catalog_app_generation",
+            name="uq_actor_mcp_server_connections_actor_catalog_generation",
+        ),
+        CheckConstraint(
+            "CAST(lifecycle_generation AS VARCHAR) <> ''",
+            name="ck_actor_mcp_server_connections_generation_nonempty",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    lifecycle_generation: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        default=uuid.uuid4,
+        server_default=RandomUUID(),
+        nullable=False,
+    )
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    resource_owner_key: Mapped[str] = mapped_column(
+        String(ACTOR_MCP_RESOURCE_OWNER_KEY_MAX_LENGTH), nullable=False
+    )
+    app_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    catalog_app_generation: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("public_mcp_apps.generation", ondelete="CASCADE"),
+        nullable=False,
+    )
+    encrypted_env: Mapped[dict[str, str] | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[Any] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[Any] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    user = relationship("User")
+    catalog_app = relationship("PublicMCPApp")
+
+    def __repr__(self) -> str:
+        return (
+            "<ActorMCPServerConnection("
+            f"id={self.id}, user_id={self.user_id}, app_id={self.app_id!r}, "
+            f"catalog_app_generation={self.catalog_app_generation})>"
+        )
+
+
+@event.listens_for(ActorMCPServerConnection, "before_update")
+def _prevent_actor_mcp_connection_generation_update(
+    _mapper: Any, _connection: Any, target: ActorMCPServerConnection
+) -> None:
+    if inspect(target).attrs.lifecycle_generation.history.has_changes():
+        raise ValueError("ActorMCPServerConnection.lifecycle_generation is immutable")

--- a/src/xagent/web/repositories/__init__.py
+++ b/src/xagent/web/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Internal persistence helpers for web services."""

--- a/src/xagent/web/repositories/actor_mcp_connections.py
+++ b/src/xagent/web/repositories/actor_mcp_connections.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Query, Session
+
+from ..models.actor_mcp_connection import ActorMCPServerConnection
+
+
+def scoped_actor_mcp_connection_query(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+) -> Query[ActorMCPServerConnection]:
+    """Build the only permitted base query for actor MCP connections."""
+    return db.query(ActorMCPServerConnection).filter(
+        ActorMCPServerConnection.user_id == user_id,
+        ActorMCPServerConnection.resource_owner_key == resource_owner_key,
+    )
+
+
+def get_actor_mcp_connection(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+    app_id: str,
+    for_update: bool = False,
+) -> ActorMCPServerConnection | None:
+    query = scoped_actor_mcp_connection_query(
+        db,
+        user_id=user_id,
+        resource_owner_key=resource_owner_key,
+    ).filter(ActorMCPServerConnection.app_id == app_id)
+    if for_update:
+        query = query.with_for_update()
+    return query.populate_existing().one_or_none()
+
+
+def list_actor_mcp_connections(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+) -> list[ActorMCPServerConnection]:
+    return (
+        scoped_actor_mcp_connection_query(
+            db,
+            user_id=user_id,
+            resource_owner_key=resource_owner_key,
+        )
+        .order_by(ActorMCPServerConnection.id)
+        .all()
+    )
+
+
+def add_actor_mcp_connection(
+    db: Session, connection: ActorMCPServerConnection
+) -> ActorMCPServerConnection:
+    db.add(connection)
+    db.flush()
+    return connection
+
+
+def hard_delete_actor_mcp_connection(
+    db: Session, connection: ActorMCPServerConnection
+) -> None:
+    db.delete(connection)
+    db.flush()

--- a/src/xagent/web/repositories/actor_mcp_connections.py
+++ b/src/xagent/web/repositories/actor_mcp_connections.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from typing import Any, cast
+from uuid import UUID
+
+from sqlalchemy import delete, exists, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import Query, Session
 
 from ..models.actor_mcp_connection import ActorMCPServerConnection
+from ..models.public_mcp import PublicMCPApp
 
 
 def scoped_actor_mcp_connection_query(
@@ -24,16 +30,109 @@ def get_actor_mcp_connection(
     user_id: int,
     resource_owner_key: str,
     app_id: str,
+    catalog_app_generation: UUID | None = None,
+    expected_lifecycle_generation: UUID,
     for_update: bool = False,
 ) -> ActorMCPServerConnection | None:
     query = scoped_actor_mcp_connection_query(
         db,
         user_id=user_id,
         resource_owner_key=resource_owner_key,
-    ).filter(ActorMCPServerConnection.app_id == app_id)
+    ).filter(
+        ActorMCPServerConnection.app_id == app_id,
+        ActorMCPServerConnection.lifecycle_generation == expected_lifecycle_generation,
+        *(
+            (ActorMCPServerConnection.catalog_app_generation == catalog_app_generation,)
+            if catalog_app_generation is not None
+            else ()
+        ),
+        exists().where(
+            PublicMCPApp.app_id == ActorMCPServerConnection.app_id,
+            PublicMCPApp.generation == ActorMCPServerConnection.catalog_app_generation,
+        ),
+    )
     if for_update:
         query = query.with_for_update()
-    return query.populate_existing().one_or_none()
+    return cast(
+        ActorMCPServerConnection | None,
+        query.populate_existing().one_or_none(),
+    )
+
+
+def get_actor_mcp_connection_metadata_row(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+    app_id: str,
+) -> ActorMCPServerConnection | None:
+    return cast(
+        ActorMCPServerConnection | None,
+        scoped_actor_mcp_connection_query(
+            db,
+            user_id=user_id,
+            resource_owner_key=resource_owner_key,
+        )
+        .filter(
+            ActorMCPServerConnection.app_id == app_id,
+            exists().where(
+                PublicMCPApp.app_id == ActorMCPServerConnection.app_id,
+                PublicMCPApp.generation
+                == ActorMCPServerConnection.catalog_app_generation,
+            ),
+        )
+        .populate_existing()
+        .one_or_none(),
+    )
+
+
+def get_current_actor_mcp_connection_for_create(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+    app_id: str,
+    catalog_app_generation: UUID,
+) -> ActorMCPServerConnection | None:
+    """Read a current-lifecycle row only to converge an idempotent create."""
+    return (
+        scoped_actor_mcp_connection_query(
+            db,
+            user_id=user_id,
+            resource_owner_key=resource_owner_key,
+        )
+        .filter(
+            ActorMCPServerConnection.app_id == app_id,
+            ActorMCPServerConnection.catalog_app_generation == catalog_app_generation,
+            exists().where(
+                PublicMCPApp.app_id == ActorMCPServerConnection.app_id,
+                PublicMCPApp.generation
+                == ActorMCPServerConnection.catalog_app_generation,
+            ),
+        )
+        .populate_existing()
+        .one_or_none()
+    )
+
+
+def actor_mcp_connection_identity_exists_for_create(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+    app_id: str,
+) -> bool:
+    """Classify a create collision without exposing an unfenced row."""
+    return (
+        scoped_actor_mcp_connection_query(
+            db,
+            user_id=user_id,
+            resource_owner_key=resource_owner_key,
+        )
+        .filter(ActorMCPServerConnection.app_id == app_id)
+        .first()
+        is not None
+    )
 
 
 def list_actor_mcp_connections(
@@ -48,7 +147,15 @@ def list_actor_mcp_connections(
             user_id=user_id,
             resource_owner_key=resource_owner_key,
         )
+        .filter(
+            exists().where(
+                PublicMCPApp.app_id == ActorMCPServerConnection.app_id,
+                PublicMCPApp.generation
+                == ActorMCPServerConnection.catalog_app_generation,
+            )
+        )
         .order_by(ActorMCPServerConnection.id)
+        .populate_existing()
         .all()
     )
 
@@ -61,8 +168,63 @@ def add_actor_mcp_connection(
     return connection
 
 
+def update_actor_mcp_connection_env(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+    app_id: str,
+    expected_lifecycle_generation: UUID,
+    encrypted_env: dict[str, str] | None,
+) -> bool:
+    result = cast(
+        CursorResult[Any],
+        db.execute(
+            update(ActorMCPServerConnection)
+            .where(
+                ActorMCPServerConnection.user_id == user_id,
+                ActorMCPServerConnection.resource_owner_key == resource_owner_key,
+                ActorMCPServerConnection.app_id == app_id,
+                ActorMCPServerConnection.lifecycle_generation
+                == expected_lifecycle_generation,
+                exists().where(
+                    PublicMCPApp.app_id == ActorMCPServerConnection.app_id,
+                    PublicMCPApp.generation
+                    == ActorMCPServerConnection.catalog_app_generation,
+                ),
+            )
+            .values(encrypted_env=encrypted_env)
+            .execution_options(synchronize_session=False)
+        ),
+    )
+    return bool(result.rowcount == 1)
+
+
 def hard_delete_actor_mcp_connection(
-    db: Session, connection: ActorMCPServerConnection
-) -> None:
-    db.delete(connection)
-    db.flush()
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+    app_id: str,
+    expected_lifecycle_generation: UUID,
+) -> bool:
+    result = cast(
+        CursorResult[Any],
+        db.execute(
+            delete(ActorMCPServerConnection)
+            .where(
+                ActorMCPServerConnection.user_id == user_id,
+                ActorMCPServerConnection.resource_owner_key == resource_owner_key,
+                ActorMCPServerConnection.app_id == app_id,
+                ActorMCPServerConnection.lifecycle_generation
+                == expected_lifecycle_generation,
+                exists().where(
+                    PublicMCPApp.app_id == ActorMCPServerConnection.app_id,
+                    PublicMCPApp.generation
+                    == ActorMCPServerConnection.catalog_app_generation,
+                ),
+            )
+            .execution_options(synchronize_session=False)
+        ),
+    )
+    return bool(result.rowcount == 1)

--- a/src/xagent/web/services/actor_mcp_connections.py
+++ b/src/xagent/web/services/actor_mcp_connections.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field as dataclass_field
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ...core.utils.encryption import decrypt_env_dict_strict, encrypt_env_dict
+from ..builtin_mcp_registry import get_builtin_execution_fields
+from ..models.actor_mcp_connection import (
+    ACTOR_MCP_RESOURCE_OWNER_KEY_MAX_LENGTH,
+    ActorMCPServerConnection,
+)
+from ..models.public_mcp import PublicMCPApp
+from ..repositories.actor_mcp_connections import (
+    add_actor_mcp_connection,
+    get_actor_mcp_connection,
+    hard_delete_actor_mcp_connection,
+    list_actor_mcp_connections,
+)
+
+ACTOR_MCP_CREDENTIAL_VALUE_MAX_LENGTH = 4096
+
+
+class ActorMCPConnectionValidationError(ValueError):
+    """The actor connection request violates the internal storage contract."""
+
+
+@dataclass(frozen=True)
+class ActorMCPConnectionSnapshot:
+    id: int
+    lifecycle_generation: UUID
+    user_id: int
+    resource_owner_key: str
+    app_id: str
+    catalog_app_generation: UUID
+    credentials: dict[str, str] | None = dataclass_field(repr=False)
+
+
+def _positive_id(value: Any, *, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ActorMCPConnectionValidationError(
+            f"{field_name} must be a persisted positive integer"
+        )
+    return value
+
+
+def _owner_key(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ActorMCPConnectionValidationError("resource_owner_key must be a string")
+    if not value or value != value.strip():
+        raise ActorMCPConnectionValidationError(
+            "resource_owner_key must be an exact non-blank string"
+        )
+    if len(value) > ACTOR_MCP_RESOURCE_OWNER_KEY_MAX_LENGTH:
+        raise ActorMCPConnectionValidationError(
+            "resource_owner_key exceeds "
+            f"{ACTOR_MCP_RESOURCE_OWNER_KEY_MAX_LENGTH} characters"
+        )
+    return value
+
+
+def _exact_app_id(value: Any) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ActorMCPConnectionValidationError(
+            "app_id must be an exact non-blank canonical app id"
+        )
+    if len(value) > 100:
+        raise ActorMCPConnectionValidationError("app_id exceeds 100 characters")
+    return value
+
+
+def _builtin_stdio_definition(
+    db: Session, *, app_id: str
+) -> tuple[PublicMCPApp, frozenset[str]]:
+    app = db.query(PublicMCPApp).filter(PublicMCPApp.app_id == app_id).one_or_none()
+    execution = get_builtin_execution_fields(app_id)
+    if (
+        app is None
+        or execution is None
+        or str(execution.get("transport") or "").lower() != "stdio"
+    ):
+        raise ActorMCPConnectionValidationError(
+            "app_id must identify a code-defined built-in stdio app"
+        )
+    launch = execution.get("launch_config")
+    if not isinstance(launch, dict) or not launch.get("command"):
+        raise ActorMCPConnectionValidationError(
+            "built-in stdio app has an invalid execution definition"
+        )
+    raw_fields = launch.get("required_env")
+    if raw_fields is None:
+        fields: list[Any] = []
+    elif isinstance(raw_fields, list):
+        fields = raw_fields
+    else:
+        raise ActorMCPConnectionValidationError(
+            "canonical stdio app has an invalid credential schema"
+        )
+    if any(not isinstance(field, str) or not field for field in fields) or len(
+        fields
+    ) != len(set(fields)):
+        raise ActorMCPConnectionValidationError(
+            "canonical stdio app has an invalid credential schema"
+        )
+    return app, frozenset(fields)
+
+
+def _validated_credentials(
+    credentials: Mapping[str, Any] | None,
+    *,
+    allowed_fields: frozenset[str],
+    require_complete: bool,
+) -> dict[str, str] | None:
+    if credentials is None:
+        supplied: Mapping[str, Any] = {}
+    elif not isinstance(credentials, Mapping):
+        raise ActorMCPConnectionValidationError("credentials must be an object")
+    else:
+        supplied = credentials
+
+    unknown = set(supplied) - allowed_fields
+    if unknown:
+        raise ActorMCPConnectionValidationError(
+            "credentials contain fields outside the canonical app schema"
+        )
+    if require_complete and set(supplied) != allowed_fields:
+        raise ActorMCPConnectionValidationError(
+            "connection creation requires every canonical credential field"
+        )
+    validated: dict[str, str] = {}
+    for field, value in supplied.items():
+        if not isinstance(field, str):
+            raise ActorMCPConnectionValidationError(
+                "credential field names must be strings"
+            )
+        if value is None:
+            raise ActorMCPConnectionValidationError(
+                "credential values must not be null"
+            )
+        if not isinstance(value, str):
+            raise ActorMCPConnectionValidationError("credential values must be strings")
+        if not value.strip():
+            raise ActorMCPConnectionValidationError(
+                "credential values must not be blank"
+            )
+        if len(value) > ACTOR_MCP_CREDENTIAL_VALUE_MAX_LENGTH:
+            raise ActorMCPConnectionValidationError(
+                "credential value exceeds "
+                f"{ACTOR_MCP_CREDENTIAL_VALUE_MAX_LENGTH} characters"
+            )
+        validated[field] = value
+    return validated or None
+
+
+def _snapshot(row: ActorMCPServerConnection) -> ActorMCPConnectionSnapshot:
+    decrypted = decrypt_env_dict_strict(row.encrypted_env)
+    return ActorMCPConnectionSnapshot(
+        id=row.id,
+        lifecycle_generation=row.lifecycle_generation,
+        user_id=row.user_id,
+        resource_owner_key=row.resource_owner_key,
+        app_id=row.app_id,
+        catalog_app_generation=row.catalog_app_generation,
+        credentials=dict(decrypted) if decrypted is not None else None,
+    )
+
+
+def create_actor_mcp_connection(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+    app_id: str,
+    credentials: Mapping[str, Any] | None,
+) -> ActorMCPConnectionSnapshot:
+    user_id = _positive_id(user_id, field_name="user_id")
+    owner_key = _owner_key(resource_owner_key)
+    app_id = _exact_app_id(app_id)
+    app, allowed_fields = _builtin_stdio_definition(db, app_id=app_id)
+    validated = _validated_credentials(
+        credentials, allowed_fields=allowed_fields, require_complete=True
+    )
+    encrypted = encrypt_env_dict(validated)
+    row = add_actor_mcp_connection(
+        db,
+        ActorMCPServerConnection(
+            user_id=user_id,
+            resource_owner_key=owner_key,
+            app_id=app_id,
+            catalog_app_generation=app.generation,
+            encrypted_env=encrypted,
+        ),
+    )
+    return _snapshot(row)
+
+
+def get_actor_mcp_connection_snapshot(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+    app_id: str,
+) -> ActorMCPConnectionSnapshot | None:
+    row = get_actor_mcp_connection(
+        db,
+        user_id=_positive_id(user_id, field_name="user_id"),
+        resource_owner_key=_owner_key(resource_owner_key),
+        app_id=_exact_app_id(app_id),
+    )
+    return _snapshot(row) if row is not None else None
+
+
+def list_actor_mcp_connection_snapshots(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+) -> list[ActorMCPConnectionSnapshot]:
+    rows = list_actor_mcp_connections(
+        db,
+        user_id=_positive_id(user_id, field_name="user_id"),
+        resource_owner_key=_owner_key(resource_owner_key),
+    )
+    return [_snapshot(row) for row in rows]
+
+
+def update_actor_mcp_connection_credentials(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+    app_id: str,
+    credentials: Mapping[str, Any],
+) -> ActorMCPConnectionSnapshot | None:
+    user_id = _positive_id(user_id, field_name="user_id")
+    owner_key = _owner_key(resource_owner_key)
+    app_id = _exact_app_id(app_id)
+    row = get_actor_mcp_connection(
+        db,
+        user_id=user_id,
+        resource_owner_key=owner_key,
+        app_id=app_id,
+        for_update=True,
+    )
+    if row is None:
+        return None
+    app, allowed_fields = _builtin_stdio_definition(db, app_id=app_id)
+    if app.generation != row.catalog_app_generation:
+        raise ActorMCPConnectionValidationError(
+            "actor connection belongs to a stale catalog app lifecycle"
+        )
+    updates = _validated_credentials(
+        credentials, allowed_fields=allowed_fields, require_complete=False
+    )
+    existing = decrypt_env_dict_strict(row.encrypted_env) or {}
+    if updates:
+        existing.update(updates)
+    row.encrypted_env = encrypt_env_dict(existing) or None
+    db.flush()
+    return _snapshot(row)
+
+
+def delete_actor_mcp_connection(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+    app_id: str,
+) -> bool:
+    row = get_actor_mcp_connection(
+        db,
+        user_id=_positive_id(user_id, field_name="user_id"),
+        resource_owner_key=_owner_key(resource_owner_key),
+        app_id=_exact_app_id(app_id),
+        for_update=True,
+    )
+    if row is None:
+        return False
+    hard_delete_actor_mcp_connection(db, row)
+    return True

--- a/src/xagent/web/services/actor_mcp_connections.py
+++ b/src/xagent/web/services/actor_mcp_connections.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, field as dataclass_field
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import Any
 from uuid import UUID
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ...core.utils.encryption import decrypt_env_dict_strict, encrypt_env_dict
+from ...core.utils.encryption import (
+    EncryptionDecodeError,
+    _is_encrypted,
+    decrypt_env_dict_strict,
+    get_cipher,
+)
 from ..builtin_mcp_registry import get_builtin_execution_fields
 from ..models.actor_mcp_connection import (
     ACTOR_MCP_RESOURCE_OWNER_KEY_MAX_LENGTH,
@@ -15,10 +22,14 @@ from ..models.actor_mcp_connection import (
 )
 from ..models.public_mcp import PublicMCPApp
 from ..repositories.actor_mcp_connections import (
+    actor_mcp_connection_identity_exists_for_create,
     add_actor_mcp_connection,
     get_actor_mcp_connection,
+    get_actor_mcp_connection_metadata_row,
+    get_current_actor_mcp_connection_for_create,
     hard_delete_actor_mcp_connection,
     list_actor_mcp_connections,
+    update_actor_mcp_connection_env,
 )
 
 ACTOR_MCP_CREDENTIAL_VALUE_MAX_LENGTH = 4096
@@ -26,6 +37,18 @@ ACTOR_MCP_CREDENTIAL_VALUE_MAX_LENGTH = 4096
 
 class ActorMCPConnectionValidationError(ValueError):
     """The actor connection request violates the internal storage contract."""
+
+
+class ActorMCPConnectionConflictError(RuntimeError):
+    """Creation conflicts with an existing connection's credentials."""
+
+
+class ActorMCPConnectionCredentialCorruptionError(RuntimeError):
+    """Stored credentials cannot be safely encoded or decoded."""
+
+
+class ActorMCPConnectionNotFoundOrStaleError(LookupError):
+    """The exact actor connection lifecycle is absent or catalog-stale."""
 
 
 @dataclass(frozen=True)
@@ -39,12 +62,23 @@ class ActorMCPConnectionSnapshot:
     credentials: dict[str, str] | None = dataclass_field(repr=False)
 
 
+@dataclass(frozen=True)
+class ActorMCPConnectionMetadata:
+    id: int
+    lifecycle_generation: UUID
+    user_id: int
+    resource_owner_key: str
+    app_id: str
+    catalog_app_generation: UUID
+    configured_field_names: frozenset[str]
+
+
 def _positive_id(value: Any, *, field_name: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         raise ActorMCPConnectionValidationError(
             f"{field_name} must be a persisted positive integer"
         )
-    return value
+    return int(value)
 
 
 def _owner_key(value: Any) -> str:
@@ -72,16 +106,18 @@ def _exact_app_id(value: Any) -> str:
     return value
 
 
+def _generation(value: Any, *, field_name: str) -> UUID:
+    if not isinstance(value, UUID):
+        raise ActorMCPConnectionValidationError(f"{field_name} must be a UUID")
+    return value
+
+
 def _builtin_stdio_definition(
     db: Session, *, app_id: str
 ) -> tuple[PublicMCPApp, frozenset[str]]:
     app = db.query(PublicMCPApp).filter(PublicMCPApp.app_id == app_id).one_or_none()
     execution = get_builtin_execution_fields(app_id)
-    if (
-        app is None
-        or execution is None
-        or str(execution.get("transport") or "").lower() != "stdio"
-    ):
+    if app is None or execution is None or execution.get("transport") != "stdio":
         raise ActorMCPConnectionValidationError(
             "app_id must identify a code-defined built-in stdio app"
         )
@@ -99,9 +135,10 @@ def _builtin_stdio_definition(
         raise ActorMCPConnectionValidationError(
             "canonical stdio app has an invalid credential schema"
         )
-    if any(not isinstance(field, str) or not field for field in fields) or len(
-        fields
-    ) != len(set(fields)):
+    if any(
+        not isinstance(field, str) or not field or field != field.strip()
+        for field in fields
+    ) or len(fields) != len(set(fields)):
         raise ActorMCPConnectionValidationError(
             "canonical stdio app has an invalid credential schema"
         )
@@ -151,12 +188,68 @@ def _validated_credentials(
                 "credential value exceeds "
                 f"{ACTOR_MCP_CREDENTIAL_VALUE_MAX_LENGTH} characters"
             )
+        try:
+            value.encode("utf-8")
+        except UnicodeEncodeError:
+            raise ActorMCPConnectionValidationError(
+                "credential values must be valid UTF-8 text"
+            ) from None
         validated[field] = value
     return validated or None
 
 
+def _credentials_from_row(
+    row: ActorMCPServerConnection,
+) -> dict[str, str] | None:
+    try:
+        encrypted = row.encrypted_env
+        if encrypted is not None and (
+            not isinstance(encrypted, dict)
+            or any(
+                not isinstance(key, str)
+                or not isinstance(value, str)
+                or not _is_encrypted(value)
+                for key, value in encrypted.items()
+            )
+        ):
+            raise ActorMCPConnectionCredentialCorruptionError(
+                "stored actor MCP credentials are unreadable"
+            )
+        decrypted = decrypt_env_dict_strict(row.encrypted_env)
+        if decrypted is not None and (
+            not isinstance(decrypted, dict)
+            or any(
+                not isinstance(key, str) or not isinstance(value, str)
+                for key, value in decrypted.items()
+            )
+        ):
+            raise ActorMCPConnectionCredentialCorruptionError(
+                "stored actor MCP credentials are unreadable"
+            )
+    except (EncryptionDecodeError, UnicodeError, ValueError, TypeError):
+        raise ActorMCPConnectionCredentialCorruptionError(
+            "stored actor MCP credentials are unreadable"
+        ) from None
+    return dict(decrypted) if decrypted is not None else None
+
+
+def _encrypt_credentials(credentials: dict[str, str] | None) -> dict[str, str] | None:
+    if credentials is None:
+        return None
+    try:
+        cipher = get_cipher()
+        encrypted = {
+            field: cipher.encrypt(value.encode("utf-8")).decode("ascii")
+            for field, value in credentials.items()
+        }
+    except (UnicodeError, ValueError, TypeError):
+        raise ActorMCPConnectionCredentialCorruptionError(
+            "actor MCP credentials could not be encrypted"
+        ) from None
+    return encrypted
+
+
 def _snapshot(row: ActorMCPServerConnection) -> ActorMCPConnectionSnapshot:
-    decrypted = decrypt_env_dict_strict(row.encrypted_env)
     return ActorMCPConnectionSnapshot(
         id=row.id,
         lifecycle_generation=row.lifecycle_generation,
@@ -164,7 +257,30 @@ def _snapshot(row: ActorMCPServerConnection) -> ActorMCPConnectionSnapshot:
         resource_owner_key=row.resource_owner_key,
         app_id=row.app_id,
         catalog_app_generation=row.catalog_app_generation,
-        credentials=dict(decrypted) if decrypted is not None else None,
+        credentials=_credentials_from_row(row),
+    )
+
+
+def _metadata(row: ActorMCPServerConnection) -> ActorMCPConnectionMetadata:
+    encrypted = row.encrypted_env
+    if encrypted is None:
+        configured_field_names: frozenset[str] = frozenset()
+    elif isinstance(encrypted, dict) and all(
+        isinstance(field, str) for field in encrypted
+    ):
+        configured_field_names = frozenset(encrypted)
+    else:
+        raise ActorMCPConnectionCredentialCorruptionError(
+            "stored actor MCP credential metadata is unreadable"
+        )
+    return ActorMCPConnectionMetadata(
+        id=row.id,
+        lifecycle_generation=row.lifecycle_generation,
+        user_id=row.user_id,
+        resource_owner_key=row.resource_owner_key,
+        app_id=row.app_id,
+        catalog_app_generation=row.catalog_app_generation,
+        configured_field_names=configured_field_names,
     )
 
 
@@ -175,7 +291,7 @@ def create_actor_mcp_connection(
     resource_owner_key: str,
     app_id: str,
     credentials: Mapping[str, Any] | None,
-) -> ActorMCPConnectionSnapshot:
+) -> ActorMCPConnectionMetadata:
     user_id = _positive_id(user_id, field_name="user_id")
     owner_key = _owner_key(resource_owner_key)
     app_id = _exact_app_id(app_id)
@@ -183,48 +299,118 @@ def create_actor_mcp_connection(
     validated = _validated_credentials(
         credentials, allowed_fields=allowed_fields, require_complete=True
     )
-    encrypted = encrypt_env_dict(validated)
-    row = add_actor_mcp_connection(
+    existing = get_current_actor_mcp_connection_for_create(
         db,
-        ActorMCPServerConnection(
+        user_id=user_id,
+        resource_owner_key=owner_key,
+        app_id=app_id,
+        catalog_app_generation=app.generation,
+    )
+    if existing is not None:
+        if _credentials_from_row(existing) == validated:
+            return _metadata(existing)
+        raise ActorMCPConnectionConflictError(
+            "actor MCP connection already exists; use generation-protected update"
+        )
+
+    encrypted = _encrypt_credentials(validated)
+    try:
+        with db.begin_nested():
+            row = add_actor_mcp_connection(
+                db,
+                ActorMCPServerConnection(
+                    user_id=user_id,
+                    resource_owner_key=owner_key,
+                    app_id=app_id,
+                    catalog_app_generation=app.generation,
+                    encrypted_env=encrypted,
+                ),
+            )
+    except IntegrityError:
+        winner = get_current_actor_mcp_connection_for_create(
+            db,
             user_id=user_id,
             resource_owner_key=owner_key,
             app_id=app_id,
             catalog_app_generation=app.generation,
-            encrypted_env=encrypted,
-        ),
-    )
-    return _snapshot(row)
+        )
+        if winner is not None and _credentials_from_row(winner) == validated:
+            return _metadata(winner)
+        if winner is not None or actor_mcp_connection_identity_exists_for_create(
+            db,
+            user_id=user_id,
+            resource_owner_key=owner_key,
+            app_id=app_id,
+        ):
+            raise ActorMCPConnectionConflictError(
+                "actor MCP connection already exists; use generation-protected update"
+            ) from None
+        raise
+    return _metadata(row)
 
 
-def get_actor_mcp_connection_snapshot(
+def get_actor_mcp_connection_metadata(
     db: Session,
     *,
     user_id: int,
     resource_owner_key: str,
     app_id: str,
-) -> ActorMCPConnectionSnapshot | None:
-    row = get_actor_mcp_connection(
+) -> ActorMCPConnectionMetadata:
+    app_id = _exact_app_id(app_id)
+    row = get_actor_mcp_connection_metadata_row(
         db,
         user_id=_positive_id(user_id, field_name="user_id"),
         resource_owner_key=_owner_key(resource_owner_key),
-        app_id=_exact_app_id(app_id),
+        app_id=app_id,
     )
-    return _snapshot(row) if row is not None else None
+    if row is None:
+        raise ActorMCPConnectionNotFoundOrStaleError(
+            "actor MCP connection was not found or is stale"
+        )
+    return _metadata(row)
 
 
-def list_actor_mcp_connection_snapshots(
+def list_actor_mcp_connection_metadata(
     db: Session,
     *,
     user_id: int,
     resource_owner_key: str,
-) -> list[ActorMCPConnectionSnapshot]:
+) -> list[ActorMCPConnectionMetadata]:
     rows = list_actor_mcp_connections(
         db,
         user_id=_positive_id(user_id, field_name="user_id"),
         resource_owner_key=_owner_key(resource_owner_key),
     )
-    return [_snapshot(row) for row in rows]
+    return [_metadata(row) for row in rows]
+
+
+def get_actor_mcp_connection_credentials_internal(
+    db: Session,
+    *,
+    user_id: int,
+    resource_owner_key: str,
+    app_id: str,
+    catalog_app_generation: UUID,
+    expected_lifecycle_generation: UUID,
+) -> ActorMCPConnectionSnapshot:
+    row = get_actor_mcp_connection(
+        db,
+        user_id=_positive_id(user_id, field_name="user_id"),
+        resource_owner_key=_owner_key(resource_owner_key),
+        app_id=_exact_app_id(app_id),
+        catalog_app_generation=_generation(
+            catalog_app_generation, field_name="catalog_app_generation"
+        ),
+        expected_lifecycle_generation=_generation(
+            expected_lifecycle_generation,
+            field_name="expected_lifecycle_generation",
+        ),
+    )
+    if row is None:
+        raise ActorMCPConnectionNotFoundOrStaleError(
+            "actor MCP connection was not found or is stale"
+        )
+    return _snapshot(row)
 
 
 def update_actor_mcp_connection_credentials(
@@ -233,20 +419,28 @@ def update_actor_mcp_connection_credentials(
     user_id: int,
     resource_owner_key: str,
     app_id: str,
+    expected_lifecycle_generation: UUID,
     credentials: Mapping[str, Any],
-) -> ActorMCPConnectionSnapshot | None:
+) -> ActorMCPConnectionMetadata:
     user_id = _positive_id(user_id, field_name="user_id")
     owner_key = _owner_key(resource_owner_key)
     app_id = _exact_app_id(app_id)
+    expected_generation = _generation(
+        expected_lifecycle_generation,
+        field_name="expected_lifecycle_generation",
+    )
     row = get_actor_mcp_connection(
         db,
         user_id=user_id,
         resource_owner_key=owner_key,
         app_id=app_id,
+        expected_lifecycle_generation=expected_generation,
         for_update=True,
     )
     if row is None:
-        return None
+        raise ActorMCPConnectionNotFoundOrStaleError(
+            "actor MCP connection was not found or is stale"
+        )
     app, allowed_fields = _builtin_stdio_definition(db, app_id=app_id)
     if app.generation != row.catalog_app_generation:
         raise ActorMCPConnectionValidationError(
@@ -255,12 +449,34 @@ def update_actor_mcp_connection_credentials(
     updates = _validated_credentials(
         credentials, allowed_fields=allowed_fields, require_complete=False
     )
-    existing = decrypt_env_dict_strict(row.encrypted_env) or {}
+    existing = _credentials_from_row(row) or {}
     if updates:
         existing.update(updates)
-    row.encrypted_env = encrypt_env_dict(existing) or None
-    db.flush()
-    return _snapshot(row)
+    encrypted = _encrypt_credentials(existing) or None
+    if not update_actor_mcp_connection_env(
+        db,
+        user_id=user_id,
+        resource_owner_key=owner_key,
+        app_id=app_id,
+        expected_lifecycle_generation=expected_generation,
+        encrypted_env=encrypted,
+    ):
+        raise ActorMCPConnectionNotFoundOrStaleError(
+            "actor MCP connection was not found or is stale"
+        )
+    db.expire(row)
+    updated = get_actor_mcp_connection(
+        db,
+        user_id=user_id,
+        resource_owner_key=owner_key,
+        app_id=app_id,
+        expected_lifecycle_generation=expected_generation,
+    )
+    if updated is None:
+        raise ActorMCPConnectionNotFoundOrStaleError(
+            "actor MCP connection was not found or is stale"
+        )
+    return _metadata(updated)
 
 
 def delete_actor_mcp_connection(
@@ -269,15 +485,19 @@ def delete_actor_mcp_connection(
     user_id: int,
     resource_owner_key: str,
     app_id: str,
-) -> bool:
-    row = get_actor_mcp_connection(
+    expected_lifecycle_generation: UUID,
+) -> None:
+    deleted = hard_delete_actor_mcp_connection(
         db,
         user_id=_positive_id(user_id, field_name="user_id"),
         resource_owner_key=_owner_key(resource_owner_key),
         app_id=_exact_app_id(app_id),
-        for_update=True,
+        expected_lifecycle_generation=_generation(
+            expected_lifecycle_generation,
+            field_name="expected_lifecycle_generation",
+        ),
     )
-    if row is None:
-        return False
-    hard_delete_actor_mcp_connection(db, row)
-    return True
+    if not deleted:
+        raise ActorMCPConnectionNotFoundOrStaleError(
+            "actor MCP connection was not found or is stale"
+        )

--- a/tests/alembic/test_20260909_add_actor_mcp_server_connections.py
+++ b/tests/alembic/test_20260909_add_actor_mcp_server_connections.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from pathlib import Path
 import uuid
+from pathlib import Path
 
+import pytest
 import sqlalchemy as sa
 from alembic import command
 
@@ -98,5 +99,53 @@ def test_sqlite_upgrade_constraints_and_downgrade() -> None:
 
         command.downgrade(config, DOWN_REVISION)
         assert TABLE not in sa.inspect(connection).get_table_names()
+
+    engine.dispose()
+
+
+def test_sqlite_upgrade_adopts_exact_metadata_table() -> None:
+    from xagent.web.models.actor_mcp_connection import ActorMCPServerConnection
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    config = create_alembic_config(engine)
+    config.set_main_option("script_location", str(MIGRATIONS_DIR))
+    with engine.connect() as connection:
+        connection.execute(sa.text("PRAGMA foreign_keys=ON"))
+        _legacy_schema(connection)
+        ActorMCPServerConnection.__table__.create(bind=connection)
+        config.attributes["connection"] = connection
+
+        command.upgrade(config, REVISION)
+
+        assert sa.inspect(connection).get_table_names().count(TABLE) == 1
+        assert (
+            connection.scalar(sa.text("SELECT version_num FROM alembic_version"))
+            == REVISION
+        )
+
+    engine.dispose()
+
+
+def test_sqlite_upgrade_rejects_partial_preexisting_table() -> None:
+    engine = sa.create_engine("sqlite:///:memory:")
+    config = create_alembic_config(engine)
+    config.set_main_option("script_location", str(MIGRATIONS_DIR))
+    with engine.connect() as connection:
+        _legacy_schema(connection)
+        connection.execute(
+            sa.text(
+                f"CREATE TABLE {TABLE} (id INTEGER NOT NULL PRIMARY KEY, "
+                "user_id INTEGER NOT NULL)"
+            )
+        )
+        config.attributes["connection"] = connection
+
+        with pytest.raises(RuntimeError, match="incompatible schema"):
+            command.upgrade(config, REVISION)
+
+        assert (
+            connection.scalar(sa.text("SELECT version_num FROM alembic_version"))
+            == DOWN_REVISION
+        )
 
     engine.dispose()

--- a/tests/alembic/test_20260909_add_actor_mcp_server_connections.py
+++ b/tests/alembic/test_20260909_add_actor_mcp_server_connections.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+import uuid
+
+import sqlalchemy as sa
+from alembic import command
+
+from xagent.db.config import create_alembic_config
+
+REVISION = "20260909_actor_mcp_connections"
+DOWN_REVISION = "20260901_seed_zendesk_mcp_app"
+TABLE = "actor_mcp_server_connections"
+MIGRATIONS_DIR = Path(__file__).parents[2] / "src" / "xagent" / "migrations"
+
+
+def _legacy_schema(connection: sa.Connection) -> None:
+    connection.execute(sa.text("CREATE TABLE users (id INTEGER PRIMARY KEY NOT NULL)"))
+    connection.execute(
+        sa.text(
+            "CREATE TABLE public_mcp_apps ("
+            "id INTEGER PRIMARY KEY NOT NULL, app_id VARCHAR(100) NOT NULL UNIQUE, "
+            "generation CHAR(32) NOT NULL UNIQUE)"
+        )
+    )
+    connection.execute(
+        sa.text(
+            "CREATE TABLE alembic_version ("
+            "version_num VARCHAR(255) NOT NULL PRIMARY KEY)"
+        )
+    )
+    connection.execute(
+        sa.text("INSERT INTO alembic_version VALUES (:revision)"),
+        {"revision": DOWN_REVISION},
+    )
+
+
+def test_sqlite_upgrade_constraints_and_downgrade() -> None:
+    engine = sa.create_engine("sqlite:///:memory:")
+    config = create_alembic_config(engine)
+    config.set_main_option("script_location", str(MIGRATIONS_DIR))
+    with engine.connect() as connection:
+        connection.execute(sa.text("PRAGMA foreign_keys=ON"))
+        _legacy_schema(connection)
+        config.attributes["connection"] = connection
+        command.upgrade(config, REVISION)
+
+        inspector = sa.inspect(connection)
+        columns = {item["name"]: item for item in inspector.get_columns(TABLE)}
+        assert columns["resource_owner_key"]["type"].length == 512
+        assert columns["app_id"]["type"].length == 100
+        assert columns["encrypted_env"]["nullable"] is True
+        assert columns["lifecycle_generation"]["nullable"] is False
+        assert columns["lifecycle_generation"]["default"] is not None
+        assert {
+            tuple(item["column_names"])
+            for item in inspector.get_unique_constraints(TABLE)
+        } >= {
+            ("lifecycle_generation",),
+            ("user_id", "resource_owner_key", "app_id"),
+            ("user_id", "resource_owner_key", "catalog_app_generation"),
+        }
+        foreign_keys = {
+            tuple(item["constrained_columns"]): (
+                item["referred_table"],
+                item["options"].get("ondelete"),
+            )
+            for item in inspector.get_foreign_keys(TABLE)
+        }
+        assert foreign_keys == {
+            ("catalog_app_generation",): ("public_mcp_apps", "CASCADE"),
+            ("user_id",): ("users", "CASCADE"),
+        }
+
+        connection.execute(sa.text("INSERT INTO users (id) VALUES (1)"))
+        app_generation = uuid.uuid4()
+        connection.execute(
+            sa.text(
+                "INSERT INTO public_mcp_apps (id, app_id, generation) "
+                "VALUES (1, 'test-app', :generation)"
+            ),
+            {"generation": app_generation.hex},
+        )
+        connection.execute(
+            sa.text(
+                f"INSERT INTO {TABLE} "
+                "(user_id, resource_owner_key, app_id, catalog_app_generation) "
+                "VALUES (1, 'toby:test', 'test-app', :generation)"
+            ),
+            {"generation": app_generation.hex},
+        )
+        generation = uuid.UUID(
+            str(connection.scalar(sa.text(f"SELECT lifecycle_generation FROM {TABLE}")))
+        )
+        assert generation.version == 4
+        connection.execute(sa.text("DELETE FROM public_mcp_apps WHERE id = 1"))
+        assert connection.scalar(sa.text(f"SELECT count(*) FROM {TABLE}")) == 0
+
+        command.downgrade(config, DOWN_REVISION)
+        assert TABLE not in sa.inspect(connection).get_table_names()
+
+    engine.dispose()

--- a/tests/alembic/test_20260909_add_actor_mcp_server_connections.py
+++ b/tests/alembic/test_20260909_add_actor_mcp_server_connections.py
@@ -8,6 +8,7 @@ import sqlalchemy as sa
 from alembic import command
 
 from xagent.db.config import create_alembic_config
+from xagent.web.models.generation import RandomUUID
 
 REVISION = "20260909_actor_mcp_connections"
 DOWN_REVISION = "20260901_seed_zendesk_mcp_app"
@@ -34,6 +35,94 @@ def _legacy_schema(connection: sa.Connection) -> None:
         sa.text("INSERT INTO alembic_version VALUES (:revision)"),
         {"revision": DOWN_REVISION},
     )
+
+
+def _create_actor_table(
+    connection: sa.Connection,
+    *,
+    encrypted_env_type: sa.types.TypeEngine | None = None,
+    lifecycle_default: sa.sql.ClauseElement | None = None,
+    check_expression: str = "CAST(lifecycle_generation AS VARCHAR) <> ''",
+    extra_user_unique: bool = False,
+) -> None:
+    metadata = sa.MetaData()
+    sa.Table("users", metadata, autoload_with=connection)
+    sa.Table("public_mcp_apps", metadata, autoload_with=connection)
+    constraints: list[sa.Constraint] = [
+        sa.CheckConstraint(
+            check_expression,
+            name="ck_actor_mcp_server_connections_generation_nonempty",
+        ),
+        sa.UniqueConstraint(
+            "lifecycle_generation",
+            name="uq_actor_mcp_server_connections_lifecycle_generation",
+        ),
+        sa.UniqueConstraint(
+            "user_id",
+            "resource_owner_key",
+            "app_id",
+            name="uq_actor_mcp_server_connections_actor_app",
+        ),
+        sa.UniqueConstraint(
+            "user_id",
+            "resource_owner_key",
+            "catalog_app_generation",
+            name="uq_actor_mcp_server_connections_actor_catalog_generation",
+        ),
+    ]
+    if extra_user_unique:
+        constraints.append(
+            sa.UniqueConstraint(
+                "user_id", name="uq_actor_mcp_server_connections_user_id_drift"
+            )
+        )
+    table = sa.Table(
+        TABLE,
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "lifecycle_generation",
+            sa.Uuid(),
+            server_default=(
+                lifecycle_default if lifecycle_default is not None else RandomUUID()
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("resource_owner_key", sa.String(512), nullable=False),
+        sa.Column("app_id", sa.String(100), nullable=False),
+        sa.Column(
+            "catalog_app_generation",
+            sa.Uuid(),
+            sa.ForeignKey("public_mcp_apps.generation", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "encrypted_env",
+            encrypted_env_type if encrypted_env_type is not None else sa.JSON(),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        *constraints,
+    )
+    table.create(connection)
+    sa.Index("ix_actor_mcp_server_connections_id", table.c.id).create(connection)
 
 
 def test_sqlite_upgrade_constraints_and_downgrade() -> None:
@@ -138,6 +227,40 @@ def test_sqlite_upgrade_rejects_partial_preexisting_table() -> None:
                 "user_id INTEGER NOT NULL)"
             )
         )
+        config.attributes["connection"] = connection
+
+        with pytest.raises(RuntimeError, match="incompatible schema"):
+            command.upgrade(config, REVISION)
+
+        assert (
+            connection.scalar(sa.text("SELECT version_num FROM alembic_version"))
+            == DOWN_REVISION
+        )
+
+    engine.dispose()
+
+
+@pytest.mark.parametrize(
+    "drift",
+    ["encrypted-type", "fixed-uuid-default", "same-name-check", "extra-unique"],
+)
+def test_sqlite_upgrade_rejects_semantic_schema_drift(drift: str) -> None:
+    engine = sa.create_engine("sqlite:///:memory:")
+    config = create_alembic_config(engine)
+    config.set_main_option("script_location", str(MIGRATIONS_DIR))
+    with engine.connect() as connection:
+        connection.execute(sa.text("PRAGMA foreign_keys=ON"))
+        _legacy_schema(connection)
+        kwargs: dict[str, object] = {}
+        if drift == "encrypted-type":
+            kwargs["encrypted_env_type"] = sa.Text()
+        elif drift == "fixed-uuid-default":
+            kwargs["lifecycle_default"] = sa.text("'00000000000000000000000000000000'")
+        elif drift == "same-name-check":
+            kwargs["check_expression"] = "1 = 1"
+        elif drift == "extra-unique":
+            kwargs["extra_user_unique"] = True
+        _create_actor_table(connection, **kwargs)  # type: ignore[arg-type]
         config.attributes["connection"] = connection
 
         with pytest.raises(RuntimeError, match="incompatible schema"):

--- a/tests/migrations/test_migration_integration.py
+++ b/tests/migrations/test_migration_integration.py
@@ -12,8 +12,10 @@ Usage:
 """
 
 import argparse
+import concurrent.futures
 import os
 import tempfile
+import threading
 from pathlib import Path
 
 import pytest
@@ -594,6 +596,123 @@ class TestMigrations:
             version2 = result.scalar()
 
         assert version1 == version2, "Version should not change on re-run"
+
+    @pytest.mark.postgresql
+    @pytest.mark.parametrize(
+        "drift_sql",
+        [
+            "ALTER TABLE actor_mcp_server_connections "
+            "ALTER COLUMN encrypted_env TYPE TEXT USING encrypted_env::text",
+            "ALTER TABLE actor_mcp_server_connections "
+            "ALTER COLUMN lifecycle_generation SET DEFAULT "
+            "'00000000-0000-0000-0000-000000000000'::uuid",
+            "ALTER TABLE actor_mcp_server_connections DROP CONSTRAINT "
+            "ck_actor_mcp_server_connections_generation_nonempty; "
+            "ALTER TABLE actor_mcp_server_connections ADD CONSTRAINT "
+            "ck_actor_mcp_server_connections_generation_nonempty CHECK (1 = 1)",
+            "ALTER TABLE actor_mcp_server_connections ADD CONSTRAINT "
+            "uq_actor_mcp_server_connections_user_id_drift UNIQUE (user_id)",
+        ],
+        ids=["encrypted-type", "fixed-uuid-default", "same-name-check", "extra-unique"],
+    )
+    def test_postgresql_actor_metadata_adoption_rejects_schema_drift(
+        self, postgresql_tester, drift_sql
+    ):
+        """The actor-storage revision fails closed on reflected semantic drift."""
+        from xagent.web.models.database import Base
+
+        Base.metadata.create_all(bind=postgresql_tester.engine)
+        with postgresql_tester.engine.begin() as conn:
+            conn.exec_driver_sql(drift_sql)
+        command.stamp(
+            postgresql_tester.alembic_cfg,
+            "20260901_seed_zendesk_mcp_app",
+        )
+
+        with pytest.raises(RuntimeError, match="incompatible schema"):
+            command.upgrade(
+                postgresql_tester.alembic_cfg,
+                "20260909_actor_mcp_connections",
+            )
+
+    @pytest.mark.postgresql
+    def test_postgresql_actor_create_is_idempotent_under_real_concurrency(
+        self, postgresql_tester, monkeypatch
+    ):
+        """Two database sessions converge on one row without damaging either tx."""
+        import xagent.web.services.actor_mcp_connections as service
+        from xagent.web.models.database import Base
+        from xagent.web.models.public_mcp import PublicMCPApp
+        from xagent.web.models.user import User
+
+        Base.metadata.create_all(bind=postgresql_tester.engine)
+        session_factory = sessionmaker(bind=postgresql_tester.engine)
+        with session_factory.begin() as session:
+            user = User(username="pg-race-owner", password_hash="x")
+            app = PublicMCPApp(
+                app_id="posthog",
+                name="posthog",
+                transport="stdio",
+                launch_config={"command": "stored-command-is-not-trusted"},
+            )
+            session.add_all([user, app])
+            session.flush()
+            user_id = user.id
+
+        barrier = threading.Barrier(2)
+        thread_state = threading.local()
+        real_lookup = service.get_current_actor_mcp_connection_for_create
+
+        def synchronized_initial_lookup(session, **kwargs):
+            row = real_lookup(session, **kwargs)
+            if row is None and not getattr(thread_state, "initial_lookup_seen", False):
+                thread_state.initial_lookup_seen = True
+                barrier.wait(timeout=10)
+            return row
+
+        monkeypatch.setattr(
+            service,
+            "get_current_actor_mcp_connection_for_create",
+            synchronized_initial_lookup,
+        )
+
+        def create(index):
+            with session_factory() as session:
+                snapshot = service.create_actor_mcp_connection(
+                    session,
+                    user_id=user_id,
+                    resource_owner_key="toby:postgres:race-owner",
+                    app_id="posthog",
+                    credentials={
+                        "POSTHOG_API_KEY": "same-secret",
+                        "POSTHOG_HOST": "https://x.test",
+                    },
+                )
+                session.add(
+                    User(username=f"pg-race-transaction-{index}", password_hash="x")
+                )
+                session.commit()
+                return snapshot.lifecycle_generation
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            generations = list(executor.map(create, range(2)))
+
+        assert generations[0] == generations[1]
+        with session_factory() as session:
+            assert (
+                session.execute(
+                    text("SELECT count(*) FROM actor_mcp_server_connections")
+                ).scalar_one()
+                == 1
+            )
+            assert (
+                session.execute(
+                    text(
+                        "SELECT count(*) FROM users WHERE username LIKE 'pg-race-transaction-%'"
+                    )
+                ).scalar_one()
+                == 2
+            )
 
     def test_sqlite_incremental_upgrade(self, sqlite_tester):
         """Test incremental upgrades from b9d890ed31b5 to head on SQLite.

--- a/tests/web/services/test_actor_mcp_connections.py
+++ b/tests/web/services/test_actor_mcp_connections.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from xagent.core.utils.encryption import _is_encrypted
+from xagent.web.models.actor_mcp_connection import ActorMCPServerConnection
+from xagent.web.models.database import Base
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.services.actor_mcp_connections import (
+    ACTOR_MCP_CREDENTIAL_VALUE_MAX_LENGTH,
+    ActorMCPConnectionValidationError,
+    create_actor_mcp_connection,
+    delete_actor_mcp_connection,
+    get_actor_mcp_connection_snapshot,
+    list_actor_mcp_connection_snapshots,
+    update_actor_mcp_connection_credentials,
+)
+
+ALICE_OWNER = "toby:slack:T1:alice"
+BOB_OWNER = "toby:slack:T1:bob"
+
+
+@pytest.fixture()
+def db() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    with engine.connect() as connection:
+        connection.execute(text("PRAGMA foreign_keys=ON"))
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _seed_app(db: Session, *, app_id: str = "posthog") -> PublicMCPApp:
+    app = PublicMCPApp(
+        app_id=app_id,
+        name=app_id,
+        transport="stdio",
+        launch_config={"command": "persisted-values-are-not-trusted"},
+    )
+    db.add(app)
+    db.flush()
+    return app
+
+
+def _seed_users(db: Session) -> tuple[User, User]:
+    users = (
+        User(username="actor-owner", password_hash="x"),
+        User(username="other-user", password_hash="x"),
+    )
+    db.add_all(users)
+    db.flush()
+    return users
+
+
+def _create(
+    db: Session,
+    *,
+    user_id: int,
+    owner: str,
+    app_id: str,
+    credentials: dict[str, str] | None = None,
+):
+    return create_actor_mcp_connection(
+        db,
+        user_id=user_id,
+        resource_owner_key=owner,
+        app_id=app_id,
+        credentials=credentials
+        if credentials is not None
+        else {"POSTHOG_API_KEY": "secret-value", "POSTHOG_HOST": "https://x.test"},
+    )
+
+
+def test_credentials_are_encrypted_at_rest_and_decrypted_in_snapshot(
+    db: Session,
+) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+
+    snapshot = _create(
+        db,
+        user_id=user.id,
+        owner=ALICE_OWNER,
+        app_id=app.app_id,
+    )
+    stored = db.query(ActorMCPServerConnection).one()
+
+    assert snapshot.credentials == {
+        "POSTHOG_API_KEY": "secret-value",
+        "POSTHOG_HOST": "https://x.test",
+    }
+    assert stored.encrypted_env is not None
+    assert all(_is_encrypted(value) for value in stored.encrypted_env.values())
+    assert "secret-value" not in str(stored.encrypted_env)
+    assert "https://x.test" not in str(stored.encrypted_env)
+    assert "secret-value" not in repr(stored)
+    assert "secret-value" not in repr(snapshot)
+    assert "https://x.test" not in repr(snapshot)
+
+
+def test_reads_and_deletes_require_exact_user_owner_and_app_tuple(db: Session) -> None:
+    user, other_user = _seed_users(db)
+    app = _seed_app(db)
+    created = _create(
+        db,
+        user_id=user.id,
+        owner=ALICE_OWNER,
+        app_id=app.app_id,
+    )
+
+    assert (
+        get_actor_mcp_connection_snapshot(
+            db,
+            user_id=user.id,
+            resource_owner_key=BOB_OWNER,
+            app_id=app.app_id,
+        )
+        is None
+    )
+    assert (
+        get_actor_mcp_connection_snapshot(
+            db,
+            user_id=other_user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+        )
+        is None
+    )
+    assert (
+        list_actor_mcp_connection_snapshots(
+            db, user_id=other_user.id, resource_owner_key=ALICE_OWNER
+        )
+        == []
+    )
+    assert not delete_actor_mcp_connection(
+        db,
+        user_id=user.id,
+        resource_owner_key=BOB_OWNER,
+        app_id=app.app_id,
+    )
+    assert (
+        get_actor_mcp_connection_snapshot(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+        )
+        == created
+    )
+
+
+def test_actor_tuple_uniqueness_is_enforced_by_app_and_catalog_generation(
+    db: Session,
+) -> None:
+    user, _other = _seed_users(db)
+    first_app = _seed_app(db, app_id="posthog")
+    second_app = _seed_app(db, app_id="google-maps")
+    db.add(
+        ActorMCPServerConnection(
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=first_app.app_id,
+            catalog_app_generation=first_app.generation,
+        )
+    )
+    db.commit()
+
+    db.add(
+        ActorMCPServerConnection(
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=first_app.app_id,
+            catalog_app_generation=second_app.generation,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db.commit()
+    db.rollback()
+
+    db.add(
+        ActorMCPServerConnection(
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=second_app.app_id,
+            catalog_app_generation=first_app.generation,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db.commit()
+
+
+def test_partial_update_merges_omitted_fields_and_preserves_generation(
+    db: Session,
+) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    original = _create(
+        db,
+        user_id=user.id,
+        owner=ALICE_OWNER,
+        app_id=app.app_id,
+    )
+
+    updated = update_actor_mcp_connection_credentials(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        credentials={"POSTHOG_API_KEY": "rotated"},
+    )
+
+    assert updated is not None
+    assert updated.lifecycle_generation == original.lifecycle_generation
+    assert updated.credentials == {
+        "POSTHOG_API_KEY": "rotated",
+        "POSTHOG_HOST": "https://x.test",
+    }
+
+
+def test_lifecycle_generation_cannot_be_updated(db: Session) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    _create(
+        db,
+        user_id=user.id,
+        owner=ALICE_OWNER,
+        app_id=app.app_id,
+    )
+    row = db.query(ActorMCPServerConnection).one()
+    db.commit()
+    original_generation = row.lifecycle_generation
+
+    row.lifecycle_generation = uuid.uuid4()
+    with pytest.raises(ValueError, match="immutable"):
+        db.flush()
+    db.rollback()
+
+    assert (
+        db.query(ActorMCPServerConnection).one().lifecycle_generation
+        == original_generation
+    )
+
+
+def test_hard_delete_and_recreate_gets_a_new_generation(db: Session) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    original = _create(
+        db,
+        user_id=user.id,
+        owner=ALICE_OWNER,
+        app_id=app.app_id,
+    )
+
+    assert delete_actor_mcp_connection(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+    )
+    assert db.query(ActorMCPServerConnection).count() == 0
+    replacement = _create(
+        db,
+        user_id=user.id,
+        owner=ALICE_OWNER,
+        app_id=app.app_id,
+        credentials={
+            "POSTHOG_API_KEY": "new-secret",
+            "POSTHOG_HOST": "https://new.test",
+        },
+    )
+
+    assert isinstance(replacement.lifecycle_generation, uuid.UUID)
+    assert replacement.lifecycle_generation != original.lifecycle_generation
+    assert replacement.credentials == {
+        "POSTHOG_API_KEY": "new-secret",
+        "POSTHOG_HOST": "https://new.test",
+    }
+
+
+def test_create_rejects_incomplete_unknown_blank_null_and_oversize_credentials(
+    db: Session,
+) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    invalid_credentials = [
+        {"POSTHOG_API_KEY": "secret-value"},
+        {
+            "POSTHOG_API_KEY": "secret-value",
+            "POSTHOG_HOST": "https://x.test",
+            "EXTRA": "x",
+        },
+        {"POSTHOG_API_KEY": "secret-value", "POSTHOG_HOST": ""},
+        {"POSTHOG_API_KEY": "secret-value", "POSTHOG_HOST": None},
+        {
+            "POSTHOG_API_KEY": "x" * (ACTOR_MCP_CREDENTIAL_VALUE_MAX_LENGTH + 1),
+            "POSTHOG_HOST": "https://x.test",
+        },
+    ]
+    for credentials in invalid_credentials:
+        with pytest.raises(ActorMCPConnectionValidationError):
+            create_actor_mcp_connection(
+                db,
+                user_id=user.id,
+                resource_owner_key=ALICE_OWNER,
+                app_id=app.app_id,
+                credentials=credentials,
+            )
+    assert db.query(ActorMCPServerConnection).count() == 0
+
+
+def test_update_rejects_unknown_blank_null_and_oversize_credentials(
+    db: Session,
+) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    original = _create(
+        db,
+        user_id=user.id,
+        owner=ALICE_OWNER,
+        app_id=app.app_id,
+    )
+    invalid_credentials = [
+        {"EXTRA": "x"},
+        {"POSTHOG_API_KEY": ""},
+        {"POSTHOG_API_KEY": None},
+        {"POSTHOG_API_KEY": "x" * (ACTOR_MCP_CREDENTIAL_VALUE_MAX_LENGTH + 1)},
+    ]
+    for credentials in invalid_credentials:
+        with pytest.raises(ActorMCPConnectionValidationError):
+            update_actor_mcp_connection_credentials(
+                db,
+                user_id=user.id,
+                resource_owner_key=ALICE_OWNER,
+                app_id=app.app_id,
+                credentials=credentials,
+            )
+    db.expire_all()
+    assert (
+        get_actor_mcp_connection_snapshot(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+        )
+        == original
+    )
+
+
+def test_keyless_connection_persists_null_env(db: Session) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db, app_id="chrome-devtools")
+
+    snapshot = create_actor_mcp_connection(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        credentials=None,
+    )
+
+    assert snapshot.credentials is None
+    assert db.query(ActorMCPServerConnection).one().encrypted_env is None
+
+
+def test_non_builtin_public_app_is_rejected(db: Session) -> None:
+    user, _other = _seed_users(db)
+    custom = _seed_app(db, app_id="custom-stdio")
+    custom.launch_config = {
+        "command": "untrusted-command",
+        "required_env": ["POSTHOG_API_KEY", "POSTHOG_HOST"],
+    }
+
+    with pytest.raises(ActorMCPConnectionValidationError, match="built-in"):
+        _create(
+            db,
+            user_id=user.id,
+            owner=ALICE_OWNER,
+            app_id=custom.app_id,
+        )
+
+
+@pytest.mark.parametrize("required_env", [{"KEY": "bad"}, ["KEY", "KEY"], [""]])
+def test_invalid_builtin_credential_schema_is_rejected(
+    db: Session, monkeypatch, required_env
+) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    monkeypatch.setattr(
+        "xagent.web.services.actor_mcp_connections.get_builtin_execution_fields",
+        lambda _app_id: {
+            "transport": "stdio",
+            "launch_config": {"command": "trusted", "required_env": required_env},
+        },
+    )
+
+    with pytest.raises(ActorMCPConnectionValidationError, match="credential schema"):
+        _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+
+
+def test_catalog_delete_cascades_and_recreate_does_not_revive_connection(
+    db: Session,
+) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    original = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    db.commit()
+
+    db.delete(app)
+    db.commit()
+    assert db.query(ActorMCPServerConnection).count() == 0
+
+    replacement_app = _seed_app(db)
+    assert replacement_app.generation != original.catalog_app_generation
+    assert (
+        get_actor_mcp_connection_snapshot(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=replacement_app.app_id,
+        )
+        is None
+    )
+
+
+def test_update_rejects_stale_catalog_generation(db: Session) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    other_app = _seed_app(db, app_id="google-maps")
+    _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    row = db.query(ActorMCPServerConnection).one()
+    db.execute(
+        ActorMCPServerConnection.__table__.update()
+        .where(ActorMCPServerConnection.id == row.id)
+        .values(catalog_app_generation=other_app.generation)
+    )
+    db.expire_all()
+
+    with pytest.raises(ActorMCPConnectionValidationError, match="stale"):
+        update_actor_mcp_connection_credentials(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+            credentials={"POSTHOG_API_KEY": "rotated"},
+        )

--- a/tests/web/services/test_actor_mcp_connections.py
+++ b/tests/web/services/test_actor_mcp_connections.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from xagent.core.utils.encryption import _is_encrypted, encrypt_env_dict
+from xagent.core.utils.encryption import _is_encrypted, encrypt_env_dict, get_cipher
 from xagent.web.models.actor_mcp_connection import ActorMCPServerConnection
 from xagent.web.models.database import Base
 from xagent.web.models.public_mcp import PublicMCPApp
@@ -669,7 +669,10 @@ def test_create_is_idempotent_and_conflict_keeps_transaction_usable(
     assert db.query(User).filter(User.username == "transaction-still-usable").one()
 
 
-def test_create_race_converges_through_savepoint(tmp_path, monkeypatch) -> None:
+@pytest.mark.parametrize("winner_uses_different_credentials", [False, True])
+def test_simulated_create_race_preserves_outer_transaction(
+    tmp_path, monkeypatch, winner_uses_different_credentials: bool
+) -> None:
     import xagent.web.services.actor_mcp_connections as service
 
     engine = create_engine(f"sqlite:///{tmp_path / 'create-race.db'}")
@@ -698,7 +701,11 @@ def test_create_race_converges_through_savepoint(tmp_path, monkeypatch) -> None:
                         catalog_app_generation=catalog_generation,
                         encrypted_env=encrypt_env_dict(
                             {
-                                "POSTHOG_API_KEY": "secret-value",
+                                "POSTHOG_API_KEY": (
+                                    "winner-secret"
+                                    if winner_uses_different_credentials
+                                    else "secret-value"
+                                ),
                                 "POSTHOG_HOST": "https://x.test",
                             }
                         ),
@@ -712,24 +719,33 @@ def test_create_race_converges_through_savepoint(tmp_path, monkeypatch) -> None:
         service, "get_current_actor_mcp_connection_for_create", racing_lookup
     )
     with Session(engine) as contender:
-        snapshot = _create(
-            contender,
-            user_id=user_id,
-            owner=ALICE_OWNER,
-            app_id=app_id,
-        )
-        secret_snapshot = get_actor_mcp_connection_snapshot(
-            contender,
-            user_id=user_id,
-            resource_owner_key=ALICE_OWNER,
-            app_id=app_id,
-            expected_lifecycle_generation=snapshot.lifecycle_generation,
-        )
-        assert secret_snapshot is not None
-        assert secret_snapshot.credentials == {
-            "POSTHOG_API_KEY": "secret-value",
-            "POSTHOG_HOST": "https://x.test",
-        }
+        if winner_uses_different_credentials:
+            with pytest.raises(ActorMCPConnectionConflictError):
+                _create(
+                    contender,
+                    user_id=user_id,
+                    owner=ALICE_OWNER,
+                    app_id=app_id,
+                )
+        else:
+            snapshot = _create(
+                contender,
+                user_id=user_id,
+                owner=ALICE_OWNER,
+                app_id=app_id,
+            )
+            secret_snapshot = get_actor_mcp_connection_snapshot(
+                contender,
+                user_id=user_id,
+                resource_owner_key=ALICE_OWNER,
+                app_id=app_id,
+                expected_lifecycle_generation=snapshot.lifecycle_generation,
+            )
+            assert secret_snapshot is not None
+            assert secret_snapshot.credentials == {
+                "POSTHOG_API_KEY": "secret-value",
+                "POSTHOG_HOST": "https://x.test",
+            }
         contender.add(User(username="outer-write", password_hash="x"))
         contender.flush()
         assert contender.query(User).filter(User.username == "outer-write").one()
@@ -1016,11 +1032,9 @@ def test_plaintext_at_rest_is_treated_as_credential_corruption(db: Session) -> N
 
 
 def test_token_shaped_input_round_trips_as_exact_plaintext(db: Session) -> None:
-    from cryptography.fernet import Fernet
-
     user, _other = _seed_users(db)
     app = _seed_app(db)
-    token_shaped_plaintext = Fernet(Fernet.generate_key()).encrypt(b"nested").decode()
+    token_shaped_plaintext = get_cipher().encrypt(b"nested").decode()
     created = _create(
         db,
         user_id=user.id,

--- a/tests/web/services/test_actor_mcp_connections.py
+++ b/tests/web/services/test_actor_mcp_connections.py
@@ -7,23 +7,77 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from xagent.core.utils.encryption import _is_encrypted
+from xagent.core.utils.encryption import _is_encrypted, encrypt_env_dict
 from xagent.web.models.actor_mcp_connection import ActorMCPServerConnection
 from xagent.web.models.database import Base
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.services.actor_mcp_connections import (
     ACTOR_MCP_CREDENTIAL_VALUE_MAX_LENGTH,
+    ActorMCPConnectionConflictError,
+    ActorMCPConnectionCredentialCorruptionError,
+    ActorMCPConnectionNotFoundOrStaleError,
     ActorMCPConnectionValidationError,
     create_actor_mcp_connection,
-    delete_actor_mcp_connection,
-    get_actor_mcp_connection_snapshot,
-    list_actor_mcp_connection_snapshots,
-    update_actor_mcp_connection_credentials,
+)
+from xagent.web.services.actor_mcp_connections import (
+    delete_actor_mcp_connection as _delete_exact,
+)
+from xagent.web.services.actor_mcp_connections import (
+    get_actor_mcp_connection_credentials_internal as _get_internal,
+)
+from xagent.web.services.actor_mcp_connections import (
+    get_actor_mcp_connection_metadata,
+)
+from xagent.web.services.actor_mcp_connections import (
+    list_actor_mcp_connection_metadata as list_actor_mcp_connection_snapshots,
+)
+from xagent.web.services.actor_mcp_connections import (
+    update_actor_mcp_connection_credentials as _update_exact,
 )
 
 ALICE_OWNER = "toby:slack:T1:alice"
 BOB_OWNER = "toby:slack:T1:bob"
+
+
+def get_actor_mcp_connection_snapshot(db: Session, **kwargs):
+    try:
+        metadata = get_actor_mcp_connection_metadata(
+            db,
+            user_id=kwargs["user_id"],
+            resource_owner_key=kwargs["resource_owner_key"],
+            app_id=kwargs["app_id"],
+        )
+        return _get_internal(
+            db,
+            catalog_app_generation=metadata.catalog_app_generation,
+            **kwargs,
+        )
+    except ActorMCPConnectionNotFoundOrStaleError:
+        return None
+
+
+def update_actor_mcp_connection_credentials(db: Session, **kwargs):
+    try:
+        metadata = _update_exact(db, **kwargs)
+    except ActorMCPConnectionNotFoundOrStaleError:
+        return None
+    return _get_internal(
+        db,
+        user_id=metadata.user_id,
+        resource_owner_key=metadata.resource_owner_key,
+        app_id=metadata.app_id,
+        catalog_app_generation=metadata.catalog_app_generation,
+        expected_lifecycle_generation=metadata.lifecycle_generation,
+    )
+
+
+def delete_actor_mcp_connection(db: Session, **kwargs) -> bool:
+    try:
+        _delete_exact(db, **kwargs)
+    except ActorMCPConnectionNotFoundOrStaleError:
+        return False
+    return True
 
 
 @pytest.fixture()
@@ -90,9 +144,17 @@ def test_credentials_are_encrypted_at_rest_and_decrypted_in_snapshot(
         owner=ALICE_OWNER,
         app_id=app.app_id,
     )
+    secret_snapshot = get_actor_mcp_connection_snapshot(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        expected_lifecycle_generation=snapshot.lifecycle_generation,
+    )
     stored = db.query(ActorMCPServerConnection).one()
 
-    assert snapshot.credentials == {
+    assert secret_snapshot is not None
+    assert secret_snapshot.credentials == {
         "POSTHOG_API_KEY": "secret-value",
         "POSTHOG_HOST": "https://x.test",
     }
@@ -101,8 +163,8 @@ def test_credentials_are_encrypted_at_rest_and_decrypted_in_snapshot(
     assert "secret-value" not in str(stored.encrypted_env)
     assert "https://x.test" not in str(stored.encrypted_env)
     assert "secret-value" not in repr(stored)
-    assert "secret-value" not in repr(snapshot)
-    assert "https://x.test" not in repr(snapshot)
+    assert "secret-value" not in repr(secret_snapshot)
+    assert "https://x.test" not in repr(secret_snapshot)
 
 
 def test_reads_and_deletes_require_exact_user_owner_and_app_tuple(db: Session) -> None:
@@ -121,6 +183,7 @@ def test_reads_and_deletes_require_exact_user_owner_and_app_tuple(db: Session) -
             user_id=user.id,
             resource_owner_key=BOB_OWNER,
             app_id=app.app_id,
+            expected_lifecycle_generation=created.lifecycle_generation,
         )
         is None
     )
@@ -130,6 +193,7 @@ def test_reads_and_deletes_require_exact_user_owner_and_app_tuple(db: Session) -
             user_id=other_user.id,
             resource_owner_key=ALICE_OWNER,
             app_id=app.app_id,
+            expected_lifecycle_generation=created.lifecycle_generation,
         )
         is None
     )
@@ -144,9 +208,10 @@ def test_reads_and_deletes_require_exact_user_owner_and_app_tuple(db: Session) -
         user_id=user.id,
         resource_owner_key=BOB_OWNER,
         app_id=app.app_id,
+        expected_lifecycle_generation=created.lifecycle_generation,
     )
     assert (
-        get_actor_mcp_connection_snapshot(
+        get_actor_mcp_connection_metadata(
             db,
             user_id=user.id,
             resource_owner_key=ALICE_OWNER,
@@ -213,6 +278,7 @@ def test_partial_update_merges_omitted_fields_and_preserves_generation(
         user_id=user.id,
         resource_owner_key=ALICE_OWNER,
         app_id=app.app_id,
+        expected_lifecycle_generation=original.lifecycle_generation,
         credentials={"POSTHOG_API_KEY": "rotated"},
     )
 
@@ -263,6 +329,7 @@ def test_hard_delete_and_recreate_gets_a_new_generation(db: Session) -> None:
         user_id=user.id,
         resource_owner_key=ALICE_OWNER,
         app_id=app.app_id,
+        expected_lifecycle_generation=original.lifecycle_generation,
     )
     assert db.query(ActorMCPServerConnection).count() == 0
     replacement = _create(
@@ -278,7 +345,15 @@ def test_hard_delete_and_recreate_gets_a_new_generation(db: Session) -> None:
 
     assert isinstance(replacement.lifecycle_generation, uuid.UUID)
     assert replacement.lifecycle_generation != original.lifecycle_generation
-    assert replacement.credentials == {
+    replacement_secret = get_actor_mcp_connection_snapshot(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        expected_lifecycle_generation=replacement.lifecycle_generation,
+    )
+    assert replacement_secret is not None
+    assert replacement_secret.credentials == {
         "POSTHOG_API_KEY": "new-secret",
         "POSTHOG_HOST": "https://new.test",
     }
@@ -339,11 +414,12 @@ def test_update_rejects_unknown_blank_null_and_oversize_credentials(
                 user_id=user.id,
                 resource_owner_key=ALICE_OWNER,
                 app_id=app.app_id,
+                expected_lifecycle_generation=original.lifecycle_generation,
                 credentials=credentials,
             )
     db.expire_all()
     assert (
-        get_actor_mcp_connection_snapshot(
+        get_actor_mcp_connection_metadata(
             db,
             user_id=user.id,
             resource_owner_key=ALICE_OWNER,
@@ -365,7 +441,15 @@ def test_keyless_connection_persists_null_env(db: Session) -> None:
         credentials=None,
     )
 
-    assert snapshot.credentials is None
+    secret_snapshot = get_actor_mcp_connection_snapshot(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        expected_lifecycle_generation=snapshot.lifecycle_generation,
+    )
+    assert secret_snapshot is not None
+    assert secret_snapshot.credentials is None
     assert db.query(ActorMCPServerConnection).one().encrypted_env is None
 
 
@@ -386,7 +470,9 @@ def test_non_builtin_public_app_is_rejected(db: Session) -> None:
         )
 
 
-@pytest.mark.parametrize("required_env", [{"KEY": "bad"}, ["KEY", "KEY"], [""]])
+@pytest.mark.parametrize(
+    "required_env", [{"KEY": "bad"}, ["KEY", "KEY"], [""], [" KEY"], ["KEY "]]
+)
 def test_invalid_builtin_credential_schema_is_rejected(
     db: Session, monkeypatch, required_env
 ) -> None:
@@ -424,16 +510,352 @@ def test_catalog_delete_cascades_and_recreate_does_not_revive_connection(
             user_id=user.id,
             resource_owner_key=ALICE_OWNER,
             app_id=replacement_app.app_id,
+            expected_lifecycle_generation=original.lifecycle_generation,
         )
         is None
     )
 
 
-def test_update_rejects_stale_catalog_generation(db: Session) -> None:
+def test_old_generation_cannot_read_update_or_delete_replacement(db: Session) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    original = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    assert delete_actor_mcp_connection(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        expected_lifecycle_generation=original.lifecycle_generation,
+    )
+    replacement = _create(
+        db,
+        user_id=user.id,
+        owner=ALICE_OWNER,
+        app_id=app.app_id,
+        credentials={
+            "POSTHOG_API_KEY": "replacement-secret",
+            "POSTHOG_HOST": "https://replacement.test",
+        },
+    )
+
+    assert (
+        get_actor_mcp_connection_snapshot(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+            expected_lifecycle_generation=original.lifecycle_generation,
+        )
+        is None
+    )
+    assert (
+        update_actor_mcp_connection_credentials(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+            expected_lifecycle_generation=original.lifecycle_generation,
+            credentials={"POSTHOG_API_KEY": "stale-writer"},
+        )
+        is None
+    )
+    assert not delete_actor_mcp_connection(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        expected_lifecycle_generation=original.lifecycle_generation,
+    )
+    assert (
+        get_actor_mcp_connection_metadata(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+        )
+        == replacement
+    )
+
+
+def test_update_sql_generation_fence_survives_delete_recreate_race(
+    db: Session, monkeypatch
+) -> None:
+    import xagent.web.services.actor_mcp_connections as service
+
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    original = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    replacement_generation = uuid.uuid4()
+    replacement_credentials = {
+        "POSTHOG_API_KEY": "replacement-secret",
+        "POSTHOG_HOST": "https://replacement.test",
+    }
+    real_update = service.update_actor_mcp_connection_env
+
+    def replace_before_update(session: Session, **kwargs) -> bool:
+        session.execute(
+            ActorMCPServerConnection.__table__.delete().where(
+                ActorMCPServerConnection.user_id == user.id,
+                ActorMCPServerConnection.resource_owner_key == ALICE_OWNER,
+                ActorMCPServerConnection.app_id == app.app_id,
+            )
+        )
+        session.execute(
+            ActorMCPServerConnection.__table__.insert().values(
+                lifecycle_generation=replacement_generation,
+                user_id=user.id,
+                resource_owner_key=ALICE_OWNER,
+                app_id=app.app_id,
+                catalog_app_generation=app.generation,
+                encrypted_env=encrypt_env_dict(replacement_credentials),
+            )
+        )
+        return real_update(session, **kwargs)
+
+    monkeypatch.setattr(
+        service, "update_actor_mcp_connection_env", replace_before_update
+    )
+
+    assert (
+        update_actor_mcp_connection_credentials(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+            expected_lifecycle_generation=original.lifecycle_generation,
+            credentials={"POSTHOG_API_KEY": "stale-writer"},
+        )
+        is None
+    )
+    db.expire_all()
+    replacement = get_actor_mcp_connection_snapshot(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        expected_lifecycle_generation=replacement_generation,
+    )
+    assert replacement is not None
+    assert replacement.credentials == replacement_credentials
+
+
+def test_create_is_idempotent_and_conflict_keeps_transaction_usable(
+    db: Session,
+) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    original = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+
+    assert (
+        _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id) == original
+    )
+    with pytest.raises(
+        ActorMCPConnectionConflictError,
+        match="generation-protected update",
+    ):
+        _create(
+            db,
+            user_id=user.id,
+            owner=ALICE_OWNER,
+            app_id=app.app_id,
+            credentials={
+                "POSTHOG_API_KEY": "different",
+                "POSTHOG_HOST": "https://different.test",
+            },
+        )
+
+    db.add(User(username="transaction-still-usable", password_hash="x"))
+    db.flush()
+    assert db.query(User).filter(User.username == "transaction-still-usable").one()
+
+
+def test_create_race_converges_through_savepoint(tmp_path, monkeypatch) -> None:
+    import xagent.web.services.actor_mcp_connections as service
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'create-race.db'}")
+    Base.metadata.create_all(engine)
+    with Session(engine) as setup:
+        user, _other = _seed_users(setup)
+        app = _seed_app(setup)
+        setup.commit()
+        user_id = user.id
+        app_id = app.app_id
+        catalog_generation = app.generation
+
+    real_lookup = service.get_current_actor_mcp_connection_for_create
+    calls = 0
+
+    def racing_lookup(session: Session, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            with Session(engine) as winner:
+                winner.add(
+                    ActorMCPServerConnection(
+                        user_id=user_id,
+                        resource_owner_key=ALICE_OWNER,
+                        app_id=app_id,
+                        catalog_app_generation=catalog_generation,
+                        encrypted_env=encrypt_env_dict(
+                            {
+                                "POSTHOG_API_KEY": "secret-value",
+                                "POSTHOG_HOST": "https://x.test",
+                            }
+                        ),
+                    )
+                )
+                winner.commit()
+            return None
+        return real_lookup(session, **kwargs)
+
+    monkeypatch.setattr(
+        service, "get_current_actor_mcp_connection_for_create", racing_lookup
+    )
+    with Session(engine) as contender:
+        snapshot = _create(
+            contender,
+            user_id=user_id,
+            owner=ALICE_OWNER,
+            app_id=app_id,
+        )
+        secret_snapshot = get_actor_mcp_connection_snapshot(
+            contender,
+            user_id=user_id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app_id,
+            expected_lifecycle_generation=snapshot.lifecycle_generation,
+        )
+        assert secret_snapshot is not None
+        assert secret_snapshot.credentials == {
+            "POSTHOG_API_KEY": "secret-value",
+            "POSTHOG_HOST": "https://x.test",
+        }
+        contender.add(User(username="outer-write", password_hash="x"))
+        contender.flush()
+        assert contender.query(User).filter(User.username == "outer-write").one()
+    engine.dispose()
+
+
+def test_nonduplicate_integrity_error_is_not_misclassified(db: Session) -> None:
+    app = _seed_app(db)
+    with pytest.raises(IntegrityError):
+        _create(db, user_id=999_999, owner=ALICE_OWNER, app_id=app.app_id)
+
+    user = User(username="savepoint-remains-usable", password_hash="x")
+    db.add(user)
+    db.flush()
+    assert user.id is not None
+
+
+def test_list_returns_only_metadata_without_decrypting(
+    db: Session, monkeypatch
+) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    created = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    monkeypatch.setattr(
+        "xagent.web.services.actor_mcp_connections.decrypt_env_dict_strict",
+        lambda _value: (_ for _ in ()).throw(AssertionError("must not decrypt")),
+    )
+
+    listed = list_actor_mcp_connection_snapshots(
+        db, user_id=user.id, resource_owner_key=ALICE_OWNER
+    )
+    exact = get_actor_mcp_connection_metadata(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+    )
+
+    assert len(listed) == 1
+    assert exact == listed[0]
+    assert listed[0].lifecycle_generation == created.lifecycle_generation
+    assert listed[0].configured_field_names == frozenset(
+        {"POSTHOG_API_KEY", "POSTHOG_HOST"}
+    )
+    assert "secret-value" not in repr(listed[0])
+
+
+def test_internal_secret_get_requires_both_exact_generations(db: Session) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    created = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+
+    with pytest.raises(ActorMCPConnectionNotFoundOrStaleError):
+        _get_internal(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+            catalog_app_generation=uuid.uuid4(),
+            expected_lifecycle_generation=created.lifecycle_generation,
+        )
+    with pytest.raises(ActorMCPConnectionNotFoundOrStaleError):
+        _get_internal(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+            catalog_app_generation=created.catalog_app_generation,
+            expected_lifecycle_generation=uuid.uuid4(),
+        )
+
+    exact = _get_internal(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        catalog_app_generation=created.catalog_app_generation,
+        expected_lifecycle_generation=created.lifecycle_generation,
+    )
+    assert exact.credentials == {
+        "POSTHOG_API_KEY": "secret-value",
+        "POSTHOG_HOST": "https://x.test",
+    }
+    assert "secret-value" not in repr(exact)
+
+
+def test_stale_mutations_raise_stable_not_found_error(db: Session) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    created = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    stale_generation = uuid.uuid4()
+
+    with pytest.raises(ActorMCPConnectionNotFoundOrStaleError):
+        _update_exact(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+            expected_lifecycle_generation=stale_generation,
+            credentials={"POSTHOG_API_KEY": "stale"},
+        )
+    with pytest.raises(ActorMCPConnectionNotFoundOrStaleError):
+        _delete_exact(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+            expected_lifecycle_generation=stale_generation,
+        )
+
+    assert (
+        get_actor_mcp_connection_metadata(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+        )
+        == created
+    )
+
+
+def test_catalog_fence_filters_read_list_and_delete(db: Session) -> None:
     user, _other = _seed_users(db)
     app = _seed_app(db)
     other_app = _seed_app(db, app_id="google-maps")
-    _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    created = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
     row = db.query(ActorMCPServerConnection).one()
     db.execute(
         ActorMCPServerConnection.__table__.update()
@@ -442,11 +864,225 @@ def test_update_rejects_stale_catalog_generation(db: Session) -> None:
     )
     db.expire_all()
 
-    with pytest.raises(ActorMCPConnectionValidationError, match="stale"):
+    assert (
+        get_actor_mcp_connection_snapshot(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+            expected_lifecycle_generation=created.lifecycle_generation,
+        )
+        is None
+    )
+    assert (
+        list_actor_mcp_connection_snapshots(
+            db, user_id=user.id, resource_owner_key=ALICE_OWNER
+        )
+        == []
+    )
+    assert not delete_actor_mcp_connection(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        expected_lifecycle_generation=created.lifecycle_generation,
+    )
+
+
+def test_exact_get_refreshes_identity_map_state(db: Session) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    created = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    row = db.query(ActorMCPServerConnection).one()
+    replacement = {
+        "POSTHOG_API_KEY": "database-value",
+        "POSTHOG_HOST": "https://database.test",
+    }
+    db.execute(
+        ActorMCPServerConnection.__table__.update()
+        .where(ActorMCPServerConnection.id == row.id)
+        .values(encrypted_env=encrypt_env_dict(replacement))
+        .execution_options(synchronize_session=False)
+    )
+
+    refreshed = get_actor_mcp_connection_snapshot(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        expected_lifecycle_generation=created.lifecycle_generation,
+    )
+    assert refreshed is not None
+    assert refreshed.credentials == replacement
+
+
+@pytest.mark.parametrize("transport", ["STDIO", "stdio ", " stdio"])
+def test_registry_transport_must_be_exact(
+    db: Session, monkeypatch, transport: str
+) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    monkeypatch.setattr(
+        "xagent.web.services.actor_mcp_connections.get_builtin_execution_fields",
+        lambda _app_id: {
+            "transport": transport,
+            "launch_config": {
+                "command": "trusted",
+                "required_env": ["POSTHOG_API_KEY", "POSTHOG_HOST"],
+            },
+        },
+    )
+    with pytest.raises(ActorMCPConnectionValidationError, match="built-in stdio"):
+        _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+
+
+def test_unpaired_surrogate_is_rejected_without_echoing_secret(db: Session) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    secret = "sensitive\ud800value"
+
+    with pytest.raises(ActorMCPConnectionValidationError) as exc_info:
+        _create(
+            db,
+            user_id=user.id,
+            owner=ALICE_OWNER,
+            app_id=app.app_id,
+            credentials={
+                "POSTHOG_API_KEY": secret,
+                "POSTHOG_HOST": "https://x.test",
+            },
+        )
+    assert "sensitive" not in str(exc_info.value)
+    assert db.query(ActorMCPServerConnection).count() == 0
+
+
+def test_wrong_key_and_corrupt_ciphertext_map_to_redacted_domain_error(
+    db: Session,
+) -> None:
+    from cryptography.fernet import Fernet
+
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    created = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    wrong_key_token = (
+        Fernet(Fernet.generate_key()).encrypt(b"never-expose-this").decode()
+    )
+    valid_token = encrypt_env_dict({"key": "never-expose-this"})["key"]
+    corrupt_token = (
+        f"{valid_token[:20]}{'A' if valid_token[20] != 'A' else 'B'}{valid_token[21:]}"
+    )
+    row = db.query(ActorMCPServerConnection).one()
+    for token in (wrong_key_token, corrupt_token):
+        db.execute(
+            ActorMCPServerConnection.__table__.update()
+            .where(ActorMCPServerConnection.id == row.id)
+            .values(encrypted_env={"POSTHOG_API_KEY": token})
+        )
+        db.expire_all()
+
+        with pytest.raises(ActorMCPConnectionCredentialCorruptionError) as exc_info:
+            get_actor_mcp_connection_snapshot(
+                db,
+                user_id=user.id,
+                resource_owner_key=ALICE_OWNER,
+                app_id=app.app_id,
+                expected_lifecycle_generation=created.lifecycle_generation,
+            )
+        assert token not in str(exc_info.value)
+        assert "never-expose-this" not in repr(exc_info.value)
+
+
+def test_plaintext_at_rest_is_treated_as_credential_corruption(db: Session) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    created = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    row = db.query(ActorMCPServerConnection).one()
+    db.execute(
+        ActorMCPServerConnection.__table__.update()
+        .where(ActorMCPServerConnection.id == row.id)
+        .values(encrypted_env={"POSTHOG_API_KEY": "plaintext-secret"})
+    )
+    db.expire_all()
+
+    with pytest.raises(ActorMCPConnectionCredentialCorruptionError) as exc_info:
+        get_actor_mcp_connection_snapshot(
+            db,
+            user_id=user.id,
+            resource_owner_key=ALICE_OWNER,
+            app_id=app.app_id,
+            expected_lifecycle_generation=created.lifecycle_generation,
+        )
+    assert "plaintext-secret" not in str(exc_info.value)
+
+
+def test_token_shaped_input_round_trips_as_exact_plaintext(db: Session) -> None:
+    from cryptography.fernet import Fernet
+
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    token_shaped_plaintext = Fernet(Fernet.generate_key()).encrypt(b"nested").decode()
+    created = _create(
+        db,
+        user_id=user.id,
+        owner=ALICE_OWNER,
+        app_id=app.app_id,
+        credentials={
+            "POSTHOG_API_KEY": token_shaped_plaintext,
+            "POSTHOG_HOST": "https://x.test",
+        },
+    )
+
+    exact = get_actor_mcp_connection_snapshot(
+        db,
+        user_id=user.id,
+        resource_owner_key=ALICE_OWNER,
+        app_id=app.app_id,
+        expected_lifecycle_generation=created.lifecycle_generation,
+    )
+    assert exact is not None
+    assert exact.credentials is not None
+    assert exact.credentials["POSTHOG_API_KEY"] == token_shaped_plaintext
+
+
+@pytest.mark.parametrize("field", ["app_id", "catalog_app_generation"])
+def test_catalog_binding_is_immutable(db: Session, field: str) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    other_app = _seed_app(db, app_id="google-maps")
+    _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    row = db.query(ActorMCPServerConnection).one()
+    db.commit()
+    setattr(
+        row,
+        field,
+        other_app.app_id if field == "app_id" else other_app.generation,
+    )
+
+    with pytest.raises(ValueError, match="catalog binding"):
+        db.flush()
+
+
+def test_update_rejects_stale_catalog_generation(db: Session) -> None:
+    user, _other = _seed_users(db)
+    app = _seed_app(db)
+    other_app = _seed_app(db, app_id="google-maps")
+    original = _create(db, user_id=user.id, owner=ALICE_OWNER, app_id=app.app_id)
+    row = db.query(ActorMCPServerConnection).one()
+    db.execute(
+        ActorMCPServerConnection.__table__.update()
+        .where(ActorMCPServerConnection.id == row.id)
+        .values(catalog_app_generation=other_app.generation)
+    )
+    db.expire_all()
+
+    assert (
         update_actor_mcp_connection_credentials(
             db,
             user_id=user.id,
             resource_owner_key=ALICE_OWNER,
             app_id=app.app_id,
+            expected_lifecycle_generation=original.lifecycle_generation,
             credentials={"POSTHOG_API_KEY": "rotated"},
         )
+        is None
+    )


### PR DESCRIPTION
## Summary

- add actor-scoped personal stdio connection storage with immutable lifecycle generations
- encrypt credential values at rest and enforce complete-create/partial-update validation against code-defined builtin schemas
- fence connections to the exact PublicMCPApp generation and hard-delete them when that catalog lifecycle is removed

## Security boundary

Actor connections intentionally do not reference MCPServer or UserMCPServer. Those rows are mutable and do not carry an unforgeable builtin provenance marker. The service accepts only exact code-registry builtin stdio apps, persists the current immutable PublicMCPApp generation, and leaves runtime construction to the follow-up registry-only execution layer. This PR does not enable Toby UI or runtime flows and does not change ordinary xagent connector behavior.

## Validation

- `PYTHONPATH=src /opt/anaconda3/envs/xagent/bin/python -m pytest -q tests/web/services/test_actor_mcp_connections.py tests/alembic/test_20260909_add_actor_mcp_server_connections.py` (16 passed)
- `PYTHONPATH=src /opt/anaconda3/envs/xagent/bin/python -m pytest -q tests/web/test_mcp_lifecycle_generation_models.py` (10 passed)
- focused Ruff and py_compile checks passed
- Alembic single-head check passed
- mutation checks proved the actor-owner predicate, encryption write, builtin-registry gate, and catalog-generation fence are each covered by failing tests

Closes #2260

Parent tracking: https://github.com/xorbitsai/xagent-saas/issues/1161