### PR TITLE
feat(mcp): support frozen remote OAuth classification (toby)

### DIFF
--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -192,19 +192,26 @@ def _app_to_dict(app: PublicMCPApp) -> Dict[str, Any]:
 
 @dataclass(frozen=True)
 class MCPAppSnapshot:
-    """One catalog/server view for repeated canonical builtin validation."""
+    """One catalog/server/ownership view for repeated canonical validation."""
 
     catalog_apps: tuple[PublicMCPApp, ...]
     servers: tuple[Any, ...]
+    owner_mcpserver_ids: frozenset[int]
 
 
 def load_mcp_app_snapshot(db: Session) -> MCPAppSnapshot:
     """Load the catalog and server rows once for one validation projection."""
-    from .models.mcp import MCPServer
+    from .models.mcp import MCPServer, UserMCPServer
 
     return MCPAppSnapshot(
         catalog_apps=tuple(db.query(PublicMCPApp).all()),
         servers=tuple(db.query(MCPServer).all()),
+        owner_mcpserver_ids=frozenset(
+            int(server_id)
+            for (server_id,) in db.query(UserMCPServer.mcpserver_id)
+            .filter(UserMCPServer.is_owner)
+            .all()
+        ),
     )
 
 
@@ -745,9 +752,16 @@ def ensure_builtin_oauth_server_visibility_for_user(
     return server
 
 
-def _get_app_for_server_name(db: Session, name: str) -> Dict[str, Any] | None:
-    candidates = (
-        db.query(PublicMCPApp)
+def _get_app_for_server_name(
+    db: Session,
+    name: str,
+    *,
+    snapshot: MCPAppSnapshot | None = None,
+) -> Dict[str, Any] | None:
+    candidates: Sequence[PublicMCPApp] = (
+        [app for app in snapshot.catalog_apps if app.app_id == name or app.name == name]
+        if snapshot is not None
+        else db.query(PublicMCPApp)
         .filter((PublicMCPApp.app_id == name) | (PublicMCPApp.name == name))
         .all()
     )
@@ -809,6 +823,7 @@ def classify_actor_remote_oauth_server(
     definition_ownership: RemoteOAuthDefinitionOwnership = (
         RemoteOAuthDefinitionOwnership.UNKNOWN
     ),
+    snapshot: MCPAppSnapshot | None = None,
 ) -> Dict[str, Any] | None:
     """Validate catalog OAuth or preserve a proven custom definition."""
 
@@ -821,21 +836,31 @@ def classify_actor_remote_oauth_server(
         and isinstance(auth, Mapping)
         and auth.get("type") == "mcp_oauth"
     )
-    app_info = _get_app_for_server_name(db, str(getattr(server, "name", "")))
+    app_info = _get_app_for_server_name(
+        db,
+        str(getattr(server, "name", "")),
+        snapshot=snapshot,
+    )
+
+    def has_owner() -> bool:
+        server_id = int(server.id)
+        if snapshot is not None:
+            return server_id in snapshot.owner_mcpserver_ids
+        return (
+            db.query(UserMCPServer.id)
+            .filter(
+                UserMCPServer.mcpserver_id == server_id,
+                UserMCPServer.is_owner,
+            )
+            .first()
+            is not None
+        )
+
     if app_info is None or app_info.get("auth_type") != "mcp_oauth":
         if is_remote_oauth:
             # Native OAuth servers have an owner. Catalog rows do not.
-            has_owner = (
-                db.query(UserMCPServer.id)
-                .filter(
-                    UserMCPServer.mcpserver_id == int(server.id),
-                    UserMCPServer.is_owner,
-                )
-                .first()
-                is not None
-            )
             if (
-                not has_owner
+                not has_owner()
                 and definition_ownership is not RemoteOAuthDefinitionOwnership.TEAM
             ):
                 raise RemoteOAuthServerDefinitionError(
@@ -848,8 +873,10 @@ def classify_actor_remote_oauth_server(
     app_id = str(app_info["id"])
     app_name = str(app_info["name"])
     # Remote catalog identity is the reserved server name, not mutable auth.
-    candidates = (
-        db.query(MCPServer).filter(MCPServer.name.in_((app_id, app_name))).all()
+    candidates: Sequence[Any] = (
+        [row for row in snapshot.servers if row.name in (app_id, app_name)]
+        if snapshot is not None
+        else db.query(MCPServer).filter(MCPServer.name.in_((app_id, app_name))).all()
     )
     if len(candidates) != 1 or int(candidates[0].id) != int(server.id):
         raise RemoteOAuthServerDefinitionError(
@@ -875,15 +902,7 @@ def classify_actor_remote_oauth_server(
         failures.append("url")
     if actual_auth != expected_auth:
         failures.append("auth")
-    if (
-        db.query(UserMCPServer.id)
-        .filter(
-            UserMCPServer.mcpserver_id == int(server.id),
-            UserMCPServer.is_owner,
-        )
-        .first()
-        is not None
-    ):
+    if has_owner():
         failures.append("ownership")
     if failures:
         raise RemoteOAuthServerDefinitionError(

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -261,6 +261,153 @@ def test_actor_policy_rejects_invalid_owner(value: object) -> None:
         MCPBuiltinOAuthActorPolicy(resource_owner_key=value)  # type: ignore[arg-type]
 
 
+def test_actor_remote_legacy_classification_queries_each_live_view(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    query = db_session.db.query
+    queried: list[object] = []
+
+    def recording_query(*entities):
+        queried.extend(entities)
+        return query(*entities)
+
+    db_session.db.query = recording_query  # type: ignore[method-assign]
+
+    resolved = mcp_apps.classify_actor_remote_oauth_server(db_session.db, server)
+
+    assert resolved is not None and resolved["id"] == REMOTE_APP_ID
+    assert PublicMCPApp in queried
+    assert MCPServer in queried
+    assert any(entity is UserMCPServer.id for entity in queried)
+
+
+def test_actor_remote_legacy_non_remote_unpersisted_row_remains_native(
+    db_session,
+) -> None:
+    server = SimpleNamespace(name="uncataloged", transport="stdio", auth=None, id=None)
+
+    assert mcp_apps.classify_actor_remote_oauth_server(db_session.db, server) is None
+
+
+def test_actor_remote_snapshot_freezes_catalog_server_and_owner_view(
+    db_session, monkeypatch
+) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    snapshot = mcp_apps.load_mcp_app_snapshot(db_session.db)
+
+    with db_session.session_factory() as live_db:
+        live_db.query(PublicMCPApp).filter(PublicMCPApp.app_id == REMOTE_APP_ID).update(
+            {"is_visible_in_connector": False}
+        )
+        live_db.query(MCPServer).filter(MCPServer.id == int(server.id)).update(
+            {"name": "changed-live-server"}
+        )
+        live_db.query(UserMCPServer).filter(
+            UserMCPServer.mcpserver_id == int(server.id)
+        ).update({"is_owner": True})
+        live_db.commit()
+
+    monkeypatch.setattr(
+        db_session.db,
+        "query",
+        lambda *_args, **_kwargs: pytest.fail(
+            "snapshot classification queried the database"
+        ),
+    )
+
+    resolved = mcp_apps.classify_actor_remote_oauth_server(
+        db_session.db,
+        server,
+        snapshot=snapshot,
+    )
+
+    assert resolved is not None and resolved["id"] == REMOTE_APP_ID
+
+
+def test_actor_remote_snapshot_rejects_ambiguous_server_identity(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    duplicate = MCPServer.from_config(
+        {
+            "name": "Actor Remote",
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://mcp.example.com/mcp",
+            "auth": dict(server.auth),
+        }
+    )
+    db_session.db.add(duplicate)
+    db_session.db.commit()
+    snapshot = mcp_apps.load_mcp_app_snapshot(db_session.db)
+
+    with pytest.raises(
+        mcp_apps.RemoteOAuthServerDefinitionError,
+        match="exactly one server definition",
+    ):
+        mcp_apps.classify_actor_remote_oauth_server(
+            db_session.db, server, snapshot=snapshot
+        )
+
+
+@pytest.mark.parametrize("drift", ["owner", "invalid_auth"])
+def test_actor_remote_snapshot_rejects_noncanonical_definition(
+    db_session, drift
+) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    if drift == "owner":
+        db_session.db.query(UserMCPServer).one().is_owner = True
+    else:
+        server.auth = {**server.auth, "scope": "records.write"}
+    db_session.db.commit()
+    snapshot = mcp_apps.load_mcp_app_snapshot(db_session.db)
+
+    with pytest.raises(mcp_apps.RemoteOAuthServerDefinitionError):
+        mcp_apps.classify_actor_remote_oauth_server(
+            db_session.db, server, snapshot=snapshot
+        )
+
+
+def test_actor_remote_snapshot_preserves_only_proven_custom_definition(
+    db_session,
+) -> None:
+    server = MCPServer.from_config(
+        {
+            "name": "custom-remote",
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://custom.example.com/mcp",
+            "auth": {"type": "mcp_oauth"},
+        }
+    )
+    db_session.db.add(server)
+    db_session.db.flush()
+    association = UserMCPServer(
+        user_id=int(db_session.user.id),
+        mcpserver_id=int(server.id),
+        is_owner=True,
+        is_active=True,
+    )
+    db_session.db.add(association)
+    db_session.db.commit()
+    snapshot = mcp_apps.load_mcp_app_snapshot(db_session.db)
+
+    assert (
+        mcp_apps.classify_actor_remote_oauth_server(
+            db_session.db, server, snapshot=snapshot
+        )
+        is None
+    )
+
+    association.is_owner = False
+    db_session.db.commit()
+    unowned_snapshot = mcp_apps.load_mcp_app_snapshot(db_session.db)
+    with pytest.raises(
+        mcp_apps.RemoteOAuthServerDefinitionError,
+        match="catalog identity is unavailable",
+    ):
+        mcp_apps.classify_actor_remote_oauth_server(
+            db_session.db, server, snapshot=unowned_snapshot
+        )
+
+
 @pytest.mark.asyncio
 async def test_actor_remote_prefers_exact_owner_over_workspace_grant(
     db_session,


### PR DESCRIPTION
## Summary

- allow remote MCP OAuth actor classification to consume an MCP app snapshot
- freeze catalog, server candidate, and ownership decisions within one operation
- preserve legacy live-query behavior when no snapshot is supplied

## Validation

- 25 focused actor remote OAuth and builtin snapshot tests
- ruff format/check
- py_compile
- mutation checks for live-query fallback, ambiguity, and ownership gates

Closes #2266

Parent: xorbitsai/xagent-saas#1161
Unblocks: xorbitsai/xagent-saas#1165