### PR TITLE
fix(agent): keep question turn in LLM view when healing legacy waiting checkpoints

### DIFF
--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -275,6 +275,7 @@ class ExecutionContext:
         tool_call_id: str | None = None,
         *,
         context_refs: Any = (),
+        insert_before_last_user: bool = False,
     ) -> Message:
         public_result, supersedes_scope = split_tool_result_supersedes_scope(result)
         public_result, embedded_refs = split_tool_result_context_references(
@@ -305,13 +306,31 @@ class ExecutionContext:
         if supersedes_scope:
             metadata["supersedes_scope"] = supersedes_scope
             self._compact_superseded_tool_messages(supersedes_scope)
-        return self.add_message(
-            "tool",
-            content,
+        message = Message(
+            role="tool",
+            content=content,
             tool_call_id=tool_call_id,
             metadata=metadata,
             context_refs=tuple(all_context_refs),
         )
+        if insert_before_last_user:
+            # Keep the tool result adjacent to its assistant tool-call turn
+            # when a user message was injected in between (legacy waiting
+            # checkpoint heal): OpenAI-style chat requires tool messages to
+            # immediately follow the assistant message that declared them,
+            # and _sanitize_tool_message_pairs drops the whole assistant turn
+            # if a user message breaks the run (xorbitsai/xagent#2223).
+            self.messages.insert(self._last_user_message_index(), message)
+        else:
+            self.messages.append(message)
+        return message
+
+    def _last_user_message_index(self) -> int:
+        """Index of the last user message; appends after system/task text."""
+        for index in range(len(self.messages) - 1, -1, -1):
+            if self.messages[index].role == "user":
+                return index
+        return len(self.messages)
 
     def _compact_superseded_tool_messages(self, scope: str) -> None:
         """Keep stale observations durable while removing them from live prompts."""

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections import Counter
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
@@ -116,6 +117,8 @@ COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES = 20
 # Wire name: request_context keys reach metadata verbatim, so renaming this
 # breaks the clients that populate it.
 CLOCK_TIMEZONE_METADATA_KEY = "timezone"
+
+logger = logging.getLogger(__name__)
 
 
 def estimate_provider_prompt_tokens(
@@ -320,7 +323,38 @@ class ExecutionContext:
             # immediately follow the assistant message that declared them,
             # and _sanitize_tool_message_pairs drops the whole assistant turn
             # if a user message breaks the run (xorbitsai/xagent#2223).
-            self.messages.insert(self._last_user_message_index(), message)
+            insert_index = self._last_user_message_index()
+            # The heal shape is assistant[tool_calls] -> tool* -> user(answer):
+            # the cancellation must extend the contiguous tool run before the
+            # answer. Walk back over any tool messages to find the assistant
+            # turn that owns the run; anything else (no user message, user at
+            # start, user->user, assistant without tool_calls) violates the
+            # placement contract and falls back to append so the sanitizer
+            # cannot drop an earlier turn.
+            anchor_index = insert_index - 1
+            while (
+                anchor_index >= 0
+                and self.messages[anchor_index].role == "tool"
+            ):
+                anchor_index -= 1
+            anchor = (
+                self.messages[anchor_index] if anchor_index >= 0 else None
+            )
+            if (
+                insert_index >= len(self.messages)
+                or anchor is None
+                or anchor.role != "assistant"
+                or not anchor.tool_calls
+            ):
+                logger.warning(
+                    "insert_before_last_user placement contract violated: "
+                    "last user message at index %d is not preceded by an "
+                    "assistant tool-call turn; appending tool result instead",
+                    insert_index,
+                )
+                self.messages.append(message)
+            else:
+                self.messages.insert(insert_index, message)
         else:
             self.messages.append(message)
         return message

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1756,6 +1756,12 @@ class ReActPattern(AgentPattern):
                     "written before user input arrived; the agent replans "
                     "from the user's response."
                 ),
+                # The user answer is already in context at this point (resume
+                # only runs after the reply arrives), so the cancellation
+                # results must land BEFORE it to stay adjacent to their
+                # assistant turn; appending would break the tool→assistant
+                # pairing and hide the question turn from the LLM view.
+                insert_before_last_user=True,
             )
         waiting_task = self.waiting_for_user_request.get("task_text")
         if waiting_task and self.task_text is None:
@@ -2697,7 +2703,12 @@ class ReActPattern(AgentPattern):
         return segment, "concurrent"
 
     def _backfill_result(
-        self, tool_call: dict[str, Any], result: Any, context: Any
+        self,
+        tool_call: dict[str, Any],
+        result: Any,
+        context: Any,
+        *,
+        insert_before_last_user: bool = False,
     ) -> None:
         """Record one tool result into the context and drop its cached content.
 
@@ -2708,11 +2719,16 @@ class ReActPattern(AgentPattern):
             tool_name=tool_call["name"],
             result=result,
             tool_call_id=tool_call.get("id"),
+            insert_before_last_user=insert_before_last_user,
         )
         self._forget_tool_call_content(tool_call)
 
     def _discard_pending_tool_plan_after_pause(
-        self, context: Any, *, reason: str | None = None
+        self,
+        context: Any,
+        *,
+        reason: str | None = None,
+        insert_before_last_user: bool = False,
     ) -> None:
         """Close unexecuted calls so resume always starts with a fresh LLM plan."""
 
@@ -2728,10 +2744,16 @@ class ReActPattern(AgentPattern):
                 "Discarded because an earlier tool requires user input; "
                 "the agent will replan after the user responds."
             ),
+            insert_before_last_user=insert_before_last_user,
         )
 
     def _cancel_tool_calls(
-        self, tool_calls: list[dict[str, Any]], context: Any, *, reason: str
+        self,
+        tool_calls: list[dict[str, Any]],
+        context: Any,
+        *,
+        reason: str,
+        insert_before_last_user: bool = False,
     ) -> None:
         """Close calls that will never run, one result each.
 
@@ -2741,7 +2763,12 @@ class ReActPattern(AgentPattern):
 
         for tool_call in tool_calls:
             result = {"success": False, "status": "cancelled", "error": reason}
-            self._backfill_result(tool_call, result, context)
+            self._backfill_result(
+                tool_call,
+                result,
+                context,
+                insert_before_last_user=insert_before_last_user,
+            )
             self._record_tool_call(
                 tool_call,
                 status="cancelled",

--- a/tests/core/agent/concurrency_harness.py
+++ b/tests/core/agent/concurrency_harness.py
@@ -170,6 +170,8 @@ class RecordingContext:
         tool_name: str,
         result: Any,
         tool_call_id: str | None = None,
+        *,
+        insert_before_last_user: bool = False,
     ) -> _RecordedMessage:
         self.tool_results.append(
             {
@@ -179,7 +181,18 @@ class RecordingContext:
             }
         )
         message = _RecordedMessage("tool", result, tool_call_id=tool_call_id)
-        self.messages.append(message)
+        if insert_before_last_user:
+            # Mirrors ExecutionContext.add_tool_result's placement contract
+            # (xorbitsai/xagent#2223); the harness tracks ordering in
+            # self.tool_results so callers observe the same adjacency.
+            position = len(self.messages)
+            for index in range(len(self.messages) - 1, -1, -1):
+                if self.messages[index].role == "user":
+                    position = index
+                    break
+            self.messages.insert(position, message)
+        else:
+            self.messages.append(message)
         return message
 
     def add_assistant_message(self, content: str, **kwargs: Any) -> _RecordedMessage:

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -597,6 +597,62 @@ def test_add_messages() -> None:
     assert tool.metadata["raw_result"]["output"] == "done"
 
 
+def test_add_tool_result_insert_before_last_user_without_user_message_falls_back(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ctx = ExecutionContext()
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "read_file"}}
+        ],
+    )
+
+    with caplog.at_level("WARNING"):
+        tool = ctx.add_tool_result(
+            "read_file", {"output": "done"}, tool_call_id="call-1",
+            insert_before_last_user=True,
+        )
+
+    assert ctx.messages[-1] is tool
+    assert "placement contract" in caplog.text
+
+
+def test_add_tool_result_insert_before_last_user_without_tool_call_turn_falls_back() -> (
+    None
+):
+    ctx = ExecutionContext()
+    ctx.add_user_message("first")
+    ctx.add_user_message("second")
+
+    tool = ctx.add_tool_result(
+        "read_file", {"output": "done"}, tool_call_id="call-1",
+        insert_before_last_user=True,
+    )
+
+    assert ctx.messages[-1] is tool
+
+
+def test_add_tool_result_insert_before_last_user_keeps_tool_call_adjacency() -> None:
+    ctx = ExecutionContext()
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "read_file"}}
+        ],
+    )
+    ctx.add_user_message("answer")
+
+    tool = ctx.add_tool_result(
+        "read_file", {"output": "done"}, tool_call_id="call-1",
+        insert_before_last_user=True,
+    )
+
+    assert ctx.messages[-2] is tool
+    assert ctx.messages[-1].role == "user"
+    assert ctx.messages[-1].content == "answer"
+
+
 def test_artifact_tool_result_sanitizes_file_refs_in_raw_context_metadata() -> None:
     ctx = ExecutionContext()
 

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5675,6 +5675,58 @@ async def test_react_resume_waiting_cancels_stale_pending_from_legacy_checkpoint
 
 
 @pytest.mark.asyncio
+async def test_react_resume_waiting_keeps_question_turn_in_llm_view() -> None:
+    """#2223: cancelling a stale sibling from a legacy checkpoint must not
+    elide the question turn from the resumed LLM view.
+
+    Pre-fix, `_discard_pending_tool_plan_after_pause` appended the
+    cancellation result AFTER the already-injected user answer. The
+    sanitizer then saw assistant[tool_calls: q, stale] -> tool(q) ->
+    user(answer) -> tool(stale, cancelled): the assistant's tool results
+    were no longer contiguous, so the whole question turn and both tool
+    results were dropped from the LLM view (it saw only
+    [system, user(task), user(framed answer)]). The cancellation results
+    must land BEFORE the user answer to stay adjacent to their assistant
+    turn.
+    """
+
+    state, context = _legacy_waiting_state_and_context(_STALE_FINAL_ANSWER)
+    context.add_user_message("B")
+    pattern = ReActPattern(max_iterations=3)
+    pattern.load_state(state)
+    resumed_llm = FakeLLM([{"content": "You chose B.", "done": True}])
+
+    resumed = await pattern.run(context=context, tools=[], llm=resumed_llm)
+
+    assert resumed["success"] is True
+    resumed_messages = resumed_llm.calls[0]["messages"]
+    assistant_turns = [
+        message for message in resumed_messages if message.get("role") == "assistant"
+    ]
+    tool_messages = [
+        message for message in resumed_messages if message.get("role") == "tool"
+    ]
+    # The assistant question turn survives, carrying BOTH tool calls.
+    assert len(assistant_turns) >= 1
+    declared_ids = {
+        call["id"]
+        for call in assistant_turns[-1].get("tool_calls", [])
+        if isinstance(call, dict)
+    }
+    assert "call_question" in declared_ids
+    assert "call_stale_final" in declared_ids
+    # Both tool results stay adjacent to their assistant turn.
+    assert len(tool_messages) == 2
+    assert {message["tool_call_id"] for message in tool_messages} == {
+        "call_question",
+        "call_stale_final",
+    }
+    # The user answer still closes the resumed view for the LLM.
+    assert resumed_messages[-1]["role"] == "user"
+    assert resumed_messages[-1]["content"].endswith("B")
+
+
+@pytest.mark.asyncio
 async def test_react_pattern_resume_binds_original_task_to_store_memory() -> None:
     llm = FakeLLM(
         responses=[


### PR DESCRIPTION
## What

When `_resume_waiting_for_user_if_needed` heals a stale `pending_tool_calls` restored from a **pre-#2216** waiting checkpoint, `_discard_pending_tool_plan_after_pause` backfills the cancelled sibling's tool result via `context.add_tool_result`, which **appends** it after the already-injected user answer:

```
assistant[tool_calls: q, stale] -> tool(q) -> user(answer) -> tool(stale, cancelled)
```

`ExecutionContext._sanitize_tool_message_pairs` requires an assistant turn's tool results to be contiguous, so the LLM view drops the assistant question turn and both tool results — the resumed LLM call sees only `[system, user(task), user(framed answer)]`.

## How

- `ExecutionContext.add_tool_result` gains a keyword-only `insert_before_last_user: bool = False` flag (default preserves existing behavior). When set, the tool message is inserted adjacent to the last user message instead of appended.
- `_backfill_result` / `_cancel_tool_calls` / `_discard_pending_tool_plan_after_pause` thread the flag through.
- The legacy-checkpoint heal path passes `insert_before_last_user=True` — the user answer is already in context at resume time, so cancellation results must land **before** it to stay adjacent to their assistant turn:

```
assistant[tool_calls: q, stale] -> tool(q) -> tool(stale, cancelled) -> user(answer)
```

## Tests

- `test_react_resume_waiting_keeps_question_turn_in_llm_view`: resumes from a legacy state carrying a stale `final_answer` sibling and asserts the LLM view keeps the assistant question turn with **both** declared tool calls plus **both** contiguous tool results, with the user answer still closing the view.
- `concurrency_harness.RecordingContext.add_tool_result` mirrors the placement contract so the new parameter is type-compatible across harness tests.
- Mutation-checked: reverting `insert_before_last_user=True` makes the new test fail with `assert 0 >= 1` (assistant turn count 0) — exactly the reported elision.
- Full `tests/core/agent/` suite passes.

Fixes #2223