### PR TITLE
fix(agent): project resumed tool results onto the original call (toby)

### DIFF
--- a/src/xagent/core/agent/checkpoint.py
+++ b/src/xagent/core/agent/checkpoint.py
@@ -158,7 +158,14 @@ class TraceCheckpointStore:
         execution_id = self._execution_id(payload)
         event_payload = self._event_payload(payload, execution_id=execution_id)
 
-        event_id = await self._call_checkpoint_writer(payload, event_payload)
+        try:
+            event_id = await self._call_checkpoint_writer(payload, event_payload)
+        except CheckpointPersistenceError:
+            raise
+        except Exception as exc:
+            raise CheckpointPersistenceError(
+                "Checkpoint writer failed before persistence was confirmed."
+            ) from exc
         if event_id is None:
             raise CheckpointPersistenceError(
                 "Tracer does not expose a durable checkpoint write API."

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 from dataclasses import dataclass, replace
@@ -19,6 +20,7 @@ from ...context.enrichment import (
     pending_user_response_marker,
     top_level_user_request,
 )
+from ...checkpoint import CheckpointPersistenceError
 from ...frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
 from ...grounding import grounding_rule
 from ...language import (
@@ -177,26 +179,35 @@ class _DAGStepRuntime:
         status: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        self.dag_pattern._set_active_step_context(self.step_id, context.to_dict())
-        get_state = getattr(pattern, "get_state", None)
-        if callable(get_state):
-            self.dag_pattern._set_active_step_pattern_state(
-                self.step_id,
-                get_state(),
-            )
+        active_ids_before = list(self.dag_pattern.active_step_ids)
+        contexts_before = copy.deepcopy(self.dag_pattern.active_step_contexts)
+        states_before = copy.deepcopy(self.dag_pattern.active_step_pattern_states)
         step_metadata = {
             "active_step_id": self.step_id,
             "child_label": label,
         }
         if metadata:
             step_metadata.update(metadata)
-        return await self.parent.checkpoint(
-            label=f"dag_{label}",
-            context=self.root_context,
-            pattern=self.dag_pattern,
-            status=status,
-            metadata=step_metadata,
-        )
+        try:
+            self.dag_pattern._set_active_step_context(self.step_id, context.to_dict())
+            get_state = getattr(pattern, "get_state", None)
+            if callable(get_state):
+                self.dag_pattern._set_active_step_pattern_state(
+                    self.step_id, get_state()
+                )
+            return await self.parent.checkpoint(
+                label=f"dag_{label}",
+                context=self.root_context,
+                pattern=self.dag_pattern,
+                status=status,
+                metadata=step_metadata,
+            )
+        except BaseException:
+            self.dag_pattern.active_step_ids = active_ids_before
+            self.dag_pattern.active_step_contexts = contexts_before
+            self.dag_pattern.active_step_pattern_states = states_before
+            self.dag_pattern._sync_legacy_active_step()
+            raise
 
     async def on_tool_start(self, *, tool_call: dict[str, Any]) -> None:
         await self.parent.on_tool_start(tool_call=self._with_step(tool_call))
@@ -1047,7 +1058,7 @@ class DAGPattern(AgentPattern):
                 skill_manager=skill_manager,
                 allowed_skills=allowed_skills,
             )
-        except ExecutionInterrupted:
+        except (ExecutionInterrupted, CheckpointPersistenceError):
             raise
         except Exception as exc:
             step.status = "failed"

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -13,6 +13,7 @@ from ....task_runtime import (
     PREFERRED_INPUT_MODALITIES_METADATA_KEY,
     normalize_input_modalities,
 )
+from ...checkpoint import CheckpointPersistenceError
 from ...context.enrichment import (
     enrich_context_with_memory,
     hydrate_top_level_user_request,
@@ -20,7 +21,6 @@ from ...context.enrichment import (
     pending_user_response_marker,
     top_level_user_request,
 )
-from ...checkpoint import CheckpointPersistenceError
 from ...frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
 from ...grounding import grounding_rule
 from ...language import (

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -218,10 +218,12 @@ class _DAGStepRuntime:
                     if step_id != self.step_id
                 ]
             if had_context:
+                assert context_before is not None
                 self.dag_pattern.active_step_contexts[self.step_id] = context_before
             else:
                 self.dag_pattern.active_step_contexts.pop(self.step_id, None)
             if had_state:
+                assert state_before is not None
                 self.dag_pattern.active_step_pattern_states[self.step_id] = state_before
             else:
                 self.dag_pattern.active_step_pattern_states.pop(self.step_id, None)

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -179,9 +179,15 @@ class _DAGStepRuntime:
         status: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        active_ids_before = list(self.dag_pattern.active_step_ids)
-        contexts_before = copy.deepcopy(self.dag_pattern.active_step_contexts)
-        states_before = copy.deepcopy(self.dag_pattern.active_step_pattern_states)
+        was_active = self.step_id in self.dag_pattern.active_step_ids
+        had_context = self.step_id in self.dag_pattern.active_step_contexts
+        context_before = copy.deepcopy(
+            self.dag_pattern.active_step_contexts.get(self.step_id)
+        )
+        had_state = self.step_id in self.dag_pattern.active_step_pattern_states
+        state_before = copy.deepcopy(
+            self.dag_pattern.active_step_pattern_states.get(self.step_id)
+        )
         step_metadata = {
             "active_step_id": self.step_id,
             "child_label": label,
@@ -203,9 +209,22 @@ class _DAGStepRuntime:
                 metadata=step_metadata,
             )
         except BaseException:
-            self.dag_pattern.active_step_ids = active_ids_before
-            self.dag_pattern.active_step_contexts = contexts_before
-            self.dag_pattern.active_step_pattern_states = states_before
+            if was_active and self.step_id not in self.dag_pattern.active_step_ids:
+                self.dag_pattern.active_step_ids.append(self.step_id)
+            elif not was_active:
+                self.dag_pattern.active_step_ids = [
+                    step_id
+                    for step_id in self.dag_pattern.active_step_ids
+                    if step_id != self.step_id
+                ]
+            if had_context:
+                self.dag_pattern.active_step_contexts[self.step_id] = context_before
+            else:
+                self.dag_pattern.active_step_contexts.pop(self.step_id, None)
+            if had_state:
+                self.dag_pattern.active_step_pattern_states[self.step_id] = state_before
+            else:
+                self.dag_pattern.active_step_pattern_states.pop(self.step_id, None)
             self.dag_pattern._sync_legacy_active_step()
             raise
 

--- a/src/xagent/core/agent/pattern/react/duplicate_write_guard.py
+++ b/src/xagent/core/agent/pattern/react/duplicate_write_guard.py
@@ -7,14 +7,13 @@ structured envelope carrying the prior result instead.
 
 Scope is deliberately narrow:
 
-* Same turn only, enforced by turn_id equality on the ledger records. The
-  runner stamps a fresh turn_id on every user message (initial and
-  injected), and the pattern re-reads it at each pattern start, so a resume
-  that continues the execution — and its checkpointed ledger — under a new
-  user message compares unequal and executes, while an intra-turn resume
-  keeps suppressing the replay. A call with no turn_id (an embedding that
-  drives the pattern directly without stamping turns) is never guarded:
-  suppression must not outlive a turn, so an unknowable turn fails open.
+* Same turn only, enforced by the ledger record's guard turn identity. An
+  ordinary completion uses its original turn id. A resumed success uses the
+  settlement turn that received the result, so a model cannot immediately
+  repeat the approved write after resume. A later user turn remains a new
+  authorization boundary and may issue the same arguments again. A call with
+  no guard turn id is never guarded: suppression must not outlive a turn, so
+  an unknowable turn fails open.
 * Identical execution arguments only, compared via the ledger's canonical
   args hash.
 * Only tools that *explicitly* declare a non-idempotent write:

--- a/src/xagent/core/agent/pattern/react/duplicate_write_guard.py
+++ b/src/xagent/core/agent/pattern/react/duplicate_write_guard.py
@@ -79,22 +79,24 @@ def build_suppression_envelope(
     tool_name: str,
     prior_tool_call_id: str,
     prior_result: Any,
+    prior_succeeded: bool = True,
 ) -> dict[str, Any]:
     """Build the model-facing envelope for a suppressed duplicate write.
 
-    ``success: True`` deliberately: the requested effect exists — it was
-    produced by the earlier call — so the loop's success accounting should
-    treat this observation like the write it stands in for.
+    A successful prior call produces a successful envelope because the effect
+    already exists. A denied or dispatch-unknown settlement stays unsuccessful
+    while still preventing the write from being executed again.
     """
+    outcome = "already succeeded" if prior_succeeded else "was denied or is uncertain"
     return {
-        "success": True,
+        "success": prior_succeeded,
         DUPLICATE_WRITE_SUPPRESSED_KEY: True,
         "tool_name": tool_name,
         "suppressed_duplicate_of": prior_tool_call_id,
         "result": prior_result,
         "message": (
             f"Duplicate write suppressed: this exact {tool_name} call "
-            "already succeeded earlier in this turn "
+            f"{outcome} earlier in this turn "
             f"(tool call {prior_tool_call_id}); it was not executed again. "
             "The previous call's result is attached under 'result' — use it "
             "instead of retrying. Repeating this write with identical "

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -479,6 +479,7 @@ class ReActPattern(AgentPattern):
         self.pending_tool_call_content: dict[str, str] = {}
         self.tool_ledger: dict[str, ToolCallRecord] = {}
         self.force_final_answer_next = False
+        self.settlement_final_answer_fence = False
         self.repeated_tool_decision: dict[str, Any] | None = None
         self.waiting_for_user_request: dict[str, Any] | None = None
         self.pending_tool_interaction_responses: list[dict[str, str]] = []
@@ -679,10 +680,14 @@ class ReActPattern(AgentPattern):
                 if decision_result is not None:
                     return decision_result
 
-            force_final_answer_now = self.force_final_answer_next or (
-                self.finalize_after_tool_result
-                and not self.pending_tool_calls
-                and self._latest_tool_result_success(context)
+            force_final_answer_now = (
+                self.force_final_answer_next
+                or self.settlement_final_answer_fence
+                or (
+                    self.finalize_after_tool_result
+                    and not self.pending_tool_calls
+                    and self._latest_tool_result_success(context)
+                )
             )
             tool_schemas = (
                 [self._final_answer_tool_schema()]
@@ -799,6 +804,9 @@ class ReActPattern(AgentPattern):
                     },
                 )
                 try:
+                    restore_full_tool_set = (
+                        unavailable_tool_call and not self.settlement_final_answer_fence
+                    )
                     (
                         response,
                         answer_streamer,
@@ -809,9 +817,14 @@ class ReActPattern(AgentPattern):
                         iteration=iteration,
                         tool_schemas=base_tool_schemas,
                         force_final_answer=(
-                            force_final_answer_now and not unavailable_tool_call
+                            force_final_answer_now and not restore_full_tool_set
                         ),
-                        recovery_reason=exc.code,
+                        recovery_reason=(
+                            "settlement_final_answer_required"
+                            if unavailable_tool_call
+                            and self.settlement_final_answer_fence
+                            else exc.code
+                        ),
                     )
                 except LLMCallInterrupted:
                     interrupted = await self._interrupt_if_requested(
@@ -822,7 +835,7 @@ class ReActPattern(AgentPattern):
                     if interrupted is not None:
                         return interrupted
                     raise
-                if unavailable_tool_call:
+                if unavailable_tool_call and not self.settlement_final_answer_fence:
                     self.force_final_answer_next = False
                     force_final_answer_now = False
                 protocol_retry_performed = True
@@ -873,9 +886,12 @@ class ReActPattern(AgentPattern):
                 # prose invites it to treat that text as already committed. The cost
                 # is that a model which keeps emitting "preamble + empty answer"
                 # fails the run without the user seeing the preamble.
-                recover_full_tool_set = self._requires_full_tool_set_recovery(
-                    normalized,
-                    force_final_answer=force_final_answer_now,
+                recover_full_tool_set = (
+                    not self.settlement_final_answer_fence
+                    and self._requires_full_tool_set_recovery(
+                        normalized,
+                        force_final_answer=force_final_answer_now,
+                    )
                 )
                 empty_final_answer = self._empty_final_answer_call(normalized)
                 if empty_final_answer is not None:
@@ -889,6 +905,8 @@ class ReActPattern(AgentPattern):
                     recovery_reason: str | None = "unavailable_tool_call"
                 elif empty_final_answer is not None:
                     recovery_reason = "empty_final_answer"
+                elif self.settlement_final_answer_fence:
+                    recovery_reason = "settlement_final_answer_required"
                 else:
                     recovery_reason = None
                 try:
@@ -1268,6 +1286,13 @@ class ReActPattern(AgentPattern):
                 "when the task is actually complete and its required results exist."
             )
             retry_phase = "unavailable_tool_call_recovery"
+        elif recovery_reason == "settlement_final_answer_required":
+            retry_instruction = (
+                "A rejected or dispatch-unknown write ended this resumed turn. "
+                "Do not call or retry any work tool. Call final_answer with a "
+                "concise explanation of the recorded outcome."
+            )
+            retry_phase = "settlement_final_answer_recovery"
         elif recovery_reason == "malformed_tool_arguments":
             retry_instruction = (
                 "The previous response returned malformed JSON arguments for a "
@@ -1624,9 +1649,10 @@ class ReActPattern(AgentPattern):
                 self.repeated_tool_decision_after_consecutive_work_tool_calls
             ),
             "force_final_answer_next": self.force_final_answer_next,
+            "settlement_final_answer_fence": self.settlement_final_answer_fence,
             "repeated_tool_decision": self.repeated_tool_decision,
             "waiting_for_user_request": self.waiting_for_user_request,
-            "pending_tool_interaction_responses": (
+            "pending_tool_interaction_responses": copy.deepcopy(
                 self.pending_tool_interaction_responses
             ),
             "task_text": self.task_text,
@@ -1673,6 +1699,9 @@ class ReActPattern(AgentPattern):
                 int(raw_work_threshold) if raw_work_threshold is not None else None
             )
         self.force_final_answer_next = bool(state.get("force_final_answer_next", False))
+        self.settlement_final_answer_fence = bool(
+            state.get("settlement_final_answer_fence", False)
+        )
         repeated_tool_decision = state.get("repeated_tool_decision")
         self.repeated_tool_decision = (
             dict(repeated_tool_decision)
@@ -1753,11 +1782,16 @@ class ReActPattern(AgentPattern):
             context=context,
             after_message_count=waiting_message_count,
         )
-        self._queue_tool_interaction_responses(
+        queued = self._queue_tool_interaction_responses(
             waiting_request=self.waiting_for_user_request,
             response=response or "",
             tools=tools,
         )
+        if not queued:
+            return await self._remain_waiting_for_mapped_tool_responses(
+                context=context,
+                runtime=runtime,
+            )
         if self.pending_tool_calls:
             # Waiting checkpoints written before the pause path discarded the
             # plan pre-checkpoint still carry the parked batch's unexecuted
@@ -1836,22 +1870,83 @@ class ReActPattern(AgentPattern):
             return str(getattr(message, "content", "") or "")
         return None
 
+    async def _remain_waiting_for_mapped_tool_responses(
+        self,
+        *,
+        context: Any,
+        runtime: PatternRuntime,
+    ) -> dict[str, Any]:
+        """Fail closed when one free-text reply could authorize several writes."""
+
+        waiting_request = dict(self.waiting_for_user_request or {})
+        request_ids = [
+            str(request.get("interaction_id") or request.get("tool_call_id") or "")
+            for request in waiting_request.get("requests", [])
+            if isinstance(request, dict)
+        ]
+        request_ids = [request_id for request_id in request_ids if request_id]
+        example = json.dumps(
+            {request_id: "your response" for request_id in request_ids},
+            ensure_ascii=False,
+        )
+        message = (
+            "Several external-write interactions are waiting. For safety, one "
+            "free-text reply cannot authorize all of them. Reply with one JSON "
+            f"object mapping each interaction_id to its response, for example: {example}"
+        )
+        outbound = await runtime.send_message(
+            message=message,
+            message_type="question",
+            expect_response=True,
+            visible=True,
+            metadata={"interactions": waiting_request.get("interactions", [])},
+        )
+        waiting_request.update(
+            event_id=outbound["event_id"],
+            message=message,
+            message_type="question",
+            message_count=len(getattr(context, "messages", [])),
+        )
+        self.waiting_for_user_request = waiting_request
+        self.status = "waiting_for_user"
+        await runtime.checkpoint(
+            "waiting_for_user",
+            context=context,
+            pattern=self,
+            metadata={"waiting_for_user_request": waiting_request},
+        )
+        return {
+            "success": False,
+            "status": "waiting_for_user",
+            "message": message,
+            "message_type": "question",
+            "interactions": waiting_request.get("interactions"),
+            "context": context,
+            "clarification_draft": draft_from_waiting_request(
+                waiting_request,
+                execution_id=getattr(context, "execution_id", None),
+                step_id=None,
+            ),
+        }
+
     def _queue_tool_interaction_responses(
         self,
         *,
         waiting_request: Any,
         response: str,
         tools: list[Any],
-    ) -> None:
+    ) -> bool:
         """Queue replies only for tools that expose the optional resume callback."""
 
         if (
             not isinstance(waiting_request, dict)
             or waiting_request.get("kind") != "tool_waiting_for_user"
         ):
-            return
+            return True
         raw_requests = waiting_request.get("requests")
         requests = raw_requests if isinstance(raw_requests, list) else [waiting_request]
+        resumable: list[tuple[dict[str, Any], Any]] = []
+        external_write_count = 0
         for request in requests:
             if not isinstance(request, dict):
                 continue
@@ -1862,22 +1957,56 @@ class ReActPattern(AgentPattern):
                 tool = self._find_tool(tool_name, tools)
             except ValueError:
                 continue
+            if tool_requires_duplicate_write_guard(tool):
+                external_write_count += 1
             if user_interaction_resume_callable(tool) is None:
                 # Callback-less tools resume through the normal ReAct replan. The
                 # user's answer remains in context with waiting-response metadata.
                 continue
+            resumable.append((request, tool))
+
+        response_map: dict[str, str] | None = None
+        if external_write_count > 1:
+            try:
+                candidate = json.loads(response)
+            except (TypeError, ValueError):
+                return False
+            if not isinstance(candidate, dict):
+                return False
+            response_map = {}
+            for request in requests:
+                if not isinstance(request, dict):
+                    return False
+                interaction_id = str(
+                    request.get("interaction_id") or request.get("tool_call_id") or ""
+                )
+                mapped_response = candidate.get(interaction_id)
+                if (
+                    not interaction_id
+                    or interaction_id in response_map
+                    or not isinstance(mapped_response, str)
+                    or not mapped_response.strip()
+                ):
+                    return False
+                response_map[interaction_id] = mapped_response
+
+        for request, _ in resumable:
+            interaction_id = str(
+                request.get("interaction_id") or request.get("tool_call_id") or ""
+            )
             self.pending_tool_interaction_responses.append(
                 {
-                    "tool_name": tool_name,
+                    "tool_name": str(request.get("tool_name") or ""),
                     "tool_call_id": str(request.get("tool_call_id") or ""),
-                    "interaction_id": str(
-                        request.get("interaction_id")
-                        or request.get("tool_call_id")
-                        or ""
+                    "interaction_id": interaction_id,
+                    "response": (
+                        response_map[interaction_id]
+                        if response_map is not None
+                        else response
                     ),
-                    "response": response,
                 }
             )
+        return True
 
     async def _deliver_pending_tool_interaction_responses(
         self,
@@ -1902,24 +2031,44 @@ class ReActPattern(AgentPattern):
                 # Legacy checkpoints may contain callback delivery for a tool that
                 # no longer exists or never implemented the optional capability.
                 # The annotated user message is sufficient for the model to replan.
-                self.pending_tool_interaction_responses.pop(0)
-                await runtime.checkpoint(
-                    "tool_interaction_response_skipped",
+                await self._skip_pending_tool_interaction_response(
+                    pending=pending,
                     context=context,
-                    pattern=self,
-                    metadata={
-                        "tool_name": tool_name,
-                        "tool_call_id": pending.get("tool_call_id", ""),
-                        "interaction_id": pending.get("interaction_id", ""),
-                        "reason": "resume_callback_unavailable",
-                    },
+                    runtime=runtime,
+                    reason="resume_callback_unavailable",
                 )
                 continue
 
-            record = self._validate_tool_interaction_settlement_target(
-                pending=pending,
-                context=context,
-            )
+            try:
+                record = self._validate_tool_interaction_settlement_target(
+                    pending=pending,
+                    context=context,
+                )
+            except RuntimeError as exc:
+                tool_call_id = str(pending.get("tool_call_id") or "")
+                stale_record = self.tool_ledger.get(tool_call_id)
+                reason = (
+                    "already_settled"
+                    if stale_record is not None
+                    and stale_record.tool_name == tool_name
+                    and stale_record.status in {"completed", "failed"}
+                    else "invalid_settlement_target"
+                )
+                logger.warning(
+                    "Skipping stale tool interaction response. reason=%s "
+                    "tool=%r tool_call_id=%r error=%s",
+                    reason,
+                    tool_name,
+                    tool_call_id,
+                    exc,
+                )
+                await self._skip_pending_tool_interaction_response(
+                    pending=pending,
+                    context=context,
+                    runtime=runtime,
+                    reason=reason,
+                )
+                continue
             resumed = resume(
                 interaction_id=pending.get("interaction_id", ""),
                 response=pending.get("response", ""),
@@ -1929,17 +2078,25 @@ class ReActPattern(AgentPattern):
             if resumed is not None and not isinstance(
                 resumed, ToolInteractionSettlement
             ):
-                raise TypeError(
+                logger.error(
                     "resume_user_interaction must return "
-                    "ToolInteractionSettlement or None"
+                    "ToolInteractionSettlement or None; treating the outcome as "
+                    "dispatch_unknown. tool=%r interaction_id=%r",
+                    tool_name,
+                    pending.get("interaction_id", ""),
+                )
+                resumed = ToolInteractionSettlement.dispatch_unknown(
+                    error=(
+                        "The resume callback returned an invalid settlement. The "
+                        "external outcome is unknown and automatic retry is disabled."
+                    )
                 )
 
             ledger_before = copy.deepcopy(self.tool_ledger)
             messages = getattr(context, "messages", None)
-            messages_before = (
-                copy.deepcopy(messages) if isinstance(messages, list) else None
-            )
+            messages_before = list(messages) if isinstance(messages, list) else None
             force_final_before = self.force_final_answer_next
+            settlement_fence_before = self.settlement_final_answer_fence
             popped = False
             try:
                 if isinstance(resumed, ToolInteractionSettlement):
@@ -1976,9 +2133,74 @@ class ReActPattern(AgentPattern):
                 if messages_before is not None and isinstance(messages, list):
                     messages[:] = messages_before
                 self.force_final_answer_next = force_final_before
+                self.settlement_final_answer_fence = settlement_fence_before
                 if popped:
                     self.pending_tool_interaction_responses.insert(0, pending)
                 raise
+            if isinstance(resumed, ToolInteractionSettlement):
+                await self._trace_tool_interaction_settlement(
+                    record=record,
+                    settlement=resumed,
+                    runtime=runtime,
+                )
+
+    async def _skip_pending_tool_interaction_response(
+        self,
+        *,
+        pending: dict[str, str],
+        context: Any,
+        runtime: PatternRuntime,
+        reason: str,
+    ) -> None:
+        """Durably skip one undeliverable response without losing it on failure."""
+
+        self.pending_tool_interaction_responses.pop(0)
+        try:
+            await runtime.checkpoint(
+                "tool_interaction_response_skipped",
+                context=context,
+                pattern=self,
+                metadata={
+                    "tool_name": pending.get("tool_name", ""),
+                    "tool_call_id": pending.get("tool_call_id", ""),
+                    "interaction_id": pending.get("interaction_id", ""),
+                    "reason": reason,
+                },
+            )
+        except BaseException:
+            self.pending_tool_interaction_responses.insert(0, pending)
+            raise
+
+    @staticmethod
+    async def _trace_tool_interaction_settlement(
+        *,
+        record: ToolCallRecord,
+        settlement: ToolInteractionSettlement,
+        runtime: PatternRuntime,
+    ) -> None:
+        """Emit a paired lifecycle after the settlement is durably checkpointed."""
+
+        tool_call = {
+            "id": record.tool_call_id,
+            "name": record.tool_name,
+            "args": copy.deepcopy(record.args),
+            "turn_id": getattr(runtime, "active_turn_id", None),
+            "settlement_delivery": True,
+        }
+        result = settlement.projected_result()
+        await runtime.on_tool_start(tool_call=tool_call)
+        if settlement.status == "succeeded":
+            await runtime.on_tool_end(tool_call=tool_call, result=result)
+            return
+        error_message = str(
+            settlement.error
+            or (result.get("error") if isinstance(result, dict) else result)
+        )
+        await runtime.on_tool_error(
+            tool_call=tool_call,
+            error=RuntimeError(error_message),
+            result=result,
+        )
 
     def _validate_tool_interaction_settlement_target(
         self,
@@ -2075,6 +2297,7 @@ class ReActPattern(AgentPattern):
         # must not let the model retry the denied or potentially completed write.
         if settlement.status in {"rejected", "dispatch_unknown"}:
             self.force_final_answer_next = True
+            self.settlement_final_answer_fence = True
 
     @staticmethod
     def _replace_tool_result(
@@ -3769,6 +3992,7 @@ class ReActPattern(AgentPattern):
         self.waiting_for_user_request = None
         self.pending_tool_interaction_responses = []
         self.force_final_answer_next = False
+        self.settlement_final_answer_fence = False
         self.status = "completed"
         await runtime.checkpoint("final", context=context, pattern=self)
         result = PatternResult(
@@ -3930,11 +4154,16 @@ class ReActPattern(AgentPattern):
         # call, so every ledger entry — including one under this call's own
         # id, which a provider may have reused — belongs to an earlier call.
         for record in self.tool_ledger.values():
-            if record.status != "completed":
+            guarded_settlement = record.settlement_status in {
+                "rejected",
+                "dispatch_unknown",
+            }
+            if record.status != "completed" and not guarded_settlement:
                 continue
             guard_turn_id = (
                 record.settlement_turn_id
-                if record.settlement_status == "succeeded"
+                if record.settlement_status
+                in {"succeeded", "rejected", "dispatch_unknown"}
                 else record.turn_id
             )
             if guard_turn_id != turn_id:
@@ -3968,6 +4197,7 @@ class ReActPattern(AgentPattern):
                 tool_name=tool_name,
                 prior_tool_call_id=record.tool_call_id,
                 prior_result=prior_result,
+                prior_succeeded=record.status == "completed",
             )
         return None
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -168,6 +168,10 @@ class ToolCallRecord:
     # the embedding provides no turn tracking, and for records restored from
     # checkpoints written before the field existed.
     turn_id: str | None = None
+    # The turn that delivered a terminal settlement. This is separate from
+    # ``turn_id`` so the original call keeps its execution identity while the
+    # duplicate-write guard can protect the one resumed turn that follows it.
+    settlement_turn_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -180,6 +184,7 @@ class ToolCallRecord:
             "error": self.error,
             "settlement_status": self.settlement_status,
             "turn_id": self.turn_id,
+            "settlement_turn_id": self.settlement_turn_id,
         }
 
     @classmethod
@@ -194,10 +199,15 @@ class ToolCallRecord:
             error=data.get("error"),
             settlement_status=(
                 str(data["settlement_status"])
-                if data.get("settlement_status")
+                if data.get("settlement_status") is not None
                 else None
             ),
             turn_id=str(data["turn_id"]) if data.get("turn_id") else None,
+            settlement_turn_id=(
+                str(data["settlement_turn_id"])
+                if data.get("settlement_turn_id") is not None
+                else None
+            ),
         )
 
 
@@ -1906,27 +1916,44 @@ class ReActPattern(AgentPattern):
                 )
                 continue
 
+            record = self._validate_tool_interaction_settlement_target(
+                pending=pending,
+                context=context,
+            )
             resumed = resume(
                 interaction_id=pending.get("interaction_id", ""),
                 response=pending.get("response", ""),
             )
             if inspect.isawaitable(resumed):
                 resumed = await resumed
-
-            if isinstance(resumed, ToolInteractionSettlement):
-                await self._project_tool_interaction_settlement(
-                    pending=pending,
-                    settlement=resumed,
-                    context=context,
-                    runtime=runtime,
+            if resumed is not None and not isinstance(
+                resumed, ToolInteractionSettlement
+            ):
+                raise TypeError(
+                    "resume_user_interaction must return "
+                    "ToolInteractionSettlement or None"
                 )
 
-            # Remove the response for the checkpoint, but restore it in memory
-            # if persistence fails. The last durable checkpoint still contains
-            # the response either way, and the host callback is required to
-            # replay its already-persisted settlement on a retry.
-            self.pending_tool_interaction_responses.pop(0)
+            ledger_before = copy.deepcopy(self.tool_ledger)
+            messages = getattr(context, "messages", None)
+            messages_before = copy.deepcopy(messages) if isinstance(messages, list) else None
+            force_final_before = self.force_final_answer_next
+            popped = False
             try:
+                if isinstance(resumed, ToolInteractionSettlement):
+                    self._project_tool_interaction_settlement(
+                        record=record,
+                        settlement=resumed,
+                        context=context,
+                        runtime=runtime,
+                    )
+
+                # The checkpoint must contain the terminal projection and no
+                # pending callback. If persistence fails, restore the entire
+                # in-memory transaction so replay starts from the last durable
+                # waiting state.
+                self.pending_tool_interaction_responses.pop(0)
+                popped = True
                 await runtime.checkpoint(
                     "tool_interaction_response_delivered",
                     context=context,
@@ -1943,18 +1970,21 @@ class ReActPattern(AgentPattern):
                     },
                 )
             except BaseException:
-                self.pending_tool_interaction_responses.insert(0, pending)
+                self.tool_ledger = ledger_before
+                if messages_before is not None and isinstance(messages, list):
+                    messages[:] = messages_before
+                self.force_final_answer_next = force_final_before
+                if popped:
+                    self.pending_tool_interaction_responses.insert(0, pending)
                 raise
 
-    async def _project_tool_interaction_settlement(
+    def _validate_tool_interaction_settlement_target(
         self,
         *,
         pending: dict[str, str],
-        settlement: ToolInteractionSettlement,
         context: Any,
-        runtime: PatternRuntime,
-    ) -> None:
-        """Project a resumed outcome onto its original tool protocol slot."""
+    ) -> ToolCallRecord:
+        """Validate every durable identity before a resume callback can run."""
 
         tool_call_id = str(pending.get("tool_call_id") or "")
         record = self.tool_ledger.get(tool_call_id)
@@ -1969,13 +1999,37 @@ class ReActPattern(AgentPattern):
                 "Resumed tool interaction does not match its original ledger "
                 f"record: {pending_tool_name!r} != {record.tool_name!r}"
             )
-        if record.status != "waiting_for_user" and (
-            record.settlement_status != settlement.status
-        ):
+        if record.status != "waiting_for_user":
             raise RuntimeError(
-                "Cannot overwrite a tool call that was not waiting for this "
-                f"settlement: {tool_call_id!r} is {record.status!r}."
+                "Cannot resume a tool call that is not waiting for user input: "
+                f"{tool_call_id!r} is {record.status!r} with settlement "
+                f"{record.settlement_status!r}."
             )
+        messages = getattr(context, "messages", None)
+        if not isinstance(messages, list):
+            raise RuntimeError("Execution context does not expose a message list.")
+        matches = [
+            message
+            for message in messages
+            if getattr(message, "role", None) == "tool"
+            and getattr(message, "tool_call_id", None) == tool_call_id
+        ]
+        if len(matches) != 1:
+            raise RuntimeError(
+                "Expected exactly one tool result for resumed tool call "
+                f"{tool_call_id!r}; found {len(matches)}."
+            )
+        return record
+
+    def _project_tool_interaction_settlement(
+        self,
+        *,
+        record: ToolCallRecord,
+        settlement: ToolInteractionSettlement,
+        context: Any,
+        runtime: PatternRuntime,
+    ) -> None:
+        """Project a resumed outcome onto its original tool protocol slot."""
 
         result = settlement.projected_result()
         self._replace_tool_result(
@@ -1998,30 +2052,26 @@ class ReActPattern(AgentPattern):
                 status="completed",
                 result=result,
                 settlement_status=settlement.status,
+                settlement_turn_id=getattr(runtime, "active_turn_id", None),
             )
-            await runtime.on_tool_end(tool_call=tool_call, result=result)
-            return
-
-        error = str(
-            settlement.error
-            or (result.get("error") if isinstance(result, dict) else result)
-        )
-        self._record_tool_call(
-            tool_call,
-            status="failed",
-            result=result,
-            error=error,
-            settlement_status=settlement.status,
-        )
-        if settlement.status in {"rejected", "dispatch_unknown"}:
-            # Neither outcome authorizes another attempt in this turn. A new
-            # external write must originate from a later user request.
-            self.force_final_answer_next = True
-        await runtime.on_tool_error(
-            tool_call=tool_call,
-            error=RuntimeError(error),
-            result=result,
-        )
+        else:
+            error = str(
+                settlement.error
+                or (result.get("error") if isinstance(result, dict) else result)
+            )
+            self._record_tool_call(
+                tool_call,
+                status="failed",
+                result=result,
+                error=error,
+                settlement_status=settlement.status,
+                settlement_turn_id=getattr(runtime, "active_turn_id", None),
+            )
+        # Recompute for every entry in a multi-interaction delivery batch.
+        self.force_final_answer_next = settlement.status in {
+            "rejected",
+            "dispatch_unknown",
+        }
 
     @staticmethod
     def _replace_tool_result(
@@ -2048,12 +2098,14 @@ class ReActPattern(AgentPattern):
                 f"{tool_call_id!r}; found {len(matching_indexes)}."
             )
 
-        context.add_tool_result(
+        replacement = context.add_tool_result(
             tool_name=tool_name,
             result=result,
             tool_call_id=tool_call_id,
         )
-        replacement = messages.pop()
+        if not messages or messages[-1] is not replacement:
+            raise RuntimeError("Execution context did not append the replacement result.")
+        messages.pop()
         messages[matching_indexes[0]] = replacement
 
     def _normalize_llm_response(self, response: Any) -> dict[str, Any]:
@@ -3837,18 +3889,17 @@ class ReActPattern(AgentPattern):
     ) -> dict[str, Any] | None:
         """Return the suppression envelope when this call repeats a completed write.
 
-        The comparison key is (turn_id, tool_name, args_hash), each side
+        The comparison key is (guard turn id, tool name, args hash), each side
         computed from the same post-transform ``tool_call`` that
         ``_record_tool_call`` hashes and ``_execute_tool`` executes — so two
         calls compare equal exactly when their executions would be identical.
-        The turn_id equality is what makes the guard strictly per-turn: the
-        runner stamps a fresh turn_id on every user message (initial and
-        injected), and ``active_turn_id`` is re-resolved from the latest user
-        message at each pattern start — so an explicit repeat requested in a
-        later turn always executes, while an intra-turn resume of the
-        checkpointed ledger keeps suppressing the replay. A call with no
-        stamped turn_id is never guarded: without a turn to scope to,
-        suppression could outlive a turn, so an unknowable turn fails open.
+        An ordinary completion uses its original ``turn_id``. A resumed
+        success uses ``settlement_turn_id``, the approval turn that received
+        that result. This keeps duplicate suppression active for subsequent
+        planning in the resumed turn without rewriting the original call's
+        identity or suppressing a new request in a later turn. A call with no
+        guard turn id is never guarded: without a turn to scope to, suppression
+        could outlive a turn, so an unknowable turn fails open.
 
         Serial execution makes the check-then-record window safe for guarded
         tools: they are non-idempotent by declaration, so
@@ -3876,7 +3927,12 @@ class ReActPattern(AgentPattern):
         for record in self.tool_ledger.values():
             if record.status != "completed":
                 continue
-            if record.turn_id != turn_id:
+            guard_turn_id = (
+                record.settlement_turn_id
+                if record.settlement_status == "succeeded"
+                else record.turn_id
+            )
+            if guard_turn_id != turn_id:
                 continue
             if record.tool_name != tool_name or record.args_hash != args_hash:
                 continue
@@ -4160,6 +4216,7 @@ class ReActPattern(AgentPattern):
         result: Any = None,
         error: str | None = None,
         settlement_status: str | None = None,
+        settlement_turn_id: str | None = None,
     ) -> None:
         tool_call_id = str(tool_call.get("id") or f"tool_call_{len(self.tool_ledger)}")
         args = self._tool_call_args_dict(tool_call)
@@ -4174,6 +4231,9 @@ class ReActPattern(AgentPattern):
             error=error,
             settlement_status=settlement_status,
             turn_id=self._tool_call_turn_id(tool_call),
+            settlement_turn_id=(
+                str(settlement_turn_id) if settlement_turn_id else None
+            ),
         )
 
     @staticmethod

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -2069,11 +2069,12 @@ class ReActPattern(AgentPattern):
                 settlement_status=settlement.status,
                 settlement_turn_id=getattr(runtime, "active_turn_id", None),
             )
-        # Recompute for every entry in a multi-interaction delivery batch.
-        self.force_final_answer_next = settlement.status in {
-            "rejected",
-            "dispatch_unknown",
-        }
+        # A rejection or an unknown dispatch anywhere in the delivery batch is
+        # an authorization boundary for the whole resumed turn. Once raised,
+        # keep the fence until the final-answer path clears it; a later success
+        # must not let the model retry the denied or potentially completed write.
+        if settlement.status in {"rejected", "dispatch_unknown"}:
+            self.force_final_answer_next = True
 
     @staticmethod
     def _replace_tool_result(

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -74,6 +74,7 @@ from ....model.chat.exceptions import LLMToolProtocolError
 from ....model.chat.tool_protocol import get_tool_protocol_error
 from ....tools.adapters.vibe.interaction_types import INTERACTION_TYPES
 from ....tools.user_interaction import (
+    ToolInteractionSettlement,
     tool_result_waits_for_user,
     user_interaction_resume_callable,
 )
@@ -159,6 +160,10 @@ class ToolCallRecord:
     status: str
     result: Any = None
     error: str | None = None
+    # Terminal outcome supplied by a resumable tool callback. Kept separate
+    # from ``status`` so existing completed/failed ledger readers remain
+    # backward-compatible.
+    settlement_status: str | None = None
     # The durable turn the call ran in (see _with_runtime_turn_id). None when
     # the embedding provides no turn tracking, and for records restored from
     # checkpoints written before the field existed.
@@ -173,6 +178,7 @@ class ToolCallRecord:
             "status": self.status,
             "result": self.result,
             "error": self.error,
+            "settlement_status": self.settlement_status,
             "turn_id": self.turn_id,
         }
 
@@ -186,6 +192,11 @@ class ToolCallRecord:
             status=str(data.get("status", "pending")),
             result=data.get("result"),
             error=data.get("error"),
+            settlement_status=(
+                str(data["settlement_status"])
+                if data.get("settlement_status")
+                else None
+            ),
             turn_id=str(data["turn_id"]) if data.get("turn_id") else None,
         )
 
@@ -1900,20 +1911,150 @@ class ReActPattern(AgentPattern):
                 response=pending.get("response", ""),
             )
             if inspect.isawaitable(resumed):
-                await resumed
+                resumed = await resumed
 
-            # Keep the response retryable until the tool acknowledges delivery.
+            if isinstance(resumed, ToolInteractionSettlement):
+                await self._project_tool_interaction_settlement(
+                    pending=pending,
+                    settlement=resumed,
+                    context=context,
+                    runtime=runtime,
+                )
+
+            # Remove the response for the checkpoint, but restore it in memory
+            # if persistence fails. The last durable checkpoint still contains
+            # the response either way, and the host callback is required to
+            # replay its already-persisted settlement on a retry.
             self.pending_tool_interaction_responses.pop(0)
-            await runtime.checkpoint(
-                "tool_interaction_response_delivered",
-                context=context,
-                pattern=self,
-                metadata={
-                    "tool_name": tool_name,
-                    "tool_call_id": pending.get("tool_call_id", ""),
-                    "interaction_id": pending.get("interaction_id", ""),
-                },
+            try:
+                await runtime.checkpoint(
+                    "tool_interaction_response_delivered",
+                    context=context,
+                    pattern=self,
+                    metadata={
+                        "tool_name": tool_name,
+                        "tool_call_id": pending.get("tool_call_id", ""),
+                        "interaction_id": pending.get("interaction_id", ""),
+                        "settlement_status": (
+                            resumed.status
+                            if isinstance(resumed, ToolInteractionSettlement)
+                            else None
+                        ),
+                    },
+                )
+            except BaseException:
+                self.pending_tool_interaction_responses.insert(0, pending)
+                raise
+
+    async def _project_tool_interaction_settlement(
+        self,
+        *,
+        pending: dict[str, str],
+        settlement: ToolInteractionSettlement,
+        context: Any,
+        runtime: PatternRuntime,
+    ) -> None:
+        """Project a resumed outcome onto its original tool protocol slot."""
+
+        tool_call_id = str(pending.get("tool_call_id") or "")
+        record = self.tool_ledger.get(tool_call_id)
+        if record is None:
+            raise RuntimeError(
+                "Cannot settle resumed tool interaction without its original "
+                f"ledger record: {tool_call_id or '<missing>'}"
             )
+        pending_tool_name = str(pending.get("tool_name") or "")
+        if pending_tool_name != record.tool_name:
+            raise RuntimeError(
+                "Resumed tool interaction does not match its original ledger "
+                f"record: {pending_tool_name!r} != {record.tool_name!r}"
+            )
+        if record.status != "waiting_for_user" and (
+            record.settlement_status != settlement.status
+        ):
+            raise RuntimeError(
+                "Cannot overwrite a tool call that was not waiting for this "
+                f"settlement: {tool_call_id!r} is {record.status!r}."
+            )
+
+        result = settlement.projected_result()
+        self._replace_tool_result(
+            context=context,
+            tool_name=record.tool_name,
+            tool_call_id=record.tool_call_id,
+            result=result,
+        )
+        tool_call: dict[str, Any] = {
+            "id": record.tool_call_id,
+            "name": record.tool_name,
+            "args": copy.deepcopy(record.args),
+        }
+        if record.turn_id:
+            tool_call["turn_id"] = record.turn_id
+
+        if settlement.status == "succeeded":
+            self._record_tool_call(
+                tool_call,
+                status="completed",
+                result=result,
+                settlement_status=settlement.status,
+            )
+            await runtime.on_tool_end(tool_call=tool_call, result=result)
+            return
+
+        error = str(
+            settlement.error
+            or (result.get("error") if isinstance(result, dict) else result)
+        )
+        self._record_tool_call(
+            tool_call,
+            status="failed",
+            result=result,
+            error=error,
+            settlement_status=settlement.status,
+        )
+        if settlement.status in {"rejected", "dispatch_unknown"}:
+            # Neither outcome authorizes another attempt in this turn. A new
+            # external write must originate from a later user request.
+            self.force_final_answer_next = True
+        await runtime.on_tool_error(
+            tool_call=tool_call,
+            error=RuntimeError(error),
+            result=result,
+        )
+
+    @staticmethod
+    def _replace_tool_result(
+        *,
+        context: Any,
+        tool_name: str,
+        tool_call_id: str,
+        result: Any,
+    ) -> None:
+        """Replace the waiting observation without creating a second tool row."""
+
+        messages = getattr(context, "messages", None)
+        if not isinstance(messages, list):
+            raise RuntimeError("Execution context does not expose a message list.")
+        matching_indexes = [
+            index
+            for index, message in enumerate(messages)
+            if getattr(message, "role", None) == "tool"
+            and getattr(message, "tool_call_id", None) == tool_call_id
+        ]
+        if len(matching_indexes) != 1:
+            raise RuntimeError(
+                "Expected exactly one tool result for resumed tool call "
+                f"{tool_call_id!r}; found {len(matching_indexes)}."
+            )
+
+        context.add_tool_result(
+            tool_name=tool_name,
+            result=result,
+            tool_call_id=tool_call_id,
+        )
+        replacement = messages.pop()
+        messages[matching_indexes[0]] = replacement
 
     def _normalize_llm_response(self, response: Any) -> dict[str, Any]:
         if isinstance(response, str):
@@ -4018,6 +4159,7 @@ class ReActPattern(AgentPattern):
         status: str,
         result: Any = None,
         error: str | None = None,
+        settlement_status: str | None = None,
     ) -> None:
         tool_call_id = str(tool_call.get("id") or f"tool_call_{len(self.tool_ledger)}")
         args = self._tool_call_args_dict(tool_call)
@@ -4030,6 +4172,7 @@ class ReActPattern(AgentPattern):
             status=status,
             result=result,
             error=error,
+            settlement_status=settlement_status,
             turn_id=self._tool_call_turn_id(tool_call),
         )
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1936,7 +1936,9 @@ class ReActPattern(AgentPattern):
 
             ledger_before = copy.deepcopy(self.tool_ledger)
             messages = getattr(context, "messages", None)
-            messages_before = copy.deepcopy(messages) if isinstance(messages, list) else None
+            messages_before = (
+                copy.deepcopy(messages) if isinstance(messages, list) else None
+            )
             force_final_before = self.force_final_answer_next
             popped = False
             try:
@@ -2104,7 +2106,9 @@ class ReActPattern(AgentPattern):
             tool_call_id=tool_call_id,
         )
         if not messages or messages[-1] is not replacement:
-            raise RuntimeError("Execution context did not append the replacement result.")
+            raise RuntimeError(
+                "Execution context did not append the replacement result."
+            )
         messages.pop()
         messages[matching_indexes[0]] = replacement
 

--- a/src/xagent/core/tools/user_interaction.py
+++ b/src/xagent/core/tools/user_interaction.py
@@ -2,11 +2,12 @@
 
 Tools opt into the control flow by returning a mapping whose ``status`` is
 ``waiting_for_user``.  The execution pattern presents the returned message,
-checkpoints, and stops the current run. After the user replies, the runtime asks
-the model to replan with the annotated response in context. Tools that keep
-server-owned interaction state may additionally implement
-``resume_user_interaction``; the runtime then delivers the reply to that exact
-suspended interaction before replanning.
+checkpoints, and stops the current run. After the user replies, tools that keep
+server-owned interaction state may implement ``resume_user_interaction``; the
+runtime then delivers the reply to that exact suspended interaction. Returning
+``ToolInteractionSettlement`` projects the terminal result onto the original
+tool call before the model continues. Returning ``None`` preserves the legacy
+replan behavior.
 
 The optional runtime capability keeps server-owned interaction state out of
 model-generated tool arguments and lets those tools decide how to interpret the
@@ -15,9 +16,120 @@ user's answer. Callback-less tools use the normal ReAct context and replan path.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Protocol, runtime_checkable
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Protocol, runtime_checkable
 
 WAITING_FOR_USER_STATUS = "waiting_for_user"
+ToolInteractionSettlementStatus = Literal[
+    "succeeded",
+    "rejected",
+    "failed",
+    "dispatch_unknown",
+]
+_TOOL_INTERACTION_SETTLEMENT_STATUSES = {
+    "succeeded",
+    "rejected",
+    "failed",
+    "dispatch_unknown",
+}
+_DEFAULT_SETTLEMENT_ERRORS = {
+    "rejected": "The user rejected the tool call.",
+    "failed": "The resumed tool call failed.",
+    "dispatch_unknown": (
+        "The tool call may have reached the external system. Automatic retry is "
+        "disabled; verify the external system before trying again."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ToolInteractionSettlement:
+    """Durable outcome returned when a suspended tool call is resumed.
+
+    Returning this value asks the execution pattern to replace the original
+    ``waiting_for_user`` observation with the terminal result. A callback that
+    returns ``None`` keeps the legacy behavior: delivery is acknowledged and
+    the model replans from the user's response.
+    """
+
+    status: ToolInteractionSettlementStatus
+    result: Any = None
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status not in _TOOL_INTERACTION_SETTLEMENT_STATUSES:
+            raise ValueError(f"Invalid tool interaction settlement: {self.status!r}")
+        if self.status == "succeeded" and isinstance(self.result, dict):
+            result_status = self.result.get("status")
+            if (
+                self.result.get("success") is False
+                or self.result.get("is_error") is True
+                or (
+                    isinstance(result_status, str)
+                    and result_status.strip().lower() == "error"
+                )
+            ):
+                raise ValueError(
+                    "A succeeded tool interaction settlement cannot carry a "
+                    "failed tool result."
+                )
+
+    @classmethod
+    def succeeded(cls, result: Any) -> ToolInteractionSettlement:
+        return cls(status="succeeded", result=result)
+
+    @classmethod
+    def rejected(
+        cls,
+        *,
+        result: Any = None,
+        error: str | None = None,
+    ) -> ToolInteractionSettlement:
+        return cls(status="rejected", result=result, error=error)
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        result: Any = None,
+        error: str | None = None,
+    ) -> ToolInteractionSettlement:
+        return cls(status="failed", result=result, error=error)
+
+    @classmethod
+    def dispatch_unknown(
+        cls,
+        *,
+        result: Any = None,
+        error: str | None = None,
+    ) -> ToolInteractionSettlement:
+        return cls(status="dispatch_unknown", result=result, error=error)
+
+    def projected_result(self) -> Any:
+        """Return the model-visible result with an unambiguous outcome."""
+
+        if self.status == "succeeded":
+            return self.result
+
+        result_error = (
+            self.result.get("error") if isinstance(self.result, dict) else None
+        )
+        error = self.error or result_error or _DEFAULT_SETTLEMENT_ERRORS[self.status]
+        if isinstance(self.result, dict):
+            return {
+                **self.result,
+                "success": False,
+                "status": self.status,
+                "error": error,
+            }
+        projected = {
+            "success": False,
+            "status": self.status,
+            "error": error,
+        }
+        if self.result is not None:
+            projected["result"] = self.result
+        return projected
 
 
 @runtime_checkable
@@ -30,7 +142,7 @@ class ResumableUserInteractionTool(Protocol):
         interaction_id: str,
         response: str,
     ) -> Any:
-        """Accept one user response identified by the suspended interaction."""
+        """Accept a response and optionally settle the suspended tool call."""
 
 
 def tool_result_waits_for_user(result: Any) -> bool:

--- a/src/xagent/core/tools/user_interaction.py
+++ b/src/xagent/core/tools/user_interaction.py
@@ -59,16 +59,19 @@ class ToolInteractionSettlement:
     def __post_init__(self) -> None:
         if self.status not in _TOOL_INTERACTION_SETTLEMENT_STATUSES:
             raise ValueError(f"Invalid tool interaction settlement: {self.status!r}")
-        if self.status == "succeeded" and isinstance(self.result, dict):
-            result_status = self.result.get("status")
-            if (
-                self.result.get("success") is False
-                or self.result.get("is_error") is True
-                or (
-                    isinstance(result_status, str)
-                    and result_status.strip().lower() == "error"
+        if self.status == "succeeded":
+            if self.result is None:
+                raise ValueError(
+                    "A succeeded tool interaction settlement needs a result."
                 )
-            ):
+            if tool_result_waits_for_user(self.result):
+                raise ValueError(
+                    "A succeeded tool interaction settlement cannot wait for user input."
+                )
+            # Deferred import avoids the agent.result -> tools import cycle.
+            from ..agent.result import tool_result_succeeded
+
+            if not tool_result_succeeded(self.result):
                 raise ValueError(
                     "A succeeded tool interaction settlement cannot carry a "
                     "failed tool result."
@@ -119,12 +122,12 @@ class ToolInteractionSettlement:
             return {
                 **self.result,
                 "success": False,
-                "status": self.status,
+                "settlement_status": self.status,
                 "error": error,
             }
         projected = {
             "success": False,
-            "status": self.status,
+            "settlement_status": self.status,
             "error": error,
         }
         if self.result is not None:
@@ -141,8 +144,13 @@ class ResumableUserInteractionTool(Protocol):
         *,
         interaction_id: str,
         response: str,
-    ) -> Any:
-        """Accept a response and optionally settle the suspended tool call."""
+    ) -> ToolInteractionSettlement | None:
+        """Accept a response and optionally settle the suspended tool call.
+
+        A host may invoke this callback again after a failed checkpoint or
+        process restart. Implementations that perform external work must
+        durably replay the same terminal settlement for the interaction.
+        """
 
 
 def tool_result_waits_for_user(result: Any) -> bool:

--- a/src/xagent/core/tools/user_interaction.py
+++ b/src/xagent/core/tools/user_interaction.py
@@ -17,7 +17,7 @@ user's answer. Callback-less tools use the normal ReAct context and replan path.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Literal, Protocol, runtime_checkable
+from typing import Any, Callable, Literal, Protocol, get_args, runtime_checkable
 
 WAITING_FOR_USER_STATUS = "waiting_for_user"
 ToolInteractionSettlementStatus = Literal[
@@ -26,12 +26,9 @@ ToolInteractionSettlementStatus = Literal[
     "failed",
     "dispatch_unknown",
 ]
-_TOOL_INTERACTION_SETTLEMENT_STATUSES = {
-    "succeeded",
-    "rejected",
-    "failed",
-    "dispatch_unknown",
-}
+_TOOL_INTERACTION_SETTLEMENT_STATUSES = frozenset(
+    get_args(ToolInteractionSettlementStatus)
+)
 _DEFAULT_SETTLEMENT_ERRORS = {
     "rejected": "The user rejected the tool call.",
     "failed": "The resumed tool call failed.",
@@ -76,6 +73,10 @@ class ToolInteractionSettlement:
                     "A succeeded tool interaction settlement cannot carry a "
                     "failed tool result."
                 )
+        elif tool_result_waits_for_user(self.result):
+            raise ValueError(
+                "A terminal tool interaction settlement cannot wait for user input."
+            )
 
     @classmethod
     def succeeded(cls, result: Any) -> ToolInteractionSettlement:

--- a/tests/core/agent/test_checkpoint.py
+++ b/tests/core/agent/test_checkpoint.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import sqlite3
 from typing import Any
 
 import pytest
@@ -83,6 +85,14 @@ class NoneReturningTraceEventBackend:
     ) -> None:
         del event_type, task_id, data, require_persisted
         return None
+
+
+class RaisingCheckpointBackend:
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+
+    async def checkpoint(self, **_: Any) -> None:
+        raise self.error
 
 
 class LegacyCheckpointBackend:
@@ -237,6 +247,41 @@ async def test_trace_checkpoint_store_rejects_none_trace_event_writer() -> None:
             label="before_llm",
             execution_id="exec-none-trace-event",
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [RuntimeError, sqlite3.OperationalError])
+async def test_trace_checkpoint_store_normalizes_writer_failures(
+    error_type: type[Exception],
+) -> None:
+    failure = error_type("checkpoint unavailable")
+    store = TraceCheckpointStore(RaisingCheckpointBackend(failure))
+
+    with pytest.raises(CheckpointPersistenceError) as exc_info:
+        await store.checkpoint(
+            type="checkpoint",
+            label="before_llm",
+            execution_id="exec-failed-writer",
+        )
+
+    assert exc_info.value.__cause__ is failure
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [asyncio.CancelledError(), SystemExit()])
+async def test_trace_checkpoint_store_preserves_base_exception_semantics(
+    failure: BaseException,
+) -> None:
+    store = TraceCheckpointStore(RaisingCheckpointBackend(failure))
+
+    with pytest.raises(type(failure)) as exc_info:
+        await store.checkpoint(
+            type="checkpoint",
+            label="before_llm",
+            execution_id="exec-interrupted-writer",
+        )
+
+    assert exc_info.value is failure
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -26,6 +26,7 @@ from xagent.core.agent.clarification import (
     ClarificationDraft,
     draft_from_waiting_request,
 )
+from xagent.core.agent.checkpoint import CheckpointPersistenceError
 from xagent.core.agent.context.enrichment import MEMORY_CONTEXT_METADATA_KEY
 from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_METADATA_KEY,
@@ -35,6 +36,7 @@ from xagent.core.agent.language import (
 from xagent.core.agent.pattern.base import RequiredToolCallError
 from xagent.core.agent.pattern.dag import dag as dag_module
 from xagent.core.agent.pattern.dag.dag import _DAGStepRuntime
+from xagent.core.agent.pattern.react import ReActPattern
 from xagent.core.agent.pattern.dag.plan_generator import (
     PLAN_GENERATION_REQUIRED_TOOL_MESSAGE,
     PlanLanguageMismatchError,
@@ -683,6 +685,60 @@ async def test_dag_step_runtime_forwards_llm_error_with_step_metadata() -> None:
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_dag_step_checkpoint_rolls_back_child_snapshot_on_failure() -> None:
+    class FailingRuntime(PatternRuntime):
+        async def checkpoint(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise CheckpointPersistenceError("checkpoint unavailable")
+
+    dag = DAGPattern(lambda **_: build_plan())
+    dag._set_active_step_context("creative", {"marker": "old-context"})
+    dag._set_active_step_pattern_state("creative", {"marker": "old-state"})
+    runtime = _DAGStepRuntime(
+        parent=FailingRuntime(),
+        dag_pattern=dag,
+        root_context=ExecutionContext(execution_id="dag-root"),
+        step_id="creative",
+    )
+
+    with pytest.raises(CheckpointPersistenceError, match="checkpoint unavailable"):
+        await runtime.checkpoint(
+            "tool_interaction_response_delivered",
+            context=ExecutionContext(execution_id="dag-root:creative"),
+            pattern=ReActPattern(),
+        )
+
+    assert dag.active_step_contexts["creative"] == {"marker": "old-context"}
+    assert dag.active_step_pattern_states["creative"] == {"marker": "old-state"}
+
+
+@pytest.mark.asyncio
+async def test_dag_step_does_not_convert_checkpoint_failure_into_step_failure(
+    monkeypatch,
+) -> None:
+    failure = CheckpointPersistenceError("checkpoint unavailable")
+
+    async def fail_run(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise failure
+
+    monkeypatch.setattr(ReActPattern, "run", fail_run)
+    dag = DAGPattern(lambda **_: build_plan())
+    step = PlanStep(id="creative", task="Create", tool_names=[])
+
+    with pytest.raises(CheckpointPersistenceError) as caught:
+        await dag._execute_step_impl(
+            step=step,
+            root_context=ExecutionContext(execution_id="dag-root"),
+            tools=[],
+            llm=object(),
+            runtime=PatternRuntime(),
+        )
+
+    assert caught.value is failure
+    assert step.status == "running"
+    assert "creative" in dag.active_step_ids
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -22,7 +22,10 @@ from xagent.core.agent import (
     PlanStep,
     PlanValidationError,
 )
-from xagent.core.agent.checkpoint import CheckpointPersistenceError
+from xagent.core.agent.checkpoint import (
+    CheckpointPersistenceError,
+    TraceCheckpointStore,
+)
 from xagent.core.agent.clarification import (
     ClarificationDraft,
     draft_from_waiting_request,
@@ -739,6 +742,58 @@ async def test_dag_step_does_not_convert_checkpoint_failure_into_step_failure(
     assert caught.value is failure
     assert step.status == "running"
     assert "creative" in dag.active_step_ids
+
+
+@pytest.mark.asyncio
+async def test_dag_step_preserves_state_on_raw_checkpoint_writer_failure(
+    monkeypatch,
+) -> None:
+    class FailingWriter:
+        def __init__(self) -> None:
+            self.persisted_labels: list[str] = []
+
+        async def checkpoint(self, **payload: Any) -> str:
+            if payload["label"] == "dag_child_checkpoint":
+                raise RuntimeError("database unavailable")
+            self.persisted_labels.append(payload["label"])
+            return f"checkpoint-{len(self.persisted_labels)}"
+
+    async def checkpoint_run(
+        _pattern: ReActPattern,
+        *,
+        context: Any,
+        runtime: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        await runtime.checkpoint(
+            "child_checkpoint",
+            context=context,
+            pattern=_pattern,
+        )
+        raise AssertionError("checkpoint failure must stop the step")
+
+    monkeypatch.setattr(ReActPattern, "run", checkpoint_run)
+    writer = FailingWriter()
+    runtime = PatternRuntime(
+        tracer=TraceCheckpointStore(writer),
+        execution_id="dag-root",
+    )
+    dag = DAGPattern(lambda **_: build_plan())
+    step = PlanStep(id="creative", task="Create", tool_names=[])
+
+    with pytest.raises(CheckpointPersistenceError) as exc_info:
+        await dag._execute_step_impl(
+            step=step,
+            root_context=ExecutionContext(execution_id="dag-root"),
+            tools=[],
+            llm=object(),
+            runtime=runtime,
+        )
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert step.status == "running"
+    assert "creative" in dag.active_step_ids
+    assert writer.persisted_labels == ["dag_before_step"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -718,6 +718,57 @@ async def test_dag_step_checkpoint_rolls_back_child_snapshot_on_failure() -> Non
 
 
 @pytest.mark.asyncio
+async def test_dag_step_checkpoint_rollback_preserves_concurrent_step_progress() -> (
+    None
+):
+    checkpoint_started = asyncio.Event()
+    release_checkpoint = asyncio.Event()
+
+    class FailingRuntime(PatternRuntime):
+        async def checkpoint(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            checkpoint_started.set()
+            await release_checkpoint.wait()
+            raise CheckpointPersistenceError("checkpoint unavailable")
+
+    class MustNotBeCopied:
+        def __deepcopy__(self, _memo: dict[int, Any]) -> Any:
+            raise AssertionError("an unrelated step must not be deep-copied")
+
+    dag = DAGPattern(lambda **_: build_plan())
+    dag._set_active_step_context("a", {"marker": "a-old"})
+    dag._set_active_step_pattern_state("a", {"marker": "a-old"})
+    dag._set_active_step_context("b", {"marker": "b-old"})
+    dag._set_active_step_pattern_state("b", MustNotBeCopied())
+    runtime = _DAGStepRuntime(
+        parent=FailingRuntime(),
+        dag_pattern=dag,
+        root_context=ExecutionContext(execution_id="dag-root"),
+        step_id="a",
+    )
+
+    checkpoint_task = asyncio.create_task(
+        runtime.checkpoint(
+            "child_checkpoint",
+            context=ExecutionContext(execution_id="dag-root:a"),
+            pattern=ReActPattern(),
+        )
+    )
+    await checkpoint_started.wait()
+    concurrent_state = {"marker": "b-new"}
+    dag._set_active_step_context("b", {"marker": "b-new"})
+    dag._set_active_step_pattern_state("b", concurrent_state)
+    release_checkpoint.set()
+
+    with pytest.raises(CheckpointPersistenceError, match="checkpoint unavailable"):
+        await checkpoint_task
+
+    assert dag.active_step_contexts["a"] == {"marker": "a-old"}
+    assert dag.active_step_pattern_states["a"] == {"marker": "a-old"}
+    assert dag.active_step_contexts["b"] == {"marker": "b-new"}
+    assert dag.active_step_pattern_states["b"] is concurrent_state
+
+
+@pytest.mark.asyncio
 async def test_dag_step_does_not_convert_checkpoint_failure_into_step_failure(
     monkeypatch,
 ) -> None:

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -22,11 +22,11 @@ from xagent.core.agent import (
     PlanStep,
     PlanValidationError,
 )
+from xagent.core.agent.checkpoint import CheckpointPersistenceError
 from xagent.core.agent.clarification import (
     ClarificationDraft,
     draft_from_waiting_request,
 )
-from xagent.core.agent.checkpoint import CheckpointPersistenceError
 from xagent.core.agent.context.enrichment import MEMORY_CONTEXT_METADATA_KEY
 from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_METADATA_KEY,
@@ -36,11 +36,11 @@ from xagent.core.agent.language import (
 from xagent.core.agent.pattern.base import RequiredToolCallError
 from xagent.core.agent.pattern.dag import dag as dag_module
 from xagent.core.agent.pattern.dag.dag import _DAGStepRuntime
-from xagent.core.agent.pattern.react import ReActPattern
 from xagent.core.agent.pattern.dag.plan_generator import (
     PLAN_GENERATION_REQUIRED_TOOL_MESSAGE,
     PlanLanguageMismatchError,
 )
+from xagent.core.agent.pattern.react import ReActPattern
 from xagent.core.memory.core import MemoryNote as StoredMemoryNote
 from xagent.core.memory.core import MemoryResponse
 from xagent.core.model.chat.types import ChunkType, StreamChunk

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -7480,7 +7480,12 @@ async def test_resume_target_is_validated_before_callback_or_projection(
 
 
 @pytest.mark.asyncio
-async def test_later_success_clears_an_earlier_terminal_batch_fence() -> None:
+@pytest.mark.parametrize("terminal_status", ["rejected", "dispatch_unknown"])
+@pytest.mark.parametrize("terminal_first", [True, False])
+async def test_terminal_settlement_keeps_the_batch_final_answer_fence(
+    terminal_status: str,
+    terminal_first: bool,
+) -> None:
     class ResumableTool:
         metadata = SimpleNamespace(
             name="approval_gate",
@@ -7490,18 +7495,21 @@ async def test_later_success_clears_an_earlier_terminal_batch_fence() -> None:
         async def resume_user_interaction(
             self, *, interaction_id: str, **_: str
         ) -> Any:
-            if interaction_id == "interaction-1":
-                return ToolInteractionSettlement.rejected()
+            if interaction_id == "terminal":
+                return ToolInteractionSettlement(status=terminal_status)  # type: ignore[arg-type]
             return ToolInteractionSettlement.succeeded({"success": True})
 
     pattern = ReActPattern()
     context = ExecutionContext(execution_id="settlement-batch")
-    for index in (1, 2):
+    interaction_ids = (
+        ["terminal", "succeeded"] if terminal_first else ["succeeded", "terminal"]
+    )
+    for index, interaction_id in enumerate(interaction_ids, 1):
         pattern.pending_tool_interaction_responses.append(
             {
                 "tool_name": "approval_gate",
                 "tool_call_id": f"call-{index}",
-                "interaction_id": f"interaction-{index}",
+                "interaction_id": interaction_id,
                 "response": "Approve",
             }
         )
@@ -7522,7 +7530,7 @@ async def test_later_success_clears_an_earlier_terminal_batch_fence() -> None:
         context=context,
         runtime=PatternRuntime(),
     )
-    assert pattern.force_final_answer_next is False
+    assert pattern.force_final_answer_next is True
 
 
 def test_resumed_success_guards_only_its_settlement_turn() -> None:

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -6985,15 +6985,13 @@ async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() 
             )
             return self.resume_result
 
-    first_tool = WaitingTool()
     first_context = ExecutionContext(execution_id="durable-interaction-task")
     first_context.add_user_message("Publish the approved post.")
     first_pattern = ReActPattern(max_iterations=3)
     first_runtime = PatternRuntime(execution_id="durable-interaction-task")
-
     waiting = await first_pattern.run(
         context=first_context,
-        tools=[first_tool],
+        tools=[WaitingTool()],
         llm=FakeLLM(
             [
                 {
@@ -7011,14 +7009,12 @@ async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() 
         ),
         runtime=first_runtime,
     )
-
     assert waiting["status"] == "waiting_for_user"
     checkpoint = next(
         checkpoint
         for checkpoint in reversed(first_runtime.checkpoints)
         if checkpoint["label"] == "waiting_for_user"
     )
-
     # Rebuild every runtime-owned object from the durable checkpoint.
     restored_context = ExecutionContext.from_dict(checkpoint["context"])
     restored_context.add_user_message("Approve")
@@ -7053,14 +7049,12 @@ async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() 
         execution_id="durable-interaction-task",
         tracer=tracer,
     )
-
     resumed = await restored_pattern.run(
         context=restored_context,
         tools=[resumed_tool],
         llm=resumed_llm,
         runtime=resumed_runtime,
     )
-
     assert resumed["success"] is True
     assert resumed_tool.run_calls == []
     assert resumed_tool.resume_calls == [
@@ -7082,10 +7076,9 @@ async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() 
     assert projected_messages[0].metadata["raw_result"] == record.result
     assert "urn:li:share:123" in str(resumed_llm.calls[0]["messages"])
     assert restored_pattern.pending_tool_interaction_responses == []
-    assert any(
-        event["event_type"] == "action_end_tool"
+    assert not any(
+        event["event_type"] in {"action_end_tool", "action_error_tool"}
         and event["data"].get("tool_call_id") == "original-publish-call"
-        and event["data"].get("result") == record.result
         for event in tracer.events
     )
 
@@ -7238,8 +7231,22 @@ async def test_pending_interaction_delivery_is_exact_and_retryable() -> None:
     ]
     pattern = ReActPattern()
     pattern.pending_tool_interaction_responses = list(pending)
+    for index in (1, 2):
+        pattern.tool_ledger[f"call-{index}"] = ToolCallRecord(
+            tool_call_id=f"call-{index}",
+            tool_name="approval_gate",
+            args={},
+            args_hash="stored-hash",
+            status="waiting_for_user",
+        )
     tool = ResumableTool()
     context = ExecutionContext(execution_id="interaction-delivery")
+    for index in (1, 2):
+        context.add_tool_result(
+            "approval_gate",
+            {"success": False, "status": "waiting_for_user"},
+            f"call-{index}",
+        )
     runtime = PatternRuntime(execution_id="interaction-delivery")
 
     with pytest.raises(RuntimeError, match="delivery failed"):
@@ -7276,7 +7283,6 @@ async def test_settled_interaction_remains_retryable_until_checkpoint_succeeds()
     settlement = ToolInteractionSettlement.succeeded(
         {"success": True, "post_urn": "urn:li:share:123"}
     )
-
     class ResumableTool:
         metadata = SimpleNamespace(
             name="approval_gate",
@@ -7317,15 +7323,15 @@ async def test_settled_interaction_remains_retryable_until_checkpoint_succeeds()
         "call-1",
     )
     tool = ResumableTool()
-
     with pytest.raises(RuntimeError, match="checkpoint unavailable"):
         await pattern._deliver_pending_tool_interaction_responses(
             tools=[tool],
             context=context,
             runtime=PatternRuntime(tracer=FailingCheckpointTracer()),
         )
-
     assert pattern.pending_tool_interaction_responses == [pending]
+    assert pattern.tool_ledger["call-1"].status == "waiting_for_user"
+    assert context.messages[0].metadata["raw_result"]["status"] == "waiting_for_user"
     assert (
         len(
             [
@@ -7342,7 +7348,6 @@ async def test_settled_interaction_remains_retryable_until_checkpoint_succeeds()
         context=context,
         runtime=PatternRuntime(),
     )
-
     assert tool.calls == 2
     assert pattern.pending_tool_interaction_responses == []
     assert pattern.tool_ledger["call-1"].result == settlement.result
@@ -7385,26 +7390,166 @@ async def test_non_successful_settlement_fails_the_original_tool_call(
         "call-1",
     )
     tracer = TraceEventRecorder()
-
     await pattern._deliver_pending_tool_interaction_responses(
         tools=[ResumableTool()],
         context=context,
         runtime=PatternRuntime(tracer=tracer),
     )
-
     record = pattern.tool_ledger["call-1"]
     assert record.status == "failed"
     assert record.settlement_status == status
     assert record.result["success"] is False
-    assert record.result["status"] == status
+    assert record.result["settlement_status"] == status
     assert pattern.force_final_answer_next is (
         status in {"rejected", "dispatch_unknown"}
     )
-    assert any(
-        event["event_type"] == "action_error_tool"
+    assert not any(
+        event["event_type"] in {"action_end_tool", "action_error_tool"}
         and event["data"].get("tool_call_id") == "call-1"
         for event in tracer.events
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "message", "expected_calls"),
+    [
+        ("missing_ledger", "without its original ledger", 0),
+        ("wrong_tool", "does not match its original ledger", 0),
+        ("not_waiting", "not waiting for user input", 0),
+        ("missing_result", "found 0", 0),
+        ("duplicate_result", "found 2", 0),
+        ("wrong_return", "must return ToolInteractionSettlement or None", 1),
+    ],
+)
+async def test_resume_target_is_validated_before_callback_or_projection(
+    case: str, message: str, expected_calls: int
+) -> None:
+    class ResumableTool:
+        metadata = SimpleNamespace(
+            name="approval_gate",
+            description="Resume a persisted interaction.",
+        )
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def resume_user_interaction(self, **_: str) -> Any:
+            self.calls += 1
+            return {"unexpected": True}
+
+    pattern = ReActPattern()
+    pending = {
+        "tool_name": "approval_gate",
+        "tool_call_id": "call-1",
+        "interaction_id": "interaction-1",
+        "response": "Approve",
+    }
+    pattern.pending_tool_interaction_responses = [pending]
+    if case != "missing_ledger":
+        pattern.tool_ledger["call-1"] = ToolCallRecord(
+            tool_call_id="call-1",
+            tool_name="different_tool" if case == "wrong_tool" else "approval_gate",
+            args={},
+            args_hash="stored-hash",
+            status="completed" if case == "not_waiting" else "waiting_for_user",
+        )
+    context = ExecutionContext(execution_id="invalid-resume-target")
+    if case not in {"missing_result"}:
+        context.add_tool_result(
+            "approval_gate",
+            {"success": False, "status": "waiting_for_user"},
+            "call-1",
+        )
+    if case == "duplicate_result":
+        context.add_tool_result(
+            "approval_gate",
+            {"success": False, "status": "waiting_for_user"},
+            "call-1",
+        )
+    tool = ResumableTool()
+    with pytest.raises((RuntimeError, TypeError), match=message):
+        await pattern._deliver_pending_tool_interaction_responses(
+            tools=[tool],
+            context=context,
+            runtime=PatternRuntime(),
+        )
+    assert tool.calls == expected_calls
+    assert pattern.pending_tool_interaction_responses == [pending]
+
+
+@pytest.mark.asyncio
+async def test_later_success_clears_an_earlier_terminal_batch_fence() -> None:
+    class ResumableTool:
+        metadata = SimpleNamespace(
+            name="approval_gate",
+            description="Resume persisted interactions.",
+        )
+
+        async def resume_user_interaction(self, *, interaction_id: str, **_: str) -> Any:
+            if interaction_id == "interaction-1":
+                return ToolInteractionSettlement.rejected()
+            return ToolInteractionSettlement.succeeded({"success": True})
+
+    pattern = ReActPattern()
+    context = ExecutionContext(execution_id="settlement-batch")
+    for index in (1, 2):
+        pattern.pending_tool_interaction_responses.append(
+            {
+                "tool_name": "approval_gate",
+                "tool_call_id": f"call-{index}",
+                "interaction_id": f"interaction-{index}",
+                "response": "Approve",
+            }
+        )
+        pattern.tool_ledger[f"call-{index}"] = ToolCallRecord(
+            tool_call_id=f"call-{index}",
+            tool_name="approval_gate",
+            args={},
+            args_hash="stored-hash",
+            status="waiting_for_user",
+        )
+        context.add_tool_result(
+            "approval_gate",
+            {"success": False, "status": "waiting_for_user"},
+            f"call-{index}",
+        )
+    await pattern._deliver_pending_tool_interaction_responses(
+        tools=[ResumableTool()],
+        context=context,
+        runtime=PatternRuntime(),
+    )
+    assert pattern.force_final_answer_next is False
+
+
+def test_resumed_success_guards_only_its_settlement_turn() -> None:
+    pattern = ReActPattern()
+    args = {"text": "approved"}
+    pattern.tool_ledger["original-call"] = ToolCallRecord(
+        tool_call_id="original-call",
+        tool_name="publish",
+        args=args,
+        args_hash=pattern._args_hash(args),
+        status="completed",
+        result={"success": True},
+        settlement_status="succeeded",
+        turn_id="original-turn",
+        settlement_turn_id="approval-turn",
+    )
+    tool = SimpleNamespace(
+        non_idempotent=True,
+        metadata=SimpleNamespace(name="publish"),
+    )
+    same_turn = pattern._suppressed_duplicate_write_result(
+        {"id": "new-call", "name": "publish", "args": args, "turn_id": "approval-turn"},
+        [tool],
+    )
+    later_turn = pattern._suppressed_duplicate_write_result(
+        {"id": "later-call", "name": "publish", "args": args, "turn_id": "later-turn"},
+        [tool],
+    )
+    assert same_turn["duplicate_write_suppressed"] is True
+    assert later_turn is None
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -7067,6 +7067,10 @@ async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() 
     assert record.status == "completed"
     assert record.settlement_status == "succeeded"
     assert record.result == {"success": True, "post_urn": "urn:li:share:123"}
+    assert (
+        restored_pattern._consecutive_successful_tool_group_count("approval_gate") == 1
+    )
+    assert restored_pattern._consecutive_work_tool_call_count() == 1
     projected_messages = [
         message
         for message in restored_context.messages
@@ -7076,11 +7080,15 @@ async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() 
     assert projected_messages[0].metadata["raw_result"] == record.result
     assert "urn:li:share:123" in str(resumed_llm.calls[0]["messages"])
     assert restored_pattern.pending_tool_interaction_responses == []
-    assert not any(
-        event["event_type"] in {"action_end_tool", "action_error_tool"}
-        and event["data"].get("tool_call_id") == "original-publish-call"
+    settlement_events = [
+        event
         for event in tracer.events
-    )
+        if event["data"].get("tool_call_id") == "original-publish-call"
+    ]
+    assert [event["event_type"] for event in settlement_events] == [
+        "action_start_tool",
+        "action_end_tool",
+    ]
 
 
 @pytest.mark.parametrize("waiting_request", [None, [], "malformed"])
@@ -7404,27 +7412,32 @@ async def test_non_successful_settlement_fails_the_original_tool_call(
     assert pattern.force_final_answer_next is (
         status in {"rejected", "dispatch_unknown"}
     )
-    assert not any(
-        event["event_type"] in {"action_end_tool", "action_error_tool"}
-        and event["data"].get("tool_call_id") == "call-1"
+    assert pattern._consecutive_successful_tool_group_count("approval_gate") == 0
+    assert pattern._consecutive_work_tool_call_count() == 1
+    settlement_events = [
+        event
         for event in tracer.events
-    )
+        if event["data"].get("tool_call_id") == "call-1"
+    ]
+    assert [event["event_type"] for event in settlement_events] == [
+        "action_start_tool",
+        "action_error_tool",
+    ]
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("case", "message", "expected_calls"),
+    ("case", "reason"),
     [
-        ("missing_ledger", "without its original ledger", 0),
-        ("wrong_tool", "does not match its original ledger", 0),
-        ("not_waiting", "not waiting for user input", 0),
-        ("missing_result", "found 0", 0),
-        ("duplicate_result", "found 2", 0),
-        ("wrong_return", "must return ToolInteractionSettlement or None", 1),
+        ("missing_ledger", "invalid_settlement_target"),
+        ("wrong_tool", "invalid_settlement_target"),
+        ("not_waiting", "already_settled"),
+        ("missing_result", "invalid_settlement_target"),
+        ("duplicate_result", "invalid_settlement_target"),
     ],
 )
-async def test_resume_target_is_validated_before_callback_or_projection(
-    case: str, message: str, expected_calls: int
+async def test_invalid_resume_target_is_skipped_before_callback(
+    case: str, reason: str
 ) -> None:
     class ResumableTool:
         metadata = SimpleNamespace(
@@ -7469,14 +7482,56 @@ async def test_resume_target_is_validated_before_callback_or_projection(
             "call-1",
         )
     tool = ResumableTool()
-    with pytest.raises((RuntimeError, TypeError), match=message):
-        await pattern._deliver_pending_tool_interaction_responses(
-            tools=[tool],
-            context=context,
-            runtime=PatternRuntime(),
-        )
-    assert tool.calls == expected_calls
-    assert pattern.pending_tool_interaction_responses == [pending]
+    runtime = PatternRuntime()
+    await pattern._deliver_pending_tool_interaction_responses(
+        tools=[tool],
+        context=context,
+        runtime=runtime,
+    )
+    assert tool.calls == 0
+    assert pattern.pending_tool_interaction_responses == []
+    assert runtime.last_checkpoint["metadata"]["reason"] == reason
+
+
+@pytest.mark.asyncio
+async def test_invalid_resume_callback_result_fails_closed() -> None:
+    class ResumableTool:
+        metadata = SimpleNamespace(name="approval_gate")
+
+        async def resume_user_interaction(self, **_: str) -> Any:
+            return {"unexpected": True}
+
+    pattern = ReActPattern()
+    pending = {
+        "tool_name": "approval_gate",
+        "tool_call_id": "call-1",
+        "interaction_id": "interaction-1",
+        "response": "Approve",
+    }
+    pattern.pending_tool_interaction_responses = [pending]
+    pattern.tool_ledger["call-1"] = ToolCallRecord(
+        tool_call_id="call-1",
+        tool_name="approval_gate",
+        args={},
+        args_hash="stored-hash",
+        status="waiting_for_user",
+    )
+    context = ExecutionContext(execution_id="invalid-resume-return")
+    context.add_tool_result(
+        "approval_gate",
+        {"success": False, "status": "waiting_for_user"},
+        "call-1",
+    )
+
+    await pattern._deliver_pending_tool_interaction_responses(
+        tools=[ResumableTool()],
+        context=context,
+        runtime=PatternRuntime(),
+    )
+
+    assert pattern.pending_tool_interaction_responses == []
+    assert pattern.tool_ledger["call-1"].settlement_status == "dispatch_unknown"
+    assert pattern.settlement_final_answer_fence is True
 
 
 @pytest.mark.asyncio
@@ -7531,6 +7586,280 @@ async def test_terminal_settlement_keeps_the_batch_final_answer_fence(
         runtime=PatternRuntime(),
     )
     assert pattern.force_final_answer_next is True
+    assert pattern.settlement_final_answer_fence is True
+
+
+@pytest.mark.asyncio
+async def test_settlement_fence_survives_tool_protocol_recovery() -> None:
+    class DeniedWriteTool:
+        non_idempotent = True
+        metadata = SimpleNamespace(name="publish", description="Publish a post.")
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def args_type(self) -> type[BaseModel]:
+            return CalculatorArgs
+
+        async def run_json_async(self, _args: dict[str, Any]) -> Any:
+            self.calls += 1
+            return {"success": True}
+
+    pattern = ReActPattern(max_iterations=2)
+    pattern.settlement_final_answer_fence = True
+    context = ExecutionContext(execution_id="settlement-fence")
+    context.add_user_message("Do not publish it.")
+    tool = DeniedWriteTool()
+    llm = FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "invalid-retry",
+                        "function": {
+                            "name": "publish",
+                            "arguments": '{"expression":"publish"}',
+                        },
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "final-call",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": (
+                                '{"response_language":"English",'
+                                '"answer":"The write was not retried.",'
+                                '"outcome":"blocked"}'
+                            ),
+                        },
+                    }
+                ]
+            },
+        ]
+    )
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm)
+
+    assert result["completion_outcome"] == "blocked"
+    assert tool.calls == 0
+    assert [
+        [schema["function"]["name"] for schema in call["tools"]] for call in llm.calls
+    ] == [["final_answer"], ["final_answer"]]
+
+
+@pytest.mark.asyncio
+async def test_settlement_fence_survives_unavailable_tool_exception_recovery() -> None:
+    class RecoveryLLM:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        async def chat(self, **kwargs: Any) -> Any:
+            self.calls.append(kwargs)
+            if len(self.calls) == 1:
+                raise LLMToolProtocolError(
+                    provider="deepseek",
+                    code="unavailable_tool_call",
+                    message="The narrowed schema rejected a work tool.",
+                )
+            return {
+                "tool_calls": [
+                    {
+                        "id": "final-call",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": (
+                                '{"response_language":"English",'
+                                '"answer":"The write was not retried.",'
+                                '"outcome":"blocked"}'
+                            ),
+                        },
+                    }
+                ]
+            }
+
+    pattern = ReActPattern(max_iterations=1)
+    pattern.settlement_final_answer_fence = True
+    context = ExecutionContext(execution_id="settlement-exception-fence")
+    context.add_user_message("Do not publish it.")
+    llm = RecoveryLLM()
+
+    result = await pattern.run(context=context, tools=[], llm=llm)
+
+    assert result["completion_outcome"] == "blocked"
+    assert [
+        [schema["function"]["name"] for schema in call["tools"]] for call in llm.calls
+    ] == [["final_answer"], ["final_answer"]]
+
+
+def test_multiple_write_interactions_require_a_structured_response_map() -> None:
+    class ResumableWriteTool:
+        non_idempotent = True
+
+        def __init__(self, name: str) -> None:
+            self.metadata = SimpleNamespace(name=name)
+
+        def resume_user_interaction(self, **_: str) -> None:
+            return None
+
+    tools = [ResumableWriteTool("publish_a"), ResumableWriteTool("publish_b")]
+    waiting_request = {
+        "kind": "tool_waiting_for_user",
+        "requests": [
+            {
+                "tool_name": "publish_a",
+                "tool_call_id": "call-a",
+                "interaction_id": "approval-a",
+            },
+            {
+                "tool_name": "publish_b",
+                "tool_call_id": "call-b",
+                "interaction_id": "approval-b",
+            },
+        ],
+    }
+    pattern = ReActPattern()
+
+    assert (
+        pattern._queue_tool_interaction_responses(
+            waiting_request=waiting_request,
+            response="Approve",
+            tools=tools,
+        )
+        is False
+    )
+    assert pattern.pending_tool_interaction_responses == []
+
+    assert (
+        pattern._queue_tool_interaction_responses(
+            waiting_request=waiting_request,
+            response='{"approval-a":"Approve A","approval-b":"Reject B"}',
+            tools=tools,
+        )
+        is True
+    )
+    assert [
+        pending["response"] for pending in pattern.pending_tool_interaction_responses
+    ] == ["Approve A", "Reject B"]
+
+
+def test_multiple_writes_require_mapping_even_without_two_resume_callbacks() -> None:
+    class ResumableWriteTool:
+        non_idempotent = True
+        metadata = SimpleNamespace(name="publish_a")
+
+        def resume_user_interaction(self, **_: str) -> None:
+            return None
+
+    callback_less_write = SimpleNamespace(
+        non_idempotent=True,
+        metadata=SimpleNamespace(name="publish_b"),
+    )
+    waiting_request = {
+        "kind": "tool_waiting_for_user",
+        "requests": [
+            {
+                "tool_name": "publish_a",
+                "tool_call_id": "call-a",
+                "interaction_id": "approval-a",
+            },
+            {
+                "tool_name": "publish_b",
+                "tool_call_id": "call-b",
+                "interaction_id": "approval-b",
+            },
+        ],
+    }
+    pattern = ReActPattern()
+
+    assert not pattern._queue_tool_interaction_responses(
+        waiting_request=waiting_request,
+        response="Approve",
+        tools=[ResumableWriteTool(), callback_less_write],
+    )
+    assert pattern.pending_tool_interaction_responses == []
+
+    assert pattern._queue_tool_interaction_responses(
+        waiting_request=waiting_request,
+        response='{"approval-a":"Approve A","approval-b":"Reject B"}',
+        tools=[ResumableWriteTool(), callback_less_write],
+    )
+    assert pattern.pending_tool_interaction_responses == [
+        {
+            "tool_name": "publish_a",
+            "tool_call_id": "call-a",
+            "interaction_id": "approval-a",
+            "response": "Approve A",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_multiple_write_response_remains_safely_paused() -> None:
+    class ResumableWriteTool:
+        non_idempotent = True
+
+        def __init__(self, name: str) -> None:
+            self.metadata = SimpleNamespace(name=name)
+
+        def resume_user_interaction(self, **_: str) -> None:
+            raise AssertionError("ambiguous response must not be delivered")
+
+    pattern = ReActPattern()
+    pattern.status = "waiting_for_user"
+    pattern.waiting_for_user_request = {
+        "kind": "tool_waiting_for_user",
+        "message": "Approve both writes?",
+        "message_type": "question",
+        "message_count": 0,
+        "requests": [
+            {
+                "tool_name": "publish_a",
+                "tool_call_id": "call-a",
+                "interaction_id": "approval-a",
+            },
+            {
+                "tool_name": "publish_b",
+                "tool_call_id": "call-b",
+                "interaction_id": "approval-b",
+            },
+        ],
+        "interactions": [],
+    }
+    context = ExecutionContext(execution_id="ambiguous-authorization")
+    context.add_user_message("Approve")
+    runtime = PatternRuntime()
+
+    result = await pattern._resume_waiting_for_user_if_needed(
+        context=context,
+        runtime=runtime,
+        tools=[ResumableWriteTool("publish_a"), ResumableWriteTool("publish_b")],
+    )
+
+    assert result["status"] == "waiting_for_user"
+    assert pattern.status == "waiting_for_user"
+    assert pattern.pending_tool_interaction_responses == []
+    assert pattern.waiting_for_user_request["message_count"] == 1
+    assert "mapping each interaction_id" in result["message"]
+
+
+def test_checkpoint_state_copies_pending_interaction_responses() -> None:
+    pattern = ReActPattern()
+    pattern.pending_tool_interaction_responses = [
+        {
+            "tool_name": "publish",
+            "tool_call_id": "call-1",
+            "interaction_id": "approval-1",
+            "response": "Approve",
+        }
+    ]
+
+    state = pattern.get_state()
+    pattern.pending_tool_interaction_responses[0]["response"] = "Changed"
+
+    assert state["pending_tool_interaction_responses"][0]["response"] == "Approve"
 
 
 def test_resumed_success_guards_only_its_settlement_turn() -> None:
@@ -7561,6 +7890,36 @@ def test_resumed_success_guards_only_its_settlement_turn() -> None:
     )
     assert same_turn["duplicate_write_suppressed"] is True
     assert later_turn is None
+
+
+@pytest.mark.parametrize("settlement_status", ["rejected", "dispatch_unknown"])
+def test_denied_settlement_suppresses_the_same_write_in_its_turn(
+    settlement_status: str,
+) -> None:
+    pattern = ReActPattern()
+    args = {"text": "denied"}
+    pattern.tool_ledger["original-call"] = ToolCallRecord(
+        tool_call_id="original-call",
+        tool_name="publish",
+        args=args,
+        args_hash=pattern._args_hash(args),
+        status="failed",
+        result={"success": False, "settlement_status": settlement_status},
+        settlement_status=settlement_status,
+        settlement_turn_id="approval-turn",
+    )
+    tool = SimpleNamespace(
+        non_idempotent=True,
+        metadata=SimpleNamespace(name="publish"),
+    )
+
+    suppressed = pattern._suppressed_duplicate_write_result(
+        {"id": "retry", "name": "publish", "args": args, "turn_id": "approval-turn"},
+        [tool],
+    )
+
+    assert suppressed["success"] is False
+    assert suppressed["duplicate_write_suppressed"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -38,6 +38,7 @@ from xagent.core.model.chat.tool_protocol import (
     tool_protocol_error_response,
 )
 from xagent.core.model.chat.types import ChunkType, StreamChunk
+from xagent.core.tools.user_interaction import ToolInteractionSettlement
 
 
 class CalculatorArgs(BaseModel):
@@ -6945,6 +6946,150 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() -> None:
+    class WaitingTool:
+        def __init__(self, *, resume_result: Any = None) -> None:
+            self.metadata = SimpleNamespace(
+                name="approval_gate",
+                description="Publish after explicit approval.",
+            )
+            self.resume_result = resume_result
+            self.run_calls: list[dict[str, Any]] = []
+            self.resume_calls: list[dict[str, str]] = []
+
+        def args_type(self) -> type[BaseModel]:
+            return CalculatorArgs
+
+        async def run_json_async(self, args: dict[str, Any]) -> Any:
+            self.run_calls.append(args)
+            if self.resume_result is not None:
+                raise AssertionError("resume must not execute a new tool call")
+            return {
+                "success": False,
+                "status": "waiting_for_user",
+                "interaction_id": "publish-interaction-1",
+                "message": "Publish this exact post?",
+                "message_type": "confirmation",
+                "interactions": [],
+            }
+
+        async def resume_user_interaction(
+            self,
+            *,
+            interaction_id: str,
+            response: str,
+        ) -> Any:
+            self.resume_calls.append(
+                {"interaction_id": interaction_id, "response": response}
+            )
+            return self.resume_result
+
+    first_tool = WaitingTool()
+    first_context = ExecutionContext(execution_id="durable-interaction-task")
+    first_context.add_user_message("Publish the approved post.")
+    first_pattern = ReActPattern(max_iterations=3)
+    first_runtime = PatternRuntime(execution_id="durable-interaction-task")
+
+    waiting = await first_pattern.run(
+        context=first_context,
+        tools=[first_tool],
+        llm=FakeLLM(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "id": "original-publish-call",
+                            "function": {
+                                "name": "approval_gate",
+                                "arguments": '{"expression":"publish"}',
+                            },
+                        }
+                    ]
+                }
+            ]
+        ),
+        runtime=first_runtime,
+    )
+
+    assert waiting["status"] == "waiting_for_user"
+    checkpoint = next(
+        checkpoint
+        for checkpoint in reversed(first_runtime.checkpoints)
+        if checkpoint["label"] == "waiting_for_user"
+    )
+
+    # Rebuild every runtime-owned object from the durable checkpoint.
+    restored_context = ExecutionContext.from_dict(checkpoint["context"])
+    restored_context.add_user_message("Approve")
+    restored_pattern = ReActPattern(max_iterations=3)
+    restored_pattern.load_state(checkpoint["pattern_state"])
+    resumed_tool = WaitingTool(
+        resume_result=ToolInteractionSettlement.succeeded(
+            {"success": True, "post_urn": "urn:li:share:123"}
+        )
+    )
+    resumed_llm = FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "final-call",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": (
+                                '{"response_language":"English",'
+                                '"answer":"Published.",'
+                                '"outcome":"completed"}'
+                            ),
+                        },
+                    }
+                ]
+            }
+        ]
+    )
+    tracer = TraceEventRecorder()
+    resumed_runtime = PatternRuntime(
+        execution_id="durable-interaction-task",
+        tracer=tracer,
+    )
+
+    resumed = await restored_pattern.run(
+        context=restored_context,
+        tools=[resumed_tool],
+        llm=resumed_llm,
+        runtime=resumed_runtime,
+    )
+
+    assert resumed["success"] is True
+    assert resumed_tool.run_calls == []
+    assert resumed_tool.resume_calls == [
+        {
+            "interaction_id": "publish-interaction-1",
+            "response": "Approve",
+        }
+    ]
+    record = restored_pattern.tool_ledger["original-publish-call"]
+    assert record.status == "completed"
+    assert record.settlement_status == "succeeded"
+    assert record.result == {"success": True, "post_urn": "urn:li:share:123"}
+    projected_messages = [
+        message
+        for message in restored_context.messages
+        if message.role == "tool" and message.tool_call_id == "original-publish-call"
+    ]
+    assert len(projected_messages) == 1
+    assert projected_messages[0].metadata["raw_result"] == record.result
+    assert "urn:li:share:123" in str(resumed_llm.calls[0]["messages"])
+    assert restored_pattern.pending_tool_interaction_responses == []
+    assert any(
+        event["event_type"] == "action_end_tool"
+        and event["data"].get("tool_call_id") == "original-publish-call"
+        and event["data"].get("result") == record.result
+        for event in tracer.events
+    )
+
+
 @pytest.mark.parametrize("waiting_request", [None, [], "malformed"])
 def test_tool_interaction_response_queue_ignores_malformed_requests(
     waiting_request: Any,
@@ -7122,6 +7267,144 @@ async def test_pending_interaction_delivery_is_exact_and_retryable() -> None:
         "response": "Reject second",
     }
     assert pattern.pending_tool_interaction_responses == []
+
+
+@pytest.mark.asyncio
+async def test_settled_interaction_remains_retryable_until_checkpoint_succeeds() -> (
+    None
+):
+    settlement = ToolInteractionSettlement.succeeded(
+        {"success": True, "post_urn": "urn:li:share:123"}
+    )
+
+    class ResumableTool:
+        metadata = SimpleNamespace(
+            name="approval_gate",
+            description="Resume a persisted interaction.",
+        )
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def resume_user_interaction(self, **_: str) -> Any:
+            self.calls += 1
+            return settlement
+
+    class FailingCheckpointTracer:
+        async def checkpoint(self, **_: Any) -> None:
+            raise RuntimeError("checkpoint unavailable")
+
+    pending = {
+        "tool_name": "approval_gate",
+        "tool_call_id": "call-1",
+        "interaction_id": "interaction-1",
+        "response": "Approve",
+    }
+    pattern = ReActPattern()
+    pattern.pending_tool_interaction_responses = [pending]
+    pattern.tool_ledger["call-1"] = ToolCallRecord(
+        tool_call_id="call-1",
+        tool_name="approval_gate",
+        args={"expression": "publish"},
+        args_hash="stored-hash",
+        status="waiting_for_user",
+        result={"status": "waiting_for_user"},
+    )
+    context = ExecutionContext(execution_id="interaction-retry")
+    context.add_tool_result(
+        "approval_gate",
+        {"success": False, "status": "waiting_for_user"},
+        "call-1",
+    )
+    tool = ResumableTool()
+
+    with pytest.raises(RuntimeError, match="checkpoint unavailable"):
+        await pattern._deliver_pending_tool_interaction_responses(
+            tools=[tool],
+            context=context,
+            runtime=PatternRuntime(tracer=FailingCheckpointTracer()),
+        )
+
+    assert pattern.pending_tool_interaction_responses == [pending]
+    assert (
+        len(
+            [
+                message
+                for message in context.messages
+                if message.tool_call_id == "call-1"
+            ]
+        )
+        == 1
+    )
+
+    await pattern._deliver_pending_tool_interaction_responses(
+        tools=[tool],
+        context=context,
+        runtime=PatternRuntime(),
+    )
+
+    assert tool.calls == 2
+    assert pattern.pending_tool_interaction_responses == []
+    assert pattern.tool_ledger["call-1"].result == settlement.result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["rejected", "failed", "dispatch_unknown"])
+async def test_non_successful_settlement_fails_the_original_tool_call(
+    status: str,
+) -> None:
+    class ResumableTool:
+        metadata = SimpleNamespace(
+            name="approval_gate",
+            description="Resume a persisted interaction.",
+        )
+
+        async def resume_user_interaction(self, **_: str) -> Any:
+            return ToolInteractionSettlement(status=status)  # type: ignore[arg-type]
+
+    pattern = ReActPattern()
+    pattern.pending_tool_interaction_responses = [
+        {
+            "tool_name": "approval_gate",
+            "tool_call_id": "call-1",
+            "interaction_id": "interaction-1",
+            "response": "Reject",
+        }
+    ]
+    pattern.tool_ledger["call-1"] = ToolCallRecord(
+        tool_call_id="call-1",
+        tool_name="approval_gate",
+        args={},
+        args_hash="stored-hash",
+        status="waiting_for_user",
+    )
+    context = ExecutionContext(execution_id="terminal-interaction")
+    context.add_tool_result(
+        "approval_gate",
+        {"success": False, "status": "waiting_for_user"},
+        "call-1",
+    )
+    tracer = TraceEventRecorder()
+
+    await pattern._deliver_pending_tool_interaction_responses(
+        tools=[ResumableTool()],
+        context=context,
+        runtime=PatternRuntime(tracer=tracer),
+    )
+
+    record = pattern.tool_ledger["call-1"]
+    assert record.status == "failed"
+    assert record.settlement_status == status
+    assert record.result["success"] is False
+    assert record.result["status"] == status
+    assert pattern.force_final_answer_next is (
+        status in {"rejected", "dispatch_unknown"}
+    )
+    assert any(
+        event["event_type"] == "action_error_tool"
+        and event["data"].get("tool_call_id") == "call-1"
+        for event in tracer.events
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -7283,6 +7283,7 @@ async def test_settled_interaction_remains_retryable_until_checkpoint_succeeds()
     settlement = ToolInteractionSettlement.succeeded(
         {"success": True, "post_urn": "urn:li:share:123"}
     )
+
     class ResumableTool:
         metadata = SimpleNamespace(
             name="approval_gate",
@@ -7486,7 +7487,9 @@ async def test_later_success_clears_an_earlier_terminal_batch_fence() -> None:
             description="Resume persisted interactions.",
         )
 
-        async def resume_user_interaction(self, *, interaction_id: str, **_: str) -> Any:
+        async def resume_user_interaction(
+            self, *, interaction_id: str, **_: str
+        ) -> Any:
             if interaction_id == "interaction-1":
                 return ToolInteractionSettlement.rejected()
             return ToolInteractionSettlement.succeeded({"success": True})

--- a/tests/core/tools/test_user_interaction.py
+++ b/tests/core/tools/test_user_interaction.py
@@ -58,6 +58,15 @@ def test_successful_settlement_rejects_non_terminal_results(
         ToolInteractionSettlement.succeeded(result)
 
 
+@pytest.mark.parametrize("status", ["rejected", "failed", "dispatch_unknown"])
+def test_terminal_settlement_rejects_a_waiting_result(status: str) -> None:
+    with pytest.raises(ValueError, match="cannot wait for user input"):
+        ToolInteractionSettlement(  # type: ignore[arg-type]
+            status=status,
+            result={"status": "waiting_for_user"},
+        )
+
+
 def test_successful_settlement_uses_the_canonical_failure_classifier() -> None:
     result = {"status": " error "}
 

--- a/tests/core/tools/test_user_interaction.py
+++ b/tests/core/tools/test_user_interaction.py
@@ -44,6 +44,26 @@ def test_successful_settlement_rejects_a_failed_tool_result() -> None:
         ToolInteractionSettlement.succeeded({"success": False, "error": "failed"})
 
 
+@pytest.mark.parametrize(
+    "result, message",
+    [
+        (None, "needs a result"),
+        ({"status": "waiting_for_user"}, "cannot wait for user input"),
+    ],
+)
+def test_successful_settlement_rejects_non_terminal_results(
+    result, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        ToolInteractionSettlement.succeeded(result)
+
+
+def test_successful_settlement_uses_the_canonical_failure_classifier() -> None:
+    result = {"status": " error "}
+
+    assert ToolInteractionSettlement.succeeded(result).result is result
+
+
 @pytest.mark.parametrize("status", ["rejected", "failed", "dispatch_unknown"])
 def test_non_successful_settlement_has_an_unambiguous_failure_shape(
     status: str,
@@ -52,7 +72,7 @@ def test_non_successful_settlement_has_an_unambiguous_failure_shape(
 
     assert settlement.projected_result() == {
         "success": False,
-        "status": status,
+        "settlement_status": status,
         "error": {
             "rejected": "The user rejected the tool call.",
             "failed": "The resumed tool call failed.",
@@ -63,6 +83,15 @@ def test_non_successful_settlement_has_an_unambiguous_failure_shape(
         }[status],
         "detail": "safe",
     }
+
+
+def test_failed_settlement_preserves_a_tool_specific_status() -> None:
+    settlement = ToolInteractionSettlement.failed(
+        result={"status": "cancelled_by_policy"}
+    )
+
+    assert settlement.projected_result()["status"] == "cancelled_by_policy"
+    assert settlement.projected_result()["settlement_status"] == "failed"
 
 
 def test_settlement_rejects_an_unknown_status() -> None:

--- a/tests/core/tools/test_user_interaction.py
+++ b/tests/core/tools/test_user_interaction.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 from xagent.core.tools.user_interaction import (
+    ToolInteractionSettlement,
     tool_result_waits_for_user,
     user_interaction_resume_callable,
 )
@@ -26,3 +29,42 @@ def test_resume_capability_detection() -> None:
 
     assert callable(user_interaction_resume_callable(Resumable()))
     assert user_interaction_resume_callable(object()) is None
+
+
+def test_successful_settlement_preserves_the_tool_result() -> None:
+    result = {"success": True, "post_urn": "urn:li:share:123"}
+
+    settlement = ToolInteractionSettlement.succeeded(result)
+
+    assert settlement.projected_result() is result
+
+
+def test_successful_settlement_rejects_a_failed_tool_result() -> None:
+    with pytest.raises(ValueError, match="cannot carry a failed tool result"):
+        ToolInteractionSettlement.succeeded({"success": False, "error": "failed"})
+
+
+@pytest.mark.parametrize("status", ["rejected", "failed", "dispatch_unknown"])
+def test_non_successful_settlement_has_an_unambiguous_failure_shape(
+    status: str,
+) -> None:
+    settlement = ToolInteractionSettlement(status=status, result={"detail": "safe"})  # type: ignore[arg-type]
+
+    assert settlement.projected_result() == {
+        "success": False,
+        "status": status,
+        "error": {
+            "rejected": "The user rejected the tool call.",
+            "failed": "The resumed tool call failed.",
+            "dispatch_unknown": (
+                "The tool call may have reached the external system. Automatic retry "
+                "is disabled; verify the external system before trying again."
+            ),
+        }[status],
+        "detail": "safe",
+    }
+
+
+def test_settlement_rejects_an_unknown_status() -> None:
+    with pytest.raises(ValueError, match="Invalid tool interaction settlement"):
+        ToolInteractionSettlement(status="unknown")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- add a structured `ToolInteractionSettlement` contract for succeeded, rejected, failed, and dispatch-unknown outcomes
- project resumed outcomes onto the original tool-call ledger, execution context, trace, and checkpoint
- keep pending responses retryable until checkpoint persistence succeeds while preserving legacy callback-less and `None` callback behavior
- prevent rejected and dispatch-unknown settlements from triggering another tool attempt in the same turn

## Safety properties

- restored results replace the original waiting observation instead of creating a second tool result
- the original `tool_call_id`, arguments, and turn identity remain authoritative
- missing or mismatched ledger/context state fails closed
- callbacks may be invoked again after a crash or checkpoint failure and can replay a host-persisted terminal result

## Verification

- `pytest -q tests/core/agent/test_react.py tests/core/tools/test_user_interaction.py`
- `ruff check src/xagent/core/tools/user_interaction.py src/xagent/core/agent/pattern/react/react.py tests/core/tools/test_user_interaction.py tests/core/agent/test_react.py`
- mutation check: appending rather than replacing the original tool result makes the runtime-rebuild regression test fail

Closes #2256