### PR TITLE
feat(mcp): add the Shopify connector (toby)

### DIFF
--- a/src/xagent/builtin_identity.py
+++ b/src/xagent/builtin_identity.py
@@ -1,0 +1,11 @@
+"""Stable normalization for built-in catalog collision detection."""
+
+from __future__ import annotations
+
+
+def canonicalize_builtin_identity(value: object) -> str | None:
+    """Normalize an identity only for collision checks, never persistence."""
+    if value is None:
+        return None
+    normalized = "-".join(str(value).strip().casefold().split())
+    return normalized or None

--- a/src/xagent/builtin_identity.py
+++ b/src/xagent/builtin_identity.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 
 def canonicalize_builtin_identity(value: object) -> str | None:
     """Normalize an identity only for collision checks, never persistence."""
@@ -9,3 +11,16 @@ def canonicalize_builtin_identity(value: object) -> str | None:
         return None
     normalized = "-".join(str(value).strip().casefold().split())
     return normalized or None
+
+
+def builtin_provenance_identity(value: Any) -> tuple[str, str] | None:
+    """Return stable ownership identity, excluding schema/version metadata."""
+    if not isinstance(value, dict):
+        return None
+    registry = value.get("registry")
+    app_id = value.get("app_id")
+    if not isinstance(registry, str) or not isinstance(app_id, str):
+        return None
+    if not registry or not app_id:
+        return None
+    return registry, app_id

--- a/src/xagent/core/tools/core/mcp/model.py
+++ b/src/xagent/core/tools/core/mcp/model.py
@@ -199,11 +199,20 @@ def create_mcp_server_table(Base: Type[Any]) -> Type[Any]:
             if getattr(self, "auth", None) is not None:
                 # HTTP transports consume auth via generated headers above; keep non-dict
                 # auth values for compatibility with callers that provide httpx.Auth.
-                if self.transport not in [
+                provenance_only = isinstance(decrypted_auth, dict) and set(
+                    decrypted_auth
+                ) == {"builtin_provenance"}
+                # Provenance is catalog metadata, not a transport auth object.
+                # Keep it persisted in to_config_dict(), but never pass it to
+                # the stdio client constructor.
+                is_http_transport = self.transport in {
                     "sse",
                     "websocket",
                     "streamable_http",
-                ] or not isinstance(decrypted_auth, dict):
+                }
+                if not isinstance(decrypted_auth, dict) or (
+                    not is_http_transport and not provenance_only
+                ):
                     connection["auth"] = decrypted_auth
 
             connection["concurrency_safe"] = bool(

--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -38,6 +38,7 @@ AUTH_HEADER_PATTERN = re.compile(
 HEADER_KEY_PATTERNS = [
     re.compile(r"(?i)(x-goog-api-key\s*[:=]\s*)([^\s,;]+)"),
     re.compile(r"(?i)(x-api-key\s*[:=]\s*)([^\s,;]+)"),
+    re.compile(r"(?i)(x-shopify-access-token\s*[:=]\s*)([^\s,;]+)"),
 ]
 
 

--- a/src/xagent/migrations/versions/20260909_seed_shopify_mcp_app.py
+++ b/src/xagent/migrations/versions/20260909_seed_shopify_mcp_app.py
@@ -1,0 +1,151 @@
+"""Seed the built-in Shopify key-based MCP connector.
+
+Revision ID: 20260909_seed_shopify_mcp_app
+Revises: 20260901_seed_zendesk_mcp_app
+"""
+
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+logger = logging.getLogger(__name__)
+
+revision: str = "20260909_seed_shopify_mcp_app"
+down_revision: Union[str, None] = "20260901_seed_zendesk_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+MCP_SERVERS_TABLE = sa.table(
+    "mcp_servers",
+    sa.column("name", sa.String),
+)
+
+APP_ID = "shopify"
+BUILTIN_PROVENANCE = {
+    "registry": "xagent",
+    "app_id": APP_ID,
+    "version": 1,
+}
+ROW = {
+    "app_id": APP_ID,
+    "name": "Shopify",
+    "description": "Connect a Shopify custom app with a store label (for example, acme for acme.myshopify.com) and Admin API access token. Grant write_products, write_orders, and read_customers; read_all_orders is optional for orders older than 60 days.",
+    "icon": "https://www.google.com/s2/favicons?domain=shopify.com&sz=128",
+    "transport": "stdio",
+    "provider_name": None,
+    "category": "Commerce",
+    "oauth_scopes": None,
+    "is_visible_in_connector": True,
+    "launch_config": {
+        "command": "python",
+        "args": ["-m", "xagent.web.tools.mcp.shopify"],
+        "required_env": ["SHOPIFY_STORE_DOMAIN", "SHOPIFY_ACCESS_TOKEN"],
+        "required_admin_scopes": [
+            "write_products",
+            "write_orders",
+            "read_customers",
+        ],
+        "optional_admin_scopes": ["read_all_orders"],
+        "credential_scope": "personal",
+        "builtin_provenance": BUILTIN_PROVENANCE,
+    },
+}
+
+
+def _has_provenance(launch_config: object) -> bool:
+    return (
+        isinstance(launch_config, dict)
+        and launch_config.get("builtin_provenance") == BUILTIN_PROVENANCE
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+    if "public_mcp_apps" not in tables:
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("public_mcp_apps")}
+    if "launch_config" not in columns:
+        raise RuntimeError(
+            "Cannot seed builtin Shopify identity: public_mcp_apps.launch_config "
+            "is required for provenance"
+        )
+
+    existing = (
+        bind.execute(
+            sa.select(
+                PUBLIC_MCP_APPS_TABLE.c.app_id,
+                PUBLIC_MCP_APPS_TABLE.c.launch_config,
+            ).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        )
+        .mappings()
+        .first()
+    )
+    if existing is not None:
+        if _has_provenance(existing["launch_config"]):
+            return
+        raise RuntimeError(
+            "Cannot seed builtin Shopify connector: custom public_mcp_apps "
+            "row with app_id 'shopify' already exists"
+        )
+
+    if "mcp_servers" in tables:
+        server_collision = bind.execute(
+            sa.select(MCP_SERVERS_TABLE.c.name).where(
+                MCP_SERVERS_TABLE.c.name == APP_ID
+            )
+        ).first()
+        if server_collision is not None:
+            raise RuntimeError(
+                "Cannot seed builtin Shopify connector: custom mcp_servers "
+                "row named 'shopify' already exists"
+            )
+
+    dropped_keys = sorted(set(ROW) - columns)
+    if dropped_keys:
+        logger.warning(
+            "public_mcp_apps is missing columns %s; seeding %r without them",
+            dropped_keys,
+            APP_ID,
+        )
+    bind.execute(
+        sa.insert(PUBLIC_MCP_APPS_TABLE),
+        [{key: value for key, value in ROW.items() if key in columns}],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+    columns = {column["name"] for column in inspector.get_columns("public_mcp_apps")}
+    if "launch_config" not in columns:
+        return
+    existing = bind.execute(
+        sa.select(PUBLIC_MCP_APPS_TABLE.c.launch_config).where(
+            PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID
+        )
+    ).scalar_one_or_none()
+    if not _has_provenance(existing):
+        return
+    bind.execute(
+        sa.delete(PUBLIC_MCP_APPS_TABLE).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+    )

--- a/src/xagent/migrations/versions/20260909_seed_shopify_mcp_app.py
+++ b/src/xagent/migrations/versions/20260909_seed_shopify_mcp_app.py
@@ -1,7 +1,7 @@
 """Seed the built-in Shopify key-based MCP connector.
 
 Revision ID: 20260909_seed_shopify_mcp_app
-Revises: 20260901_seed_zendesk_mcp_app
+Revises: 370740d9125a
 """
 
 import logging
@@ -18,7 +18,7 @@ from xagent.builtin_identity import (
 logger = logging.getLogger(__name__)
 
 revision: str = "20260909_seed_shopify_mcp_app"
-down_revision: Union[str, None] = "20260901_seed_zendesk_mcp_app"
+down_revision: Union[str, None] = "370740d9125a"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260909_seed_shopify_mcp_app.py
+++ b/src/xagent/migrations/versions/20260909_seed_shopify_mcp_app.py
@@ -10,6 +10,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
+from xagent.builtin_identity import canonicalize_builtin_identity
+
 logger = logging.getLogger(__name__)
 
 revision: str = "20260909_seed_shopify_mcp_app"
@@ -33,6 +35,7 @@ PUBLIC_MCP_APPS_TABLE = sa.table(
 MCP_SERVERS_TABLE = sa.table(
     "mcp_servers",
     sa.column("name", sa.String),
+    sa.column("auth", sa.JSON),
 )
 
 APP_ID = "shopify"
@@ -74,6 +77,19 @@ def _has_provenance(launch_config: object) -> bool:
     )
 
 
+def _has_server_provenance(auth: object) -> bool:
+    return (
+        isinstance(auth, dict) and auth.get("builtin_provenance") == BUILTIN_PROVENANCE
+    )
+
+
+def _collides_with_shopify_identity(value: object) -> bool:
+    return canonicalize_builtin_identity(value) in {
+        canonicalize_builtin_identity(APP_ID),
+        canonicalize_builtin_identity(ROW["name"]),
+    }
+
+
 def upgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
@@ -88,34 +104,63 @@ def upgrade() -> None:
             "is required for provenance"
         )
 
-    existing = (
+    catalog_rows = list(
         bind.execute(
             sa.select(
                 PUBLIC_MCP_APPS_TABLE.c.app_id,
+                PUBLIC_MCP_APPS_TABLE.c.name,
                 PUBLIC_MCP_APPS_TABLE.c.launch_config,
-            ).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
-        )
-        .mappings()
-        .first()
+            )
+        ).mappings()
     )
-    if existing is not None:
-        if _has_provenance(existing["launch_config"]):
+    colliding_catalog_rows = [
+        row
+        for row in catalog_rows
+        if _collides_with_shopify_identity(row["app_id"])
+        or _collides_with_shopify_identity(row["name"])
+    ]
+    exact_app_rows = [row for row in catalog_rows if row["app_id"] == APP_ID]
+    if exact_app_rows:
+        existing = exact_app_rows[0]
+        if _has_provenance(existing["launch_config"]) and colliding_catalog_rows == [
+            existing
+        ]:
             return
         raise RuntimeError(
+            "Cannot seed builtin Shopify connector: custom or ambiguous "
+            "public_mcp_apps identity collides with 'shopify'"
+        )
+    if colliding_catalog_rows:
+        raise RuntimeError(
             "Cannot seed builtin Shopify connector: custom public_mcp_apps "
-            "row with app_id 'shopify' already exists"
+            "identity collides with 'shopify'"
         )
 
     if "mcp_servers" in tables:
-        server_collision = bind.execute(
-            sa.select(MCP_SERVERS_TABLE.c.name).where(
-                MCP_SERVERS_TABLE.c.name == APP_ID
+        server_columns = {
+            column["name"] for column in inspector.get_columns("mcp_servers")
+        }
+        if "auth" not in server_columns:
+            raise RuntimeError(
+                "Cannot verify builtin Shopify server provenance: "
+                "mcp_servers.auth is required"
             )
-        ).first()
-        if server_collision is not None:
+        colliding_servers = [
+            row
+            for row in bind.execute(
+                sa.select(MCP_SERVERS_TABLE.c.name, MCP_SERVERS_TABLE.c.auth)
+            ).mappings()
+            if _collides_with_shopify_identity(row["name"])
+        ]
+        trusted_round_trip = (
+            len(colliding_servers) == 1
+            and colliding_servers[0]["name"] == APP_ID
+            and _has_server_provenance(colliding_servers[0]["auth"])
+        )
+        if colliding_servers and not trusted_round_trip:
             raise RuntimeError(
                 "Cannot seed builtin Shopify connector: custom mcp_servers "
-                "row named 'shopify' already exists"
+                "identity collides with 'shopify'"
             )
 
     dropped_keys = sorted(set(ROW) - columns)

--- a/src/xagent/migrations/versions/20260909_seed_shopify_mcp_app.py
+++ b/src/xagent/migrations/versions/20260909_seed_shopify_mcp_app.py
@@ -10,7 +10,10 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-from xagent.builtin_identity import canonicalize_builtin_identity
+from xagent.builtin_identity import (
+    builtin_provenance_identity,
+    canonicalize_builtin_identity,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -71,16 +74,15 @@ ROW = {
 
 
 def _has_provenance(launch_config: object) -> bool:
-    return (
-        isinstance(launch_config, dict)
-        and launch_config.get("builtin_provenance") == BUILTIN_PROVENANCE
-    )
+    return isinstance(launch_config, dict) and builtin_provenance_identity(
+        launch_config.get("builtin_provenance")
+    ) == builtin_provenance_identity(BUILTIN_PROVENANCE)
 
 
 def _has_server_provenance(auth: object) -> bool:
-    return (
-        isinstance(auth, dict) and auth.get("builtin_provenance") == BUILTIN_PROVENANCE
-    )
+    return isinstance(auth, dict) and builtin_provenance_identity(
+        auth.get("builtin_provenance")
+    ) == builtin_provenance_identity(BUILTIN_PROVENANCE)
 
 
 def _collides_with_shopify_identity(value: object) -> bool:

--- a/src/xagent/web/api/admin_mcp.py
+++ b/src/xagent/web/api/admin_mcp.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from ...core.utils.encryption import encrypt_value
 from ..auth_dependencies import get_current_user
 from ..builtin_mcp_registry import (
+    _persisted_builtin_provenance_matches,
     get_builtin_execution_fields,
     get_builtin_public_mcp_app,
     is_builtin_public_mcp_app,
@@ -215,7 +216,11 @@ def _commit_public_mcp_app_write(
 
 def _public_mcp_app_response(app: PublicMCPApp) -> Dict[str, Any]:
     values = _public_mcp_app_values(app)
-    execution_fields = get_builtin_execution_fields(app.app_id, app.launch_config)
+    execution_fields = get_builtin_execution_fields(app.app_id)
+    if execution_fields is not None and not _persisted_builtin_provenance_matches(
+        app.app_id, app.launch_config
+    ):
+        execution_fields = None
     if execution_fields is not None:
         values.update(execution_fields)
     return {
@@ -248,7 +253,7 @@ def _validate_public_mcp_app_values(
 
 def _apply_public_mcp_app_update(db_app: PublicMCPApp, changes: Dict[str, Any]) -> None:
     canonical = get_builtin_public_mcp_app(db_app.app_id)
-    if canonical is not None and not is_builtin_public_mcp_app(
+    if canonical is not None and not _persisted_builtin_provenance_matches(
         db_app.app_id, db_app.launch_config
     ):
         canonical = None
@@ -557,7 +562,9 @@ async def delete_app(
     db_app = db.query(PublicMCPApp).filter(PublicMCPApp.id == app_id).first()
     if not db_app:
         raise HTTPException(status_code=404, detail="App not found")
-    if is_builtin_public_mcp_app(db_app.app_id, db_app.launch_config):
+    if is_builtin_public_mcp_app(
+        db_app.app_id
+    ) and _persisted_builtin_provenance_matches(db_app.app_id, db_app.launch_config):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Built-in MCP apps are managed by code",

--- a/src/xagent/web/api/admin_mcp.py
+++ b/src/xagent/web/api/admin_mcp.py
@@ -215,7 +215,7 @@ def _commit_public_mcp_app_write(
 
 def _public_mcp_app_response(app: PublicMCPApp) -> Dict[str, Any]:
     values = _public_mcp_app_values(app)
-    execution_fields = get_builtin_execution_fields(app.app_id)
+    execution_fields = get_builtin_execution_fields(app.app_id, app.launch_config)
     if execution_fields is not None:
         values.update(execution_fields)
     return {
@@ -248,6 +248,10 @@ def _validate_public_mcp_app_values(
 
 def _apply_public_mcp_app_update(db_app: PublicMCPApp, changes: Dict[str, Any]) -> None:
     canonical = get_builtin_public_mcp_app(db_app.app_id)
+    if canonical is not None and not is_builtin_public_mcp_app(
+        db_app.app_id, db_app.launch_config
+    ):
+        canonical = None
     persisted = _public_mcp_app_values(db_app)
     enforce_connect_shape = bool({"transport", "launch_config"} & changes.keys())
 
@@ -553,7 +557,7 @@ async def delete_app(
     db_app = db.query(PublicMCPApp).filter(PublicMCPApp.id == app_id).first()
     if not db_app:
         raise HTTPException(status_code=404, detail="App not found")
-    if is_builtin_public_mcp_app(db_app.app_id):
+    if is_builtin_public_mcp_app(db_app.app_id, db_app.launch_config):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Built-in MCP apps are managed by code",

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3370,6 +3370,64 @@ def _reject_hidden_catalog_app(app_info: dict) -> None:
         )
 
 
+def _catalog_server_provenance_auth(app_info: dict) -> dict[str, Any] | None:
+    launch = app_info.get("launch_config")
+    marker = launch.get("builtin_provenance") if isinstance(launch, dict) else None
+    if not isinstance(marker, dict):
+        return None
+    return {"builtin_provenance": marker}
+
+
+def _reject_provenance_catalog_collisions(
+    db: Session, app_info: dict, expected_auth: dict[str, Any]
+) -> MCPServer | None:
+    """Return the exact stamped server, rejecting every normalized collision."""
+    from xagent.builtin_identity import canonicalize_builtin_identity
+
+    identity_keys = {
+        canonicalize_builtin_identity(app_info.get("id")),
+        canonicalize_builtin_identity(app_info.get("name")),
+    } - {None}
+    catalog_collisions = [
+        app
+        for app in db.query(PublicMCPApp).all()
+        if {
+            canonicalize_builtin_identity(app.app_id),
+            canonicalize_builtin_identity(app.name),
+        }
+        & identity_keys
+    ]
+    if len(catalog_collisions) != 1 or (
+        str(catalog_collisions[0].app_id) != str(app_info["id"])
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="The built-in catalog identity conflicts with a custom app",
+        )
+
+    server_collisions = [
+        server
+        for server in db.query(MCPServer).all()
+        if canonicalize_builtin_identity(server.name) in identity_keys
+    ]
+    if not server_collisions:
+        return None
+    exact_server = next(
+        (
+            server
+            for server in server_collisions
+            if server.name == str(app_info["id"]) and server.auth == expected_auth
+        ),
+        None,
+    )
+    if len(server_collisions) != 1 or exact_server is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="The built-in catalog identity conflicts with a custom server",
+        )
+    return exact_server
+
+
 def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dict]:
     """Idempotently ensure the shared server row for a key-based or keyless
     catalog app exists, without creating any per-user association. Returns
@@ -3403,7 +3461,12 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
     # is what the connector uses to detect an app as connected.
     server_name = str(app_info["id"])
 
-    server = db.query(MCPServer).filter(MCPServer.name == server_name).first()
+    expected_provenance_auth = _catalog_server_provenance_auth(app_info)
+    server = (
+        _reject_provenance_catalog_collisions(db, app_info, expected_provenance_auth)
+        if expected_provenance_auth is not None
+        else db.query(MCPServer).filter(MCPServer.name == server_name).first()
+    )
     # Server names are a single global namespace. A row under this catalog id may
     # be a hijack — a custom server someone created with their own command — so
     # only reuse it if the command/transport match the official launch config.
@@ -3449,7 +3512,10 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
             # transport/args; otherwise fall through to the same 409 every
             # such row already got before this change, leaving it and
             # whatever it holds untouched for an operator to resolve.
-            if _server_has_policy_beyond_catalog_identity(server):
+            if (
+                expected_provenance_auth is None
+                and _server_has_policy_beyond_catalog_identity(server)
+            ):
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail="A server with this name already exists with a different configuration",
@@ -3481,7 +3547,15 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
                     name=server_name,
                     transport="stdio",
                     description=app_info.get("description"),
-                    config={"command": command, "args": launch.get("args") or []},
+                    config={
+                        "command": command,
+                        "args": launch.get("args") or [],
+                        **(
+                            {"auth": expected_provenance_auth}
+                            if expected_provenance_auth is not None
+                            else {}
+                        ),
+                    },
                 )
             )
         except ValueError as e:
@@ -3490,6 +3564,14 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
                 detail=f"Invalid app configuration: {str(e)}",
             )
         server = _add_catalog_server_with_race_recovery(db, config, server_name)
+        if (
+            expected_provenance_auth is not None
+            and server.auth != expected_provenance_auth
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="The built-in catalog identity conflicts with a custom server",
+            )
     return server, app_info
 
 

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -1534,7 +1534,6 @@ _BUILTIN_EXECUTION_FIELD_NAMES = (
     "oauth_scopes",
     "launch_config",
 )
-_UNSPECIFIED_LAUNCH_CONFIG = object()
 
 
 def _matches_builtin_provenance(
@@ -1546,7 +1545,7 @@ def _matches_builtin_provenance(
         if isinstance(canonical_launch, dict)
         else None
     )
-    if marker is None or persisted_launch_config is _UNSPECIFIED_LAUNCH_CONFIG:
+    if marker is None:
         return True
     return (
         isinstance(persisted_launch_config, dict)
@@ -1561,18 +1560,25 @@ def get_builtin_public_mcp_app(app_id: str) -> dict[str, Any] | None:
     return None
 
 
-def is_builtin_public_mcp_app(
-    app_id: str, persisted_launch_config: Any = _UNSPECIFIED_LAUNCH_CONFIG
+def _persisted_builtin_provenance_matches(
+    app_id: str, persisted_launch_config: Any
 ) -> bool:
+    """Whether a persisted row carries any provenance required by its builtin.
+
+    An absent registry row has no provenance constraint. This keeps callers
+    composable with an injected registry while Shopify's real row is checked.
+    """
     row = get_builtin_public_mcp_app(app_id)
-    return row is not None and _matches_builtin_provenance(row, persisted_launch_config)
+    return row is None or _matches_builtin_provenance(row, persisted_launch_config)
 
 
-def get_builtin_execution_fields(
-    app_id: str, persisted_launch_config: Any = _UNSPECIFIED_LAUNCH_CONFIG
-) -> dict[str, Any] | None:
+def is_builtin_public_mcp_app(app_id: str) -> bool:
+    return get_builtin_public_mcp_app(app_id) is not None
+
+
+def get_builtin_execution_fields(app_id: str) -> dict[str, Any] | None:
     row = get_builtin_public_mcp_app(app_id)
-    if row is None or not _matches_builtin_provenance(row, persisted_launch_config):
+    if row is None:
         return None
     return deepcopy(
         {field_name: row[field_name] for field_name in _BUILTIN_EXECUTION_FIELD_NAMES}
@@ -1581,7 +1587,6 @@ def get_builtin_execution_fields(
 
 def get_builtin_execution_fields_and_optional_scopes(
     app_id: str,
-    persisted_launch_config: Any = _UNSPECIFIED_LAUNCH_CONFIG,
 ) -> tuple[dict[str, Any] | None, list[str]]:
     """The app's execution fields, plus OAuth scopes requested via the
     authorize request's optional_scope parameter rather than its required
@@ -1600,7 +1605,7 @@ def get_builtin_execution_fields_and_optional_scopes(
     scopes at all, hence the plain ``.get`` default.
     """
     row = get_builtin_public_mcp_app(app_id)
-    if row is None or not _matches_builtin_provenance(row, persisted_launch_config):
+    if row is None:
         return None, []
     execution_fields = {
         field_name: row[field_name] for field_name in _BUILTIN_EXECUTION_FIELD_NAMES

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -9,6 +9,11 @@ from typing import Any
 import sqlalchemy as sa
 from sqlalchemy.engine import Connection
 
+from ..builtin_identity import (
+    builtin_provenance_identity,
+    canonicalize_builtin_identity,
+)
+
 OAUTH_PROVIDERS_TABLE = sa.table(
     "oauth_providers",
     sa.column("provider_name", sa.String),
@@ -36,6 +41,12 @@ PUBLIC_MCP_APPS_TABLE = sa.table(
     sa.column("oauth_scopes", sa.JSON),
     sa.column("is_visible_in_connector", sa.Boolean),
     sa.column("launch_config", sa.JSON),
+)
+
+MCP_SERVERS_IDENTITY_TABLE = sa.table(
+    "mcp_servers",
+    sa.column("name", sa.String),
+    sa.column("auth", sa.JSON),
 )
 
 
@@ -1547,9 +1558,13 @@ def _matches_builtin_provenance(
     )
     if marker is None:
         return True
-    return (
-        isinstance(persisted_launch_config, dict)
-        and persisted_launch_config.get("builtin_provenance") == marker
+    persisted_marker = (
+        persisted_launch_config.get("builtin_provenance")
+        if isinstance(persisted_launch_config, dict)
+        else None
+    )
+    return builtin_provenance_identity(persisted_marker) == builtin_provenance_identity(
+        marker
     )
 
 
@@ -1653,6 +1668,27 @@ def validate_builtin_public_mcp_apps(bind: Connection) -> list[dict[str, Any]]:
         if not _matches_builtin_provenance(
             canonical_row, persisted_row["launch_config"]
         ):
+            canonical_marker = canonical_row.get("launch_config", {}).get(
+                "builtin_provenance"
+            )
+            persisted_launch = persisted_row["launch_config"]
+            persisted_marker = (
+                persisted_launch.get("builtin_provenance")
+                if isinstance(persisted_launch, dict)
+                else None
+            )
+            mismatches.append(
+                {
+                    "app_id": app_id,
+                    "mismatched_fields": ["builtin_provenance"],
+                    "canonical_hash": _safe_configuration_hash(
+                        {"builtin_provenance": canonical_marker}
+                    ),
+                    "persisted_hash": _safe_configuration_hash(
+                        {"builtin_provenance": persisted_marker}
+                    ),
+                }
+            )
             continue
 
         mismatched_fields = [
@@ -1683,6 +1719,50 @@ def validate_builtin_public_mcp_apps(bind: Connection) -> list[dict[str, Any]]:
 
 def _filter_row(row: dict[str, Any], allowed_columns: set[str]) -> dict[str, Any]:
     return {key: value for key, value in row.items() if key in allowed_columns}
+
+
+def _validate_shopify_seed_server_identity(
+    bind: Connection, existing_tables: set[str]
+) -> None:
+    """Reject a fresh-seed server collision unless it is provably official."""
+    if "mcp_servers" not in existing_tables:
+        return
+    inspector = sa.inspect(bind)
+    server_columns = {column["name"] for column in inspector.get_columns("mcp_servers")}
+    if "auth" not in server_columns:
+        raise RuntimeError(
+            "Cannot verify builtin Shopify server provenance: mcp_servers.auth "
+            "is required"
+        )
+    shopify_keys = {
+        canonicalize_builtin_identity("shopify"),
+        canonicalize_builtin_identity("Shopify"),
+    }
+    collisions = [
+        row
+        for row in bind.execute(
+            sa.select(
+                MCP_SERVERS_IDENTITY_TABLE.c.name,
+                MCP_SERVERS_IDENTITY_TABLE.c.auth,
+            )
+        ).mappings()
+        if canonicalize_builtin_identity(row["name"]) in shopify_keys
+    ]
+    official_identity = builtin_provenance_identity(
+        {"registry": "xagent", "app_id": "shopify"}
+    )
+    trusted = (
+        len(collisions) == 1
+        and collisions[0]["name"] == "shopify"
+        and isinstance(collisions[0]["auth"], dict)
+        and builtin_provenance_identity(collisions[0]["auth"].get("builtin_provenance"))
+        == official_identity
+    )
+    if collisions and not trusted:
+        raise RuntimeError(
+            "Cannot seed builtin Shopify connector: custom mcp_servers identity "
+            "collides with 'shopify'"
+        )
 
 
 def seed_builtin_oauth_and_public_mcp_apps(bind: Connection) -> None:
@@ -1725,9 +1805,14 @@ def seed_builtin_oauth_and_public_mcp_apps(bind: Connection) -> None:
         existing_app_ids = set(
             bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars()
         )
+        builtin_app_rows = get_builtin_public_mcp_app_rows()
+        if "shopify" not in existing_app_ids and any(
+            row["app_id"] == "shopify" for row in builtin_app_rows
+        ):
+            _validate_shopify_seed_server_identity(bind, existing_tables)
         app_rows_to_insert = [
             _filter_row(row, app_columns)
-            for row in get_builtin_public_mcp_app_rows()
+            for row in builtin_app_rows
             if row["app_id"] not in existing_app_ids
         ]
         if app_rows_to_insert:

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -1434,6 +1434,44 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             },
         },
         {
+            "app_id": "shopify",
+            "name": "Shopify",
+            "description": "Connect a Shopify custom app with a store label (for example, acme for acme.myshopify.com) and Admin API access token. Grant write_products, write_orders, and read_customers; read_all_orders is optional for orders older than 60 days.",
+            "icon": "https://www.google.com/s2/favicons?domain=shopify.com&sz=128",
+            "transport": "stdio",
+            "provider_name": None,
+            "category": "Commerce",
+            "oauth_scopes": None,
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.shopify"],
+                "required_env": [
+                    "SHOPIFY_STORE_DOMAIN",
+                    "SHOPIFY_ACCESS_TOKEN",
+                ],
+                "required_admin_scopes": [
+                    "write_products",
+                    "write_orders",
+                    "read_customers",
+                ],
+                "optional_admin_scopes": ["read_all_orders"],
+                # Compatibility metadata only. Current main ignores this
+                # field; a later actor-scoped stdio runtime can recognize
+                # that credentials are personal without this PR enabling
+                # delegated/Toby access or bypassing current isolation.
+                "credential_scope": "personal",
+                # Stable ownership marker used by the seed migration. It is
+                # intentionally inside launch_config because current main
+                # has no dedicated catalog-provenance column.
+                "builtin_provenance": {
+                    "registry": "xagent",
+                    "app_id": "shopify",
+                    "version": 1,
+                },
+            },
+        },
+        {
             "app_id": "magento",
             "name": "Magento",
             "description": 'Connect to a self-hosted Magento/Adobe Commerce store with an Integration access token to search and manage products, look up orders and add order comments, and browse customers and categories. On Magento 2.4.4+, enable Stores > Configuration > Services > OAuth > Consumer Settings > "Allow OAuth Access Tokens to be used as standalone Bearer tokens" first.',
@@ -1496,6 +1534,24 @@ _BUILTIN_EXECUTION_FIELD_NAMES = (
     "oauth_scopes",
     "launch_config",
 )
+_UNSPECIFIED_LAUNCH_CONFIG = object()
+
+
+def _matches_builtin_provenance(
+    canonical_row: dict[str, Any], persisted_launch_config: Any
+) -> bool:
+    canonical_launch = canonical_row.get("launch_config")
+    marker = (
+        canonical_launch.get("builtin_provenance")
+        if isinstance(canonical_launch, dict)
+        else None
+    )
+    if marker is None or persisted_launch_config is _UNSPECIFIED_LAUNCH_CONFIG:
+        return True
+    return (
+        isinstance(persisted_launch_config, dict)
+        and persisted_launch_config.get("builtin_provenance") == marker
+    )
 
 
 def get_builtin_public_mcp_app(app_id: str) -> dict[str, Any] | None:
@@ -1505,13 +1561,18 @@ def get_builtin_public_mcp_app(app_id: str) -> dict[str, Any] | None:
     return None
 
 
-def is_builtin_public_mcp_app(app_id: str) -> bool:
-    return any(row["app_id"] == app_id for row in get_builtin_public_mcp_app_rows())
-
-
-def get_builtin_execution_fields(app_id: str) -> dict[str, Any] | None:
+def is_builtin_public_mcp_app(
+    app_id: str, persisted_launch_config: Any = _UNSPECIFIED_LAUNCH_CONFIG
+) -> bool:
     row = get_builtin_public_mcp_app(app_id)
-    if row is None:
+    return row is not None and _matches_builtin_provenance(row, persisted_launch_config)
+
+
+def get_builtin_execution_fields(
+    app_id: str, persisted_launch_config: Any = _UNSPECIFIED_LAUNCH_CONFIG
+) -> dict[str, Any] | None:
+    row = get_builtin_public_mcp_app(app_id)
+    if row is None or not _matches_builtin_provenance(row, persisted_launch_config):
         return None
     return deepcopy(
         {field_name: row[field_name] for field_name in _BUILTIN_EXECUTION_FIELD_NAMES}
@@ -1520,6 +1581,7 @@ def get_builtin_execution_fields(app_id: str) -> dict[str, Any] | None:
 
 def get_builtin_execution_fields_and_optional_scopes(
     app_id: str,
+    persisted_launch_config: Any = _UNSPECIFIED_LAUNCH_CONFIG,
 ) -> tuple[dict[str, Any] | None, list[str]]:
     """The app's execution fields, plus OAuth scopes requested via the
     authorize request's optional_scope parameter rather than its required
@@ -1538,7 +1600,7 @@ def get_builtin_execution_fields_and_optional_scopes(
     scopes at all, hence the plain ``.get`` default.
     """
     row = get_builtin_public_mcp_app(app_id)
-    if row is None:
+    if row is None or not _matches_builtin_provenance(row, persisted_launch_config):
         return None, []
     execution_fields = {
         field_name: row[field_name] for field_name in _BUILTIN_EXECUTION_FIELD_NAMES
@@ -1582,6 +1644,10 @@ def validate_builtin_public_mcp_apps(bind: Connection) -> list[dict[str, Any]]:
     for app_id, canonical_row in canonical_by_app_id.items():
         persisted_row = persisted_by_app_id.get(app_id)
         if persisted_row is None:
+            continue
+        if not _matches_builtin_provenance(
+            canonical_row, persisted_row["launch_config"]
+        ):
             continue
 
         mismatched_fields = [

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -158,7 +158,7 @@ def _app_to_dict(app: PublicMCPApp) -> Dict[str, Any]:
     # One registry scan (not two - see the helper's own docstring) since
     # this runs per app on the connector-listing path.
     execution_fields, optional_oauth_scopes = (
-        get_builtin_execution_fields_and_optional_scopes(app.app_id)
+        get_builtin_execution_fields_and_optional_scopes(app.app_id, app.launch_config)
     )
     if execution_fields is None:
         execution_fields = {
@@ -301,7 +301,7 @@ def _strict_catalog_app_by_id(
         )
 
     execution_fields, _optional_scopes = (
-        get_builtin_execution_fields_and_optional_scopes(app.app_id)
+        get_builtin_execution_fields_and_optional_scopes(app.app_id, app.launch_config)
     )
     if require_builtin_oauth and execution_fields is None:
         raise BuiltinOAuthServerDefinitionError(

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -13,7 +13,10 @@ from typing import Any, Dict, List
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from .builtin_mcp_registry import get_builtin_execution_fields_and_optional_scopes
+from .builtin_mcp_registry import (
+    _persisted_builtin_provenance_matches,
+    get_builtin_execution_fields_and_optional_scopes,
+)
 from .models.public_mcp import PublicMCPApp
 
 # Apps that must not be satisfied by a bare provider-level OAuth grant (one
@@ -158,8 +161,13 @@ def _app_to_dict(app: PublicMCPApp) -> Dict[str, Any]:
     # One registry scan (not two - see the helper's own docstring) since
     # this runs per app on the connector-listing path.
     execution_fields, optional_oauth_scopes = (
-        get_builtin_execution_fields_and_optional_scopes(app.app_id, app.launch_config)
+        get_builtin_execution_fields_and_optional_scopes(app.app_id)
     )
+    if execution_fields is not None and not _persisted_builtin_provenance_matches(
+        app.app_id, app.launch_config
+    ):
+        execution_fields = None
+        optional_oauth_scopes = []
     if execution_fields is None:
         execution_fields = {
             "name": app.name,
@@ -254,10 +262,9 @@ class RemoteOAuthDefinitionOwnership(Enum):
 
 def _normalized_catalog_key(value: object) -> str | None:
     """Normalize only for collision detection, never for persisted identity."""
-    if value is None:
-        return None
-    normalized = "-".join(str(value).strip().lower().split())
-    return normalized or None
+    from ..builtin_identity import canonicalize_builtin_identity
+
+    return canonicalize_builtin_identity(value)
 
 
 def _strict_catalog_app_by_id(
@@ -301,8 +308,12 @@ def _strict_catalog_app_by_id(
         )
 
     execution_fields, _optional_scopes = (
-        get_builtin_execution_fields_and_optional_scopes(app.app_id, app.launch_config)
+        get_builtin_execution_fields_and_optional_scopes(app.app_id)
     )
+    if execution_fields is not None and not _persisted_builtin_provenance_matches(
+        app.app_id, app.launch_config
+    ):
+        execution_fields = None
     if require_builtin_oauth and execution_fields is None:
         raise BuiltinOAuthServerDefinitionError(
             f"OAuth catalog app {app_id!r} is absent from the builtin registry"

--- a/src/xagent/web/tools/mcp/shopify.py
+++ b/src/xagent/web/tools/mcp/shopify.py
@@ -313,7 +313,7 @@ def _throttle_wait_seconds(status_code: int, payload: Any) -> float | None:
         extensions = payload.get("extensions")
         cost = extensions.get("cost") if isinstance(extensions, dict) else None
         throttle_status = cost.get("throttleStatus") if isinstance(cost, dict) else None
-        if not isinstance(throttle_status, dict):
+        if not isinstance(cost, dict) or not isinstance(throttle_status, dict):
             return 1.0
         requested = cost.get("requestedQueryCost")
         available = throttle_status.get("currentlyAvailable")

--- a/src/xagent/web/tools/mcp/shopify.py
+++ b/src/xagent/web/tools/mcp/shopify.py
@@ -41,7 +41,17 @@ SHOPIFY_REQUIRED_ADMIN_SCOPES = frozenset(
     {"write_products", "write_orders", "read_customers"}
 )
 SHOPIFY_OPTIONAL_ADMIN_SCOPES = frozenset({"read_all_orders"})
+# The host currently starts a fresh stdio process for every tool invocation, so
+# this cache only deduplicates checks within one invocation. Keeping it keyed by
+# credential still makes it safe if stdio sessions are pooled in the future.
 _scope_cache: tuple[str, frozenset[str]] | None = None
+
+_READ_CAPABILITY_SCOPE_GROUPS = {
+    "products": frozenset({"read_products", "write_products"}),
+    "orders": frozenset({"read_orders", "write_orders"}),
+    "customers": frozenset({"read_customers", "write_customers"}),
+}
+_WRITE_CAPABILITY_SCOPES = frozenset({"write_products", "write_orders"})
 
 # Only a DNS *label* (no dots, scheme, port, or slashes) is ever accepted, so
 # the string itself can never name a host outside "*.myshopify.com" -- but a
@@ -112,6 +122,13 @@ def _indeterminate(message: str) -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _mutation_indeterminate(message: str) -> str:
+    """Log and return an unsafe-to-retry mutation outcome."""
+    safe_message = _safe_text(message)
+    logger.error("Shopify mutation outcome indeterminate: %s", safe_message)
+    return _indeterminate(safe_message)
 
 
 def _headers() -> dict[str, str]:
@@ -273,7 +290,9 @@ def _throttle_wait_seconds(status_code: int, payload: Any) -> float | None:
     """
     throttled = status_code == 429
     if not throttled and isinstance(payload, dict):
-        for entry in payload.get("errors") or []:
+        raw_errors = payload.get("errors")
+        errors = raw_errors if isinstance(raw_errors, list) else []
+        for entry in errors:
             if not isinstance(entry, dict):
                 continue
             if str(entry.get("message", "")).strip().lower() == "throttled":
@@ -291,8 +310,11 @@ def _throttle_wait_seconds(status_code: int, payload: Any) -> float | None:
     # precise wait (how long until enough "bucket" capacity restores to
     # cover the query that was just rejected) instead of guessing.
     if isinstance(payload, dict):
-        cost = (payload.get("extensions") or {}).get("cost") or {}
-        throttle_status = cost.get("throttleStatus") or {}
+        extensions = payload.get("extensions")
+        cost = extensions.get("cost") if isinstance(extensions, dict) else None
+        throttle_status = cost.get("throttleStatus") if isinstance(cost, dict) else None
+        if not isinstance(throttle_status, dict):
+            return 1.0
         requested = cost.get("requestedQueryCost")
         available = throttle_status.get("currentlyAvailable")
         restore_rate = throttle_status.get("restoreRate")
@@ -373,20 +395,32 @@ def _require_admin_scopes(*accepted_scopes: str) -> None:
 def shopify_validate_connection() -> str:
     """Validate the token and its Admin API scopes before using tools.
 
-    Required: write_products, write_orders, read_customers. Optional:
-    read_all_orders, which expands order history beyond the default 60 days.
+    A token is valid when it can read products, orders, and customers. The
+    response separately reports whether every write tool is available.
+    read_all_orders is optional and expands order history beyond 60 days.
     """
     try:
         granted = _granted_admin_scopes()
-        missing = sorted(SHOPIFY_REQUIRED_ADMIN_SCOPES - granted)
-        if missing:
+        missing_read_capabilities = sorted(
+            resource
+            for resource, alternatives in _READ_CAPABILITY_SCOPE_GROUPS.items()
+            if not alternatives.intersection(granted)
+        )
+        if missing_read_capabilities:
             return _error(
-                "Shopify token is missing required Admin API scopes: "
-                + ", ".join(missing)
+                "Shopify token cannot read required resources: "
+                + ", ".join(missing_read_capabilities)
             )
+        missing_write_scopes = sorted(_WRITE_CAPABILITY_SCOPES - granted)
         return _success(
             connection_valid=True,
-            required_scopes=sorted(SHOPIFY_REQUIRED_ADMIN_SCOPES),
+            read_capable=True,
+            write_capable=not missing_write_scopes,
+            missing_write_scopes=missing_write_scopes,
+            read_scope_alternatives={
+                resource: sorted(alternatives)
+                for resource, alternatives in _READ_CAPABILITY_SCOPE_GROUPS.items()
+            },
             optional_scopes=sorted(SHOPIFY_OPTIONAL_ADMIN_SCOPES),
             granted_optional_scopes=sorted(SHOPIFY_OPTIONAL_ADMIN_SCOPES & granted),
         )
@@ -526,18 +560,52 @@ def _extract_connection(
     summary_fn: Callable[[dict[str, Any]], dict[str, Any]],
 ) -> tuple[list[tuple[dict[str, Any], str | None]], bool, str | None]:
     """Return summarized nodes paired with their own Relay edge cursors."""
-    connection = data.get(field_name) or {}
+    connection = data.get(field_name)
+    if not isinstance(connection, dict):
+        raise RuntimeError(
+            f"Shopify API response has an invalid {field_name} connection"
+        )
     edges = connection.get("edges")
-    page_info = connection.get("pageInfo") or {}
+    page_info = connection.get("pageInfo")
+    if not isinstance(page_info, dict):
+        raise RuntimeError(
+            f"Shopify API response has an invalid {field_name}.pageInfo object"
+        )
     end_cursor = page_info.get("endCursor")
-    has_more = bool(page_info.get("hasNextPage")) and bool(end_cursor)
+    has_next_page = page_info.get("hasNextPage")
+    if not isinstance(has_next_page, bool):
+        raise RuntimeError(
+            f"Shopify API response has an invalid {field_name}.pageInfo.hasNextPage"
+        )
+    has_more = has_next_page
+    if has_more and not end_cursor:
+        raise RuntimeError(
+            "Shopify returned hasNextPage=true without a continuation cursor; "
+            "pagination stopped to prevent an infinite loop"
+        )
+    if end_cursor is not None and not isinstance(end_cursor, str):
+        raise RuntimeError(
+            f"Shopify API response has an invalid {field_name}.pageInfo.endCursor"
+        )
 
-    # Defensive fallback for a non-conforming response. Without edge cursors,
-    # local truncation is rejected later rather than guessing a cursor.
+    # Some mocked/legacy responses use nodes instead of the requested edges.
+    # Support that shape only when nodes is itself a valid list; without edge
+    # cursors, local output truncation will fail closed rather than guess one.
+    if edges is None:
+        nodes = connection.get("nodes")
+        if not isinstance(nodes, list):
+            raise RuntimeError(
+                f"Shopify API response has an invalid {field_name}.nodes list"
+            )
+        if not all(isinstance(node, dict) for node in nodes):
+            raise RuntimeError(
+                f"Shopify API response has an invalid node in {field_name}.nodes"
+            )
+        return [(summary_fn(node), None) for node in nodes], has_more, end_cursor
     if not isinstance(edges, list):
-        nodes = connection.get("nodes") or []
-        summarized = [summary_fn(node) for node in nodes if isinstance(node, dict)]
-        return [(item, None) for item in summarized], has_more, end_cursor
+        raise RuntimeError(
+            f"Shopify API response has an invalid {field_name}.edges list"
+        )
 
     items: list[tuple[dict[str, Any], str | None]] = []
     for edge in edges:
@@ -667,44 +735,50 @@ def _run_mutation(
     try:
         data, errors = _graphql(mutation, variables, mutation=True)
     except MutationOutcomeIndeterminate as exc:
-        return _indeterminate(str(exc))
-    result = data.get(mutation_field)
-    if not isinstance(result, dict):
-        detail = f": {_errors_detail(errors)}" if errors else ""
-        return _indeterminate(
-            f"Shopify returned no valid {mutation_field} projection after the "
-            f"mutation request{detail}"
+        return _mutation_indeterminate(str(exc))
+    try:
+        result = data.get(mutation_field)
+        if not isinstance(result, dict):
+            detail = f": {_errors_detail(errors)}" if errors else ""
+            return _mutation_indeterminate(
+                f"Shopify returned no valid {mutation_field} projection after the "
+                f"mutation request{detail}"
+            )
+        user_errors = result.get("userErrors")
+        if not isinstance(user_errors, list) or not all(
+            isinstance(entry, dict) for entry in user_errors
+        ):
+            return _mutation_indeterminate(
+                f"Shopify returned an invalid userErrors projection for {mutation_field}"
+            )
+        if user_errors:
+            # userErrors alone can omit useful context a top-level GraphQL
+            # `errors` entry carries (e.g. a query-level access-scope warning
+            # attached to the same response) -- fold both in, mirroring
+            # linear.py's `_mutation_failure_message`, which does the same for
+            # Linear's boolean `success` discriminator.
+            message = _user_errors_message(user_errors)
+            if errors:
+                message = f"{message} ({_errors_detail(errors)})"
+            return _error(message)
+        object_value = result.get(object_key)
+        if not isinstance(object_value, dict):
+            # userErrors is empty, but the object itself is also null -- e.g. an
+            # access-scope error on one selected field null-propagated up to the
+            # whole object, with the real cause only in the top-level `errors`
+            # this response still carries. Reporting this as success with an
+            # all-null object would hide that entirely.
+            detail = f": {_errors_detail(errors)}" if errors else ""
+            return _mutation_indeterminate(
+                f"Shopify returned no valid {object_key} projection after "
+                f"{mutation_field}{detail}"
+            )
+        return _success_capped(object_key, summary_fn(object_value), errors)
+    except Exception as exc:
+        return _mutation_indeterminate(
+            f"Shopify could not validate the {mutation_field} response after "
+            f"dispatch ({type(exc).__name__}): {_safe_text(exc)}"
         )
-    user_errors = result.get("userErrors")
-    if not isinstance(user_errors, list) or not all(
-        isinstance(entry, dict) for entry in user_errors
-    ):
-        return _indeterminate(
-            f"Shopify returned an invalid userErrors projection for {mutation_field}"
-        )
-    if user_errors:
-        # userErrors alone can omit useful context a top-level GraphQL
-        # `errors` entry carries (e.g. a query-level access-scope warning
-        # attached to the same response) -- fold both in, mirroring
-        # linear.py's `_mutation_failure_message`, which does the same for
-        # Linear's boolean `success` discriminator.
-        message = _user_errors_message(user_errors)
-        if errors:
-            message = f"{message} ({_errors_detail(errors)})"
-        return _error(message)
-    object_value = result.get(object_key)
-    if not isinstance(object_value, dict):
-        # userErrors is empty, but the object itself is also null -- e.g. an
-        # access-scope error on one selected field null-propagated up to the
-        # whole object, with the real cause only in the top-level `errors`
-        # this response still carries. Reporting this as success with an
-        # all-null object would hide that entirely.
-        detail = f": {_errors_detail(errors)}" if errors else ""
-        return _indeterminate(
-            f"Shopify returned no valid {object_key} projection after "
-            f"{mutation_field}{detail}"
-        )
-    return _success_capped(object_key, summary_fn(object_value), errors)
 
 
 def _success_capped(field_name: str, value: dict[str, Any], errors: list[Any]) -> str:
@@ -797,7 +871,14 @@ _ORDER_FIELDS = (
 
 
 def _order_summary(order: dict[str, Any]) -> dict[str, Any]:
-    total_price = (order.get("totalPriceSet") or {}).get("shopMoney") or {}
+    total_price_set = order.get("totalPriceSet")
+    if not isinstance(total_price_set, dict):
+        raise RuntimeError("Shopify API response has an invalid order.totalPriceSet")
+    total_price = total_price_set.get("shopMoney")
+    if not isinstance(total_price, dict):
+        raise RuntimeError(
+            "Shopify API response has an invalid order.totalPriceSet.shopMoney"
+        )
     return {
         "id": order.get("id"),
         "name": order.get("name"),
@@ -819,12 +900,22 @@ _CUSTOMER_FIELDS = (
 
 
 def _customer_summary(customer: dict[str, Any]) -> dict[str, Any]:
+    email_address = customer.get("defaultEmailAddress")
+    if email_address is not None and not isinstance(email_address, dict):
+        raise RuntimeError(
+            "Shopify API response has an invalid customer.defaultEmailAddress"
+        )
+    phone_number = customer.get("defaultPhoneNumber")
+    if phone_number is not None and not isinstance(phone_number, dict):
+        raise RuntimeError(
+            "Shopify API response has an invalid customer.defaultPhoneNumber"
+        )
     return {
         "id": customer.get("id"),
         "first_name": customer.get("firstName"),
         "last_name": customer.get("lastName"),
-        "email": (customer.get("defaultEmailAddress") or {}).get("emailAddress"),
-        "phone": (customer.get("defaultPhoneNumber") or {}).get("phoneNumber"),
+        "email": email_address.get("emailAddress") if email_address else None,
+        "phone": phone_number.get("phoneNumber") if phone_number else None,
         "number_of_orders": customer.get("numberOfOrders"),
         "tags": customer.get("tags"),
         "created_at": customer.get("createdAt"),
@@ -835,11 +926,16 @@ _COLLECTION_FIELDS = "id title handle productsCount { count }"
 
 
 def _collection_summary(collection: dict[str, Any]) -> dict[str, Any]:
+    products_count = collection.get("productsCount")
+    if not isinstance(products_count, dict):
+        raise RuntimeError(
+            "Shopify API response has an invalid collection.productsCount"
+        )
     return {
         "id": collection.get("id"),
         "title": collection.get("title"),
         "handle": collection.get("handle"),
-        "products_count": (collection.get("productsCount") or {}).get("count"),
+        "products_count": products_count.get("count"),
     }
 
 
@@ -855,7 +951,7 @@ def shopify_get_shop() -> str:
             "query { shop { name myshopifyDomain email currencyCode ianaTimezone } }"
         )
         shop = data.get("shop")
-        if not shop:
+        if not isinstance(shop, dict) or not shop:
             return _error("Shopify did not return shop info")
         return _success_capped("shop", _shop_summary(shop), errors)
     except Exception as exc:
@@ -895,7 +991,7 @@ def shopify_get_product(product_id: str) -> str:
             {"id": _gid("Product", product_id)},
         )
         product = data.get("product")
-        if not product:
+        if not isinstance(product, dict) or not product:
             return _error(f"Product '{product_id}' not found")
         return _success_capped("product", _product_summary(product), errors)
     except Exception as exc:
@@ -1039,7 +1135,7 @@ def shopify_get_order(order_id: str) -> str:
             {"id": _gid("Order", order_id)},
         )
         order = data.get("order")
-        if not order:
+        if not isinstance(order, dict) or not order:
             return _error(f"Order '{order_id}' not found")
         return _success_capped("order", _order_summary(order), errors)
     except Exception as exc:
@@ -1114,7 +1210,7 @@ def shopify_get_customer(customer_id: str) -> str:
             {"id": _gid("Customer", customer_id)},
         )
         customer = data.get("customer")
-        if not customer:
+        if not isinstance(customer, dict) or not customer:
             return _error(f"Customer '{customer_id}' not found")
         return _success_capped("customer", _customer_summary(customer), errors)
     except Exception as exc:

--- a/src/xagent/web/tools/mcp/shopify.py
+++ b/src/xagent/web/tools/mcp/shopify.py
@@ -1,0 +1,1101 @@
+import hashlib
+import json
+import logging
+import re
+import socket
+import time
+from collections.abc import Callable
+from os import environ
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from ....config import get_tool_max_output_length
+from ....core.utils.security import (
+    PrivateNetworkHostError,
+    redact_sensitive_text,
+    reject_private_network_host,
+)
+from ...utils.graphql_errors import graphql_errors_message, truncate_error_text
+from .utils import clamp_limit, setup_proxy_env, success_with_capped_dict
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("shopify-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("shopify-mcp")
+
+DEFAULT_TIMEOUT_SECONDS = 30
+MAX_LIMIT = 100
+# Shopify releases a new Admin API version quarterly (YYYY-01/04/07/10) and
+# supports each one for about a year; pinned so a version bump on Shopify's
+# side can't silently change response shapes underneath these tools.
+# Re-check this against shopify.dev/docs/api/admin-graphql whenever this
+# version is scheduled for retirement, and bump deliberately.
+SHOPIFY_API_VERSION = "2026-07"
+MAX_RETRY_AFTER_SECONDS = 30
+SHOPIFY_REQUIRED_ADMIN_SCOPES = frozenset(
+    {"write_products", "write_orders", "read_customers"}
+)
+SHOPIFY_OPTIONAL_ADMIN_SCOPES = frozenset({"read_all_orders"})
+_scope_cache: tuple[str, frozenset[str]] | None = None
+
+# Only a DNS *label* (no dots, scheme, port, or slashes) is ever accepted, so
+# the string itself can never name a host outside "*.myshopify.com" -- but a
+# legitimate hostname can still be rebound by DNS to a private/internal
+# address at request time (orthogonal to who chose the hostname string), so
+# _graphql_url() below still resolves and checks every address, same
+# defense-in-depth posthog.py's _base_url() applies to its own two
+# hardcoded-enum hostnames.
+_SUBDOMAIN_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+
+# [0-9], not \d -- \d matches any Unicode decimal digit in a str pattern
+# (e.g. Arabic-Indic), which would let a lookalike id through this format
+# check even though Shopify's own numeric ids are always ASCII.
+_GID_PATTERN = re.compile(r"^gid://shopify/[A-Za-z]+/[0-9]+$")
+
+_PRODUCT_STATUSES = frozenset({"ACTIVE", "ARCHIVED", "DRAFT", "UNLISTED"})
+
+
+def _success(*, _errors: list[Any] | None = None, **payload: Any) -> str:
+    body: dict[str, Any] = {"status": "success", **payload}
+    if _errors:
+        # A genuine partial GraphQL success (one sub-field failed, others
+        # resolved) -- surface it in the result instead of only the server
+        # log, matching linear.py's identical warnings contract. Routed
+        # through _errors_detail (not graphql_errors_message directly) for
+        # the same reason every other consumer of a GraphQL response's
+        # top-level "errors" value in this module is: Shopify doesn't
+        # always send a list there.
+        body["warnings"] = [_errors_detail(_errors)]
+    return json.dumps(body, ensure_ascii=False)
+
+
+def _safe_text(value: Any) -> str:
+    text = redact_sensitive_text(truncate_error_text(str(value)))
+    token = environ.get("SHOPIFY_ACCESS_TOKEN", "")
+    return text.replace(token, "[REDACTED]") if token else text
+
+
+def _log_failure(operation: str, exc: BaseException) -> None:
+    # Do not use exc_info here: an arbitrary requests exception may embed the
+    # credential-bearing request/headers in its own representation.
+    logger.error(
+        "Shopify %s failed (%s): %s",
+        operation,
+        type(exc).__name__,
+        _safe_text(exc),
+    )
+
+
+def _error(message: str) -> str:
+    return json.dumps(
+        {"status": "error", "message": _safe_text(message)}, ensure_ascii=False
+    )
+
+
+def _indeterminate(message: str) -> str:
+    """Return an explicit unsafe-to-retry mutation outcome."""
+    return json.dumps(
+        {
+            "status": "indeterminate",
+            "retryable": False,
+            "mutation_may_have_completed": True,
+            "message": _safe_text(message),
+        },
+        ensure_ascii=False,
+    )
+
+
+def _headers() -> dict[str, str]:
+    access_token = environ.get("SHOPIFY_ACCESS_TOKEN")
+    if not access_token:
+        raise ValueError("SHOPIFY_ACCESS_TOKEN environment variable is missing")
+    if (
+        access_token != access_token.strip()
+        or not 16 <= len(access_token) <= 512
+        or any(ord(char) < 33 or ord(char) > 126 for char in access_token)
+    ):
+        raise ValueError(
+            "SHOPIFY_ACCESS_TOKEN must be 16-512 printable ASCII characters "
+            "without surrounding whitespace"
+        )
+    return {
+        "X-Shopify-Access-Token": access_token,
+        "Content-Type": "application/json",
+    }
+
+
+def _graphql_url() -> str:
+    subdomain = environ.get("SHOPIFY_STORE_DOMAIN", "").strip().lower()
+    if not subdomain:
+        raise ValueError("SHOPIFY_STORE_DOMAIN environment variable is missing")
+    if not _SUBDOMAIN_PATTERN.match(subdomain):
+        raise ValueError(
+            "SHOPIFY_STORE_DOMAIN must be a single DNS label (letters, digits, "
+            "and hyphens only, no leading/trailing hyphen) -- pass just the "
+            "store name, e.g. 'acme' for acme.myshopify.com, not a full URL"
+        )
+    hostname = f"{subdomain}.myshopify.com"
+    try:
+        resolved = socket.getaddrinfo(
+            hostname, 443, socket.AF_UNSPEC, socket.SOCK_STREAM
+        )
+        for *_, sockaddr in resolved:
+            reject_private_network_host(str(sockaddr[0]))
+    except PrivateNetworkHostError as exc:
+        raise ValueError(f"SHOPIFY_STORE_DOMAIN is not allowed: {exc}") from exc
+    except OSError as exc:
+        raise ValueError(f"Shopify host could not be resolved: {exc}") from exc
+    return f"https://{hostname}/admin/api/{SHOPIFY_API_VERSION}/graphql.json"
+
+
+def _scopes_url() -> str:
+    return _graphql_url().split("/admin/api/", 1)[0] + "/admin/oauth/access_scopes.json"
+
+
+def _require_non_blank(value: str, field_name: str) -> str:
+    if not value or not value.strip():
+        raise ValueError(f"{field_name} must not be blank")
+    return value
+
+
+def _gid(resource: str, value: str) -> str:
+    """Normalize a caller-supplied id to Shopify's global id (gid) form.
+
+    Every Shopify Admin GraphQL id argument is typed `ID!` and expects the
+    full "gid://shopify/<Resource>/<numeric id>" string, but a caller (or an
+    LLM copying an id from a list result) is just as likely to pass the
+    bare numeric id -- accept either rather than making every tool's
+    docstring explain the gid format. A full gid is only accepted for the
+    matching resource type -- e.g. passing an Order's gid to a tool that
+    expects a product_id is rejected here instead of being sent to Shopify
+    as-is, which would otherwise either 404 or (worse, since ids aren't
+    scoped per-type in this check) resolve to the wrong object type.
+    """
+    text = str(value).strip()
+    if text.startswith("gid://shopify/"):
+        if _GID_PATTERN.match(text) and text.split("/")[-2] == resource:
+            return text
+        raise ValueError(
+            f"{resource.lower()}_id must be a gid://shopify/{resource}/... "
+            f"string (or a bare numeric id), got {value!r}"
+        )
+    # str.isdigit() also accepts non-ASCII Unicode decimal digits (e.g.
+    # Arabic-Indic "١٢٣"), which Shopify's numeric id would never actually
+    # contain -- a stricter ASCII-only check here means a lookalike value
+    # gets this function's clear local error instead of an opaque failure
+    # from Shopify after being forwarded as-is.
+    if text.isascii() and text.isdigit():
+        return f"gid://shopify/{resource}/{text}"
+    raise ValueError(
+        f"{resource.lower()}_id must be numeric or a gid://shopify/{resource}/... "
+        f"string, got {value!r}"
+    )
+
+
+def _user_errors_message(user_errors: list[dict[str, Any]]) -> str:
+    """Join a mutation's userErrors array into one message.
+
+    Every write mutation in this module returns `userErrors { field message
+    }` as its primary error channel (a non-empty list means the write did
+    not happen, even on an otherwise-200 GraphQL response) -- `field` is a
+    path array (e.g. ["title"]) for a nested input, not a plain string.
+    """
+    parts = []
+    for err in user_errors:
+        field = err.get("field")
+        # field is a path array (e.g. ["variants", 0, "price"]) that can mix
+        # strings with integer array indices -- ".".join() requires every
+        # element to already be a str, so an index entry raises TypeError
+        # without the str() conversion.
+        field_path = ".".join(map(str, field)) if isinstance(field, list) else field
+        message = err.get("message") or "unknown error"
+        parts.append(f"{field_path}: {message}" if field_path else message)
+    return "; ".join(parts) if parts else "Shopify reported a validation error"
+
+
+def _errors_detail(errors_field: Any) -> str:
+    """Render a GraphQL response's top-level "errors" value as text.
+
+    Per the GraphQL spec this is always a list of error objects, but
+    Shopify's own auth-failure responses (e.g. a 401 for an invalid access
+    token) put a plain string here instead -- "[API] Invalid API key or
+    access token (...)" -- and a malformed/non-conforming backend could in
+    principle put a bare dict. graphql_errors_message assumes a list and
+    iterates whatever it's given: over a str that walks it one character at
+    a time (producing a mangled "a; p; i" message), and over a dict that
+    walks its keys, silently dropping the actual diagnostic text in its
+    values. Both are handled here before ever reaching that helper.
+
+    The result is truncated and redacted here, once, rather than leaving
+    every call site responsible for remembering to do both -- this is the
+    single choke point every top-level "errors" value passes through
+    before becoming user- or log-facing text (a raised RuntimeError, a
+    logged warning, or a tool's "warnings"/error message), so a caller
+    that forgot either step would otherwise let an unbounded or
+    credential-bearing error body straight through, same class of issue
+    already fixed for the raw-response-body fallback text elsewhere in
+    this module.
+    """
+    if isinstance(errors_field, str):
+        text = errors_field
+    elif isinstance(errors_field, list):
+        text = graphql_errors_message(errors_field)
+    else:
+        text = str(errors_field)
+    return _safe_text(text)
+
+
+def _split_tags(tags: str) -> list[str]:
+    return [t.strip() for t in tags.split(",") if t.strip()]
+
+
+def _throttle_wait_seconds(status_code: int, payload: Any) -> float | None:
+    """Return how long to wait before retrying, or None if this response
+    doesn't signal throttling.
+
+    Shopify's GraphQL cost-based throttling can surface as either an HTTP
+    429 or an HTTP 200 whose body carries a "Throttled" error (the request
+    cost more "leaky bucket" points than were available) -- checked
+    defensively for both shapes since Shopify's own docs and real-world
+    responses aren't fully consistent on which one to expect. `payload` is
+    the response body already parsed once by the caller (or None if it
+    wasn't valid JSON) -- shared with `_graphql`'s own data-extraction
+    parse rather than decoding the same body a second time.
+    """
+    throttled = status_code == 429
+    if not throttled and isinstance(payload, dict):
+        for entry in payload.get("errors") or []:
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("message", "")).strip().lower() == "throttled":
+                throttled = True
+                break
+            extensions = entry.get("extensions")
+            if isinstance(extensions, dict) and extensions.get("code") == "THROTTLED":
+                throttled = True
+                break
+    if not throttled:
+        return None
+
+    # Shopify's own rate-limit docs recommend a flat one-second backoff;
+    # when extensions.cost.throttleStatus is present, compute a more
+    # precise wait (how long until enough "bucket" capacity restores to
+    # cover the query that was just rejected) instead of guessing.
+    if isinstance(payload, dict):
+        cost = (payload.get("extensions") or {}).get("cost") or {}
+        throttle_status = cost.get("throttleStatus") or {}
+        requested = cost.get("requestedQueryCost")
+        available = throttle_status.get("currentlyAvailable")
+        restore_rate = throttle_status.get("restoreRate")
+        if (
+            isinstance(requested, (int, float))
+            and isinstance(available, (int, float))
+            and isinstance(restore_rate, (int, float))
+            and restore_rate > 0
+        ):
+            return max(1.0, (requested - available) / restore_rate)
+    return 1.0
+
+
+class MutationOutcomeIndeterminate(RuntimeError):
+    """The request may have reached Shopify, so retrying could duplicate a write."""
+
+
+def _granted_admin_scopes() -> set[str]:
+    """Read the scopes granted to the current custom-app token."""
+    try:
+        response = requests.get(
+            _scopes_url(),
+            headers=_headers(),
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+            allow_redirects=False,
+        )
+    except requests.RequestException as exc:
+        raise RuntimeError(
+            f"Could not validate Shopify Admin API scopes: {_safe_text(exc)}"
+        ) from exc
+    if 300 <= response.status_code < 400:
+        raise RuntimeError(
+            "Shopify scope validation returned an unexpected redirect "
+            f"(HTTP {response.status_code})"
+        )
+    if response.status_code >= 400:
+        raise RuntimeError(
+            f"Shopify scope validation failed (HTTP {response.status_code})"
+        )
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise RuntimeError("Shopify scope validation returned non-JSON data") from exc
+    entries = payload.get("access_scopes") if isinstance(payload, dict) else None
+    if not isinstance(entries, list):
+        raise RuntimeError("Shopify scope validation returned an invalid response")
+    return {
+        entry["handle"]
+        for entry in entries
+        if isinstance(entry, dict) and isinstance(entry.get("handle"), str)
+    }
+
+
+def _require_admin_scopes(*accepted_scopes: str) -> None:
+    """Require at least one equivalent scope, caching by credential identity."""
+    global _scope_cache
+
+    token = environ.get("SHOPIFY_ACCESS_TOKEN", "")
+    domain = environ.get("SHOPIFY_STORE_DOMAIN", "")
+    cache_key = hashlib.sha256(f"{domain}\0{token}".encode()).hexdigest()
+    if _scope_cache is None or _scope_cache[0] != cache_key:
+        _scope_cache = (cache_key, frozenset(_granted_admin_scopes()))
+    granted = _scope_cache[1]
+    if not granted.intersection(accepted_scopes):
+        raise ValueError(
+            "Shopify token requires one of these Admin API scopes: "
+            + ", ".join(accepted_scopes)
+        )
+
+
+@mcp.tool()
+def shopify_validate_connection() -> str:
+    """Validate the token and its Admin API scopes before using tools.
+
+    Required: write_products, write_orders, read_customers. Optional:
+    read_all_orders, which expands order history beyond the default 60 days.
+    """
+    try:
+        granted = _granted_admin_scopes()
+        missing = sorted(SHOPIFY_REQUIRED_ADMIN_SCOPES - granted)
+        if missing:
+            return _error(
+                "Shopify token is missing required Admin API scopes: "
+                + ", ".join(missing)
+            )
+        return _success(
+            connection_valid=True,
+            required_scopes=sorted(SHOPIFY_REQUIRED_ADMIN_SCOPES),
+            optional_scopes=sorted(SHOPIFY_OPTIONAL_ADMIN_SCOPES),
+            granted_optional_scopes=sorted(SHOPIFY_OPTIONAL_ADMIN_SCOPES & granted),
+        )
+    except Exception as exc:
+        _log_failure("connection validation", exc)
+        return _error(str(exc))
+
+
+def _graphql(
+    query: str,
+    variables: dict[str, Any] | None = None,
+    *,
+    mutation: bool = False,
+) -> tuple[dict[str, Any], list[Any]]:
+    """Run one GraphQL query/mutation against this store's Admin API
+    endpoint.
+
+    Returns (data, errors). Every query/mutation in this module selects
+    exactly one top-level field, so if that field comes back null alongside
+    a non-empty "errors" array there is nothing usable to return -- that is
+    treated as a hard failure and raises instead. If at least one top-level
+    field is non-null, it's a genuine partial success (e.g. a nested
+    sub-field's resolver failed): errors is returned alongside data so the
+    caller can surface it as a warning rather than only logging it. Mirrors
+    linear.py's `_graphql`, adapted for Shopify's cost-based throttling
+    instead of Linear's rate-limit-header scheme.
+    """
+    # Resolved once and reused across both attempts (not re-resolved inside
+    # the loop) -- a throttled request already pays the retry's sleep cost;
+    # repeating the DNS resolution + private-IP check on the retry would
+    # just be duplicated work for the same store, not additional safety.
+    url = _graphql_url()
+    try:
+        for attempt in (0, 1):
+            response = requests.post(
+                url,
+                headers=_headers(),
+                json={"query": query, "variables": variables or {}},
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+                allow_redirects=False,
+            )
+            # Parsed once per attempt and carried past the loop for reuse by
+            # the status-code branches below -- every prior version of this
+            # function parsed the same (non-retried) response body a second
+            # time in the success/error branch, doubling the JSON-decode
+            # cost of every call on the common, non-throttled path.
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = None
+            if attempt == 0:
+                wait_seconds = _throttle_wait_seconds(response.status_code, payload)
+                if wait_seconds is not None and wait_seconds <= MAX_RETRY_AFTER_SECONDS:
+                    time.sleep(wait_seconds)
+                    continue
+            break
+    except requests.RequestException as exc:
+        message = _safe_text(exc)
+        if mutation:
+            raise MutationOutcomeIndeterminate(
+                "Shopify did not provide a mutation response. The write may have "
+                "completed; verify store state before any manual retry. "
+                f"Transport detail: {message}"
+            ) from exc
+        raise RuntimeError(message) from exc
+
+    if 300 <= response.status_code < 400:
+        raise RuntimeError(
+            f"Shopify returned an unexpected redirect (HTTP {response.status_code}); "
+            "refusing to follow it with credentials attached"
+        )
+    if response.status_code >= 400:
+        detail: str | None = None
+        if isinstance(payload, dict) and payload.get("errors"):
+            detail = _errors_detail(payload["errors"])
+        if detail is None:
+            detail = truncate_error_text(response.text.strip())
+        message = (
+            f"Shopify API error (status {response.status_code}): {_safe_text(detail)}"
+        )
+        if mutation and response.status_code >= 500:
+            raise MutationOutcomeIndeterminate(
+                message
+                + "; Shopify returned a server error after receiving the mutation"
+            )
+        raise RuntimeError(message)
+
+    if payload is None:
+        detail = truncate_error_text(response.text.strip())
+        raise RuntimeError(
+            f"Shopify API returned a non-JSON response: {detail}"
+        ) from None
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            "Shopify API returned an unexpected (non-object) response body"
+        )
+
+    data = payload.get("data") or {}
+    if len(data) > 1:
+        raise RuntimeError(
+            f"Shopify API response had {len(data)} top-level fields "
+            f"({sorted(data)}), but this module's error handling assumes exactly one"
+        )
+    errors = payload.get("errors") or []
+    if errors:
+        message = _errors_detail(errors)
+        if all(value is None for value in data.values()):
+            if mutation:
+                return data, errors
+            raise RuntimeError(message)
+        logger.warning(
+            f"Shopify GraphQL partial error (data still returned): {message}"
+        )
+    return data, errors
+
+
+def _extract_connection(
+    data: dict[str, Any],
+    field_name: str,
+    summary_fn: Callable[[dict[str, Any]], dict[str, Any]],
+) -> tuple[list[tuple[dict[str, Any], str | None]], bool, str | None]:
+    """Return summarized nodes paired with their own Relay edge cursors."""
+    connection = data.get(field_name) or {}
+    edges = connection.get("edges")
+    page_info = connection.get("pageInfo") or {}
+    end_cursor = page_info.get("endCursor")
+    has_more = bool(page_info.get("hasNextPage")) and bool(end_cursor)
+
+    # Defensive fallback for a non-conforming response. Without edge cursors,
+    # local truncation is rejected later rather than guessing a cursor.
+    if not isinstance(edges, list):
+        nodes = connection.get("nodes") or []
+        summarized = [summary_fn(node) for node in nodes if isinstance(node, dict)]
+        return [(item, None) for item in summarized], has_more, end_cursor
+
+    items: list[tuple[dict[str, Any], str | None]] = []
+    for edge in edges:
+        if not isinstance(edge, dict) or not isinstance(edge.get("node"), dict):
+            continue
+        cursor = edge.get("cursor")
+        items.append(
+            (summary_fn(edge["node"]), cursor if isinstance(cursor, str) else None)
+        )
+    return items, has_more, end_cursor
+
+
+def _list_connection(
+    root_field: str,
+    selection: str,
+    limit: int,
+    query: str,
+    after: str,
+    summary_fn: Callable[[dict[str, Any]], dict[str, Any]],
+) -> str:
+    """Shared body for every paginated "list X" tool below (products,
+    orders, customers, collections) -- only the field name, per-item GraphQL
+    selection, and summarizer differ between them."""
+    max_results = clamp_limit(limit, max_limit=MAX_LIMIT)
+    args = ["first: $first"]
+    signature = ["$first: Int!"]
+    variables: dict[str, Any] = {"first": max_results}
+    if query:
+        args.append("query: $query")
+        signature.append("$query: String!")
+        variables["query"] = query
+    if after:
+        args.append("after: $after")
+        signature.append("$after: String!")
+        variables["after"] = after
+    data, errors = _graphql(
+        f"query({', '.join(signature)}) {{ {root_field}({', '.join(args)}) {{"
+        f" edges {{ cursor node {{ {selection} }} }}"
+        " pageInfo { hasNextPage endCursor } } }",
+        variables,
+    )
+    entries, has_more, next_cursor = _extract_connection(data, root_field, summary_fn)
+    return _success_paginated(root_field, entries, has_more, next_cursor, after, errors)
+
+
+def _success_paginated(
+    field_name: str,
+    entries: list[tuple[dict[str, Any], str | None]],
+    has_more: bool,
+    next_cursor: str | None,
+    input_after: str,
+    errors: list[Any],
+) -> str:
+    """Build a bounded page whose cursor follows the last returned item."""
+
+    def _build(
+        page: list[dict[str, Any]], more: bool, cursor: str | None, truncated: bool
+    ) -> str:
+        return _success(
+            **{field_name: page},
+            truncated=truncated,
+            has_more=more,
+            after_cursor=cursor,
+            _errors=errors,
+        )
+
+    if has_more and (not next_cursor or next_cursor == input_after):
+        return _error(
+            "Shopify returned a pagination cursor that did not advance; "
+            "pagination stopped to prevent an infinite loop"
+        )
+
+    items = [item for item, _cursor in entries]
+    response = _build(items, has_more, next_cursor if has_more else None, False)
+    max_output_length = get_tool_max_output_length()
+    if len(response) <= max_output_length:
+        return response
+
+    for count in range(len(entries) - 1, 0, -1):
+        cursor = entries[count - 1][1]
+        if not cursor or cursor == input_after:
+            continue
+        response = _build(items[:count], True, cursor, True)
+        if len(response) <= max_output_length:
+            return response
+
+    # A single record can itself exceed the output budget. Return its stable
+    # identity plus an explicit truncation marker, and still advance by the
+    # edge cursor so later records remain reachable.
+    if entries:
+        first_item, first_cursor = entries[0]
+        if first_cursor and first_cursor != input_after:
+            compact = {
+                "id": str(first_item.get("id", ""))[:256] or None,
+                "truncated": True,
+            }
+            response = _build([compact], True, first_cursor, True)
+            if len(response) <= max_output_length:
+                return response
+
+    return _error(
+        "Shopify page exceeds the output limit and has no safe continuation cursor"
+    )
+
+
+def _run_mutation(
+    mutation: str,
+    variables: dict[str, Any],
+    mutation_field: str,
+    object_key: str,
+    summary_fn: Callable[[dict[str, Any]], dict[str, Any]],
+) -> str:
+    """Shared body for every write tool below (create/update product,
+    update order): run the mutation, then apply the same
+    result-missing/userErrors/success discriminator each one needs.
+
+    `result.get(mutation_field)` being falsy covers two distinct failure
+    shapes the same way: the mutation field resolved to null (Shopify's own
+    signal that the input's id/lookup didn't resolve to anything), or --
+    defensively -- a malformed response where the field was omitted
+    entirely with no errors at all. Either way there is nothing usable to
+    return, so this fails closed instead of reporting an empty object as a
+    success, matching linear.py's `if not result.get("success")` check
+    (Shopify's write mutations here use an empty `userErrors` list as their
+    success signal instead of Linear's boolean `success` field, but an
+    absent result must still be treated as failure, not vacuously "no
+    errors").
+    """
+    try:
+        data, errors = _graphql(mutation, variables, mutation=True)
+    except MutationOutcomeIndeterminate as exc:
+        return _indeterminate(str(exc))
+    result = data.get(mutation_field)
+    if not result:
+        if errors:
+            return _indeterminate(
+                f"Shopify returned no {mutation_field} projection after the "
+                f"mutation request: {_errors_detail(errors)}"
+            )
+        return _error(f"Shopify returned no result for {mutation_field}")
+    user_errors = result.get("userErrors") or []
+    if user_errors:
+        # userErrors alone can omit useful context a top-level GraphQL
+        # `errors` entry carries (e.g. a query-level access-scope warning
+        # attached to the same response) -- fold both in, mirroring
+        # linear.py's `_mutation_failure_message`, which does the same for
+        # Linear's boolean `success` discriminator.
+        message = _user_errors_message(user_errors)
+        if errors:
+            message = f"{message} ({_errors_detail(errors)})"
+        return _error(message)
+    object_value = result.get(object_key)
+    if not object_value:
+        # userErrors is empty, but the object itself is also null -- e.g. an
+        # access-scope error on one selected field null-propagated up to the
+        # whole object, with the real cause only in the top-level `errors`
+        # this response still carries. Reporting this as success with an
+        # all-null object would hide that entirely.
+        if errors:
+            return _indeterminate(
+                f"Shopify returned no {object_key} projection after "
+                f"{mutation_field}: {_errors_detail(errors)}"
+            )
+        return _error(f"Shopify did not return a {object_key} for {mutation_field}")
+    return _success_capped(object_key, summary_fn(object_value), errors)
+
+
+def _success_capped(field_name: str, value: dict[str, Any], errors: list[Any]) -> str:
+    """Build a single-object success response, shrinking `value` if it
+    doesn't fit the platform's output-size cap.
+
+    Every list tool below goes through `_success_paginated`'s size-capping
+    on the way out, but a single get/create/update result can be just as
+    unbounded -- e.g. `_product_summary`'s `tags` (Shopify allows up to 250)
+    or `_order_summary`'s `note` (up to ~5000 chars) -- and was previously
+    returned via a bare `_success()` call with no cap at all, so an
+    oversized single object hit the same hard-truncated-into-broken-JSON
+    failure mode the pagination helper exists to prevent. Reuses
+    `success_with_capped_dict` (utils.py) for the actual shrinking rather
+    than reimplementing its halving logic locally -- unlike the pagination
+    case, there's no cursor to invalidate here, so the generic dict-capping
+    helper's usual contract applies unmodified.
+    """
+    response = _success(**{field_name: value}, _errors=errors)
+    max_output_length = get_tool_max_output_length()
+    if len(response) <= max_output_length:
+        return response
+
+    capped = success_with_capped_dict(field_name, value)
+    if not errors:
+        return capped
+    # success_with_capped_dict's payload shape has no room for the
+    # `_errors`-derived "warnings" key `_success` above would have added --
+    # re-add it only if the now-shrunk response still fits, since appending
+    # it unconditionally could push an already-fitted response back over
+    # the cap (the same reasoning `_success_paginated`'s dead-end message
+    # follows).
+    payload = json.loads(capped)
+    payload["warnings"] = [_errors_detail(errors)]
+    with_warnings = json.dumps(payload, ensure_ascii=False)
+    return with_warnings if len(with_warnings) <= max_output_length else capped
+
+
+def _shop_summary(shop: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": shop.get("name"),
+        "domain": shop.get("myshopifyDomain"),
+        "email": shop.get("email"),
+        "currency": shop.get("currencyCode"),
+        "timezone": shop.get("ianaTimezone"),
+    }
+
+
+_PRODUCT_FIELDS = (
+    "id title handle status vendor productType tags totalInventory createdAt updatedAt"
+)
+
+
+def _product_summary(product: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": product.get("id"),
+        "title": product.get("title"),
+        "handle": product.get("handle"),
+        "status": product.get("status"),
+        "vendor": product.get("vendor"),
+        "product_type": product.get("productType"),
+        "tags": product.get("tags"),
+        "total_inventory": product.get("totalInventory"),
+        "created_at": product.get("createdAt"),
+        "updated_at": product.get("updatedAt"),
+    }
+
+
+_ORDER_FIELDS = (
+    "id name email displayFinancialStatus displayFulfillmentStatus"
+    " totalPriceSet { shopMoney { amount currencyCode } } tags note createdAt"
+)
+
+
+def _order_summary(order: dict[str, Any]) -> dict[str, Any]:
+    total_price = (order.get("totalPriceSet") or {}).get("shopMoney") or {}
+    return {
+        "id": order.get("id"),
+        "name": order.get("name"),
+        "email": order.get("email"),
+        "financial_status": order.get("displayFinancialStatus"),
+        "fulfillment_status": order.get("displayFulfillmentStatus"),
+        "total_price": total_price.get("amount"),
+        "currency": total_price.get("currencyCode"),
+        "tags": order.get("tags"),
+        "note": order.get("note"),
+        "created_at": order.get("createdAt"),
+    }
+
+
+_CUSTOMER_FIELDS = (
+    "id firstName lastName defaultEmailAddress { emailAddress }"
+    " defaultPhoneNumber { phoneNumber } numberOfOrders tags createdAt"
+)
+
+
+def _customer_summary(customer: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": customer.get("id"),
+        "first_name": customer.get("firstName"),
+        "last_name": customer.get("lastName"),
+        "email": (customer.get("defaultEmailAddress") or {}).get("emailAddress"),
+        "phone": (customer.get("defaultPhoneNumber") or {}).get("phoneNumber"),
+        "number_of_orders": customer.get("numberOfOrders"),
+        "tags": customer.get("tags"),
+        "created_at": customer.get("createdAt"),
+    }
+
+
+_COLLECTION_FIELDS = "id title handle productsCount { count }"
+
+
+def _collection_summary(collection: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": collection.get("id"),
+        "title": collection.get("title"),
+        "handle": collection.get("handle"),
+        "products_count": (collection.get("productsCount") or {}).get("count"),
+    }
+
+
+@mcp.tool()
+def shopify_get_shop() -> str:
+    """
+    Get basic info about the connected Shopify store (name, domain,
+    currency, timezone). Use this to verify the connection instead of
+    asking the user for their store's details.
+    """
+    try:
+        data, errors = _graphql(
+            "query { shop { name myshopifyDomain email currencyCode ianaTimezone } }"
+        )
+        shop = data.get("shop")
+        if not shop:
+            return _error("Shopify did not return shop info")
+        return _success_capped("shop", _shop_summary(shop), errors)
+    except Exception as exc:
+        _log_failure("shop lookup", exc)
+        return _error(str(exc))
+
+
+@mcp.tool()
+def shopify_list_products(query: str = "", limit: int = 25, after: str = "") -> str:
+    """
+    List/search products.
+    query: optional Shopify search-syntax filter, e.g. "status:active" or
+    "title:*shirt*". Leave empty to list all products.
+    limit: max products to return (default 25, hard cap 100).
+    after: pass the previous call's own after_cursor to fetch the next
+    page; omit for the first page.
+    """
+    try:
+        _require_admin_scopes("read_products", "write_products")
+        return _list_connection(
+            "products", _PRODUCT_FIELDS, limit, query, after, _product_summary
+        )
+    except Exception as exc:
+        _log_failure("product listing", exc)
+        return _error(str(exc))
+
+
+@mcp.tool()
+def shopify_get_product(product_id: str) -> str:
+    """
+    Get a Shopify product by id (numeric id or full gid://shopify/Product/...).
+    """
+    try:
+        _require_admin_scopes("read_products", "write_products")
+        data, errors = _graphql(
+            f"query($id: ID!) {{ product(id: $id) {{ {_PRODUCT_FIELDS} }} }}",
+            {"id": _gid("Product", product_id)},
+        )
+        product = data.get("product")
+        if not product:
+            return _error(f"Product '{product_id}' not found")
+        return _success_capped("product", _product_summary(product), errors)
+    except Exception as exc:
+        _log_failure("product lookup", exc)
+        return _error(str(exc))
+
+
+@mcp.tool()
+def shopify_create_product(
+    title: str,
+    description: str = "",
+    vendor: str = "",
+    product_type: str = "",
+    tags: str = "",
+    status: str = "DRAFT",
+) -> str:
+    """
+    Create a new product.
+    title: the product's name.
+    description: optional HTML description.
+    vendor: optional supplier/brand name.
+    product_type: optional category/classification.
+    tags: optional comma-separated tags.
+    status: one of "ACTIVE", "ARCHIVED", "DRAFT", "UNLISTED" (default
+    "DRAFT" -- Shopify creates products unavailable to customers by
+    default; note that "ACTIVE" alone does not add it to a sales channel,
+    which this connector has no tool for).
+    """
+    try:
+        _require_admin_scopes("write_products")
+        _require_non_blank(title, "title")
+        if status not in _PRODUCT_STATUSES:
+            return _error(
+                f"status must be one of {sorted(_PRODUCT_STATUSES)}, got {status!r}"
+            )
+        product_input: dict[str, Any] = {"title": title, "status": status}
+        if description:
+            product_input["descriptionHtml"] = description
+        if vendor:
+            product_input["vendor"] = vendor
+        if product_type:
+            product_input["productType"] = product_type
+        if tags:
+            product_input["tags"] = _split_tags(tags)
+        return _run_mutation(
+            "mutation($product: ProductCreateInput!) { productCreate(product: $product)"
+            f" {{ product {{ {_PRODUCT_FIELDS} }} userErrors {{ field message }} }} }}",
+            {"product": product_input},
+            "productCreate",
+            "product",
+            _product_summary,
+        )
+    except Exception as exc:
+        _log_failure("product creation", exc)
+        return _error(str(exc))
+
+
+@mcp.tool()
+def shopify_update_product(
+    product_id: str,
+    title: str | None = None,
+    description: str | None = None,
+    vendor: str | None = None,
+    product_type: str | None = None,
+    tags: str | None = None,
+    status: str | None = None,
+) -> str:
+    """
+    Update an existing product. Only the fields explicitly provided (not
+    None) are changed -- pass an empty string for description/vendor/
+    product_type to clear that field (title cannot be cleared to blank).
+    status: optional, one of "ACTIVE", "ARCHIVED", "DRAFT", "UNLISTED".
+    """
+    try:
+        _require_admin_scopes("write_products")
+        product_input: dict[str, Any] = {"id": _gid("Product", product_id)}
+        if title is not None:
+            _require_non_blank(title, "title")
+            product_input["title"] = title
+        if description is not None:
+            product_input["descriptionHtml"] = description
+        if vendor is not None:
+            product_input["vendor"] = vendor
+        if product_type is not None:
+            product_input["productType"] = product_type
+        if tags is not None:
+            product_input["tags"] = _split_tags(tags)
+        if status is not None:
+            if status not in _PRODUCT_STATUSES:
+                return _error(
+                    f"status must be one of {sorted(_PRODUCT_STATUSES)}, got {status!r}"
+                )
+            product_input["status"] = status
+        if len(product_input) == 1:
+            return _error("at least one field to update must be provided")
+
+        return _run_mutation(
+            "mutation($product: ProductUpdateInput!) { productUpdate(product: $product)"
+            f" {{ product {{ {_PRODUCT_FIELDS} }} userErrors {{ field message }} }} }}",
+            {"product": product_input},
+            "productUpdate",
+            "product",
+            _product_summary,
+        )
+    except Exception as exc:
+        _log_failure("product update", exc)
+        return _error(str(exc))
+
+
+@mcp.tool()
+def shopify_list_orders(query: str = "", limit: int = 25, after: str = "") -> str:
+    """
+    List/search orders. Shopify's Admin API only returns orders from
+    roughly the last 60 days by default unless this connection has been
+    granted the read_all_orders scope.
+    query: optional Shopify search-syntax filter, e.g.
+    "financial_status:paid" or "fulfillment_status:unfulfilled".
+    limit: max orders to return (default 25, hard cap 100).
+    after: pass the previous call's own after_cursor to fetch the next
+    page; omit for the first page.
+    """
+    try:
+        _require_admin_scopes("read_orders", "write_orders")
+        return _list_connection(
+            "orders", _ORDER_FIELDS, limit, query, after, _order_summary
+        )
+    except Exception as exc:
+        _log_failure("order listing", exc)
+        return _error(str(exc))
+
+
+@mcp.tool()
+def shopify_get_order(order_id: str) -> str:
+    """
+    Get a Shopify order by id (numeric id or full gid://shopify/Order/...).
+    """
+    try:
+        _require_admin_scopes("read_orders", "write_orders")
+        data, errors = _graphql(
+            f"query($id: ID!) {{ order(id: $id) {{ {_ORDER_FIELDS} }} }}",
+            {"id": _gid("Order", order_id)},
+        )
+        order = data.get("order")
+        if not order:
+            return _error(f"Order '{order_id}' not found")
+        return _success_capped("order", _order_summary(order), errors)
+    except Exception as exc:
+        _log_failure("order lookup", exc)
+        return _error(str(exc))
+
+
+@mcp.tool()
+def shopify_update_order(
+    order_id: str, tags: str | None = None, note: str | None = None
+) -> str:
+    """
+    Update an order's tags and/or note -- this tool does not touch payment,
+    fulfillment, or customer-contact fields. Only the fields explicitly
+    provided (not None) are changed -- pass an empty string to clear tags
+    or the note entirely.
+    tags: optional comma-separated tags, replacing the order's existing tags.
+    note: optional internal note text.
+    """
+    try:
+        _require_admin_scopes("write_orders")
+        order_input: dict[str, Any] = {"id": _gid("Order", order_id)}
+        if tags is not None:
+            order_input["tags"] = _split_tags(tags)
+        if note is not None:
+            order_input["note"] = note
+        if len(order_input) == 1:
+            return _error("at least one of tags/note must be provided")
+
+        return _run_mutation(
+            "mutation($input: OrderInput!) { orderUpdate(input: $input)"
+            f" {{ order {{ {_ORDER_FIELDS} }} userErrors {{ field message }} }} }}",
+            {"input": order_input},
+            "orderUpdate",
+            "order",
+            _order_summary,
+        )
+    except Exception as exc:
+        _log_failure("order update", exc)
+        return _error(str(exc))
+
+
+@mcp.tool()
+def shopify_list_customers(query: str = "", limit: int = 25, after: str = "") -> str:
+    """
+    List/search customers.
+    query: optional Shopify search-syntax filter, e.g.
+    "email:jane@example.com" or "tag:vip".
+    limit: max customers to return (default 25, hard cap 100).
+    after: pass the previous call's own after_cursor to fetch the next
+    page; omit for the first page.
+    """
+    try:
+        _require_admin_scopes("read_customers", "write_customers")
+        return _list_connection(
+            "customers", _CUSTOMER_FIELDS, limit, query, after, _customer_summary
+        )
+    except Exception as exc:
+        _log_failure("customer listing", exc)
+        return _error(str(exc))
+
+
+@mcp.tool()
+def shopify_get_customer(customer_id: str) -> str:
+    """
+    Get a Shopify customer by id (numeric id or full gid://shopify/Customer/...).
+    """
+    try:
+        _require_admin_scopes("read_customers", "write_customers")
+        data, errors = _graphql(
+            f"query($id: ID!) {{ customer(id: $id) {{ {_CUSTOMER_FIELDS} }} }}",
+            {"id": _gid("Customer", customer_id)},
+        )
+        customer = data.get("customer")
+        if not customer:
+            return _error(f"Customer '{customer_id}' not found")
+        return _success_capped("customer", _customer_summary(customer), errors)
+    except Exception as exc:
+        _log_failure("customer lookup", exc)
+        return _error(str(exc))
+
+
+@mcp.tool()
+def shopify_list_collections(query: str = "", limit: int = 25, after: str = "") -> str:
+    """
+    List collections (product groupings) -- id, title, handle, and how many
+    products each contains.
+    query: optional Shopify search-syntax filter, e.g. "title:*sale*".
+    Leave empty to list all collections.
+    limit: max collections to return (default 25, hard cap 100).
+    after: pass the previous call's own after_cursor to fetch the next
+    page; omit for the first page.
+    """
+    try:
+        _require_admin_scopes("read_products", "write_products")
+        return _list_connection(
+            "collections", _COLLECTION_FIELDS, limit, query, after, _collection_summary
+        )
+    except Exception as exc:
+        _log_failure("collection listing", exc)
+        return _error(str(exc))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/shopify.py
+++ b/src/xagent/web/tools/mcp/shopify.py
@@ -6,7 +6,7 @@ import socket
 import time
 from collections.abc import Callable
 from os import environ
-from typing import Any
+from typing import Any, NoReturn
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -75,9 +75,13 @@ def _success(*, _errors: list[Any] | None = None, **payload: Any) -> str:
 
 
 def _safe_text(value: Any) -> str:
-    text = redact_sensitive_text(truncate_error_text(str(value)))
+    # Redact the complete value before truncating. Reversing this order can
+    # leave a recognizable token prefix when the boundary splits the token.
+    text = str(value)
     token = environ.get("SHOPIFY_ACCESS_TOKEN", "")
-    return text.replace(token, "[REDACTED]") if token else text
+    if token:
+        text = text.replace(token, "[REDACTED]")
+    return truncate_error_text(redact_sensitive_text(text))
 
 
 def _log_failure(operation: str, exc: BaseException) -> None:
@@ -306,6 +310,12 @@ class MutationOutcomeIndeterminate(RuntimeError):
     """The request may have reached Shopify, so retrying could duplicate a write."""
 
 
+def _raise_response_shape(message: str, *, mutation: bool) -> NoReturn:
+    if mutation:
+        raise MutationOutcomeIndeterminate(message)
+    raise RuntimeError(message)
+
+
 def _granted_admin_scopes() -> set[str]:
     """Read the scopes granted to the current custom-app token."""
     try:
@@ -396,9 +406,10 @@ def _graphql(
 
     Returns (data, errors). Every query/mutation in this module selects
     exactly one top-level field, so if that field comes back null alongside
-    a non-empty "errors" array there is nothing usable to return -- that is
-    treated as a hard failure and raises instead. If at least one top-level
-    field is non-null, it's a genuine partial success (e.g. a nested
+    a non-empty "errors" array there is nothing usable to return. Reads fail;
+    mutations retain that response so the dispatched write can be reported as
+    indeterminate. If at least one top-level field is non-null, it's a genuine
+    partial success (e.g. a nested
     sub-field's resolver failed): errors is returned alongside data so the
     caller can surface it as a warning rather than only logging it. Mirrors
     linear.py's `_graphql`, adapted for Shopify's cost-based throttling
@@ -465,22 +476,38 @@ def _graphql(
         raise RuntimeError(message)
 
     if payload is None:
-        detail = truncate_error_text(response.text.strip())
-        raise RuntimeError(
-            f"Shopify API returned a non-JSON response: {detail}"
-        ) from None
+        detail = _safe_text(response.text.strip())
+        _raise_response_shape(
+            f"Shopify API returned a non-JSON response: {detail}",
+            mutation=mutation,
+        )
     if not isinstance(payload, dict):
-        raise RuntimeError(
-            "Shopify API returned an unexpected (non-object) response body"
+        _raise_response_shape(
+            "Shopify API returned an unexpected (non-object) response body",
+            mutation=mutation,
         )
 
-    data = payload.get("data") or {}
-    if len(data) > 1:
-        raise RuntimeError(
-            f"Shopify API response had {len(data)} top-level fields "
-            f"({sorted(data)}), but this module's error handling assumes exactly one"
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        _raise_response_shape(
+            "Shopify API response has an invalid top-level data field",
+            mutation=mutation,
         )
-    errors = payload.get("errors") or []
+    if len(data) > 1:
+        _raise_response_shape(
+            f"Shopify API response had {len(data)} top-level fields "
+            f"({sorted(data)}), but this module's error handling assumes exactly one",
+            mutation=mutation,
+        )
+    raw_errors = payload.get("errors", [])
+    if not isinstance(raw_errors, list) or not all(
+        isinstance(entry, dict) for entry in raw_errors
+    ):
+        _raise_response_shape(
+            "Shopify API response has an invalid top-level errors field",
+            mutation=mutation,
+        )
+    errors = raw_errors
     if errors:
         message = _errors_detail(errors)
         if all(value is None for value in data.values()):
@@ -627,31 +654,34 @@ def _run_mutation(
     update order): run the mutation, then apply the same
     result-missing/userErrors/success discriminator each one needs.
 
-    `result.get(mutation_field)` being falsy covers two distinct failure
-    shapes the same way: the mutation field resolved to null (Shopify's own
-    signal that the input's id/lookup didn't resolve to anything), or --
-    defensively -- a malformed response where the field was omitted
-    entirely with no errors at all. Either way there is nothing usable to
-    return, so this fails closed instead of reporting an empty object as a
-    success, matching linear.py's `if not result.get("success")` check
+    A missing, null, or non-object mutation projection covers two ambiguous
+    shapes: the field resolved to null, or a malformed response omitted it.
+    Either way there is nothing usable to return after dispatch, so this
+    reports an unsafe-to-retry indeterminate outcome instead of an empty
+    success or an ordinary retryable-looking error
     (Shopify's write mutations here use an empty `userErrors` list as their
     success signal instead of Linear's boolean `success` field, but an
-    absent result must still be treated as failure, not vacuously "no
-    errors").
+    absent result must still be treated as indeterminate, not vacuously
+    "no errors").
     """
     try:
         data, errors = _graphql(mutation, variables, mutation=True)
     except MutationOutcomeIndeterminate as exc:
         return _indeterminate(str(exc))
     result = data.get(mutation_field)
-    if not result:
-        if errors:
-            return _indeterminate(
-                f"Shopify returned no {mutation_field} projection after the "
-                f"mutation request: {_errors_detail(errors)}"
-            )
-        return _error(f"Shopify returned no result for {mutation_field}")
-    user_errors = result.get("userErrors") or []
+    if not isinstance(result, dict):
+        detail = f": {_errors_detail(errors)}" if errors else ""
+        return _indeterminate(
+            f"Shopify returned no valid {mutation_field} projection after the "
+            f"mutation request{detail}"
+        )
+    user_errors = result.get("userErrors")
+    if not isinstance(user_errors, list) or not all(
+        isinstance(entry, dict) for entry in user_errors
+    ):
+        return _indeterminate(
+            f"Shopify returned an invalid userErrors projection for {mutation_field}"
+        )
     if user_errors:
         # userErrors alone can omit useful context a top-level GraphQL
         # `errors` entry carries (e.g. a query-level access-scope warning
@@ -663,18 +693,17 @@ def _run_mutation(
             message = f"{message} ({_errors_detail(errors)})"
         return _error(message)
     object_value = result.get(object_key)
-    if not object_value:
+    if not isinstance(object_value, dict):
         # userErrors is empty, but the object itself is also null -- e.g. an
         # access-scope error on one selected field null-propagated up to the
         # whole object, with the real cause only in the top-level `errors`
         # this response still carries. Reporting this as success with an
         # all-null object would hide that entirely.
-        if errors:
-            return _indeterminate(
-                f"Shopify returned no {object_key} projection after "
-                f"{mutation_field}: {_errors_detail(errors)}"
-            )
-        return _error(f"Shopify did not return a {object_key} for {mutation_field}")
+        detail = f": {_errors_detail(errors)}" if errors else ""
+        return _indeterminate(
+            f"Shopify returned no valid {object_key} projection after "
+            f"{mutation_field}{detail}"
+        )
     return _success_capped(object_key, summary_fn(object_value), errors)
 
 
@@ -702,16 +731,33 @@ def _success_capped(field_name: str, value: dict[str, Any], errors: list[Any]) -
     capped = success_with_capped_dict(field_name, value)
     if not errors:
         return capped
-    # success_with_capped_dict's payload shape has no room for the
-    # `_errors`-derived "warnings" key `_success` above would have added --
-    # re-add it only if the now-shrunk response still fits, since appending
-    # it unconditionally could push an already-fitted response back over
-    # the cap (the same reasoning `_success_paginated`'s dead-end message
-    # follows).
     payload = json.loads(capped)
-    payload["warnings"] = [_errors_detail(errors)]
+    warning = _errors_detail(errors)
+    payload["warnings"] = [warning]
+    payload["warnings_truncated"] = False
     with_warnings = json.dumps(payload, ensure_ascii=False)
-    return with_warnings if len(with_warnings) <= max_output_length else capped
+    if len(with_warnings) <= max_output_length:
+        return with_warnings
+
+    payload["warnings_truncated"] = True
+    payload["truncated"] = True
+    marker = "... [truncated]"
+    low, high = 0, len(warning)
+    while low < high:
+        middle = (low + high + 1) // 2
+        payload["warnings"] = [warning[:middle] + marker]
+        if len(json.dumps(payload, ensure_ascii=False)) <= max_output_length:
+            low = middle
+        else:
+            high = middle - 1
+    payload["warnings"] = [warning[:low] + marker]
+    while len(json.dumps(payload, ensure_ascii=False)) > max_output_length:
+        value = payload.get(field_name)
+        if not isinstance(value, dict) or not value:
+            break
+        keys = list(value)
+        payload[field_name] = {key: value[key] for key in keys[: len(keys) // 2]}
+    return json.dumps(payload, ensure_ascii=False)
 
 
 def _shop_summary(shop: dict[str, Any]) -> dict[str, Any]:

--- a/tests/alembic/test_20260909_seed_shopify_mcp_app.py
+++ b/tests/alembic/test_20260909_seed_shopify_mcp_app.py
@@ -8,6 +8,7 @@ import pytest
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
 
 
 def _load_migration():
@@ -51,7 +52,8 @@ def _create_tables(connection):
             """
             CREATE TABLE mcp_servers (
                 id INTEGER PRIMARY KEY,
-                name VARCHAR(100) NOT NULL UNIQUE
+                name VARCHAR(100) NOT NULL UNIQUE,
+                auth JSON
             )
             """
         )
@@ -105,7 +107,7 @@ def test_upgrade_refuses_custom_catalog_collision(tmp_path):
             )
         )
         with patch.object(migration, "op", _operations(connection)):
-            with pytest.raises(RuntimeError, match="custom public_mcp_apps"):
+            with pytest.raises(RuntimeError, match="public_mcp_apps"):
                 migration.upgrade()
         row = connection.execute(
             text("SELECT name FROM public_mcp_apps WHERE app_id='shopify'")
@@ -126,6 +128,46 @@ def test_upgrade_refuses_custom_server_name_collision(tmp_path):
             text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='shopify'")
         ).scalar_one()
     assert count == 0
+
+
+@pytest.mark.parametrize(
+    "app_id,name",
+    [
+        (" SHOPIFY ", "Unrelated"),
+        ("other", " shopify "),
+        ("ShOpIfY", "Unrelated"),
+    ],
+)
+def test_upgrade_refuses_normalized_custom_catalog_collision(tmp_path, app_id, name):
+    migration = _load_migration()
+    engine = create_engine(f"sqlite:///{tmp_path / 'db.sqlite'}")
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps "
+                "(app_id, name, transport, launch_config) "
+                "VALUES (:app_id, :name, 'stdio', '{\"command\": \"custom\"}')"
+            ),
+            {"app_id": app_id, "name": name},
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            with pytest.raises(RuntimeError, match="public_mcp_apps"):
+                migration.upgrade()
+
+
+@pytest.mark.parametrize("name", [" SHOPIFY ", "ShOpIfY"])
+def test_upgrade_refuses_normalized_custom_server_collision(tmp_path, name):
+    migration = _load_migration()
+    engine = create_engine(f"sqlite:///{tmp_path / 'db.sqlite'}")
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text("INSERT INTO mcp_servers (name) VALUES (:name)"), {"name": name}
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            with pytest.raises(RuntimeError, match="custom mcp_servers"):
+                migration.upgrade()
 
 
 def test_downgrade_only_deletes_provenance_owned_row(tmp_path):
@@ -170,3 +212,65 @@ def test_seed_row_matches_registry():
         row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "shopify"
     )
     assert migration.ROW == registry
+
+
+def test_upgrade_connect_downgrade_reupgrade_preserves_official_connection(tmp_path):
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+    from xagent.web.models.database import Base
+    from xagent.web.models.mcp import MCPServer, UserMCPServer
+    from xagent.web.models.user import User
+
+    migration = _load_migration()
+    engine = create_engine(f"sqlite:///{tmp_path / 'roundtrip.sqlite'}")
+    Base.metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+    session_factory = sessionmaker(bind=engine)
+    db = session_factory()
+    user = User(id=1, username="shop-owner", password_hash="x")
+    db.add(user)
+    db.commit()
+    connect_mcp_app(
+        "shopify",
+        MCPAppConnectRequest(
+            env={
+                "SHOPIFY_STORE_DOMAIN": "acme",
+                "SHOPIFY_ACCESS_TOKEN": "shpat_roundtrip_secret",
+            }
+        ),
+        current_user=user,
+        db=db,
+    )
+    server = db.query(MCPServer).filter(MCPServer.name == "shopify").one()
+    association = (
+        db.query(UserMCPServer)
+        .filter(UserMCPServer.mcpserver_id == server.id, UserMCPServer.user_id == 1)
+        .one()
+    )
+    server_id = int(server.id)
+    association_id = int(association.id)
+    encrypted_env = association.env
+    assert server.auth == {"builtin_provenance": migration.BUILTIN_PROVENANCE}
+    db.close()
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.downgrade()
+            migration.upgrade()
+
+    db = session_factory()
+    assert db.query(MCPServer).filter(MCPServer.id == server_id).one().auth == {
+        "builtin_provenance": migration.BUILTIN_PROVENANCE
+    }
+    preserved = db.query(UserMCPServer).filter(UserMCPServer.id == association_id).one()
+    assert preserved.env == encrypted_env
+    assert (
+        db.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='shopify'")
+        ).scalar_one()
+        == 1
+    )
+    db.close()

--- a/tests/alembic/test_20260909_seed_shopify_mcp_app.py
+++ b/tests/alembic/test_20260909_seed_shopify_mcp_app.py
@@ -1,0 +1,172 @@
+"""Tests for the provenance-safe Shopify connector seed."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration():
+    path = (
+        Path(__file__).parents[2]
+        / "src/xagent/migrations/versions/20260909_seed_shopify_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location("seed_shopify_migration", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_tables(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL,
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+    connection.execute(
+        text(
+            """
+            CREATE TABLE mcp_servers (
+                id INTEGER PRIMARY KEY,
+                name VARCHAR(100) NOT NULL UNIQUE
+            )
+            """
+        )
+    )
+
+
+def test_upgrade_inserts_provenance_and_personal_credential_metadata(tmp_path):
+    migration = _load_migration()
+    engine = create_engine(f"sqlite:///{tmp_path / 'db.sqlite'}")
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        row = connection.execute(
+            text(
+                "SELECT transport, launch_config FROM public_mcp_apps "
+                "WHERE app_id='shopify'"
+            )
+        ).first()
+
+    assert row is not None
+    assert row[0] == "stdio"
+    assert '"credential_scope": "personal"' in row[1]
+    assert '"builtin_provenance"' in row[1]
+
+
+def test_upgrade_is_idempotent_for_provenance_owned_row(tmp_path):
+    migration = _load_migration()
+    engine = create_engine(f"sqlite:///{tmp_path / 'db.sqlite'}")
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()
+        count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='shopify'")
+        ).scalar_one()
+    assert count == 1
+
+
+def test_upgrade_refuses_custom_catalog_collision(tmp_path):
+    migration = _load_migration()
+    engine = create_engine(f"sqlite:///{tmp_path / 'db.sqlite'}")
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps "
+                "(app_id, name, transport, launch_config) "
+                "VALUES ('shopify', 'Custom Shopify', 'stdio', '{\"command\": \"custom\"}')"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            with pytest.raises(RuntimeError, match="custom public_mcp_apps"):
+                migration.upgrade()
+        row = connection.execute(
+            text("SELECT name FROM public_mcp_apps WHERE app_id='shopify'")
+        ).scalar_one()
+    assert row == "Custom Shopify"
+
+
+def test_upgrade_refuses_custom_server_name_collision(tmp_path):
+    migration = _load_migration()
+    engine = create_engine(f"sqlite:///{tmp_path / 'db.sqlite'}")
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(text("INSERT INTO mcp_servers (name) VALUES ('shopify')"))
+        with patch.object(migration, "op", _operations(connection)):
+            with pytest.raises(RuntimeError, match="custom mcp_servers"):
+                migration.upgrade()
+        count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='shopify'")
+        ).scalar_one()
+    assert count == 0
+
+
+def test_downgrade_only_deletes_provenance_owned_row(tmp_path):
+    migration = _load_migration()
+    engine = create_engine(f"sqlite:///{tmp_path / 'db.sqlite'}")
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='shopify'")
+        ).scalar_one()
+    assert count == 0
+
+
+def test_downgrade_preserves_custom_same_id(tmp_path):
+    migration = _load_migration()
+    engine = create_engine(f"sqlite:///{tmp_path / 'db.sqlite'}")
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps "
+                "(app_id, name, transport, launch_config) "
+                "VALUES ('shopify', 'Custom Shopify', 'stdio', '{\"command\": \"custom\"}')"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.downgrade()
+        name = connection.execute(
+            text("SELECT name FROM public_mcp_apps WHERE app_id='shopify'")
+        ).scalar_one()
+    assert name == "Custom Shopify"
+
+
+def test_seed_row_matches_registry():
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration()
+    registry = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "shopify"
+    )
+    assert migration.ROW == registry

--- a/tests/alembic/test_20260909_seed_shopify_mcp_app.py
+++ b/tests/alembic/test_20260909_seed_shopify_mcp_app.py
@@ -1,6 +1,7 @@
 """Tests for the provenance-safe Shopify connector seed."""
 
 import importlib.util
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -91,6 +92,33 @@ def test_upgrade_is_idempotent_for_provenance_owned_row(tmp_path):
         count = connection.execute(
             text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='shopify'")
         ).scalar_one()
+    assert count == 1
+
+
+def test_upgrade_accepts_owned_row_from_an_older_provenance_version(tmp_path):
+    migration = _load_migration()
+    engine = create_engine(f"sqlite:///{tmp_path / 'db.sqlite'}")
+    with engine.begin() as connection:
+        _create_tables(connection)
+        launch_config = dict(migration.ROW["launch_config"])
+        marker = dict(migration.BUILTIN_PROVENANCE)
+        marker["version"] = 0
+        launch_config["builtin_provenance"] = marker
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps "
+                "(app_id, name, transport, launch_config) "
+                "VALUES ('shopify', 'Shopify', 'stdio', :launch_config)"
+            ),
+            {"launch_config": json.dumps(launch_config)},
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='shopify'")
+        ).scalar_one()
+
     assert count == 1
 
 
@@ -255,7 +283,6 @@ def test_upgrade_connect_downgrade_reupgrade_preserves_official_connection(tmp_p
     encrypted_env = association.env
     assert server.auth == {"builtin_provenance": migration.BUILTIN_PROVENANCE}
     db.close()
-
     with engine.begin() as connection:
         with patch.object(migration, "op", _operations(connection)):
             migration.downgrade()
@@ -274,3 +301,66 @@ def test_upgrade_connect_downgrade_reupgrade_preserves_official_connection(tmp_p
         == 1
     )
     db.close()
+
+
+def test_fresh_registry_seed_rejects_normalized_custom_server_collision(tmp_path):
+    from xagent.web.builtin_mcp_registry import seed_builtin_oauth_and_public_mcp_apps
+    from xagent.web.models.database import Base
+    from xagent.web.models.mcp import MCPServer
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'fresh-seed.sqlite'}")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+    db = session_factory()
+    db.add(
+        MCPServer(
+            name=" Shopify ",
+            managed="external",
+            transport="stdio",
+            command="custom",
+        )
+    )
+    db.commit()
+    db.close()
+
+    with engine.begin() as connection:
+        with pytest.raises(RuntimeError, match="custom mcp_servers identity"):
+            seed_builtin_oauth_and_public_mcp_apps(connection)
+        count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='shopify'")
+        ).scalar_one()
+
+    assert count == 0
+
+
+def test_fresh_registry_seed_accepts_owned_server_from_older_version(tmp_path):
+    from xagent.web.builtin_mcp_registry import seed_builtin_oauth_and_public_mcp_apps
+    from xagent.web.models.database import Base
+    from xagent.web.models.mcp import MCPServer
+
+    migration = _load_migration()
+    engine = create_engine(f"sqlite:///{tmp_path / 'fresh-owned.sqlite'}")
+    Base.metadata.create_all(engine)
+    old_marker = dict(migration.BUILTIN_PROVENANCE)
+    old_marker["version"] = 0
+    session_factory = sessionmaker(bind=engine)
+    db = session_factory()
+    db.add(
+        MCPServer(
+            name="shopify",
+            managed="external",
+            transport="stdio",
+            command="python",
+            auth={"builtin_provenance": old_marker},
+        )
+    )
+    db.commit()
+    db.close()
+
+    with engine.begin() as connection:
+        seed_builtin_oauth_and_public_mcp_apps(connection)
+        count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='shopify'")
+        ).scalar_one()
+
+    assert count == 1

--- a/tests/core/model/test_security.py
+++ b/tests/core/model/test_security.py
@@ -282,6 +282,16 @@ def test_redact_sensitive_text_masks_bearer_and_header_keys() -> None:
     assert "my_api_key" not in redacted
 
 
+def test_redact_sensitive_text_masks_shopify_header_case_insensitively() -> None:
+    text = "x-ShOpIfY-aCcEsS-tOkEn: shpat-secret Other-Header: preserved"
+
+    redacted = redact_sensitive_text(text)
+
+    assert "shpat-secret" not in redacted
+    assert "x-ShOpIfY-aCcEsS-tOkEn: ***" in redacted
+    assert "Other-Header: preserved" in redacted
+
+
 def test_redact_sensitive_text_masks_basic_auth_credential() -> None:
     text = "Authorization: Basic dXNlcjpzdXBlci1zZWNyZXQtdG9rZW4="
     redacted = redact_sensitive_text(text)

--- a/tests/web/api/test_mcp_apps_connect.py
+++ b/tests/web/api/test_mcp_apps_connect.py
@@ -49,6 +49,15 @@ def _user(db, uid):
     return db.query(User).filter(User.id == uid).first()
 
 
+def _add_shopify_catalog_app(db):
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app
+
+    row = get_builtin_public_mcp_app("shopify")
+    assert row is not None
+    db.add(PublicMCPApp(**row))
+    db.commit()
+
+
 def test_connect_provisions_shared_server_with_per_user_env(test_db):
     """First connect creates the shared stdio server + a non-owner association
     whose per-user env holds the caller's key, encrypted at rest."""
@@ -78,6 +87,102 @@ def test_connect_provisions_shared_server_with_per_user_env(test_db):
     # Key stored encrypted, decrypts back to plaintext.
     assert assoc.env != {"GOOGLE_MAPS_API_KEY": "alice-key"}
     assert decrypt_env_dict(assoc.env) == {"GOOGLE_MAPS_API_KEY": "alice-key"}
+
+
+def test_shopify_connect_stamps_official_server_provenance(test_db):
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    _add_shopify_catalog_app(test_db)
+    connect_mcp_app(
+        "shopify",
+        MCPAppConnectRequest(
+            env={
+                "SHOPIFY_STORE_DOMAIN": "acme",
+                "SHOPIFY_ACCESS_TOKEN": "shpat_test_secret",
+            }
+        ),
+        current_user=_user(test_db, 1),
+        db=test_db,
+    )
+
+    server = test_db.query(MCPServer).filter(MCPServer.name == "shopify").one()
+    assert server.auth == {
+        "builtin_provenance": {
+            "registry": "xagent",
+            "app_id": "shopify",
+            "version": 1,
+        }
+    }
+    assert "auth" not in server.to_connection_dict()
+
+
+@pytest.mark.parametrize("server_name", ["shopify", " Shopify ", "ShOpIfY"])
+def test_shopify_connect_refuses_unstamped_custom_server_even_if_shape_matches(
+    test_db, server_name
+):
+    from fastapi import HTTPException
+
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    _add_shopify_catalog_app(test_db)
+    test_db.add(
+        MCPServer(
+            name=server_name,
+            description="custom",
+            managed="external",
+            transport="stdio",
+            command="python",
+            args=["-m", "xagent.web.tools.mcp.shopify"],
+        )
+    )
+    test_db.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        connect_mcp_app(
+            "shopify",
+            MCPAppConnectRequest(
+                env={
+                    "SHOPIFY_STORE_DOMAIN": "acme",
+                    "SHOPIFY_ACCESS_TOKEN": "shpat_test_secret",
+                }
+            ),
+            current_user=_user(test_db, 1),
+            db=test_db,
+        )
+
+    assert exc_info.value.status_code == 409
+
+
+def test_shopify_connect_refuses_normalized_custom_catalog_name_collision(test_db):
+    from fastapi import HTTPException
+
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    _add_shopify_catalog_app(test_db)
+    test_db.add(
+        PublicMCPApp(
+            app_id="custom-store",
+            name=" SHOPIFY ",
+            transport="stdio",
+            launch_config={"command": "custom"},
+        )
+    )
+    test_db.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        connect_mcp_app(
+            "shopify",
+            MCPAppConnectRequest(
+                env={
+                    "SHOPIFY_STORE_DOMAIN": "acme",
+                    "SHOPIFY_ACCESS_TOKEN": "shpat_test_secret",
+                }
+            ),
+            current_user=_user(test_db, 1),
+            db=test_db,
+        )
+
+    assert exc_info.value.status_code == 409
 
 
 def test_second_user_joins_same_server_with_own_key(test_db):

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -1115,6 +1115,89 @@ def test_builtin_registry_drift_validation_accepts_canonical_rows() -> None:
             pass
 
 
+def test_shopify_provenance_version_drift_keeps_ownership_and_is_reported() -> None:
+    from xagent.web.builtin_mcp_registry import (
+        _persisted_builtin_provenance_matches,
+        is_builtin_public_mcp_app,
+        validate_builtin_public_mcp_apps,
+    )
+    from xagent.web.mcp_apps import _app_to_dict
+
+    temp_dir = _setup_test_db()
+    db = next(get_db())
+    try:
+        shopify_app = (
+            db.query(PublicMCPApp).filter(PublicMCPApp.app_id == "shopify").one()
+        )
+        launch_config = dict(shopify_app.launch_config)
+        marker = dict(launch_config["builtin_provenance"])
+        marker["version"] = 999
+        launch_config["builtin_provenance"] = marker
+        shopify_app.launch_config = launch_config
+        db.commit()
+
+        assert _persisted_builtin_provenance_matches("shopify", launch_config) is True
+        assert is_builtin_public_mcp_app("shopify") is True
+        assert (
+            _app_to_dict(shopify_app)["launch_config"]["builtin_provenance"]["version"]
+            == 1
+        )
+        with get_engine().begin() as connection:
+            mismatches = validate_builtin_public_mcp_apps(connection)
+
+        shopify_mismatch = next(
+            mismatch for mismatch in mismatches if mismatch["app_id"] == "shopify"
+        )
+        assert shopify_mismatch["mismatched_fields"] == ["launch_config"]
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
+def test_shopify_foreign_provenance_is_not_owned_but_is_reported() -> None:
+    from xagent.web.builtin_mcp_registry import (
+        _persisted_builtin_provenance_matches,
+        validate_builtin_public_mcp_apps,
+    )
+
+    temp_dir = _setup_test_db()
+    db = next(get_db())
+    try:
+        shopify_app = (
+            db.query(PublicMCPApp).filter(PublicMCPApp.app_id == "shopify").one()
+        )
+        launch_config = dict(shopify_app.launch_config)
+        marker = dict(launch_config["builtin_provenance"])
+        marker["registry"] = "custom"
+        launch_config["builtin_provenance"] = marker
+        shopify_app.launch_config = launch_config
+        db.commit()
+
+        assert _persisted_builtin_provenance_matches("shopify", launch_config) is False
+        with get_engine().begin() as connection:
+            mismatches = validate_builtin_public_mcp_apps(connection)
+
+        shopify_mismatch = next(
+            mismatch for mismatch in mismatches if mismatch["app_id"] == "shopify"
+        )
+        assert shopify_mismatch["mismatched_fields"] == ["builtin_provenance"]
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
 def test_init_db_logs_safe_builtin_registry_drift_without_repairing(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/web/tools/test_shopify_mcp.py
+++ b/tests/web/tools/test_shopify_mcp.py
@@ -581,6 +581,73 @@ def test_mutation_error_log_redacts_token(caplog, monkeypatch):
     assert token not in caplog.text
 
 
+def test_mutation_redacts_token_crossing_truncation_boundary_in_result_and_log(
+    caplog, monkeypatch
+):
+    token = "shpat_boundary_secret_value"
+    monkeypatch.setenv("SHOPIFY_ACCESS_TOKEN", token)
+    detail = "x" * 985 + token
+
+    result = shopify._error(detail)
+    shopify._log_failure("mutation", RuntimeError(detail))
+
+    assert token not in result
+    assert token not in caplog.text
+    assert "shpat_boundary" not in result
+    assert "shpat_boundary" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        MockResponse(status_code=200, text="not-json", json_raises=True),
+        MockResponse(json_data=[]),
+        MockResponse(json_data={"data": None}),
+        MockResponse(json_data={"data": {}, "errors": "invalid-shape"}),
+        MockResponse(json_data={"data": {"one": {}, "two": {}}}),
+    ],
+)
+def test_mutation_anomalous_2xx_responses_are_indeterminate(monkeypatch, response):
+    monkeypatch.setattr(shopify.requests, "post", Mock(return_value=response))
+
+    result = json.loads(shopify.shopify_create_product("Shirt"))
+
+    assert result["status"] == "indeterminate"
+    assert result["retryable"] is False
+    assert result["mutation_may_have_completed"] is True
+
+
+def test_mutation_explicit_http_rejection_is_ordinary_error(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                status_code=400,
+                json_data={"errors": [{"message": "request rejected"}]},
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_create_product("Shirt"))
+
+    assert result["status"] == "error"
+    assert "request rejected" in result["message"]
+
+
+def test_read_anomalous_2xx_response_remains_ordinary_error(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(return_value=MockResponse(json_data={"data": None})),
+    )
+
+    result = json.loads(shopify.shopify_get_product("1"))
+
+    assert result["status"] == "error"
+    assert "top-level data" in result["message"]
+
+
 def test_validate_connection_checks_required_and_optional_scopes(monkeypatch):
     monkeypatch.setattr(
         shopify,
@@ -1016,6 +1083,37 @@ def test_get_product_caps_output_size(monkeypatch):
     assert len(result["product"]["tags"]) < 200
 
 
+def test_capped_single_result_keeps_bounded_warning_summary(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "product": {
+                            "id": "gid://shopify/Product/1",
+                            "title": "Shirt",
+                            "tags": [f"tag-{index}" * 20 for index in range(200)],
+                        }
+                    },
+                    "errors": [{"message": "warning-" + "w" * 2000}],
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(shopify, "get_tool_max_output_length", lambda: 500)
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 500)
+
+    raw = shopify.shopify_get_product("1")
+    result = json.loads(raw)
+
+    assert len(raw) <= 500
+    assert result["status"] == "success"
+    assert result["warnings"]
+    assert result["warnings_truncated"] is True
+
+
 def test_create_product_requires_title():
     result = json.loads(shopify.shopify_create_product(""))
 
@@ -1189,7 +1287,7 @@ def test_update_product_rejects_blank_title(monkeypatch):
     mock_post.assert_not_called()
 
 
-def test_create_product_fails_closed_when_mutation_field_missing(monkeypatch):
+def test_create_product_is_indeterminate_when_mutation_field_missing(monkeypatch):
     # A malformed/empty response for the requested mutation field must be
     # treated as a failure, not silently reported as success with an empty
     # product.
@@ -1201,7 +1299,9 @@ def test_create_product_fails_closed_when_mutation_field_missing(monkeypatch):
 
     result = json.loads(shopify.shopify_create_product("Shirt"))
 
-    assert result["status"] == "error"
+    assert result["status"] == "indeterminate"
+    assert result["retryable"] is False
+    assert result["mutation_may_have_completed"] is True
 
 
 def test_create_product_is_indeterminate_when_projection_is_null_after_mutation(
@@ -1232,7 +1332,7 @@ def test_create_product_is_indeterminate_when_projection_is_null_after_mutation(
     assert "Access denied for tags field" in result["message"]
 
 
-def test_create_product_fails_closed_when_object_null_with_no_top_level_errors(
+def test_create_product_is_indeterminate_when_object_null_with_no_top_level_errors(
     monkeypatch,
 ):
     # Same null-object-despite-empty-userErrors shape as above, but with no
@@ -1253,7 +1353,9 @@ def test_create_product_fails_closed_when_object_null_with_no_top_level_errors(
 
     result = json.loads(shopify.shopify_create_product("Shirt"))
 
-    assert result["status"] == "error"
+    assert result["status"] == "indeterminate"
+    assert result["retryable"] is False
+    assert result["mutation_may_have_completed"] is True
     assert "productCreate" in result["message"]
 
 
@@ -1306,7 +1408,7 @@ def test_success_routes_warnings_through_errors_detail(monkeypatch):
                     "data": {
                         "product": {"id": "gid://shopify/Product/1", "title": "Shirt"}
                     },
-                    "errors": "[API] partial failure",
+                    "errors": [{"message": "[API] partial failure"}],
                 }
             )
         ),
@@ -1644,4 +1746,4 @@ def test_custom_shopify_catalog_row_is_not_overlaid_as_builtin():
 
     assert rendered["name"] == "Custom Shopify"
     assert rendered["launch_config"] == custom_launch
-    assert is_builtin_public_mcp_app("shopify", custom_launch) is False
+    assert is_builtin_public_mcp_app("shopify") is True

--- a/tests/web/tools/test_shopify_mcp.py
+++ b/tests/web/tools/test_shopify_mcp.py
@@ -536,6 +536,18 @@ def test_throttle_wait_seconds_falls_back_to_one_second_when_restore_rate_not_po
     assert shopify._throttle_wait_seconds(429, payload) == 1.0
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"errors": "THROTTLED", "extensions": []},
+        {"extensions": {"cost": []}},
+        {"extensions": {"cost": {"throttleStatus": []}}},
+    ],
+)
+def test_throttle_wait_seconds_handles_malformed_nested_shapes(payload):
+    assert shopify._throttle_wait_seconds(429, payload) == 1.0
+
+
 def test_graphql_redacts_connection_error_message(monkeypatch):
     def _raise(*args, **kwargs):
         raise requests.exceptions.ProxyError(
@@ -577,6 +589,8 @@ def test_mutation_error_log_redacts_token(caplog, monkeypatch):
     result = json.loads(shopify.shopify_create_product("Shirt"))
 
     assert result["status"] == "indeterminate"
+    assert "Shopify mutation outcome indeterminate" in caplog.text
+    assert "request headers contained [REDACTED]" in caplog.text
     assert token not in result["message"]
     assert token not in caplog.text
 
@@ -635,6 +649,96 @@ def test_mutation_explicit_http_rejection_is_ordinary_error(monkeypatch):
     assert "request rejected" in result["message"]
 
 
+@pytest.mark.parametrize(
+    "tool_name,args",
+    [
+        ("shopify_create_product", ("Shirt",)),
+        ("shopify_update_product", ("1",)),
+        ("shopify_update_order", ("1",)),
+    ],
+)
+@pytest.mark.parametrize(
+    "failure",
+    [
+        requests.ConnectionError("connection dropped after dispatch"),
+        MockResponse(status_code=503, text="upstream unavailable"),
+    ],
+)
+def test_all_mutation_tools_report_transport_ambiguity_as_indeterminate(
+    monkeypatch, tool_name, args, failure
+):
+    post = (
+        Mock(side_effect=failure)
+        if isinstance(failure, Exception)
+        else Mock(return_value=failure)
+    )
+    monkeypatch.setattr(shopify.requests, "post", post)
+    kwargs = {}
+    if tool_name == "shopify_update_product":
+        kwargs = {"title": "Updated"}
+    elif tool_name == "shopify_update_order":
+        kwargs = {"note": "Updated"}
+
+    result = json.loads(getattr(shopify, tool_name)(*args, **kwargs))
+
+    assert result["status"] == "indeterminate"
+    assert result["retryable"] is False
+    assert result["mutation_may_have_completed"] is True
+
+
+def test_update_product_summary_serialization_failure_is_indeterminate(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "productUpdate": {
+                            "product": {"id": "gid://shopify/Product/1", "tags": {1}},
+                            "userErrors": [],
+                        }
+                    }
+                },
+                text="response",
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_update_product("1", title="Updated"))
+
+    assert result["status"] == "indeterminate"
+    assert result["mutation_may_have_completed"] is True
+
+
+def test_update_order_malformed_total_price_is_indeterminate(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "orderUpdate": {
+                            "order": {
+                                "id": "gid://shopify/Order/1",
+                                "totalPriceSet": [],
+                            },
+                            "userErrors": [],
+                        }
+                    }
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_update_order("1", note="Updated"))
+
+    assert result["status"] == "indeterminate"
+    assert result["retryable"] is False
+    assert "order.totalPriceSet" in result["message"]
+
+
 def test_read_anomalous_2xx_response_remains_ordinary_error(monkeypatch):
     monkeypatch.setattr(
         shopify.requests,
@@ -646,6 +750,72 @@ def test_read_anomalous_2xx_response_remains_ordinary_error(monkeypatch):
 
     assert result["status"] == "error"
     assert "top-level data" in result["message"]
+
+
+@pytest.mark.parametrize(
+    "connection,error_fragment",
+    [
+        ([], "products connection"),
+        ({"edges": [], "pageInfo": []}, "products.pageInfo"),
+        (
+            {"edges": [], "pageInfo": {"hasNextPage": "false"}},
+            "products.pageInfo.hasNextPage",
+        ),
+        (
+            {"edges": "invalid", "pageInfo": {"hasNextPage": False}},
+            "products.edges",
+        ),
+        (
+            {"nodes": ["invalid"], "pageInfo": {"hasNextPage": False}},
+            "node in products.nodes",
+        ),
+    ],
+)
+def test_list_products_returns_clean_error_for_malformed_connection_shapes(
+    monkeypatch, connection, error_fragment
+):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(return_value=MockResponse(json_data={"data": {"products": connection}})),
+    )
+
+    result = json.loads(shopify.shopify_list_products())
+
+    assert result["status"] == "error"
+    assert error_fragment in result["message"]
+    assert "AttributeError" not in result["message"]
+
+
+@pytest.mark.parametrize(
+    "summary_fn,value,error_fragment",
+    [
+        (shopify._order_summary, {"totalPriceSet": []}, "order.totalPriceSet"),
+        (
+            shopify._order_summary,
+            {"totalPriceSet": {"shopMoney": []}},
+            "order.totalPriceSet.shopMoney",
+        ),
+        (
+            shopify._customer_summary,
+            {"defaultEmailAddress": []},
+            "customer.defaultEmailAddress",
+        ),
+        (
+            shopify._customer_summary,
+            {"defaultPhoneNumber": "invalid"},
+            "customer.defaultPhoneNumber",
+        ),
+        (
+            shopify._collection_summary,
+            {"productsCount": []},
+            "collection.productsCount",
+        ),
+    ],
+)
+def test_summaries_reject_malformed_nested_objects(summary_fn, value, error_fragment):
+    with pytest.raises(RuntimeError, match=error_fragment):
+        summary_fn(value)
 
 
 def test_validate_connection_checks_required_and_optional_scopes(monkeypatch):
@@ -672,7 +842,25 @@ def test_validate_connection_reports_missing_scope(monkeypatch):
     result = json.loads(shopify.shopify_validate_connection())
 
     assert result["status"] == "error"
-    assert "write_orders" in result["message"]
+    assert "customers" in result["message"]
+    assert "orders" in result["message"]
+
+
+def test_validate_connection_accepts_read_only_token_and_reports_no_write_support(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        shopify,
+        "_granted_admin_scopes",
+        lambda: {"read_products", "read_orders", "read_customers"},
+    )
+
+    result = json.loads(shopify.shopify_validate_connection())
+
+    assert result["status"] == "success"
+    assert result["read_capable"] is True
+    assert result["write_capable"] is False
+    assert result["missing_write_scopes"] == ["write_orders", "write_products"]
 
 
 def test_required_scope_validation_is_cached_per_credential(monkeypatch):
@@ -722,7 +910,7 @@ def test_extract_connection_skips_null_nodes():
                     {"cursor": "bad", "node": None},
                     {"cursor": "c2", "node": {"id": "2"}},
                 ],
-                "pageInfo": {},
+                "pageInfo": {"hasNextPage": False},
             }
         },
         "products",
@@ -743,17 +931,48 @@ def test_extract_connection_no_cursor_when_not_truncated():
     assert after_cursor is None
 
 
-def test_extract_connection_treats_missing_end_cursor_as_no_more_pages():
-    # hasNextPage=true with no endCursor would otherwise tell a caller to
-    # retry with after=None -- the first page again, forever.
-    _items, has_more, after_cursor = shopify._extract_connection(
-        {"products": {"nodes": [{"id": "1"}], "pageInfo": {"hasNextPage": True}}},
-        "products",
-        lambda n: n,
+def test_extract_connection_rejects_missing_end_cursor_when_has_more():
+    with pytest.raises(RuntimeError, match="without a continuation cursor"):
+        shopify._extract_connection(
+            {
+                "products": {
+                    "nodes": [{"id": "1"}],
+                    "pageInfo": {"hasNextPage": True},
+                }
+            },
+            "products",
+            lambda n: n,
+        )
+
+
+@pytest.mark.parametrize("end_cursor", [None, ""])
+def test_list_products_fails_closed_on_falsy_end_cursor(monkeypatch, end_cursor):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "products": {
+                            "edges": [
+                                {"cursor": "item-1", "node": {"id": "product-1"}}
+                            ],
+                            "pageInfo": {
+                                "hasNextPage": True,
+                                "endCursor": end_cursor,
+                            },
+                        }
+                    }
+                }
+            )
+        ),
     )
 
-    assert has_more is False
-    assert after_cursor is None
+    result = json.loads(shopify.shopify_list_products())
+
+    assert result["status"] == "error"
+    assert "without a continuation cursor" in result["message"]
 
 
 def test_shop_summary_snake_cases_fields():
@@ -1491,7 +1710,12 @@ def test_update_order_sends_tags_and_note(monkeypatch):
             json_data={
                 "data": {
                     "orderUpdate": {
-                        "order": {"id": "gid://shopify/Order/1"},
+                        "order": {
+                            "id": "gid://shopify/Order/1",
+                            "totalPriceSet": {
+                                "shopMoney": {"amount": "10.00", "currencyCode": "USD"}
+                            },
+                        },
                         "userErrors": [],
                     }
                 }
@@ -1516,7 +1740,12 @@ def test_update_order_clears_note_with_explicit_empty_string(monkeypatch):
             json_data={
                 "data": {
                     "orderUpdate": {
-                        "order": {"id": "gid://shopify/Order/1"},
+                        "order": {
+                            "id": "gid://shopify/Order/1",
+                            "totalPriceSet": {
+                                "shopMoney": {"amount": "10.00", "currencyCode": "USD"}
+                            },
+                        },
                         "userErrors": [],
                     }
                 }

--- a/tests/web/tools/test_shopify_mcp.py
+++ b/tests/web/tools/test_shopify_mcp.py
@@ -1,0 +1,1647 @@
+import json
+import socket
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from xagent.web.tools.mcp import shopify
+from xagent.web.tools.mcp import utils as mcp_utils
+
+
+def _fake_getaddrinfo(*ips):
+    def _impl(host, port, *args, **kwargs):
+        return [
+            (
+                socket.AF_INET6 if ":" in ip else socket.AF_INET,
+                socket.SOCK_STREAM,
+                6,
+                "",
+                (ip, port),
+            )
+            for ip in ips
+        ]
+
+    return _impl
+
+
+class MockResponse:
+    def __init__(
+        self,
+        json_data=None,
+        status_code: int = 200,
+        text: str = "",
+        headers: dict | None = None,
+        json_raises: bool = False,
+    ):
+        self._json_data = json_data if json_data is not None else {}
+        self._json_raises = json_raises
+        self.status_code = status_code
+        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        self.headers = headers or {}
+
+    def json(self):
+        if self._json_raises:
+            raise json.JSONDecodeError("Expecting value", self.text, 0)
+        return self._json_data
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("SHOPIFY_STORE_DOMAIN", "acme")
+    monkeypatch.setenv("SHOPIFY_ACCESS_TOKEN", "shpat_test_token")
+    shopify._scope_cache = None
+    monkeypatch.setattr(
+        shopify,
+        "_granted_admin_scopes",
+        lambda: set(shopify.SHOPIFY_REQUIRED_ADMIN_SCOPES),
+    )
+    # _graphql_url() resolves DNS to catch a hostname that rebinds to a
+    # private address; tests must not depend on real network/DNS, so every
+    # test gets a fake resolver returning an unambiguously public IP.
+    monkeypatch.setattr(shopify.socket, "getaddrinfo", _fake_getaddrinfo("1.1.1.1"))
+
+
+def test_headers_require_access_token(monkeypatch):
+    monkeypatch.delenv("SHOPIFY_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="SHOPIFY_ACCESS_TOKEN"):
+        shopify._headers()
+
+
+def test_headers_include_access_token_and_json_content_type():
+    assert shopify._headers() == {
+        "X-Shopify-Access-Token": "shpat_test_token",
+        "Content-Type": "application/json",
+    }
+
+
+@pytest.mark.parametrize("token", ["short", " token-with-space", "token with space"])
+def test_headers_reject_malformed_access_token(monkeypatch, token):
+    monkeypatch.setenv("SHOPIFY_ACCESS_TOKEN", token)
+
+    with pytest.raises(ValueError, match="SHOPIFY_ACCESS_TOKEN"):
+        shopify._headers()
+
+
+def test_graphql_url_requires_store_domain(monkeypatch):
+    monkeypatch.delenv("SHOPIFY_STORE_DOMAIN")
+
+    with pytest.raises(ValueError, match="SHOPIFY_STORE_DOMAIN"):
+        shopify._graphql_url()
+
+
+def test_graphql_url_builds_from_store_domain():
+    assert shopify._graphql_url() == (
+        f"https://acme.myshopify.com/admin/api/{shopify.SHOPIFY_API_VERSION}/graphql.json"
+    )
+
+
+def test_graphql_url_lowercases_store_domain(monkeypatch):
+    monkeypatch.setenv("SHOPIFY_STORE_DOMAIN", "ACME")
+
+    assert shopify._graphql_url().startswith("https://acme.myshopify.com/")
+
+
+@pytest.mark.parametrize(
+    "subdomain",
+    [
+        "",
+        "   ",
+        "acme.evil.com",
+        "acme/../evil",
+        "https://acme",
+        "acme:8080",
+        "-acme",
+        "acme-",
+        "acme evil",
+    ],
+)
+def test_graphql_url_rejects_invalid_store_domain(monkeypatch, subdomain):
+    monkeypatch.setenv("SHOPIFY_STORE_DOMAIN", subdomain)
+
+    with pytest.raises(ValueError, match="SHOPIFY_STORE_DOMAIN"):
+        shopify._graphql_url()
+
+
+def test_graphql_url_rejects_store_domain_resolving_to_private_ip(monkeypatch):
+    monkeypatch.setattr(shopify.socket, "getaddrinfo", _fake_getaddrinfo("10.0.0.5"))
+
+    with pytest.raises(ValueError, match="not allowed"):
+        shopify._graphql_url()
+
+
+def test_graphql_url_rejects_when_any_resolved_address_is_private(monkeypatch):
+    monkeypatch.setattr(
+        shopify.socket, "getaddrinfo", _fake_getaddrinfo("1.1.1.1", "10.0.0.5")
+    )
+
+    with pytest.raises(ValueError, match="not allowed"):
+        shopify._graphql_url()
+
+
+def test_graphql_url_raises_when_dns_resolution_fails(monkeypatch):
+    def _raise(*args, **kwargs):
+        raise socket.gaierror("Name or service not known")
+
+    monkeypatch.setattr(shopify.socket, "getaddrinfo", _raise)
+
+    with pytest.raises(ValueError, match="could not be resolved"):
+        shopify._graphql_url()
+
+
+@pytest.mark.parametrize("value", ["", "   ", None])
+def test_require_non_blank_rejects_empty_values(value):
+    with pytest.raises(ValueError, match="field"):
+        shopify._require_non_blank(value, "field")
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("123", "gid://shopify/Product/123"),
+        (123, "gid://shopify/Product/123"),
+        ("gid://shopify/Product/123", "gid://shopify/Product/123"),
+        ("  123  ", "gid://shopify/Product/123"),
+    ],
+)
+def test_gid_normalizes_numeric_and_passes_through_full_gid(value, expected):
+    assert shopify._gid("Product", value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "abc",
+        "gid://shopify/Order/123",
+        "12.5",
+        "١٢٣",
+        # A full gid with non-ASCII (Arabic-Indic) digits must be rejected
+        # the same way a bare non-ASCII numeric id is -- \\d in a str
+        # pattern matches any Unicode decimal digit, not just ASCII ones.
+        "gid://shopify/Product/١٢٣",
+    ],
+)
+def test_gid_rejects_invalid_or_mismatched_values(value):
+    with pytest.raises(ValueError, match="product_id"):
+        shopify._gid("Product", value)
+
+
+def test_user_errors_message_joins_field_path_and_message():
+    message = shopify._user_errors_message(
+        [{"field": ["product", "title"], "message": "can't be blank"}]
+    )
+
+    assert message == "product.title: can't be blank"
+
+
+def test_user_errors_message_handles_integer_array_index_in_field_path():
+    # Shopify's field path can mix strings with integer array indices for a
+    # list-input error (e.g. a variant's price).
+    message = shopify._user_errors_message(
+        [{"field": ["variants", 0, "price"], "message": "must be positive"}]
+    )
+
+    assert message == "variants.0.price: must be positive"
+
+
+def test_user_errors_message_handles_missing_field():
+    message = shopify._user_errors_message([{"field": None, "message": "failed"}])
+
+    assert message == "failed"
+
+
+def test_user_errors_message_defaults_when_empty():
+    assert shopify._user_errors_message([]) == "Shopify reported a validation error"
+
+
+def test_run_mutation_folds_top_level_errors_into_user_errors_message(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "productCreate": {
+                            "product": None,
+                            "userErrors": [{"field": ["title"], "message": "too long"}],
+                        }
+                    },
+                    "errors": [{"message": "a sub-field failed"}],
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_create_product("Shirt"))
+
+    assert result["status"] == "error"
+    assert result["message"] == "title: too long (a sub-field failed)"
+
+
+def test_split_tags_strips_and_drops_empty_entries():
+    assert shopify._split_tags("vip, , priority,  ") == ["vip", "priority"]
+
+
+def test_throttle_wait_seconds_true_for_429():
+    assert shopify._throttle_wait_seconds(429, {}) is not None
+
+
+def test_throttle_wait_seconds_true_for_200_with_throttled_message():
+    payload = {"errors": [{"message": "Throttled"}]}
+
+    assert shopify._throttle_wait_seconds(200, payload) is not None
+
+
+def test_throttle_wait_seconds_true_for_200_with_throttled_extension_code():
+    payload = {"errors": [{"message": "x", "extensions": {"code": "THROTTLED"}}]}
+
+    assert shopify._throttle_wait_seconds(200, payload) is not None
+
+
+def test_throttle_wait_seconds_none_for_normal_success():
+    assert shopify._throttle_wait_seconds(200, {"data": {"ok": True}}) is None
+
+
+def test_throttle_wait_seconds_ignores_non_dict_extensions():
+    # A malformed error entry (extensions present but not a dict) must not
+    # crash the throttle check.
+    payload = {"errors": [{"message": "x", "extensions": ["not", "a", "dict"]}]}
+
+    assert shopify._throttle_wait_seconds(200, payload) is None
+
+
+def test_throttle_wait_seconds_computes_from_cost_extension():
+    payload = {
+        "extensions": {
+            "cost": {
+                "requestedQueryCost": 200,
+                "throttleStatus": {"currentlyAvailable": 100, "restoreRate": 50},
+            }
+        }
+    }
+
+    assert shopify._throttle_wait_seconds(429, payload) == 2.0
+
+
+def test_throttle_wait_seconds_falls_back_to_one_second_without_cost_data():
+    assert shopify._throttle_wait_seconds(429, {}) == 1.0
+
+
+def test_throttle_wait_seconds_none_when_body_is_not_json(monkeypatch):
+    # _graphql now parses the response body once and passes the already-
+    # parsed payload (None on a non-JSON body) in, rather than the response
+    # object -- a non-dict/None payload must not crash the throttle check.
+    assert shopify._throttle_wait_seconds(200, None) is None
+
+
+def test_graphql_sends_query_and_variables_as_json_body(monkeypatch):
+    mock_post = Mock(return_value=MockResponse(json_data={"data": {"ok": True}}))
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    data, errors = shopify._graphql("query { ok }", {"a": 1})
+
+    assert data == {"ok": True}
+    assert errors == []
+    assert mock_post.call_args.args[0] == shopify._graphql_url()
+    assert mock_post.call_args.kwargs["json"] == {
+        "query": "query { ok }",
+        "variables": {"a": 1},
+    }
+    assert mock_post.call_args.kwargs["headers"]["X-Shopify-Access-Token"] == (
+        "shpat_test_token"
+    )
+
+
+def test_graphql_raises_on_top_level_errors_with_null_data(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {"product": None},
+                    "errors": [{"message": "not found"}],
+                }
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="not found"):
+        shopify._graphql('query { product(id: "x") { id } }')
+
+
+def test_graphql_returns_warnings_for_partial_success(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {"product": {"id": "gid://shopify/Product/1"}},
+                    "errors": [{"message": "a sub-field failed"}],
+                }
+            )
+        ),
+    )
+
+    data, errors = shopify._graphql('query { product(id: "x") { id } }')
+
+    assert data == {"product": {"id": "gid://shopify/Product/1"}}
+    assert errors == [{"message": "a sub-field failed"}]
+
+
+def test_graphql_raises_with_structured_error_body_on_http_error(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                status_code=400, json_data={"errors": [{"message": "Invalid token"}]}
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid token"):
+        shopify._graphql("query { shop { id } }")
+
+
+def test_graphql_raises_with_plain_string_error_body_on_http_error(monkeypatch):
+    # Shopify's own auth-failure responses (e.g. an invalid access token)
+    # put a plain string in "errors", not the GraphQL {"errors": [{...}]}
+    # shape -- this must not be iterated character-by-character.
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                status_code=401,
+                json_data={
+                    "errors": "[API] Invalid API key or access token "
+                    "(unrecognized login or wrong password)"
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        shopify._graphql("query { shop { id } }")
+
+    message = str(excinfo.value)
+    assert "Invalid API key or access token" in message
+    assert "A; P; I" not in message
+
+
+def test_graphql_truncates_unstructured_error_body(monkeypatch):
+    long_body = "x" * 5000
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(return_value=MockResponse(status_code=500, text=long_body)),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        shopify._graphql("query { shop { id } }")
+
+    assert "[truncated]" in str(excinfo.value)
+    assert len(str(excinfo.value)) < len(long_body)
+
+
+def test_graphql_raises_clear_error_for_non_json_2xx_body(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                status_code=200, text="<html>not json</html>", json_raises=True
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="non-JSON"):
+        shopify._graphql("query { shop { id } }")
+
+
+def test_graphql_rejects_response_with_more_than_one_top_level_field(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(return_value=MockResponse(json_data={"data": {"a": 1, "b": 2}})),
+    )
+
+    with pytest.raises(RuntimeError, match="exactly one"):
+        shopify._graphql("query { a b }")
+
+
+@pytest.mark.parametrize("status_code", [301, 302, 303, 307, 308])
+def test_graphql_rejects_redirect_response(monkeypatch, status_code):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(return_value=MockResponse(status_code=status_code)),
+    )
+
+    with pytest.raises(RuntimeError, match="redirect"):
+        shopify._graphql("query { shop { id } }")
+
+
+def test_graphql_retries_once_on_throttled_and_then_succeeds(monkeypatch):
+    responses = [
+        MockResponse(status_code=429),
+        MockResponse(json_data={"data": {"ok": True}}),
+    ]
+    mock_post = Mock(side_effect=responses)
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+    monkeypatch.setattr(shopify.time, "sleep", Mock())
+
+    data, errors = shopify._graphql("query { ok }")
+
+    assert data == {"ok": True}
+    assert mock_post.call_count == 2
+    shopify.time.sleep.assert_called_once()
+
+
+def test_graphql_does_not_retry_a_second_throttle(monkeypatch):
+    mock_post = Mock(return_value=MockResponse(status_code=429))
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+    monkeypatch.setattr(shopify.time, "sleep", Mock())
+
+    with pytest.raises(RuntimeError):
+        shopify._graphql("query { ok }")
+
+    assert mock_post.call_count == 2
+
+
+def test_graphql_retries_once_on_200_throttled_shape_and_then_succeeds(monkeypatch):
+    # Shopify's cost-based throttling can surface as an HTTP 200 whose body
+    # carries a "Throttled" error, not just an HTTP 429 -- a separate code
+    # path through _graphql (falls through the status-code checks entirely
+    # and is only caught by the throttle-message scan), so it needs its own
+    # end-to-end coverage, not just the 429 shape.
+    responses = [
+        MockResponse(json_data={"errors": [{"message": "Throttled"}]}),
+        MockResponse(json_data={"data": {"ok": True}}),
+    ]
+    mock_post = Mock(side_effect=responses)
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+    monkeypatch.setattr(shopify.time, "sleep", Mock())
+
+    data, errors = shopify._graphql("query { ok }")
+
+    assert data == {"ok": True}
+    assert mock_post.call_count == 2
+    shopify.time.sleep.assert_called_once()
+
+
+def test_graphql_does_not_retry_when_wait_exceeds_max_retry_seconds(monkeypatch):
+    # A computed wait longer than MAX_RETRY_AFTER_SECONDS must fall straight
+    # through to the normal HTTP-error handling instead of sleeping.
+    response = MockResponse(
+        status_code=429,
+        json_data={
+            "extensions": {
+                "cost": {
+                    "requestedQueryCost": 10_000,
+                    "throttleStatus": {"currentlyAvailable": 0, "restoreRate": 1},
+                }
+            }
+        },
+    )
+    mock_post = Mock(return_value=response)
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+    sleep_mock = Mock()
+    monkeypatch.setattr(shopify.time, "sleep", sleep_mock)
+
+    with pytest.raises(RuntimeError):
+        shopify._graphql("query { ok }")
+
+    assert mock_post.call_count == 1
+    sleep_mock.assert_not_called()
+
+
+def test_throttle_wait_seconds_falls_back_to_one_second_when_restore_rate_not_positive():
+    # A zero/negative restoreRate must not divide by zero -- fall back to
+    # the flat one-second backoff instead.
+    payload = {
+        "extensions": {
+            "cost": {
+                "requestedQueryCost": 200,
+                "throttleStatus": {"currentlyAvailable": 100, "restoreRate": 0},
+            }
+        }
+    }
+
+    assert shopify._throttle_wait_seconds(429, payload) == 1.0
+
+
+def test_graphql_redacts_connection_error_message(monkeypatch):
+    def _raise(*args, **kwargs):
+        raise requests.exceptions.ProxyError(
+            "Unable to connect to proxy: "
+            "https://user:sp-secret-proxy-pass@proxy.internal:8080/"
+        )
+
+    monkeypatch.setattr(shopify.requests, "post", _raise)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        shopify._graphql("query { ok }")
+
+    assert "sp-secret-proxy-pass" not in str(excinfo.value)
+
+
+def test_create_product_timeout_is_indeterminate_and_not_retryable(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(side_effect=requests.Timeout("timed out after request was sent")),
+    )
+
+    result = json.loads(shopify.shopify_create_product("Shirt"))
+
+    assert result["status"] == "indeterminate"
+    assert result["retryable"] is False
+    assert result["mutation_may_have_completed"] is True
+
+
+def test_mutation_error_log_redacts_token(caplog, monkeypatch):
+    token = "shpat_super_secret_value"
+    monkeypatch.setenv("SHOPIFY_ACCESS_TOKEN", token)
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(side_effect=requests.Timeout(f"request headers contained {token}")),
+    )
+
+    result = json.loads(shopify.shopify_create_product("Shirt"))
+
+    assert result["status"] == "indeterminate"
+    assert token not in result["message"]
+    assert token not in caplog.text
+
+
+def test_validate_connection_checks_required_and_optional_scopes(monkeypatch):
+    monkeypatch.setattr(
+        shopify,
+        "_granted_admin_scopes",
+        lambda: set(shopify.SHOPIFY_REQUIRED_ADMIN_SCOPES) | {"read_all_orders"},
+    )
+
+    result = json.loads(shopify.shopify_validate_connection())
+
+    assert result["status"] == "success"
+    assert result["connection_valid"] is True
+    assert result["granted_optional_scopes"] == ["read_all_orders"]
+
+
+def test_validate_connection_reports_missing_scope(monkeypatch):
+    monkeypatch.setattr(
+        shopify,
+        "_granted_admin_scopes",
+        lambda: {"write_products"},
+    )
+
+    result = json.loads(shopify.shopify_validate_connection())
+
+    assert result["status"] == "error"
+    assert "write_orders" in result["message"]
+
+
+def test_required_scope_validation_is_cached_per_credential(monkeypatch):
+    granted = Mock(return_value={"write_products"})
+    monkeypatch.setattr(shopify, "_granted_admin_scopes", granted)
+    shopify._scope_cache = None
+
+    shopify._require_admin_scopes("read_products", "write_products")
+    shopify._require_admin_scopes("write_products")
+
+    granted.assert_called_once_with()
+
+
+def test_required_scope_validation_rejects_missing_capability(monkeypatch):
+    monkeypatch.setattr(shopify, "_granted_admin_scopes", lambda: {"read_customers"})
+    shopify._scope_cache = None
+
+    with pytest.raises(ValueError, match="write_orders"):
+        shopify._require_admin_scopes("write_orders")
+
+
+def test_extract_connection_returns_end_cursor_when_has_more():
+    items, has_more, after_cursor = shopify._extract_connection(
+        {
+            "products": {
+                "edges": [{"cursor": "cur1", "node": {"id": "1"}}],
+                "pageInfo": {"hasNextPage": True, "endCursor": "cur1"},
+            }
+        },
+        "products",
+        lambda n: n,
+    )
+
+    assert items == [({"id": "1"}, "cur1")]
+    assert has_more is True
+    assert after_cursor == "cur1"
+
+
+def test_extract_connection_skips_null_nodes():
+    # A connection's individual nodes can be null (e.g. failed to resolve
+    # due to permissions) even when the list itself is present.
+    items, _has_more, _after_cursor = shopify._extract_connection(
+        {
+            "products": {
+                "edges": [
+                    {"cursor": "c1", "node": {"id": "1"}},
+                    {"cursor": "bad", "node": None},
+                    {"cursor": "c2", "node": {"id": "2"}},
+                ],
+                "pageInfo": {},
+            }
+        },
+        "products",
+        lambda n: n,
+    )
+
+    assert items == [({"id": "1"}, "c1"), ({"id": "2"}, "c2")]
+
+
+def test_extract_connection_no_cursor_when_not_truncated():
+    _items, has_more, after_cursor = shopify._extract_connection(
+        {"products": {"nodes": [], "pageInfo": {"hasNextPage": False}}},
+        "products",
+        lambda n: n,
+    )
+
+    assert has_more is False
+    assert after_cursor is None
+
+
+def test_extract_connection_treats_missing_end_cursor_as_no_more_pages():
+    # hasNextPage=true with no endCursor would otherwise tell a caller to
+    # retry with after=None -- the first page again, forever.
+    _items, has_more, after_cursor = shopify._extract_connection(
+        {"products": {"nodes": [{"id": "1"}], "pageInfo": {"hasNextPage": True}}},
+        "products",
+        lambda n: n,
+    )
+
+    assert has_more is False
+    assert after_cursor is None
+
+
+def test_shop_summary_snake_cases_fields():
+    assert shopify._shop_summary(
+        {
+            "name": "Acme",
+            "myshopifyDomain": "acme.myshopify.com",
+            "email": "owner@acme.com",
+            "currencyCode": "USD",
+            "ianaTimezone": "America/New_York",
+        }
+    ) == {
+        "name": "Acme",
+        "domain": "acme.myshopify.com",
+        "email": "owner@acme.com",
+        "currency": "USD",
+        "timezone": "America/New_York",
+    }
+
+
+def test_get_shop_returns_shop_info(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "shop": {
+                            "name": "Acme",
+                            "myshopifyDomain": "acme.myshopify.com",
+                            "currencyCode": "USD",
+                        }
+                    }
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_get_shop())
+
+    assert result["status"] == "success"
+    assert result["shop"]["name"] == "Acme"
+    assert result["shop"]["domain"] == "acme.myshopify.com"
+    assert result["shop"]["currency"] == "USD"
+
+
+def test_get_shop_returns_error_when_shop_is_null(monkeypatch):
+    # Every other get-one-record tool (product/order/customer) fails
+    # closed when the requested object comes back null; shop must too,
+    # instead of reporting an all-null object as a success.
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(return_value=MockResponse(json_data={"data": {"shop": None}})),
+    )
+
+    result = json.loads(shopify.shopify_get_shop())
+
+    assert result["status"] == "error"
+
+
+def test_list_products_sends_query_limit_and_after(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {
+                    "products": {
+                        "nodes": [{"id": "gid://shopify/Product/1", "title": "Shirt"}],
+                        "pageInfo": {"hasNextPage": False},
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    result = json.loads(
+        shopify.shopify_list_products(query="status:active", limit=10, after="cur0")
+    )
+
+    assert result["status"] == "success"
+    assert result["products"][0]["title"] == "Shirt"
+    body = mock_post.call_args.kwargs["json"]
+    assert body["variables"] == {"first": 10, "query": "status:active", "after": "cur0"}
+    assert "$query: String!" in body["query"]
+    assert "$after: String!" in body["query"]
+
+
+def test_list_products_omits_query_and_after_when_not_provided(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {"products": {"nodes": [], "pageInfo": {"hasNextPage": False}}}
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    shopify.shopify_list_products()
+
+    body = mock_post.call_args.kwargs["json"]
+    assert body["variables"] == {"first": 25}
+    assert "query" not in body["query"] or "$query" not in body["query"]
+
+
+def test_list_products_clamps_limit_to_max(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {"products": {"nodes": [], "pageInfo": {"hasNextPage": False}}}
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    shopify.shopify_list_products(limit=10_000)
+
+    assert mock_post.call_args.kwargs["json"]["variables"]["first"] == shopify.MAX_LIMIT
+
+
+def test_list_products_surfaces_partial_success_warnings(monkeypatch):
+    # A genuine partial GraphQL success (data still returned alongside a
+    # top-level errors entry, e.g. a nullable nested field that failed to
+    # resolve) must surface as a warning at the tool boundary, not be
+    # silently dropped.
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "products": {
+                            "nodes": [
+                                {"id": "gid://shopify/Product/1", "title": "Shirt"}
+                            ],
+                            "pageInfo": {"hasNextPage": False},
+                        }
+                    },
+                    "errors": [{"message": "a sub-field failed"}],
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_list_products())
+
+    assert result["status"] == "success"
+    assert result["warnings"] == ["a sub-field failed"]
+
+
+def _product_edges(count: int, title_size: int = 1000):
+    return [
+        {
+            "cursor": f"cursor-{index}",
+            "node": {
+                "id": f"gid://shopify/Product/{index}",
+                "title": "x" * title_size,
+            },
+        }
+        for index in range(count)
+    ]
+
+
+def test_list_products_caps_output_with_last_returned_edge_cursor(monkeypatch):
+    edges = _product_edges(50)
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "products": {
+                            "edges": edges,
+                            "pageInfo": {
+                                "hasNextPage": True,
+                                "endCursor": "cursor-49",
+                            },
+                        }
+                    }
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(shopify, "get_tool_max_output_length", lambda: 2000)
+
+    raw = shopify.shopify_list_products(limit=100)
+    result = json.loads(raw)
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert 0 < len(result["products"]) < len(edges)
+    returned_last = len(result["products"]) - 1
+    assert result["after_cursor"] == f"cursor-{returned_last}"
+    assert result["after_cursor"] != "cursor-49"
+    assert result["has_more"] is True
+    assert len(raw) <= 2000
+
+
+def test_list_products_rejects_repeated_cursor(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "products": {
+                            "edges": [],
+                            "pageInfo": {
+                                "hasNextPage": True,
+                                "endCursor": "cur0",
+                            },
+                        }
+                    }
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_list_products(after="cur0"))
+
+    assert result["status"] == "error"
+    assert "did not advance" in result["message"]
+
+
+def test_list_products_compacts_oversized_first_item_and_advances(monkeypatch):
+    edge = _product_edges(1, title_size=5000)[0]
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "products": {
+                            "edges": [edge],
+                            "pageInfo": {"hasNextPage": False},
+                        }
+                    }
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(shopify, "get_tool_max_output_length", lambda: 400)
+
+    raw = shopify.shopify_list_products(limit=1)
+    result = json.loads(raw)
+
+    assert len(raw) <= 400
+    assert result["status"] == "success"
+    assert result["products"] == [{"id": "gid://shopify/Product/0", "truncated": True}]
+    assert result["after_cursor"] == "cursor-0"
+    assert result["has_more"] is True
+
+
+def test_get_product_normalizes_id_and_returns_summary(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {
+                    "product": {
+                        "id": "gid://shopify/Product/1",
+                        "title": "Shirt",
+                        "status": "ACTIVE",
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    result = json.loads(shopify.shopify_get_product("1"))
+
+    assert result["status"] == "success"
+    assert result["product"]["title"] == "Shirt"
+    assert mock_post.call_args.kwargs["json"]["variables"] == {
+        "id": "gid://shopify/Product/1"
+    }
+
+
+def test_get_product_returns_error_when_not_found(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(return_value=MockResponse(json_data={"data": {"product": None}})),
+    )
+
+    result = json.loads(shopify.shopify_get_product("999"))
+
+    assert result["status"] == "error"
+
+
+def test_get_product_caps_output_size(monkeypatch):
+    # A single get response can be just as oversized as a list page (e.g.
+    # an unusually large `tags` list) -- must shrink via _success_capped
+    # instead of returning an uncapped payload the platform's own output
+    # filter would then hard-truncate into broken JSON.
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "product": {
+                            "id": "gid://shopify/Product/1",
+                            "title": "Shirt",
+                            "tags": [f"tag-{i}" * 20 for i in range(200)],
+                        }
+                    }
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(shopify, "get_tool_max_output_length", lambda: 500)
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 500)
+
+    raw = shopify.shopify_get_product("1")
+    result = json.loads(raw)
+
+    assert len(raw) <= 500 + 200  # last halving step can overshoot
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert len(result["product"]["tags"]) < 200
+
+
+def test_create_product_requires_title():
+    result = json.loads(shopify.shopify_create_product(""))
+
+    assert result["status"] == "error"
+
+
+def test_create_product_rejects_invalid_status():
+    result = json.loads(shopify.shopify_create_product("Shirt", status="PUBLISHED"))
+
+    assert result["status"] == "error"
+
+
+def test_create_product_rejects_lowercase_status():
+    # Status values are matched exactly against Shopify's enum spelling;
+    # a caller passing "active" instead of "ACTIVE" gets a clear local
+    # error rather than a Shopify-side enum validation failure.
+    result = json.loads(shopify.shopify_create_product("Shirt", status="active"))
+
+    assert result["status"] == "error"
+
+
+def test_create_product_accepts_unlisted_status(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {
+                    "productCreate": {
+                        "product": {
+                            "id": "gid://shopify/Product/1",
+                            "status": "UNLISTED",
+                        },
+                        "userErrors": [],
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    result = json.loads(shopify.shopify_create_product("Shirt", status="UNLISTED"))
+
+    assert result["status"] == "success"
+    assert mock_post.call_args.kwargs["json"]["variables"]["product"]["status"] == (
+        "UNLISTED"
+    )
+
+
+def test_create_product_sends_expected_input(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {
+                    "productCreate": {
+                        "product": {"id": "gid://shopify/Product/1", "title": "Shirt"},
+                        "userErrors": [],
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    result = json.loads(
+        shopify.shopify_create_product(
+            "Shirt", description="<p>Nice</p>", vendor="Acme", tags="new, summer"
+        )
+    )
+
+    assert result["status"] == "success"
+    product_input = mock_post.call_args.kwargs["json"]["variables"]["product"]
+    assert product_input["title"] == "Shirt"
+    assert product_input["descriptionHtml"] == "<p>Nice</p>"
+    assert product_input["vendor"] == "Acme"
+    assert product_input["tags"] == ["new", "summer"]
+    assert product_input["status"] == "DRAFT"
+
+
+def test_create_product_surfaces_user_errors(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "productCreate": {
+                            "product": None,
+                            "userErrors": [{"field": ["title"], "message": "too long"}],
+                        }
+                    }
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_create_product("Shirt"))
+
+    assert result["status"] == "error"
+    assert "title: too long" in result["message"]
+
+
+def test_update_product_requires_at_least_one_field():
+    result = json.loads(shopify.shopify_update_product("1"))
+
+    assert result["status"] == "error"
+
+
+def test_update_product_rejects_invalid_status(monkeypatch):
+    mock_post = Mock()
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    result = json.loads(shopify.shopify_update_product("1", status="PUBLISHED"))
+
+    assert result["status"] == "error"
+    mock_post.assert_not_called()
+
+
+def test_update_product_sends_only_provided_fields(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {
+                    "productUpdate": {
+                        "product": {"id": "gid://shopify/Product/1", "title": "New"},
+                        "userErrors": [],
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    shopify.shopify_update_product("1", title="New")
+
+    product_input = mock_post.call_args.kwargs["json"]["variables"]["product"]
+    assert product_input == {"id": "gid://shopify/Product/1", "title": "New"}
+
+
+def test_update_product_clears_field_with_explicit_empty_string(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {
+                    "productUpdate": {
+                        "product": {"id": "gid://shopify/Product/1"},
+                        "userErrors": [],
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    # vendor="" is an explicit "clear this field", distinct from the
+    # default None ("leave unchanged") -- both must be forwarded, not
+    # dropped by a truthiness check.
+    result = json.loads(shopify.shopify_update_product("1", vendor=""))
+
+    assert result["status"] == "success"
+    product_input = mock_post.call_args.kwargs["json"]["variables"]["product"]
+    assert product_input == {"id": "gid://shopify/Product/1", "vendor": ""}
+
+
+def test_update_product_rejects_blank_title(monkeypatch):
+    mock_post = Mock()
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    result = json.loads(shopify.shopify_update_product("1", title="   "))
+
+    assert result["status"] == "error"
+    mock_post.assert_not_called()
+
+
+def test_create_product_fails_closed_when_mutation_field_missing(monkeypatch):
+    # A malformed/empty response for the requested mutation field must be
+    # treated as a failure, not silently reported as success with an empty
+    # product.
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(return_value=MockResponse(json_data={"data": {}})),
+    )
+
+    result = json.loads(shopify.shopify_create_product("Shirt"))
+
+    assert result["status"] == "error"
+
+
+def test_create_product_is_indeterminate_when_projection_is_null_after_mutation(
+    monkeypatch,
+):
+    # userErrors is empty, but the product itself is null (e.g. a
+    # nested field GraphQL couldn't resolve, null-propagating the whole
+    # object) -- this must not be reported as success with an all-null
+    # product.
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {"productCreate": {"product": None, "userErrors": []}},
+                    "errors": [{"message": "Access denied for tags field"}],
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_create_product("Shirt"))
+
+    assert result["status"] == "indeterminate"
+    assert result["retryable"] is False
+    assert result["mutation_may_have_completed"] is True
+    assert "Access denied for tags field" in result["message"]
+
+
+def test_create_product_fails_closed_when_object_null_with_no_top_level_errors(
+    monkeypatch,
+):
+    # Same null-object-despite-empty-userErrors shape as above, but with no
+    # top-level `errors` at all -- the generic fallback message branch,
+    # distinct from the `_errors_detail(errors)` branch the sibling test
+    # above exercises.
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {"productCreate": {"product": None, "userErrors": []}}
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_create_product("Shirt"))
+
+    assert result["status"] == "error"
+    assert "productCreate" in result["message"]
+
+
+def test_errors_detail_returns_string_as_is():
+    assert shopify._errors_detail("plain string error") == "plain string error"
+
+
+def test_errors_detail_joins_list_of_error_objects():
+    assert (
+        shopify._errors_detail([{"message": "bad"}, {"message": "worse"}])
+        == "bad; worse"
+    )
+
+
+def test_errors_detail_stringifies_unexpected_shape():
+    # Not per the GraphQL spec (errors should be a list), but must not
+    # silently iterate a dict's keys and drop the actual diagnostic text.
+    detail = shopify._errors_detail({"query": ["failed to parse query"]})
+
+    assert "failed to parse query" in detail
+
+
+def test_errors_detail_truncates_long_text():
+    detail = shopify._errors_detail("x" * 5000)
+
+    assert len(detail) < 5000
+    assert detail.endswith("[truncated]")
+
+
+def test_errors_detail_redacts_sensitive_text():
+    detail = shopify._errors_detail(
+        [{"message": "upstream call failed: https://user:sp-secret@example.com/x"}]
+    )
+
+    assert "sp-secret" not in detail
+
+
+def test_success_routes_warnings_through_errors_detail(monkeypatch):
+    # _success's `warnings` field must go through the same str/list/dict
+    # normalization + truncation/redaction as every other consumer of a
+    # GraphQL response's top-level `errors` value -- calling
+    # graphql_errors_message directly (as _success used to) mangles a
+    # plain-string errors value character by character.
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "product": {"id": "gid://shopify/Product/1", "title": "Shirt"}
+                    },
+                    "errors": "[API] partial failure",
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_get_product("1"))
+
+    assert result["status"] == "success"
+    assert result["warnings"] == ["[API] partial failure"]
+
+
+def test_list_orders_sends_query_and_limit(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {"orders": {"nodes": [], "pageInfo": {"hasNextPage": False}}}
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    shopify.shopify_list_orders(query="financial_status:paid", limit=5)
+
+    assert mock_post.call_args.kwargs["json"]["variables"] == {
+        "first": 5,
+        "query": "financial_status:paid",
+    }
+
+
+def test_get_order_returns_summary(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "order": {
+                            "id": "gid://shopify/Order/1",
+                            "name": "#1001",
+                            "totalPriceSet": {
+                                "shopMoney": {"amount": "10.00", "currencyCode": "USD"}
+                            },
+                        }
+                    }
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_get_order("1"))
+
+    assert result["status"] == "success"
+    assert result["order"]["name"] == "#1001"
+    assert result["order"]["total_price"] == "10.00"
+    assert result["order"]["currency"] == "USD"
+
+
+def test_get_order_returns_error_when_not_found(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(return_value=MockResponse(json_data={"data": {"order": None}})),
+    )
+
+    result = json.loads(shopify.shopify_get_order("999"))
+
+    assert result["status"] == "error"
+
+
+def test_update_order_requires_tags_or_note():
+    result = json.loads(shopify.shopify_update_order("1"))
+
+    assert result["status"] == "error"
+
+
+def test_update_order_sends_tags_and_note(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {
+                    "orderUpdate": {
+                        "order": {"id": "gid://shopify/Order/1"},
+                        "userErrors": [],
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    shopify.shopify_update_order("1", tags="vip, priority", note="Handle with care")
+
+    order_input = mock_post.call_args.kwargs["json"]["variables"]["input"]
+    assert order_input == {
+        "id": "gid://shopify/Order/1",
+        "tags": ["vip", "priority"],
+        "note": "Handle with care",
+    }
+
+
+def test_update_order_clears_note_with_explicit_empty_string(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {
+                    "orderUpdate": {
+                        "order": {"id": "gid://shopify/Order/1"},
+                        "userErrors": [],
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    result = json.loads(shopify.shopify_update_order("1", note=""))
+
+    assert result["status"] == "success"
+    order_input = mock_post.call_args.kwargs["json"]["variables"]["input"]
+    assert order_input == {"id": "gid://shopify/Order/1", "note": ""}
+
+
+def test_update_order_surfaces_user_errors(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "orderUpdate": {
+                            "order": None,
+                            "userErrors": [{"field": None, "message": "not found"}],
+                        }
+                    }
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_update_order("999", note="x"))
+
+    assert result["status"] == "error"
+    assert "not found" in result["message"]
+
+
+def test_list_customers_returns_summaries(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "customers": {
+                            "nodes": [
+                                {
+                                    "id": "gid://shopify/Customer/1",
+                                    "firstName": "Jane",
+                                    "defaultEmailAddress": {
+                                        "emailAddress": "jane@example.com"
+                                    },
+                                    "numberOfOrders": "3",
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": False},
+                        }
+                    }
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_list_customers())
+
+    customer = result["customers"][0]
+    assert customer["first_name"] == "Jane"
+    assert customer["email"] == "jane@example.com"
+    assert customer["number_of_orders"] == "3"
+
+
+def test_get_customer_returns_summary(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "customer": {
+                            "id": "gid://shopify/Customer/1",
+                            "firstName": "Jane",
+                            "lastName": "Doe",
+                            "defaultEmailAddress": {"emailAddress": "jane@example.com"},
+                            "numberOfOrders": "2",
+                        }
+                    }
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_get_customer("1"))
+
+    assert result["status"] == "success"
+    assert result["customer"]["email"] == "jane@example.com"
+    assert result["customer"]["number_of_orders"] == "2"
+
+
+def test_get_customer_returns_error_when_not_found(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(return_value=MockResponse(json_data={"data": {"customer": None}})),
+    )
+
+    result = json.loads(shopify.shopify_get_customer("999"))
+
+    assert result["status"] == "error"
+
+
+def test_list_collections_returns_summaries_with_products_count(monkeypatch):
+    monkeypatch.setattr(
+        shopify.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": {
+                        "collections": {
+                            "nodes": [
+                                {
+                                    "id": "gid://shopify/Collection/1",
+                                    "title": "Summer",
+                                    "productsCount": {"count": 12},
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": False},
+                        }
+                    }
+                }
+            )
+        ),
+    )
+
+    result = json.loads(shopify.shopify_list_collections())
+
+    collection = result["collections"][0]
+    assert collection["title"] == "Summer"
+    assert collection["products_count"] == 12
+
+
+def test_list_collections_forwards_after_cursor_and_clamps_limit(monkeypatch):
+    # Collections is the only list tool with no `query` parameter -- confirm
+    # the shared _list_connection/_success_paginated machinery still builds
+    # a well-formed request (limit clamped, `after` forwarded, no `query`
+    # variable/argument) when query is always "".
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {
+                    "collections": {"nodes": [], "pageInfo": {"hasNextPage": False}}
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    shopify.shopify_list_collections(limit=10_000, after="cur0")
+
+    body = mock_post.call_args.kwargs["json"]
+    assert body["variables"] == {"first": shopify.MAX_LIMIT, "after": "cur0"}
+    assert "$query" not in body["query"]
+
+
+def test_list_collections_forwards_query(monkeypatch):
+    mock_post = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": {
+                    "collections": {"nodes": [], "pageInfo": {"hasNextPage": False}}
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(shopify.requests, "post", mock_post)
+
+    shopify.shopify_list_collections(query="title:*sale*")
+
+    body = mock_post.call_args.kwargs["json"]
+    assert body["variables"]["query"] == "title:*sale*"
+    assert "$query: String!" in body["query"]
+
+
+def test_shopify_app_registry_requires_store_domain_and_token():
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    shopify_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "shopify"
+    )
+    assert shopify_app["provider_name"] is None
+    assert shopify_app["category"] == "Commerce"
+    assert shopify_app["transport"] == "stdio"
+    assert shopify_app["launch_config"]["required_env"] == [
+        "SHOPIFY_STORE_DOMAIN",
+        "SHOPIFY_ACCESS_TOKEN",
+    ]
+
+
+def test_custom_shopify_catalog_row_is_not_overlaid_as_builtin():
+    from types import SimpleNamespace
+
+    from xagent.web.builtin_mcp_registry import is_builtin_public_mcp_app
+    from xagent.web.mcp_apps import _app_to_dict
+
+    custom_launch = {
+        "command": "custom-shopify-server",
+        "required_env": ["CUSTOM_TOKEN"],
+    }
+    app = SimpleNamespace(
+        app_id="shopify",
+        name="Custom Shopify",
+        description="custom",
+        icon=None,
+        transport="stdio",
+        provider_name=None,
+        category="Custom",
+        oauth_scopes=None,
+        is_visible_in_connector=True,
+        launch_config=custom_launch,
+    )
+
+    rendered = _app_to_dict(app)
+
+    assert rendered["name"] == "Custom Shopify"
+    assert rendered["launch_config"] == custom_launch
+    assert is_builtin_public_mcp_app("shopify", custom_launch) is False


### PR DESCRIPTION
## Summary

- add a built-in Shopify Admin GraphQL MCP connector with validated personal store credentials
- register stable built-in provenance without claiming custom apps that use the `shopify` ID or server name
- bound every paginated response and expose safe continuation cursors
- model ambiguous mutation transport/server failures as indeterminate instead of successful or safely retryable
- pin the Admin API version in one module constant and validate the required Admin API scopes during tool execution

## Historical review findings

This implementation was rebuilt from the latest `main` after reviewing the closed #2017 and its complete review history. It does not reuse that branch history. The verified major findings are addressed as follows:

1. **Pagination progress and bounds:** connection queries request edge cursors; every continuation cursor must advance; empty pages terminate; repeated/missing cursors fail closed; response records and serialized output are capped; partial output uses the exact cursor of the final returned edge.
2. **Catalog identity and provenance:** Shopify has an explicit built-in provenance marker. Registry overlays and management classification require that marker, the migration aborts on custom app/server collisions, and downgrade deletes only the marked built-in row.
3. **Indeterminate mutations:** timeouts, network failures, retryable server failures, and a missing mutation projection accompanied by top-level GraphQL errors return `status: "indeterminate"`, `retryable: false`, and `mutation_may_have_completed: true`. Request exceptions are logged without traceback/header leakage, and connector secrets are redacted.

The registry records `credential_scope: "personal"` as forward-compatible metadata for actor-scoped stdio execution. Current `main` does not consume that field, and this change does not enable delegated authorization or otherwise expose the connector to Toby before runtime isolation exists.

## Shopify contract

- credentials: `SHOPIFY_STORE_DOMAIN` and `SHOPIFY_ACCESS_TOKEN`
- pinned Admin API version: `2026-07`
- required scopes: `write_products`, `write_orders`, and `read_customers`
- optional scope: `read_all_orders` for orders older than Shopify's default access window

References:

- [Shopify API versioning](https://shopify.dev/docs/api/usage/versioning)
- [Shopify access scopes](https://shopify.dev/docs/api/usage/access-scopes)

## Validation

- 182 directly related connector, migration, and public-catalog tests passed
- Ruff lint and format checks passed for all changed files
- Python bytecode compilation passed for changed source files
- Alembic reports `20260909_seed_shopify_mcp_app` as the single head
- mutation checks proved that removing the pagination guard, provenance migration filter, runtime provenance filter, or indeterminate status causes the corresponding focused tests to fail

Closes #2261

Parent tracking issue: https://github.com/xorbitsai/xagent-saas/issues/1161
