### PR TITLE
feat(mcp): enforce actor-scoped stdio execution (toby)

### DIFF
--- a/example.env
+++ b/example.env
@@ -429,6 +429,8 @@ XAGENT_PASSWORD_MIN_LENGTH="6"
 # to target localhost, private, link-local, reserved, multicast, or unspecified
 # addresses for local authorization-server testing.
 # XAGENT_MCP_OAUTH_ALLOW_PRIVATE_HOSTS="false"
+# Trusted Toby actor-scoped stdio execution. Keep disabled until rollout.
+# XAGENT_TOBY_PERSONAL_STDIO_ENABLED="false"
 # Optional explicit trusted proxy for outbound MCP OAuth discovery/token calls.
 # System HTTP_PROXY/HTTPS_PROXY environment variables are intentionally ignored.
 # XAGENT_MCP_OAUTH_PROXY_URL="http://proxy.example.com:8080"

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -215,6 +215,7 @@ OPENROUTER_OFFICIAL_PROVIDERS_ONLY = "XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY"
 XROUTER_EXCLUDED_MODELS = "XAGENT_XROUTER_EXCLUDED_MODELS"
 MCP_OAUTH_ALLOW_PRIVATE_HOSTS = "XAGENT_MCP_OAUTH_ALLOW_PRIVATE_HOSTS"
 MCP_OAUTH_PROXY_URL = "XAGENT_MCP_OAUTH_PROXY_URL"
+TOBY_PERSONAL_STDIO_ENABLED = "XAGENT_TOBY_PERSONAL_STDIO_ENABLED"
 TRUSTED_EGRESS_PROXY = "XAGENT_TRUSTED_EGRESS_PROXY"
 
 TOOL_MAX_OUTPUT_LENGTH = "XAGENT_TOOL_MAX_OUTPUT_LENGTH"
@@ -629,6 +630,12 @@ def get_mcp_oauth_allow_private_hosts() -> bool:
     servers. Production deployments should leave it disabled.
     """
     return _get_bool_env(MCP_OAUTH_ALLOW_PRIVATE_HOSTS, False)
+
+
+def get_toby_personal_stdio_enabled() -> bool:
+    """Return whether trusted Toby actor executions may use personal stdio."""
+
+    return _get_bool_env(TOBY_PERSONAL_STDIO_ENABLED, False)
 
 
 def get_trusted_egress_proxy_enabled() -> bool:

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -1118,6 +1118,7 @@ class ToolFactory:
                             "runtime_input_schema",
                             "connector_runtime",
                             "allow_delegated_authorization",
+                            "actor_stdio_session_identity",
                         ):
                             if runtime_key in config:
                                 connection_config[runtime_key] = config[runtime_key]

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -117,6 +117,7 @@ from ..services.hot_path_cache import (
 from ..services.llm_utils import AutoModelUnavailableError, resolve_llms_from_names
 from ..services.managed_file_ref import ensure_uploaded_file_local_path
 from ..services.mcp_runtime import (
+    MCPActorExecutionIdentity,
     MCPBuiltinOAuthActorPolicy,
     MCPBuiltinOAuthActorPolicyMismatchError,
     MCPBuiltinOAuthActorPolicyRequiredError,
@@ -657,6 +658,7 @@ async def create_default_tools(
     task_runtime_context: TaskRuntimeContext | None = None,
     connector_runtime_turn_id: Optional[str] = None,
     mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+    mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
     force_mcp_tools: bool = False,
     mcp_failure_policy: MCPFailurePolicy = MCPFailurePolicy.BEST_EFFORT,
     mcp_load_summary_tracer: Optional[Any] = None,
@@ -763,6 +765,7 @@ async def create_default_tools(
         voice=voice_from_runtime_user(user),
         connector_runtime_turn_id=connector_runtime_turn_id,
         mcp_runtime_authorization_policy=mcp_runtime_authorization_policy,
+        mcp_actor_execution_identity=mcp_actor_execution_identity,
         mcp_failure_policy=mcp_failure_policy,
         mcp_load_summary_tracer=mcp_load_summary_tracer,
         mcp_load_summary_trace_task_id=mcp_load_summary_trace_task_id,
@@ -2047,6 +2050,7 @@ class AgentServiceManager:
         task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
         connector_runtime_turn_id: Optional[str] = None,
         mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
     ) -> tuple[list[Any], Any]:
         """Build the tool set configured for a web task."""
         if task_setup_snapshot is not None:
@@ -2186,6 +2190,7 @@ class AgentServiceManager:
             else None,
             connector_runtime_turn_id=connector_runtime_turn_id,
             mcp_runtime_authorization_policy=mcp_runtime_authorization_policy,
+            mcp_actor_execution_identity=mcp_actor_execution_identity,
             force_mcp_tools=actor_execution,
             mcp_failure_policy=_mcp_failure_policy_for_task_source(task.source),
             mcp_load_summary_tracer=parent_tracer,
@@ -2207,6 +2212,7 @@ class AgentServiceManager:
         task_owner_user_id: Optional[int] = None,
         connector_runtime_turn_id: Optional[str] = None,
         mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
         task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
         resolved_execution_scope: Union[
             ExecutionScope, None, ExecutionScopeNotProvided
@@ -2225,6 +2231,7 @@ class AgentServiceManager:
                 task_owner_user_id=task_owner_user_id,
                 connector_runtime_turn_id=connector_runtime_turn_id,
                 mcp_runtime_authorization_policy=(mcp_runtime_authorization_policy),
+                mcp_actor_execution_identity=mcp_actor_execution_identity,
                 task_mode=task_mode,
                 resolved_execution_scope=resolved_execution_scope,
             )
@@ -2244,6 +2251,7 @@ class AgentServiceManager:
         task_owner_user_id: Optional[int] = None,
         connector_runtime_turn_id: Optional[str] = None,
         mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
         task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
         resolved_execution_scope: Union[
             ExecutionScope, None, ExecutionScopeNotProvided
@@ -2627,11 +2635,17 @@ class AgentServiceManager:
                                 mcp_runtime_authorization_policy=(
                                     mcp_runtime_authorization_policy
                                 ),
+                                mcp_actor_execution_identity=(
+                                    mcp_actor_execution_identity
+                                ),
                             )
                             self._agent_owner_ids[task_id] = runtime_user_id
                             self._agent_scope_fingerprints[task_id] = fingerprint
                             self._sync_connector_runtime_turn(
                                 task_id, connector_runtime_turn_id
+                            )
+                            self._sync_mcp_actor_execution_identity(
+                                task_id, mcp_actor_execution_identity
                             )
                             self._sync_execution_scope(task_id, scope)
                             return self._agents[task_id]
@@ -3114,6 +3128,7 @@ class AgentServiceManager:
         self._agent_owner_ids[task_id] = runtime_user_id
         self._agent_scope_fingerprints[task_id] = fingerprint
         self._sync_connector_runtime_turn(task_id, connector_runtime_turn_id)
+        self._sync_mcp_actor_execution_identity(task_id, mcp_actor_execution_identity)
         self._sync_execution_scope(task_id, scope)
         return self._agents[task_id]
 
@@ -3159,6 +3174,24 @@ class AgentServiceManager:
                 task_id,
                 connector_runtime_turn_id,
             )
+
+    def _sync_mcp_actor_execution_identity(
+        self,
+        task_id: int,
+        identity: MCPActorExecutionIdentity | None,
+    ) -> None:
+        agent = self._agents.get(task_id)
+        tool_config = getattr(agent, "tool_config", None) if agent is not None else None
+        if tool_config is None or not hasattr(
+            tool_config, "set_mcp_actor_execution_identity"
+        ):
+            return
+        if tool_config.set_mcp_actor_execution_identity(identity):
+            logger.info(
+                "Refreshing actor MCP tools for task %s execution identity",
+                task_id,
+            )
+            agent.invalidate_tools()
 
     def _sync_execution_scope(
         self, task_id: int, scope: Optional[ExecutionScope]
@@ -3979,6 +4012,7 @@ class AgentServiceManager:
         task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
         connector_runtime_turn_id: Optional[str] = None,
         mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
     ) -> None:
         """Reconstruct from the detached task-runtime snapshot.
 
@@ -4047,6 +4081,7 @@ class AgentServiceManager:
                 task_setup_snapshot=snapshot,
                 connector_runtime_turn_id=connector_runtime_turn_id,
                 mcp_runtime_authorization_policy=(mcp_runtime_authorization_policy),
+                mcp_actor_execution_identity=mcp_actor_execution_identity,
             )
 
             from .agents import (

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -705,6 +705,9 @@ async def create_default_tools(
 
     # Create a WebToolConfig to properly initialize tools
     from ..tools.config import WebToolConfig
+    from ..services.actor_mcp_runtime import (
+        production_actor_mcp_stdio_connection_adapter,
+    )
     from .agents import voice_from_runtime_user
 
     db_factory = None
@@ -765,6 +768,11 @@ async def create_default_tools(
         voice=voice_from_runtime_user(user),
         connector_runtime_turn_id=connector_runtime_turn_id,
         mcp_runtime_authorization_policy=mcp_runtime_authorization_policy,
+        mcp_actor_stdio_connection_adapter=(
+            production_actor_mcp_stdio_connection_adapter()
+            if mcp_runtime_authorization_policy is not None
+            else None
+        ),
         mcp_actor_execution_identity=mcp_actor_execution_identity,
         mcp_failure_policy=mcp_failure_policy,
         mcp_load_summary_tracer=mcp_load_summary_tracer,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -161,6 +161,7 @@ from ..services.managed_file_ref import (
     log_durable_storage_fault,
 )
 from ..services.mcp_runtime import (
+    MCPActorExecutionIdentity,
     MCPBuiltinOAuthActorPolicy,
     MCPBuiltinOAuthActorPolicyRequiredError,
 )
@@ -2768,6 +2769,23 @@ async def execute_task_background(
             )
 
         context_dict = context if isinstance(context, dict) else {}
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None
+        if (
+            mcp_runtime_authorization_policy is not None
+            and task_lease is not None
+            and task_lease.task_id == task_id
+        ):
+            try:
+                mcp_actor_execution_identity = MCPActorExecutionIdentity(
+                    task_id=task_id,
+                    run_id=task_lease.run_id,  # type: ignore[arg-type]
+                    turn_id=context_dict.get("turn_id"),  # type: ignore[arg-type]
+                    lease_attempt_id=task_lease.attempt_id,  # type: ignore[arg-type]
+                )
+            except ValueError:
+                # Only execution-scoped actor stdio requires this complete
+                # fence. Per-call stdio and existing OAuth remain available.
+                mcp_actor_execution_identity = None
         logger.info(f"Background task execution started for task {task_id}")
         task_user_id = snapshot.task.user_id
         user = snapshot.runtime_user
@@ -2804,6 +2822,7 @@ async def execute_task_background(
                 if isinstance(context_dict.get("turn_id"), str)
                 else None,
                 mcp_runtime_authorization_policy=(mcp_runtime_authorization_policy),
+                mcp_actor_execution_identity=mcp_actor_execution_identity,
                 resolved_execution_scope=execution_scope,
             )
             if hasattr(agent_service, "set_outbound_message_handler"):

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import os
 from copy import deepcopy
-from typing import Any
+from typing import Any, Literal
 
 import sqlalchemy as sa
 from sqlalchemy.engine import Connection
@@ -980,6 +980,10 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "provider_name": None,
             "category": "Productivity",
             "oauth_scopes": None,
+            # Runtime-only metadata. This is intentionally outside
+            # launch_config so enabling execution-scoped session handling does
+            # not create persisted PublicMCPApp execution drift.
+            "stdio_session_scope": "execution",
             # Hidden until the runtime supports execution-scoped (persistent)
             # stdio MCP sessions: today every tool call spawns a fresh
             # chrome-devtools-mcp process (mcp_adapter._execute_mcp_call ->
@@ -1475,6 +1479,17 @@ def get_builtin_execution_fields(app_id: str) -> dict[str, Any] | None:
     return deepcopy(
         {field_name: row[field_name] for field_name in _BUILTIN_EXECUTION_FIELD_NAMES}
     )
+
+
+def get_builtin_stdio_session_scope(
+    app_id: str,
+) -> Literal["per_call", "execution"]:
+    """Return code-owned stdio session scope; ordinary apps are per-call."""
+
+    row = get_builtin_public_mcp_app(app_id)
+    if row is not None and row.get("stdio_session_scope") == "execution":
+        return "execution"
+    return "per_call"
 
 
 def get_builtin_execution_fields_and_optional_scopes(

--- a/src/xagent/web/services/actor_mcp_runtime.py
+++ b/src/xagent/web/services/actor_mcp_runtime.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+import logging
+from typing import Any, Protocol, final
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -14,12 +15,28 @@ from ..builtin_mcp_registry import (
     get_builtin_stdio_session_scope,
 )
 from ..models.public_mcp import PublicMCPApp
+from .actor_mcp_connections import (
+    ActorMCPConnectionCredentialCorruptionError,
+    ActorMCPConnectionNotFoundOrStaleError,
+    ActorMCPConnectionValidationError,
+    get_actor_mcp_connection_credentials_internal,
+    list_actor_mcp_connection_metadata,
+)
 from .mcp_runtime import (
     MCPActorAuthorizationPolicy,
     MCPActorExecutionIdentity,
     caller_id_env,
 )
 from .user_oauth import normalize_user_oauth_resource_owner_key
+
+logger = logging.getLogger(__name__)
+
+
+_ACTOR_MCP_STORAGE_ERRORS = (
+    ActorMCPConnectionValidationError,
+    ActorMCPConnectionNotFoundOrStaleError,
+    ActorMCPConnectionCredentialCorruptionError,
+)
 
 
 class ActorMCPRuntimeDefinitionError(ValueError):
@@ -111,6 +128,63 @@ class ActorMCPStdioConnectionAdapter(Protocol):
         catalog_app_generation: UUID,
         expected_lifecycle_generation: UUID,
     ) -> Mapping[str, str] | None: ...
+
+
+@final
+class ActorMCPConnectionServiceAdapter:
+    """Stateless adapter over the lifecycle-fenced actor connection service."""
+
+    def list_connection_identities(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+    ) -> Sequence[ActorMCPStdioConnectionIdentity]:
+        metadata = list_actor_mcp_connection_metadata(
+            db,
+            user_id=user_id,
+            resource_owner_key=resource_owner_key,
+        )
+        return tuple(
+            ActorMCPStdioConnectionIdentity(
+                user_id=item.user_id,
+                resource_owner_key=item.resource_owner_key,
+                app_id=item.app_id,
+                catalog_app_generation=item.catalog_app_generation,
+                lifecycle_generation=item.lifecycle_generation,
+            )
+            for item in metadata
+        )
+
+    def get_connection_credentials(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+        app_id: str,
+        catalog_app_generation: UUID,
+        expected_lifecycle_generation: UUID,
+    ) -> Mapping[str, str] | None:
+        snapshot = get_actor_mcp_connection_credentials_internal(
+            db,
+            user_id=user_id,
+            resource_owner_key=resource_owner_key,
+            app_id=app_id,
+            catalog_app_generation=catalog_app_generation,
+            expected_lifecycle_generation=expected_lifecycle_generation,
+        )
+        return snapshot.credentials
+
+
+_ACTOR_MCP_CONNECTION_SERVICE_ADAPTER = ActorMCPConnectionServiceAdapter()
+
+
+def production_actor_mcp_stdio_connection_adapter() -> ActorMCPStdioConnectionAdapter:
+    """Return the immutable production storage adapter."""
+
+    return _ACTOR_MCP_CONNECTION_SERVICE_ADAPTER
 
 
 @dataclass(frozen=True)
@@ -267,12 +341,21 @@ def resolve_actor_mcp_stdio_configs(
         return ActorMCPStdioResolution((), blocked_server_ids)
 
     try:
-        identities = adapter.list_connection_identities(
-            db,
-            user_id=user_id,
-            resource_owner_key=policy.resource_owner_key,
+        identities = tuple(
+            adapter.list_connection_identities(
+                db,
+                user_id=user_id,
+                resource_owner_key=policy.resource_owner_key,
+            )
         )
-    except Exception:
+    except _ACTOR_MCP_STORAGE_ERRORS as exc:
+        logger.info("Actor stdio connection list unavailable (%s)", type(exc).__name__)
+        return ActorMCPStdioResolution((), blocked_server_ids)
+    except Exception as exc:
+        logger.warning(
+            "Actor stdio connection list failed unexpectedly (%s)",
+            type(exc).__name__,
+        )
         return ActorMCPStdioResolution((), blocked_server_ids)
     configs: list[dict[str, Any]] = []
     for identity in identities:
@@ -301,6 +384,17 @@ def resolve_actor_mcp_stdio_configs(
                 for server in visible_servers
             ):
                 continue
+        except ActorMCPRuntimeDefinitionError as exc:
+            logger.info("Actor stdio definition unavailable (%s)", type(exc).__name__)
+            continue
+        except Exception as exc:
+            logger.warning(
+                "Actor stdio definition failed unexpectedly (%s)",
+                type(exc).__name__,
+            )
+            continue
+
+        try:
             credentials = adapter.get_connection_credentials(
                 db,
                 user_id=user_id,
@@ -313,7 +407,16 @@ def resolve_actor_mcp_stdio_configs(
                 credentials,
                 required_fields=required_fields,
             )
-        except Exception:
+        except (*_ACTOR_MCP_STORAGE_ERRORS, ActorMCPRuntimeDefinitionError) as exc:
+            logger.info(
+                "Actor stdio credential read unavailable (%s)", type(exc).__name__
+            )
+            continue
+        except Exception as exc:
+            logger.warning(
+                "Actor stdio credential read failed unexpectedly (%s)",
+                type(exc).__name__,
+            )
             continue
 
         launch = execution["launch_config"]

--- a/src/xagent/web/services/actor_mcp_runtime.py
+++ b/src/xagent/web/services/actor_mcp_runtime.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ... import config as xagent_config
+from ..builtin_mcp_registry import (
+    get_builtin_execution_fields,
+    get_builtin_public_mcp_app_rows,
+)
+from ..models.public_mcp import PublicMCPApp
+from .mcp_runtime import MCPActorAuthorizationPolicy, caller_id_env
+from .user_oauth import normalize_user_oauth_resource_owner_key
+
+
+class ActorMCPRuntimeDefinitionError(ValueError):
+    """An actor stdio identity or its canonical definition is unavailable."""
+
+
+@dataclass(frozen=True)
+class ActorMCPStdioConnectionIdentity:
+    """Non-secret identity required to resolve one actor stdio connection."""
+
+    user_id: int
+    resource_owner_key: str = field(repr=False)
+    app_id: str
+    catalog_app_generation: UUID
+    lifecycle_generation: UUID
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.user_id, bool)
+            or not isinstance(self.user_id, int)
+            or self.user_id <= 0
+        ):
+            raise ActorMCPRuntimeDefinitionError(
+                "actor stdio identity requires a persisted user_id"
+            )
+        owner_key = normalize_user_oauth_resource_owner_key(self.resource_owner_key)
+        if owner_key != self.resource_owner_key:
+            raise ActorMCPRuntimeDefinitionError(
+                "actor stdio identity requires an exact resource_owner_key"
+            )
+        if (
+            not isinstance(self.app_id, str)
+            or not self.app_id
+            or self.app_id != self.app_id.strip()
+        ):
+            raise ActorMCPRuntimeDefinitionError(
+                "actor stdio identity requires an exact app_id"
+            )
+        if not isinstance(self.catalog_app_generation, UUID):
+            raise ActorMCPRuntimeDefinitionError(
+                "actor stdio identity requires catalog_app_generation"
+            )
+        if not isinstance(self.lifecycle_generation, UUID):
+            raise ActorMCPRuntimeDefinitionError(
+                "actor stdio identity requires lifecycle_generation"
+            )
+
+
+class ActorMCPStdioConnectionAdapter(Protocol):
+    """Narrow secret boundary implemented by actor connection storage."""
+
+    def list_connection_identities(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+    ) -> Sequence[ActorMCPStdioConnectionIdentity]: ...
+
+    def get_connection_credentials(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+        app_id: str,
+        catalog_app_generation: UUID,
+        expected_lifecycle_generation: UUID,
+    ) -> Mapping[str, str] | None: ...
+
+
+@dataclass(frozen=True)
+class ActorMCPStdioResolution:
+    configs: tuple[dict[str, Any], ...]
+    blocked_server_ids: frozenset[int]
+
+
+def _normalized_catalog_key(value: object) -> str | None:
+    if value is None:
+        return None
+    normalized = "-".join(str(value).strip().lower().split())
+    return normalized or None
+
+
+def _builtin_stdio_rows() -> tuple[dict[str, Any], ...]:
+    return tuple(
+        row
+        for row in get_builtin_public_mcp_app_rows()
+        if str(row.get("transport") or "").lower() == "stdio"
+    )
+
+
+def _reserved_stdio_keys() -> frozenset[str]:
+    return frozenset(
+        key
+        for row in _builtin_stdio_rows()
+        for key in (
+            _normalized_catalog_key(row.get("app_id")),
+            _normalized_catalog_key(row.get("name")),
+        )
+        if key is not None
+    )
+
+
+def _blocked_visible_server_ids(visible_servers: Sequence[Any]) -> frozenset[int]:
+    reserved = _reserved_stdio_keys()
+    return frozenset(
+        int(server.id)
+        for server in visible_servers
+        if _normalized_catalog_key(getattr(server, "name", None)) in reserved
+    )
+
+
+def _canonical_stdio_execution(
+    db: Session,
+    identity: ActorMCPStdioConnectionIdentity,
+) -> tuple[dict[str, Any], tuple[str, ...]]:
+    execution = get_builtin_execution_fields(identity.app_id)
+    if execution is None or execution.get("transport") != "stdio":
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio app is absent from the builtin registry"
+        )
+
+    catalog_apps = db.query(PublicMCPApp).all()
+    matches = [app for app in catalog_apps if app.app_id == identity.app_id]
+    normalized_id = _normalized_catalog_key(identity.app_id)
+    collisions = [
+        app
+        for app in catalog_apps
+        if _normalized_catalog_key(app.app_id) == normalized_id
+    ]
+    if len(matches) != 1 or len(collisions) != 1:
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio catalog identity is unavailable or ambiguous"
+        )
+    app = matches[0]
+    if (
+        app.generation != identity.catalog_app_generation
+        or not app.is_visible_in_connector
+    ):
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio catalog lifecycle is stale or hidden"
+        )
+
+    persisted_execution = {
+        "name": app.name,
+        "transport": app.transport,
+        "provider_name": app.provider_name,
+        "oauth_scopes": list(app.oauth_scopes or []),
+        "launch_config": app.launch_config or {},
+    }
+    expected_execution = {
+        "name": execution["name"],
+        "transport": execution["transport"],
+        "provider_name": execution["provider_name"],
+        "oauth_scopes": list(execution["oauth_scopes"] or []),
+        "launch_config": execution["launch_config"],
+    }
+    if persisted_execution != expected_execution:
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio persisted catalog definition has drifted"
+        )
+
+    launch = execution.get("launch_config")
+    if not isinstance(launch, Mapping) or not isinstance(launch.get("command"), str):
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio builtin execution definition is invalid"
+        )
+    args = launch.get("args", [])
+    fields = launch.get("required_env", [])
+    if (
+        not isinstance(args, list)
+        or any(not isinstance(arg, str) for arg in args)
+        or not isinstance(fields, list)
+        or any(not isinstance(name, str) or not name for name in fields)
+        or len(fields) != len(set(fields))
+    ):
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio builtin execution definition is invalid"
+        )
+    return execution, tuple(fields)
+
+
+def _validated_runtime_credentials(
+    credentials: Mapping[str, str] | None,
+    *,
+    required_fields: tuple[str, ...],
+) -> dict[str, str]:
+    if not required_fields and credentials is None:
+        return {}
+    if not isinstance(credentials, Mapping) or set(credentials) != set(required_fields):
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio credentials are incomplete"
+        )
+    values = dict(credentials)
+    if any(
+        not isinstance(value, str) or not value.strip() for value in values.values()
+    ):
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio credentials are incomplete"
+        )
+    return values
+
+
+def resolve_actor_mcp_stdio_configs(
+    db: Session,
+    *,
+    user_id: int,
+    policy: MCPActorAuthorizationPolicy | None,
+    adapter: ActorMCPStdioConnectionAdapter | None,
+    visible_servers: Sequence[Any],
+) -> ActorMCPStdioResolution:
+    """Build actor configs without consulting any persisted MCP server definition."""
+
+    if policy is None or not policy.allow_builtin_stdio:
+        return ActorMCPStdioResolution((), frozenset())
+
+    blocked_server_ids = _blocked_visible_server_ids(visible_servers)
+    if (
+        isinstance(user_id, bool)
+        or not isinstance(user_id, int)
+        or user_id <= 0
+        or not xagent_config.get_toby_personal_stdio_enabled()
+        or adapter is None
+    ):
+        return ActorMCPStdioResolution((), blocked_server_ids)
+
+    try:
+        identities = adapter.list_connection_identities(
+            db,
+            user_id=user_id,
+            resource_owner_key=policy.resource_owner_key,
+        )
+    except Exception:
+        return ActorMCPStdioResolution((), blocked_server_ids)
+    configs: list[dict[str, Any]] = []
+    for identity in identities:
+        if (
+            not isinstance(identity, ActorMCPStdioConnectionIdentity)
+            or identity.user_id != user_id
+            or identity.resource_owner_key != policy.resource_owner_key
+        ):
+            continue
+        try:
+            execution, required_fields = _canonical_stdio_execution(db, identity)
+            app_keys = {
+                _normalized_catalog_key(identity.app_id),
+                _normalized_catalog_key(execution.get("name")),
+            }
+            if any(
+                _normalized_catalog_key(getattr(server, "name", None)) in app_keys
+                for server in visible_servers
+            ):
+                continue
+            credentials = adapter.get_connection_credentials(
+                db,
+                user_id=user_id,
+                resource_owner_key=policy.resource_owner_key,
+                app_id=identity.app_id,
+                catalog_app_generation=identity.catalog_app_generation,
+                expected_lifecycle_generation=identity.lifecycle_generation,
+            )
+            env = _validated_runtime_credentials(
+                credentials,
+                required_fields=required_fields,
+            )
+        except Exception:
+            continue
+
+        launch = execution["launch_config"]
+        trusted_env = {**env, **caller_id_env(user_id)}
+        configs.append(
+            {
+                "name": identity.app_id,
+                "transport": "stdio",
+                "description": execution.get("name"),
+                "config": {
+                    "command": launch["command"],
+                    "args": list(launch.get("args") or []),
+                    "env": trusted_env,
+                    "concurrency_safe": False,
+                    "concurrent_tools": [],
+                },
+                "user_id": str(user_id),
+            }
+        )
+
+    return ActorMCPStdioResolution(tuple(configs), blocked_server_ids)

--- a/src/xagent/web/services/actor_mcp_runtime.py
+++ b/src/xagent/web/services/actor_mcp_runtime.py
@@ -11,9 +11,14 @@ from ... import config as xagent_config
 from ..builtin_mcp_registry import (
     get_builtin_execution_fields,
     get_builtin_public_mcp_app_rows,
+    get_builtin_stdio_session_scope,
 )
 from ..models.public_mcp import PublicMCPApp
-from .mcp_runtime import MCPActorAuthorizationPolicy, caller_id_env
+from .mcp_runtime import (
+    MCPActorAuthorizationPolicy,
+    MCPActorExecutionIdentity,
+    caller_id_env,
+)
 from .user_oauth import normalize_user_oauth_resource_owner_key
 
 
@@ -61,6 +66,28 @@ class ActorMCPStdioConnectionIdentity:
             raise ActorMCPRuntimeDefinitionError(
                 "actor stdio identity requires lifecycle_generation"
             )
+
+
+@dataclass(frozen=True)
+class ActorMCPStdioSessionIdentity:
+    """Complete key for one execution-scoped actor stdio child session."""
+
+    execution: MCPActorExecutionIdentity
+    connection: ActorMCPStdioConnectionIdentity
+
+    @property
+    def key(self) -> tuple[int, str, str, str, int, str, str, UUID, UUID]:
+        return (
+            self.execution.task_id,
+            self.execution.run_id,
+            self.execution.turn_id,
+            self.execution.lease_attempt_id,
+            self.connection.user_id,
+            self.connection.resource_owner_key,
+            self.connection.app_id,
+            self.connection.catalog_app_generation,
+            self.connection.lifecycle_generation,
+        )
 
 
 class ActorMCPStdioConnectionAdapter(Protocol):
@@ -206,16 +233,12 @@ def _validated_runtime_credentials(
     if not required_fields and credentials is None:
         return {}
     if not isinstance(credentials, Mapping) or set(credentials) != set(required_fields):
-        raise ActorMCPRuntimeDefinitionError(
-            "actor stdio credentials are incomplete"
-        )
+        raise ActorMCPRuntimeDefinitionError("actor stdio credentials are incomplete")
     values = dict(credentials)
     if any(
         not isinstance(value, str) or not value.strip() for value in values.values()
     ):
-        raise ActorMCPRuntimeDefinitionError(
-            "actor stdio credentials are incomplete"
-        )
+        raise ActorMCPRuntimeDefinitionError("actor stdio credentials are incomplete")
     return values
 
 
@@ -226,6 +249,7 @@ def resolve_actor_mcp_stdio_configs(
     policy: MCPActorAuthorizationPolicy | None,
     adapter: ActorMCPStdioConnectionAdapter | None,
     visible_servers: Sequence[Any],
+    execution_identity: MCPActorExecutionIdentity | None = None,
 ) -> ActorMCPStdioResolution:
     """Build actor configs without consulting any persisted MCP server definition."""
 
@@ -260,6 +284,14 @@ def resolve_actor_mcp_stdio_configs(
             continue
         try:
             execution, required_fields = _canonical_stdio_execution(db, identity)
+            session_identity: ActorMCPStdioSessionIdentity | None = None
+            if get_builtin_stdio_session_scope(identity.app_id) == "execution":
+                if execution_identity is None:
+                    continue
+                session_identity = ActorMCPStdioSessionIdentity(
+                    execution=execution_identity,
+                    connection=identity,
+                )
             app_keys = {
                 _normalized_catalog_key(identity.app_id),
                 _normalized_catalog_key(execution.get("name")),
@@ -286,20 +318,21 @@ def resolve_actor_mcp_stdio_configs(
 
         launch = execution["launch_config"]
         trusted_env = {**env, **caller_id_env(user_id)}
-        configs.append(
-            {
-                "name": identity.app_id,
-                "transport": "stdio",
-                "description": execution.get("name"),
-                "config": {
-                    "command": launch["command"],
-                    "args": list(launch.get("args") or []),
-                    "env": trusted_env,
-                    "concurrency_safe": False,
-                    "concurrent_tools": [],
-                },
-                "user_id": str(user_id),
-            }
-        )
+        config: dict[str, Any] = {
+            "name": identity.app_id,
+            "transport": "stdio",
+            "description": execution.get("name"),
+            "config": {
+                "command": launch["command"],
+                "args": list(launch.get("args") or []),
+                "env": trusted_env,
+                "concurrency_safe": False,
+                "concurrent_tools": [],
+            },
+            "user_id": str(user_id),
+        }
+        if session_identity is not None:
+            config["actor_stdio_session_identity"] = session_identity
+        configs.append(config)
 
     return ActorMCPStdioResolution(tuple(configs), blocked_server_ids)

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -25,21 +25,32 @@ class MCPBuiltinOAuthActorPolicyMismatchError(RuntimeError):
 
 
 @dataclass(frozen=True)
-class MCPBuiltinOAuthActorPolicy:
-    """Trusted actor owner namespace for catalog OAuth MCP execution.
+class MCPActorAuthorizationPolicy:
+    """Trusted actor identity and connector capabilities for MCP execution.
 
     Server visibility and catalog classification remain xagent runtime
     decisions. The caller supplies only the immutable credential owner. The
-    owner governs both builtin-provider and remote MCP OAuth credentials.
+    owner governs builtin-provider OAuth, remote MCP OAuth, and explicitly
+    enabled actor-scoped stdio credentials. Stdio remains disabled by default
+    so existing OAuth-only callers retain their current behavior.
     """
 
     resource_owner_key: str = dataclass_field(repr=False)
+    allow_builtin_stdio: bool = False
 
     def __post_init__(self) -> None:
         owner_key = normalize_user_oauth_resource_owner_key(self.resource_owner_key)
         if owner_key is None:  # pragma: no cover - normalization preserves None only
             raise ValueError("resource_owner_key must not be null")
+        if type(self.allow_builtin_stdio) is not bool:
+            raise ValueError("allow_builtin_stdio must be a boolean")
         object.__setattr__(self, "resource_owner_key", owner_key)
+
+
+# Compatibility import for trusted callers deployed before actor-scoped stdio
+# support. Keep this as a direct alias so equality and isinstance semantics do
+# not diverge between old and new callers.
+MCPBuiltinOAuthActorPolicy = MCPActorAuthorizationPolicy
 
 
 @dataclass(frozen=True)

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -54,6 +54,30 @@ MCPBuiltinOAuthActorPolicy = MCPActorAuthorizationPolicy
 
 
 @dataclass(frozen=True)
+class MCPActorExecutionIdentity:
+    """Exact task turn and lease acquisition that owns one actor execution."""
+
+    task_id: int
+    run_id: str
+    turn_id: str
+    lease_attempt_id: str
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.task_id, bool)
+            or not isinstance(self.task_id, int)
+            or self.task_id <= 0
+        ):
+            raise ValueError("actor execution identity requires a persisted task_id")
+        for field_name in ("run_id", "turn_id", "lease_attempt_id"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value or value != value.strip():
+                raise ValueError(
+                    f"actor execution identity requires an exact {field_name}"
+                )
+
+
+@dataclass(frozen=True)
 class MCPRuntimeConnectionBuild:
     """Executable MCP connection plus any runtime authorization diagnostic."""
 

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1682,6 +1682,7 @@ class WebToolConfig(BaseToolConfig):
         connector_team_id: Optional[int] = None,
         agent_creator_user_id: Optional[int] = None,
         declared_knowledge_bases: Optional[List[str]] = None,
+        mcp_actor_stdio_connection_adapter: Any = None,
         # Appended after every pre-existing parameter (not inserted
         # alongside its closest siblings above) so a caller still using
         # positional arguments for anything after agent_call_stack keeps
@@ -1714,6 +1715,12 @@ class WebToolConfig(BaseToolConfig):
         # object can be overwritten by the model, and this value must not
         # be confusable with that one at the resolution point.
         self._declared_knowledge_bases = declared_knowledge_bases
+        # Internal storage boundary for actor-scoped stdio. It is deliberately
+        # separate from ordinary MCP env/auth hooks and receives the exact
+        # actor and lifecycle identity on every secret read.
+        self._mcp_actor_stdio_connection_adapter = (
+            mcp_actor_stdio_connection_adapter
+        )
         self._task_runtime_contribution: Any = None
         self._task_runtime_workspace: Any = None
         self._live_db = db
@@ -4628,11 +4635,33 @@ class WebToolConfig(BaseToolConfig):
                     ):
                         actor_classifications[int(visible_server.id)] = (None, True)
 
+            from ..services.actor_mcp_runtime import resolve_actor_mcp_stdio_configs
+
+            actor_stdio_resolution = resolve_actor_mcp_stdio_configs(
+                self.db,
+                user_id=(
+                    int(self._user_id) if isinstance(self._user_id, int) else 0
+                ),
+                policy=self._mcp_runtime_authorization_policy,
+                adapter=self._mcp_actor_stdio_connection_adapter,
+                visible_servers=servers,
+            )
+            for blocked_server_id in actor_stdio_resolution.blocked_server_ids:
+                actor_classifications[blocked_server_id] = (None, True)
+
             # Prefetch shared runtime state once before entering the isolated
             # per-server formatter.
-            user_env_by_id = load_user_env_overrides(self.db, self._user_id)
-            shared_env_by_id = load_shared_env_overrides(self.db, self._user_id)
-            env_source_by_id = load_user_env_sources(self.db, self._user_id)
+            if servers:
+                user_env_by_id = load_user_env_overrides(self.db, self._user_id)
+                shared_env_by_id = load_shared_env_overrides(self.db, self._user_id)
+                env_source_by_id = load_user_env_sources(self.db, self._user_id)
+            else:
+                # Synthetic actor stdio is intentionally independent from
+                # every ordinary MCP credential source. Avoid even querying
+                # those stores when there are no ordinary server rows.
+                user_env_by_id = {}
+                shared_env_by_id = {}
+                env_source_by_id = {}
 
             # Re-key the shared env layer, for team-owned ids only, onto the
             # governing team's own row -- never the run owner's team, and
@@ -4643,7 +4672,7 @@ class WebToolConfig(BaseToolConfig):
             # the credential-side hook was never installed -- the shared
             # layer stays user-keyed in that state, which is exactly the
             # cross-team influence this block exists to remove.
-            if self._connector_team_id is not None and team_mcp_ids:
+            if servers and self._connector_team_id is not None and team_mcp_ids:
                 if not team_env_hook_installed():
                     warn_team_env_hook_missing_once(
                         team_id=self._connector_team_id,
@@ -4711,6 +4740,7 @@ class WebToolConfig(BaseToolConfig):
             )
             for server in servers
         ]
+        configs.extend(actor_stdio_resolution.configs)
         logger.info("Loaded %s MCP server configurations", len(configs))
         return configs
 

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -61,7 +61,10 @@ from ...core.tools.adapters.vibe.connector_runtime import (
     runtime_bindings_from_config,
 )
 from ...core.tools.adapters.vibe.db_session import tool_session_scope
-from ..services.mcp_runtime import MCPBuiltinOAuthActorPolicy
+from ..services.mcp_runtime import (
+    MCPActorExecutionIdentity,
+    MCPBuiltinOAuthActorPolicy,
+)
 from ..services.tool_credentials import (
     TOOL_CREDENTIAL_SPECS,
     get_sql_connection_map,
@@ -1688,6 +1691,7 @@ class WebToolConfig(BaseToolConfig):
         # positional arguments for anything after agent_call_stack keeps
         # binding the same values it always did.
         voice: Optional[str] = None,
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
     ):
         # ``tool_selection_spec`` accepts :class:`ToolSelectionSpec` from
         # the tools adapter package; typed as ``Any`` here to avoid an
@@ -1718,9 +1722,8 @@ class WebToolConfig(BaseToolConfig):
         # Internal storage boundary for actor-scoped stdio. It is deliberately
         # separate from ordinary MCP env/auth hooks and receives the exact
         # actor and lifecycle identity on every secret read.
-        self._mcp_actor_stdio_connection_adapter = (
-            mcp_actor_stdio_connection_adapter
-        )
+        self._mcp_actor_stdio_connection_adapter = mcp_actor_stdio_connection_adapter
+        self._mcp_actor_execution_identity = mcp_actor_execution_identity
         self._task_runtime_contribution: Any = None
         self._task_runtime_workspace: Any = None
         self._live_db = db
@@ -2157,6 +2160,19 @@ class WebToolConfig(BaseToolConfig):
             return False
         self._connector_runtime_turn_id = normalized_turn_id
         self._connector_runtime_view = None
+        self._cached_mcp_configs = None
+        self._factory_runtime_snapshot = None
+        self._pending_runtime_policy = None
+        return True
+
+    def set_mcp_actor_execution_identity(
+        self, identity: MCPActorExecutionIdentity | None
+    ) -> bool:
+        """Advance the exact actor execution fence on a reused tool config."""
+
+        if self._mcp_actor_execution_identity == identity:
+            return False
+        self._mcp_actor_execution_identity = identity
         self._cached_mcp_configs = None
         self._factory_runtime_snapshot = None
         self._pending_runtime_policy = None
@@ -4639,12 +4655,11 @@ class WebToolConfig(BaseToolConfig):
 
             actor_stdio_resolution = resolve_actor_mcp_stdio_configs(
                 self.db,
-                user_id=(
-                    int(self._user_id) if isinstance(self._user_id, int) else 0
-                ),
+                user_id=(int(self._user_id) if isinstance(self._user_id, int) else 0),
                 policy=self._mcp_runtime_authorization_policy,
                 adapter=self._mcp_actor_stdio_connection_adapter,
                 visible_servers=servers,
+                execution_identity=self._mcp_actor_execution_identity,
             )
             for blocked_server_id in actor_stdio_resolution.blocked_server_ids:
                 actor_classifications[blocked_server_id] = (None, True)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -2783,3 +2783,16 @@ def test_inline_file_delivery_budget(monkeypatch, caplog):
         caplog.clear()
         assert config.get_inline_file_delivery_max_bytes() == 0
         assert "Invalid XAGENT_INLINE_FILE_DELIVERY_MAX_BYTES" in caplog.text
+
+
+def test_toby_personal_stdio_is_disabled_by_default(monkeypatch):
+    monkeypatch.delenv(config.TOBY_PERSONAL_STDIO_ENABLED, raising=False)
+
+    assert config.get_toby_personal_stdio_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
+def test_toby_personal_stdio_explicit_opt_in(monkeypatch, value):
+    monkeypatch.setenv(config.TOBY_PERSONAL_STDIO_ENABLED, value)
+
+    assert config.get_toby_personal_stdio_enabled() is True

--- a/tests/web/api/test_execute_task_background_snapshot_passthrough.py
+++ b/tests/web/api/test_execute_task_background_snapshot_passthrough.py
@@ -42,7 +42,11 @@ from xagent.web.models.agent import AgentStatus
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import AgentRuntimeFields
-from xagent.web.services.task_lease_service import TaskLease
+from xagent.web.services.mcp_runtime import (
+    MCPActorAuthorizationPolicy,
+    MCPActorExecutionIdentity,
+)
+from xagent.web.services.task_lease_service import TaskLease, current_task_lease
 from xagent.web.services.task_setup_snapshot import (
     RuntimeUserFields,
     TaskSetupSnapshot,
@@ -244,6 +248,59 @@ async def test_snapshot_path_skips_task_and_user_queries() -> None:
     ]
     assert forwarded_snapshot is snapshot
     assert forwarded_snapshot.task.source == "trigger"
+
+
+@pytest.mark.asyncio
+async def test_actor_execution_identity_is_forwarded_before_lease_context_bind() -> (
+    None
+):
+    snapshot = _make_snapshot()
+    agent_service = _build_fake_agent_service()
+    observed: list[MCPActorExecutionIdentity | None] = []
+
+    async def get_agent_for_task(*_args: Any, **kwargs: Any) -> Any:
+        assert current_task_lease() is None
+        observed.append(kwargs.get("mcp_actor_execution_identity"))
+        return agent_service
+
+    agent_manager = MagicMock(
+        get_agent_for_task=AsyncMock(side_effect=get_agent_for_task),
+        execute_task=AsyncMock(
+            return_value={"success": True, "output": "ok", "status": "completed"}
+        ),
+    )
+    lease = TaskLease(
+        task_id=42,
+        runner_id="runner-a",
+        run_id="run-a",
+        attempt_id="attempt-a",
+    )
+    policy = MCPActorAuthorizationPolicy(
+        resource_owner_key="toby:slack:T1:U1",
+        allow_builtin_stdio=True,
+    )
+
+    with _Patches(_common_patches(MagicMock(), agent_service)):
+        await execute_task_background(
+            task_id=42,
+            user_message="hi",
+            context={"turn_id": "turn-a"},
+            agent_manager=agent_manager,
+            task_owner_user_id=1,
+            task_setup_snapshot=snapshot,
+            task_lease=lease,
+            mcp_runtime_authorization_policy=policy,
+            resolved_execution_scope=None,
+        )
+
+    assert observed == [
+        MCPActorExecutionIdentity(
+            task_id=42,
+            run_id="run-a",
+            turn_id="turn-a",
+            lease_attempt_id="attempt-a",
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
+++ b/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
@@ -338,6 +338,7 @@ async def test_running_with_prior_trace_event_runs_reconstruct() -> None:
         task_setup_snapshot=snapshot,
         connector_runtime_turn_id=None,
         mcp_runtime_authorization_policy=None,
+        mcp_actor_execution_identity=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -490,6 +491,7 @@ async def test_running_with_dag_plan_runs_reconstruct() -> None:
         task_setup_snapshot=snapshot,
         connector_runtime_turn_id=None,
         mcp_runtime_authorization_policy=None,
+        mcp_actor_execution_identity=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -539,6 +541,7 @@ async def test_paused_with_no_history_still_runs_reconstruct() -> None:
         task_setup_snapshot=snapshot,
         connector_runtime_turn_id=None,
         mcp_runtime_authorization_policy=None,
+        mcp_actor_execution_identity=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -584,6 +587,7 @@ async def test_waiting_for_user_with_no_history_still_runs_reconstruct() -> None
         task_setup_snapshot=snapshot,
         connector_runtime_turn_id=None,
         mcp_runtime_authorization_policy=None,
+        mcp_actor_execution_identity=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -624,10 +628,12 @@ async def test_reconstruct_return_path_syncs_connector_runtime_turn() -> None:
         task_setup_snapshot: TaskSetupSnapshot | None = None,
         connector_runtime_turn_id: str | None = None,
         mcp_runtime_authorization_policy: Any = None,
+        mcp_actor_execution_identity: Any = None,
     ) -> None:
         assert task_setup_snapshot is snapshot
         assert connector_runtime_turn_id == "turn-reconstructed"
         assert mcp_runtime_authorization_policy is None
+        assert mcp_actor_execution_identity is None
         manager._agents[task_id] = reconstructed_agent
 
     with (

--- a/tests/web/services/test_actor_mcp_runtime.py
+++ b/tests/web/services/test_actor_mcp_runtime.py
@@ -8,14 +8,19 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+from xagent.core.tools.adapters.vibe.factory import ToolFactory
 from xagent.web.builtin_mcp_registry import get_builtin_execution_fields
 from xagent.web.models.database import Base
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.services.actor_mcp_runtime import (
     ActorMCPStdioConnectionIdentity,
+    ActorMCPStdioSessionIdentity,
     resolve_actor_mcp_stdio_configs,
 )
-from xagent.web.services.mcp_runtime import MCPActorAuthorizationPolicy
+from xagent.web.services.mcp_runtime import (
+    MCPActorAuthorizationPolicy,
+    MCPActorExecutionIdentity,
+)
 from xagent.web.tools.config import WebToolConfig
 
 USER_ID = 41
@@ -32,11 +37,11 @@ def db() -> Session:
     engine.dispose()
 
 
-def _seed_app(db: Session) -> PublicMCPApp:
-    execution = get_builtin_execution_fields(APP_ID)
+def _seed_app(db: Session, *, app_id: str = APP_ID) -> PublicMCPApp:
+    execution = get_builtin_execution_fields(app_id)
     assert execution is not None
     app = PublicMCPApp(
-        app_id=APP_ID,
+        app_id=app_id,
         name=execution["name"],
         transport=execution["transport"],
         provider_name=execution["provider_name"],
@@ -109,7 +114,7 @@ def _identity(app: PublicMCPApp, **overrides: object):
     values = {
         "user_id": USER_ID,
         "resource_owner_key": OWNER,
-        "app_id": APP_ID,
+        "app_id": app.app_id,
         "catalog_app_generation": app.generation,
         "lifecycle_generation": uuid.uuid4(),
     }
@@ -131,6 +136,21 @@ def _policy(*, allow: bool = True) -> MCPActorAuthorizationPolicy:
     )
 
 
+def _execution_identity(
+    *,
+    task_id: int = 91,
+    run_id: str = "run-1",
+    turn_id: str = "turn-1",
+    lease_attempt_id: str = "attempt-1",
+) -> MCPActorExecutionIdentity:
+    return MCPActorExecutionIdentity(
+        task_id=task_id,
+        run_id=run_id,
+        turn_id=turn_id,
+        lease_attempt_id=lease_attempt_id,
+    )
+
+
 def test_synthetic_config_uses_exact_lifecycle_fenced_adapter_inputs(
     db: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -147,9 +167,7 @@ def test_synthetic_config_uses_exact_lifecycle_fenced_adapter_inputs(
         visible_servers=(),
     )
 
-    assert adapter.list_calls == [
-        {"user_id": USER_ID, "resource_owner_key": OWNER}
-    ]
+    assert adapter.list_calls == [{"user_id": USER_ID, "resource_owner_key": OWNER}]
     assert adapter.secret_calls == [
         {
             "user_id": USER_ID,
@@ -305,3 +323,126 @@ async def test_web_loader_appends_synthetic_config_without_env_source_queries(
     result = await config._load_mcp_server_configs()
 
     assert [item["name"] for item in result] == [APP_ID]
+
+
+def test_execution_scoped_chrome_requires_complete_execution_identity(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db, app_id="chrome-devtools")
+    adapter = _FakeAdapter(_identity(app), None)
+
+    missing = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+    present = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+        execution_identity=_execution_identity(),
+    )
+
+    assert missing.configs == ()
+    assert len(present.configs) == 1
+    session_identity = present.configs[0]["actor_stdio_session_identity"]
+    assert isinstance(session_identity, ActorMCPStdioSessionIdentity)
+    assert session_identity.key == (
+        91,
+        "run-1",
+        "turn-1",
+        "attempt-1",
+        USER_ID,
+        OWNER,
+        "chrome-devtools",
+        app.generation,
+        adapter.identity.lifecycle_generation,
+    )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("task_id", None),
+        ("run_id", None),
+        ("turn_id", None),
+        ("lease_attempt_id", None),
+    ],
+)
+def test_actor_execution_identity_rejects_each_missing_field(
+    field_name: str, value: object
+) -> None:
+    values: dict[str, object] = {
+        "task_id": 91,
+        "run_id": "run-1",
+        "turn_id": "turn-1",
+        "lease_attempt_id": "attempt-1",
+    }
+    values[field_name] = value
+
+    with pytest.raises(ValueError, match=field_name):
+        MCPActorExecutionIdentity(**values)  # type: ignore[arg-type]
+
+
+def test_chrome_session_key_changes_for_retry_and_later_turn() -> None:
+    connection = ActorMCPStdioConnectionIdentity(
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id="chrome-devtools",
+        catalog_app_generation=uuid.uuid4(),
+        lifecycle_generation=uuid.uuid4(),
+    )
+    initial = ActorMCPStdioSessionIdentity(_execution_identity(), connection)
+    retry = ActorMCPStdioSessionIdentity(
+        _execution_identity(lease_attempt_id="attempt-2"), connection
+    )
+    later_turn = ActorMCPStdioSessionIdentity(
+        _execution_identity(turn_id="turn-2"), connection
+    )
+
+    assert initial.key != retry.key
+    assert initial.key != later_turn.key
+
+
+@pytest.mark.asyncio
+async def test_tool_factory_threads_actor_stdio_session_identity_to_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = ActorMCPStdioConnectionIdentity(
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id="chrome-devtools",
+        catalog_app_generation=uuid.uuid4(),
+        lifecycle_generation=uuid.uuid4(),
+    )
+    session_identity = ActorMCPStdioSessionIdentity(_execution_identity(), connection)
+    captured: dict[str, object] = {}
+
+    async def fake_load(connections: dict[str, object], **_kwargs: object) -> object:
+        captured.update(connections)
+        return SimpleNamespace(tools=(), failures=())
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools",
+        fake_load,
+    )
+
+    await ToolFactory._create_mcp_tools_from_configs(
+        [
+            {
+                "name": "chrome-devtools",
+                "transport": "stdio",
+                "config": {"command": "npx", "args": [], "env": {}},
+                "actor_stdio_session_identity": session_identity,
+            }
+        ]
+    )
+
+    assert (
+        captured["chrome-devtools"]["actor_stdio_session_identity"] is session_identity
+    )  # type: ignore[index]

--- a/tests/web/services/test_actor_mcp_runtime.py
+++ b/tests/web/services/test_actor_mcp_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from collections.abc import Mapping, Sequence
 from types import SimpleNamespace
@@ -12,9 +13,18 @@ from xagent.core.tools.adapters.vibe.factory import ToolFactory
 from xagent.web.builtin_mcp_registry import get_builtin_execution_fields
 from xagent.web.models.database import Base
 from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.services.actor_mcp_connections import (
+    ActorMCPConnectionCredentialCorruptionError,
+    ActorMCPConnectionMetadata,
+    ActorMCPConnectionSnapshot,
+    ActorMCPConnectionValidationError,
+    create_actor_mcp_connection,
+)
 from xagent.web.services.actor_mcp_runtime import (
+    ActorMCPConnectionServiceAdapter,
     ActorMCPStdioConnectionIdentity,
     ActorMCPStdioSessionIdentity,
+    production_actor_mcp_stdio_connection_adapter,
     resolve_actor_mcp_stdio_configs,
 )
 from xagent.web.services.mcp_runtime import (
@@ -189,6 +199,248 @@ def test_synthetic_config_uses_exact_lifecycle_fenced_adapter_inputs(
         "XAGENT_MCP_CALLER_ID": str(USER_ID),
     }
     assert "id" not in config
+
+
+def test_production_adapter_is_a_stateless_exact_service_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog_generation = uuid.uuid4()
+    lifecycle_generation = uuid.uuid4()
+    metadata = ActorMCPConnectionMetadata(
+        id=7,
+        lifecycle_generation=lifecycle_generation,
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id=APP_ID,
+        catalog_app_generation=catalog_generation,
+        configured_field_names=frozenset(_credentials()),
+    )
+    snapshot = ActorMCPConnectionSnapshot(
+        id=7,
+        lifecycle_generation=lifecycle_generation,
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id=APP_ID,
+        catalog_app_generation=catalog_generation,
+        credentials=_credentials(),
+    )
+    list_calls: list[dict[str, object]] = []
+    secret_calls: list[dict[str, object]] = []
+
+    def fake_list(_db: Session, **kwargs: object) -> list[object]:
+        list_calls.append(kwargs)
+        return [metadata]
+
+    def fake_get(_db: Session, **kwargs: object) -> object:
+        secret_calls.append(kwargs)
+        return snapshot
+
+    monkeypatch.setattr(
+        "xagent.web.services.actor_mcp_runtime.list_actor_mcp_connection_metadata",
+        fake_list,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.actor_mcp_runtime.get_actor_mcp_connection_credentials_internal",
+        fake_get,
+    )
+    adapter = ActorMCPConnectionServiceAdapter()
+
+    identities = adapter.list_connection_identities(
+        object(),  # type: ignore[arg-type]
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+    )
+    credentials = adapter.get_connection_credentials(
+        object(),  # type: ignore[arg-type]
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id=APP_ID,
+        catalog_app_generation=catalog_generation,
+        expected_lifecycle_generation=lifecycle_generation,
+    )
+
+    assert identities == (
+        ActorMCPStdioConnectionIdentity(
+            user_id=USER_ID,
+            resource_owner_key=OWNER,
+            app_id=APP_ID,
+            catalog_app_generation=catalog_generation,
+            lifecycle_generation=lifecycle_generation,
+        ),
+    )
+    assert credentials == _credentials()
+    assert list_calls == [{"user_id": USER_ID, "resource_owner_key": OWNER}]
+    assert secret_calls == [
+        {
+            "user_id": USER_ID,
+            "resource_owner_key": OWNER,
+            "app_id": APP_ID,
+            "catalog_app_generation": catalog_generation,
+            "expected_lifecycle_generation": lifecycle_generation,
+        }
+    ]
+
+
+def test_production_adapter_resolves_credentials_from_storage_service(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    _seed_app(db)
+    create_actor_mcp_connection(
+        db,
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id=APP_ID,
+        credentials=_credentials(),
+    )
+
+    def forbidden_transaction_boundary() -> None:
+        raise AssertionError("runtime adapter must not own commit or rollback")
+
+    monkeypatch.setattr(db, "commit", forbidden_transaction_boundary)
+    monkeypatch.setattr(db, "rollback", forbidden_transaction_boundary)
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=production_actor_mcp_stdio_connection_adapter(),
+        visible_servers=(),
+    )
+
+    assert len(result.configs) == 1
+    assert result.configs[0]["config"]["env"] == {
+        **_credentials(),
+        "XAGENT_MCP_CALLER_ID": str(USER_ID),
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_default_tools_registers_production_adapter_only_for_actor_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.api.chat import create_default_tools
+
+    captured: list[dict[str, object]] = []
+
+    class _FakeToolConfig:
+        def __init__(self, **kwargs: object) -> None:
+            captured.append(kwargs)
+
+        def set_task_runtime_contribution(self, _contribution: object) -> None:
+            pass
+
+    async def create_tools(_config: object) -> list[object]:
+        return []
+
+    monkeypatch.setattr("xagent.web.tools.config.WebToolConfig", _FakeToolConfig)
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local", lambda: object()
+    )
+    monkeypatch.setattr(ToolFactory, "create_all_tools", create_tools)
+
+    for policy in (None, _policy()):
+        await create_default_tools(
+            None,
+            user=SimpleNamespace(id=USER_ID, is_admin=False),
+            task_id="91",
+            mcp_runtime_authorization_policy=policy,
+        )
+
+    assert captured[0]["mcp_actor_stdio_connection_adapter"] is None
+    assert (
+        captured[1]["mcp_actor_stdio_connection_adapter"]
+        is production_actor_mcp_stdio_connection_adapter()
+    )
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        ActorMCPConnectionCredentialCorruptionError("sensitive-value"),
+        RuntimeError("sensitive-value"),
+    ],
+)
+def test_credential_failures_remain_blocked_without_logging_values(
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    failure: Exception,
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    caplog.set_level(logging.INFO)
+    app = _seed_app(db)
+
+    class _FailingAdapter(_FakeAdapter):
+        def get_connection_credentials(self, *_args: object, **_kwargs: object):
+            raise failure
+
+    collision = _StableIdentityOnlyServer(73, "chrome-devtools")
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=_FailingAdapter(_identity(app), _credentials()),
+        visible_servers=(collision,),
+    )
+
+    assert result.configs == ()
+    assert result.blocked_server_ids == frozenset({73})
+    assert type(failure).__name__ in caplog.text
+    assert "sensitive-value" not in caplog.text
+
+
+def test_missing_adapter_remains_blocked_without_custom_fallback(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    collision = _StableIdentityOnlyServer(73, APP_ID)
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=None,
+        visible_servers=(collision,),
+    )
+
+    assert result.configs == ()
+    assert result.blocked_server_ids == frozenset({73})
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        ActorMCPConnectionValidationError("sensitive-value"),
+        RuntimeError("sensitive-value"),
+    ],
+)
+def test_list_failures_remain_blocked_without_logging_values(
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    failure: Exception,
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    caplog.set_level(logging.INFO)
+
+    class _FailingListAdapter:
+        def list_connection_identities(self, *_args: object, **_kwargs: object):
+            raise failure
+
+    collision = _StableIdentityOnlyServer(73, APP_ID)
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=_FailingListAdapter(),  # type: ignore[arg-type]
+        visible_servers=(collision,),
+    )
+
+    assert result.configs == ()
+    assert result.blocked_server_ids == frozenset({73})
+    assert type(failure).__name__ in caplog.text
+    assert "sensitive-value" not in caplog.text
 
 
 def test_reserved_collision_reads_only_stable_server_identity(

--- a/tests/web/services/test_actor_mcp_runtime.py
+++ b/tests/web/services/test_actor_mcp_runtime.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from xagent.web.builtin_mcp_registry import get_builtin_execution_fields
+from xagent.web.models.database import Base
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.services.actor_mcp_runtime import (
+    ActorMCPStdioConnectionIdentity,
+    resolve_actor_mcp_stdio_configs,
+)
+from xagent.web.services.mcp_runtime import MCPActorAuthorizationPolicy
+from xagent.web.tools.config import WebToolConfig
+
+USER_ID = 41
+OWNER = "toby:slack:T1:U1"
+APP_ID = "posthog"
+
+
+@pytest.fixture()
+def db() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _seed_app(db: Session) -> PublicMCPApp:
+    execution = get_builtin_execution_fields(APP_ID)
+    assert execution is not None
+    app = PublicMCPApp(
+        app_id=APP_ID,
+        name=execution["name"],
+        transport=execution["transport"],
+        provider_name=execution["provider_name"],
+        oauth_scopes=execution["oauth_scopes"],
+        launch_config=execution["launch_config"],
+        is_visible_in_connector=True,
+    )
+    db.add(app)
+    db.flush()
+    return app
+
+
+class _FakeAdapter:
+    def __init__(
+        self,
+        identity: ActorMCPStdioConnectionIdentity,
+        credentials: Mapping[str, str] | None,
+    ) -> None:
+        self.identity = identity
+        self.credentials = credentials
+        self.list_calls: list[dict[str, object]] = []
+        self.secret_calls: list[dict[str, object]] = []
+
+    def list_connection_identities(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+    ) -> Sequence[ActorMCPStdioConnectionIdentity]:
+        self.list_calls.append(
+            {"user_id": user_id, "resource_owner_key": resource_owner_key}
+        )
+        return (self.identity,)
+
+    def get_connection_credentials(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+        app_id: str,
+        catalog_app_generation: uuid.UUID,
+        expected_lifecycle_generation: uuid.UUID,
+    ) -> Mapping[str, str] | None:
+        self.secret_calls.append(
+            {
+                "user_id": user_id,
+                "resource_owner_key": resource_owner_key,
+                "app_id": app_id,
+                "catalog_app_generation": catalog_app_generation,
+                "expected_lifecycle_generation": expected_lifecycle_generation,
+            }
+        )
+        return self.credentials
+
+
+class _StableIdentityOnlyServer:
+    def __init__(self, server_id: int, name: str) -> None:
+        self.id = server_id
+        self.name = name
+        self.forbidden_accesses: list[str] = []
+
+    def __getattr__(self, name: str) -> object:
+        self.forbidden_accesses.append(name)
+        raise AssertionError(f"actor resolver read forbidden MCPServer field: {name}")
+
+
+def _identity(app: PublicMCPApp, **overrides: object):
+    values = {
+        "user_id": USER_ID,
+        "resource_owner_key": OWNER,
+        "app_id": APP_ID,
+        "catalog_app_generation": app.generation,
+        "lifecycle_generation": uuid.uuid4(),
+    }
+    values.update(overrides)
+    return ActorMCPStdioConnectionIdentity(**values)
+
+
+def _credentials() -> dict[str, str]:
+    return {
+        "POSTHOG_API_KEY": "actor-api-key",
+        "POSTHOG_HOST": "https://actor.example.test",
+    }
+
+
+def _policy(*, allow: bool = True) -> MCPActorAuthorizationPolicy:
+    return MCPActorAuthorizationPolicy(
+        resource_owner_key=OWNER,
+        allow_builtin_stdio=allow,
+    )
+
+
+def test_synthetic_config_uses_exact_lifecycle_fenced_adapter_inputs(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    identity = _identity(app)
+    adapter = _FakeAdapter(identity, _credentials())
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+
+    assert adapter.list_calls == [
+        {"user_id": USER_ID, "resource_owner_key": OWNER}
+    ]
+    assert adapter.secret_calls == [
+        {
+            "user_id": USER_ID,
+            "resource_owner_key": OWNER,
+            "app_id": APP_ID,
+            "catalog_app_generation": app.generation,
+            "expected_lifecycle_generation": identity.lifecycle_generation,
+        }
+    ]
+    assert result.blocked_server_ids == frozenset()
+    assert len(result.configs) == 1
+    config = result.configs[0]
+    execution = get_builtin_execution_fields(APP_ID)
+    assert execution is not None
+    assert config["config"]["command"] == execution["launch_config"]["command"]
+    assert config["config"]["args"] == execution["launch_config"]["args"]
+    assert config["config"]["env"] == {
+        **_credentials(),
+        "XAGENT_MCP_CALLER_ID": str(USER_ID),
+    }
+    assert "id" not in config
+
+
+def test_reserved_collision_reads_only_stable_server_identity(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    adapter = _FakeAdapter(_identity(app), _credentials())
+    collision = _StableIdentityOnlyServer(73, "  PostHog  ")
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(collision,),
+    )
+
+    assert result.configs == ()
+    assert result.blocked_server_ids == frozenset({73})
+    assert adapter.secret_calls == []
+    assert collision.forbidden_accesses == []
+
+
+def test_policy_or_feature_off_never_falls_back_to_reserved_server(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", raising=False)
+    app = _seed_app(db)
+    adapter = _FakeAdapter(_identity(app), _credentials())
+    collision = _StableIdentityOnlyServer(73, APP_ID)
+
+    feature_off = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(collision,),
+    )
+    legacy_policy = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(allow=False),
+        adapter=adapter,
+        visible_servers=(collision,),
+    )
+
+    assert feature_off.configs == ()
+    assert feature_off.blocked_server_ids == frozenset({73})
+    assert legacy_policy.blocked_server_ids == frozenset()
+    assert adapter.list_calls == []
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"user_id": 42},
+        {"resource_owner_key": "toby:slack:T1:U2"},
+        {"catalog_app_generation": uuid.uuid4()},
+    ],
+)
+def test_mismatched_connection_identity_fails_closed(
+    db: Session, monkeypatch: pytest.MonkeyPatch, override: dict[str, object]
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    adapter = _FakeAdapter(_identity(app, **override), _credentials())
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+
+    assert result.configs == ()
+    assert adapter.secret_calls == []
+
+
+def test_incomplete_runtime_credentials_fail_closed(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    adapter = _FakeAdapter(
+        _identity(app),
+        {"POSTHOG_API_KEY": "actor-api-key"},
+    )
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+
+    assert result.configs == ()
+
+
+@pytest.mark.asyncio
+async def test_web_loader_appends_synthetic_config_without_env_source_queries(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    adapter = _FakeAdapter(_identity(app), _credentials())
+    config = WebToolConfig(
+        db=db,
+        request=None,
+        user_id=USER_ID,
+        task_id="execution-id-is-not-derived-here",
+        mcp_runtime_authorization_policy=_policy(),
+        mcp_actor_stdio_connection_adapter=adapter,
+    )
+    monkeypatch.setattr(
+        config,
+        "_visible_mcp_server_query",
+        lambda _team_ids: SimpleNamespace(all=lambda: []),
+    )
+
+    def forbidden(*_args: object, **_kwargs: object):
+        raise AssertionError("ordinary MCP credential source was queried")
+
+    from xagent.web.services import mcp_runtime
+
+    monkeypatch.setattr(mcp_runtime, "load_user_env_overrides", forbidden)
+    monkeypatch.setattr(mcp_runtime, "load_shared_env_overrides", forbidden)
+    monkeypatch.setattr(mcp_runtime, "load_user_env_sources", forbidden)
+
+    result = await config._load_mcp_server_configs()
+
+    assert [item["name"] for item in result] == [APP_ID]

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -19,7 +19,10 @@ from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
 from xagent.web.services import connector_team_scope
-from xagent.web.services.mcp_runtime import MCPBuiltinOAuthActorPolicy
+from xagent.web.services.mcp_runtime import (
+    MCPActorAuthorizationPolicy,
+    MCPBuiltinOAuthActorPolicy,
+)
 from xagent.web.tools import config as web_tools_config
 from xagent.web.tools.config import (
     ResolvedToken,
@@ -245,14 +248,38 @@ def _token(config: dict) -> str:
     return config["config"]["env"]["ACTOR_ACCESS_TOKEN"]
 
 
-def test_actor_policy_is_frozen_normalized_and_owner_only() -> None:
+def test_actor_policy_is_frozen_normalized_and_stdio_disabled_by_default() -> None:
     policy = MCPBuiltinOAuthActorPolicy(resource_owner_key=f"  {OWNER_A}  ")
 
     assert policy.resource_owner_key == OWNER_A
-    assert [field.name for field in fields(policy)] == ["resource_owner_key"]
+    assert policy.allow_builtin_stdio is False
+    assert [field.name for field in fields(policy)] == [
+        "resource_owner_key",
+        "allow_builtin_stdio",
+    ]
     assert OWNER_A not in repr(policy)
     with pytest.raises(FrozenInstanceError):
         policy.resource_owner_key = OWNER_B  # type: ignore[misc]
+
+
+def test_general_actor_policy_keeps_legacy_type_identity() -> None:
+    policy = MCPActorAuthorizationPolicy(
+        resource_owner_key=OWNER_A,
+        allow_builtin_stdio=True,
+    )
+
+    assert MCPBuiltinOAuthActorPolicy is MCPActorAuthorizationPolicy
+    assert isinstance(policy, MCPBuiltinOAuthActorPolicy)
+    assert policy.allow_builtin_stdio is True
+
+
+@pytest.mark.parametrize("value", [None, 0, 1, "true"])
+def test_actor_policy_rejects_non_boolean_stdio_capability(value: object) -> None:
+    with pytest.raises(ValueError, match="allow_builtin_stdio must be a boolean"):
+        MCPActorAuthorizationPolicy(
+            resource_owner_key=OWNER_A,
+            allow_builtin_stdio=value,  # type: ignore[arg-type]
+        )
 
 
 @pytest.mark.parametrize("value", [None, 7, True, "", "   "])


### PR DESCRIPTION
## Summary

- generalize actor authorization with an opt-in built-in stdio policy
- resolve actor-scoped stdio servers exclusively from the canonical code registry and lifecycle-fenced actor connections
- thread a complete task, run, turn, and lease-attempt identity for execution-scoped Chrome sessions
- bind the read-only production adapter without exposing storage mutations to the runtime

Supersedes #2277 after the storage dependency was squash-merged.

## Security properties

- fail closed on catalog drift, normalized reserved-name collisions, missing adapters, stale lifecycles, and credential corruption
- derive synthetic command, arguments, and required child environment only from the code-owned built-in registry and the exact actor connection
- never read execution configuration or credentials from `MCPServer`, `UserMCPServer`, team, shared, platform, or custom fallback sources
- keep legacy OAuth and ordinary per-call stdio behavior unchanged
- keep `XAGENT_TOBY_PERSONAL_STDIO_ENABLED` disabled by default

## Dependencies

Depends on merged #2265.

Parent tracking: https://github.com/xorbitsai/xagent-saas/issues/1161

Chrome child PR #2263 must consume and strip `actor_stdio_session_identity` before any JSON, sandbox, or IPC serialization. This PR does not enable the hidden Chrome connector.

## Validation

- focused actor runtime, owner-isolation, and execution-identity tests
- Ruff lint checks
- Git range-diff and dependency-boundary verification
- local and global self-review

Closes #2262
