### PR TITLE
feat(mcp): add a scoped host approval gate (toby)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          python3 -m uv run python -m pytest ${{ matrix.paths }} -m "not slow and not postgresql" -n 4 --dist=loadscope -v
+          python3 -m uv run python -m pytest ${{ matrix.paths }} -m "not slow and not postgresql" -n 4 --dist=loadscope -vv --timeout=180
 
   pytest-fast-deepdoc:
     name: Pytest Fast Deepdoc (${{ matrix.name }})

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 from dataclasses import dataclass, replace
@@ -19,6 +20,7 @@ from ...context.enrichment import (
     pending_user_response_marker,
     top_level_user_request,
 )
+from ...checkpoint import CheckpointPersistenceError
 from ...frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
 from ...grounding import grounding_rule
 from ...language import (
@@ -177,26 +179,35 @@ class _DAGStepRuntime:
         status: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        self.dag_pattern._set_active_step_context(self.step_id, context.to_dict())
-        get_state = getattr(pattern, "get_state", None)
-        if callable(get_state):
-            self.dag_pattern._set_active_step_pattern_state(
-                self.step_id,
-                get_state(),
-            )
+        active_ids_before = list(self.dag_pattern.active_step_ids)
+        contexts_before = copy.deepcopy(self.dag_pattern.active_step_contexts)
+        states_before = copy.deepcopy(self.dag_pattern.active_step_pattern_states)
         step_metadata = {
             "active_step_id": self.step_id,
             "child_label": label,
         }
         if metadata:
             step_metadata.update(metadata)
-        return await self.parent.checkpoint(
-            label=f"dag_{label}",
-            context=self.root_context,
-            pattern=self.dag_pattern,
-            status=status,
-            metadata=step_metadata,
-        )
+        try:
+            self.dag_pattern._set_active_step_context(self.step_id, context.to_dict())
+            get_state = getattr(pattern, "get_state", None)
+            if callable(get_state):
+                self.dag_pattern._set_active_step_pattern_state(
+                    self.step_id, get_state()
+                )
+            return await self.parent.checkpoint(
+                label=f"dag_{label}",
+                context=self.root_context,
+                pattern=self.dag_pattern,
+                status=status,
+                metadata=step_metadata,
+            )
+        except BaseException:
+            self.dag_pattern.active_step_ids = active_ids_before
+            self.dag_pattern.active_step_contexts = contexts_before
+            self.dag_pattern.active_step_pattern_states = states_before
+            self.dag_pattern._sync_legacy_active_step()
+            raise
 
     async def on_tool_start(self, *, tool_call: dict[str, Any]) -> None:
         await self.parent.on_tool_start(tool_call=self._with_step(tool_call))
@@ -1047,7 +1058,7 @@ class DAGPattern(AgentPattern):
                 skill_manager=skill_manager,
                 allowed_skills=allowed_skills,
             )
-        except ExecutionInterrupted:
+        except (ExecutionInterrupted, CheckpointPersistenceError):
             raise
         except Exception as exc:
             step.status = "failed"

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -13,6 +13,7 @@ from ....task_runtime import (
     PREFERRED_INPUT_MODALITIES_METADATA_KEY,
     normalize_input_modalities,
 )
+from ...checkpoint import CheckpointPersistenceError
 from ...context.enrichment import (
     enrich_context_with_memory,
     hydrate_top_level_user_request,
@@ -20,7 +21,6 @@ from ...context.enrichment import (
     pending_user_response_marker,
     top_level_user_request,
 )
-from ...checkpoint import CheckpointPersistenceError
 from ...frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
 from ...grounding import grounding_rule
 from ...language import (

--- a/src/xagent/core/agent/pattern/react/duplicate_write_guard.py
+++ b/src/xagent/core/agent/pattern/react/duplicate_write_guard.py
@@ -7,14 +7,13 @@ structured envelope carrying the prior result instead.
 
 Scope is deliberately narrow:
 
-* Same turn only, enforced by turn_id equality on the ledger records. The
-  runner stamps a fresh turn_id on every user message (initial and
-  injected), and the pattern re-reads it at each pattern start, so a resume
-  that continues the execution — and its checkpointed ledger — under a new
-  user message compares unequal and executes, while an intra-turn resume
-  keeps suppressing the replay. A call with no turn_id (an embedding that
-  drives the pattern directly without stamping turns) is never guarded:
-  suppression must not outlive a turn, so an unknowable turn fails open.
+* Same turn only, enforced by the ledger record's guard turn identity. An
+  ordinary completion uses its original turn id. A resumed success uses the
+  settlement turn that received the result, so a model cannot immediately
+  repeat the approved write after resume. A later user turn remains a new
+  authorization boundary and may issue the same arguments again. A call with
+  no guard turn id is never guarded: suppression must not outlive a turn, so
+  an unknowable turn fails open.
 * Identical execution arguments only, compared via the ledger's canonical
   args hash.
 * Only tools that *explicitly* declare a non-idempotent write:

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -4293,9 +4293,7 @@ class ReActPattern(AgentPattern):
             settlement_turn_id=(
                 str(settlement_turn_id) if settlement_turn_id else None
             ),
-            step_id=(
-                str(tool_call["step_id"]) if tool_call.get("step_id") else None
-            ),
+            step_id=(str(tool_call["step_id"]) if tool_call.get("step_id") else None),
         )
 
     @staticmethod

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -73,6 +73,10 @@ from ....file_ref import (
 from ....model.chat.exceptions import LLMToolProtocolError
 from ....model.chat.tool_protocol import get_tool_protocol_error
 from ....tools.adapters.vibe.interaction_types import INTERACTION_TYPES
+from ....tools.adapters.vibe.mcp_approval_gate import (
+    ToolCallExecutionContext,
+    bind_tool_call_execution_context,
+)
 from ....tools.user_interaction import (
     ToolInteractionSettlement,
     tool_result_waits_for_user,
@@ -172,6 +176,9 @@ class ToolCallRecord:
     # ``turn_id`` so the original call keeps its execution identity while the
     # duplicate-write guard can protect the one resumed turn that follows it.
     settlement_turn_id: str | None = None
+    # The ReAct step that issued the call. Persisted so a rebuilt runtime can
+    # resume the exact gate identity instead of inventing a new execution slot.
+    step_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -185,6 +192,7 @@ class ToolCallRecord:
             "settlement_status": self.settlement_status,
             "turn_id": self.turn_id,
             "settlement_turn_id": self.settlement_turn_id,
+            "step_id": self.step_id,
         }
 
     @classmethod
@@ -208,6 +216,7 @@ class ToolCallRecord:
                 if data.get("settlement_turn_id") is not None
                 else None
             ),
+            step_id=str(data["step_id"]) if data.get("step_id") else None,
         )
 
 
@@ -1920,12 +1929,22 @@ class ReActPattern(AgentPattern):
                 pending=pending,
                 context=context,
             )
-            resumed = resume(
-                interaction_id=pending.get("interaction_id", ""),
-                response=pending.get("response", ""),
-            )
-            if inspect.isawaitable(resumed):
-                resumed = await resumed
+            tool_call_id = str(pending.get("tool_call_id") or "")
+            resume_call = {
+                "id": tool_call_id,
+                "name": tool_name,
+                "turn_id": record.turn_id,
+                "step_id": record.step_id,
+            }
+            with bind_tool_call_execution_context(
+                self._mcp_gate_execution_context(resume_call, context, runtime)
+            ):
+                resumed = resume(
+                    interaction_id=pending.get("interaction_id", ""),
+                    response=pending.get("response", ""),
+                )
+                if inspect.isawaitable(resumed):
+                    resumed = await resumed
             if resumed is not None and not isinstance(
                 resumed, ToolInteractionSettlement
             ):
@@ -2047,6 +2066,8 @@ class ReActPattern(AgentPattern):
         }
         if record.turn_id:
             tool_call["turn_id"] = record.turn_id
+        if record.step_id:
+            tool_call["step_id"] = record.step_id
 
         if settlement.status == "succeeded":
             self._record_tool_call(
@@ -3097,7 +3118,9 @@ class ReActPattern(AgentPattern):
 
         async def _guarded(tool_call: dict[str, Any]) -> Any:
             async with semaphore:
-                return await self._execute_tool_safely(tool_call, tools, runtime)
+                return await self._execute_tool_safely(
+                    tool_call, tools, runtime, context=context
+                )
 
         raw_results = await asyncio.gather(
             *(_guarded(tool_call) for tool_call in batch),
@@ -3311,7 +3334,9 @@ class ReActPattern(AgentPattern):
                     pattern=self,
                     metadata={"tool_call": tool_call},
                 )
-                result = await self._execute_tool_safely(tool_call, tools, runtime)
+                result = await self._execute_tool_safely(
+                    tool_call, tools, runtime, context=context
+                )
                 self._backfill_result(tool_call, result, context)
                 self.pending_tool_calls = self.pending_tool_calls[1:]
                 if tool_result_waits_for_user(result):
@@ -4036,9 +4061,12 @@ class ReActPattern(AgentPattern):
                 return result
             await runtime.on_tool_start(tool_call=tool_call)
             try:
-                result = await runtime.run_tool_call(
-                    lambda: self._execute_tool(tool_call, tools)
-                )
+                with bind_tool_call_execution_context(
+                    self._mcp_gate_execution_context(tool_call, context, runtime)
+                ):
+                    result = await runtime.run_tool_call(
+                        lambda: self._execute_tool(tool_call, tools)
+                    )
             except ToolCallInterrupted as exc:
                 await runtime.on_tool_cancelled(
                     tool_call=tool_call,
@@ -4175,6 +4203,33 @@ class ReActPattern(AgentPattern):
             "dag_step_id": str(step_id),
         }
 
+    @staticmethod
+    def _mcp_gate_execution_context(
+        tool_call: dict[str, Any], context: Any, runtime: PatternRuntime
+    ) -> ToolCallExecutionContext:
+        metadata = getattr(context, "metadata", None)
+        metadata = metadata if isinstance(metadata, dict) else {}
+        dag_step_id = metadata.get("dag_step_id")
+        task_source = metadata.get("task_source")
+        run_id = metadata.get("run_id")
+        return ToolCallExecutionContext(
+            task_source=str(task_source) if task_source else None,
+            task_id=str(
+                getattr(context, "execution_id", None)
+                or getattr(runtime, "execution_id", None)
+                or ""
+            )
+            or None,
+            run_id=str(run_id) if run_id else None,
+            turn_id=str(tool_call.get("turn_id")) if tool_call.get("turn_id") else None,
+            tool_call_id=str(tool_call.get("id") or ""),
+            pattern="dag" if dag_step_id else "react",
+            react_step_id=(
+                str(tool_call.get("step_id")) if tool_call.get("step_id") else None
+            ),
+            dag_step_id=str(dag_step_id) if dag_step_id else None,
+        )
+
     def _with_runtime_turn_id(
         self, tool_call: dict[str, Any], runtime: PatternRuntime
     ) -> dict[str, Any]:
@@ -4237,6 +4292,9 @@ class ReActPattern(AgentPattern):
             turn_id=self._tool_call_turn_id(tool_call),
             settlement_turn_id=(
                 str(settlement_turn_id) if settlement_turn_id else None
+            ),
+            step_id=(
+                str(tool_call["step_id"]) if tool_call.get("step_id") else None
             ),
         )
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -168,6 +168,10 @@ class ToolCallRecord:
     # the embedding provides no turn tracking, and for records restored from
     # checkpoints written before the field existed.
     turn_id: str | None = None
+    # The turn that delivered a terminal settlement. This is separate from
+    # ``turn_id`` so the original call keeps its execution identity while the
+    # duplicate-write guard can protect the one resumed turn that follows it.
+    settlement_turn_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -180,6 +184,7 @@ class ToolCallRecord:
             "error": self.error,
             "settlement_status": self.settlement_status,
             "turn_id": self.turn_id,
+            "settlement_turn_id": self.settlement_turn_id,
         }
 
     @classmethod
@@ -194,10 +199,15 @@ class ToolCallRecord:
             error=data.get("error"),
             settlement_status=(
                 str(data["settlement_status"])
-                if data.get("settlement_status")
+                if data.get("settlement_status") is not None
                 else None
             ),
             turn_id=str(data["turn_id"]) if data.get("turn_id") else None,
+            settlement_turn_id=(
+                str(data["settlement_turn_id"])
+                if data.get("settlement_turn_id") is not None
+                else None
+            ),
         )
 
 
@@ -1906,27 +1916,44 @@ class ReActPattern(AgentPattern):
                 )
                 continue
 
+            record = self._validate_tool_interaction_settlement_target(
+                pending=pending,
+                context=context,
+            )
             resumed = resume(
                 interaction_id=pending.get("interaction_id", ""),
                 response=pending.get("response", ""),
             )
             if inspect.isawaitable(resumed):
                 resumed = await resumed
-
-            if isinstance(resumed, ToolInteractionSettlement):
-                await self._project_tool_interaction_settlement(
-                    pending=pending,
-                    settlement=resumed,
-                    context=context,
-                    runtime=runtime,
+            if resumed is not None and not isinstance(
+                resumed, ToolInteractionSettlement
+            ):
+                raise TypeError(
+                    "resume_user_interaction must return "
+                    "ToolInteractionSettlement or None"
                 )
 
-            # Remove the response for the checkpoint, but restore it in memory
-            # if persistence fails. The last durable checkpoint still contains
-            # the response either way, and the host callback is required to
-            # replay its already-persisted settlement on a retry.
-            self.pending_tool_interaction_responses.pop(0)
+            ledger_before = copy.deepcopy(self.tool_ledger)
+            messages = getattr(context, "messages", None)
+            messages_before = copy.deepcopy(messages) if isinstance(messages, list) else None
+            force_final_before = self.force_final_answer_next
+            popped = False
             try:
+                if isinstance(resumed, ToolInteractionSettlement):
+                    self._project_tool_interaction_settlement(
+                        record=record,
+                        settlement=resumed,
+                        context=context,
+                        runtime=runtime,
+                    )
+
+                # The checkpoint must contain the terminal projection and no
+                # pending callback. If persistence fails, restore the entire
+                # in-memory transaction so replay starts from the last durable
+                # waiting state.
+                self.pending_tool_interaction_responses.pop(0)
+                popped = True
                 await runtime.checkpoint(
                     "tool_interaction_response_delivered",
                     context=context,
@@ -1943,18 +1970,21 @@ class ReActPattern(AgentPattern):
                     },
                 )
             except BaseException:
-                self.pending_tool_interaction_responses.insert(0, pending)
+                self.tool_ledger = ledger_before
+                if messages_before is not None and isinstance(messages, list):
+                    messages[:] = messages_before
+                self.force_final_answer_next = force_final_before
+                if popped:
+                    self.pending_tool_interaction_responses.insert(0, pending)
                 raise
 
-    async def _project_tool_interaction_settlement(
+    def _validate_tool_interaction_settlement_target(
         self,
         *,
         pending: dict[str, str],
-        settlement: ToolInteractionSettlement,
         context: Any,
-        runtime: PatternRuntime,
-    ) -> None:
-        """Project a resumed outcome onto its original tool protocol slot."""
+    ) -> ToolCallRecord:
+        """Validate every durable identity before a resume callback can run."""
 
         tool_call_id = str(pending.get("tool_call_id") or "")
         record = self.tool_ledger.get(tool_call_id)
@@ -1969,13 +1999,37 @@ class ReActPattern(AgentPattern):
                 "Resumed tool interaction does not match its original ledger "
                 f"record: {pending_tool_name!r} != {record.tool_name!r}"
             )
-        if record.status != "waiting_for_user" and (
-            record.settlement_status != settlement.status
-        ):
+        if record.status != "waiting_for_user":
             raise RuntimeError(
-                "Cannot overwrite a tool call that was not waiting for this "
-                f"settlement: {tool_call_id!r} is {record.status!r}."
+                "Cannot resume a tool call that is not waiting for user input: "
+                f"{tool_call_id!r} is {record.status!r} with settlement "
+                f"{record.settlement_status!r}."
             )
+        messages = getattr(context, "messages", None)
+        if not isinstance(messages, list):
+            raise RuntimeError("Execution context does not expose a message list.")
+        matches = [
+            message
+            for message in messages
+            if getattr(message, "role", None) == "tool"
+            and getattr(message, "tool_call_id", None) == tool_call_id
+        ]
+        if len(matches) != 1:
+            raise RuntimeError(
+                "Expected exactly one tool result for resumed tool call "
+                f"{tool_call_id!r}; found {len(matches)}."
+            )
+        return record
+
+    def _project_tool_interaction_settlement(
+        self,
+        *,
+        record: ToolCallRecord,
+        settlement: ToolInteractionSettlement,
+        context: Any,
+        runtime: PatternRuntime,
+    ) -> None:
+        """Project a resumed outcome onto its original tool protocol slot."""
 
         result = settlement.projected_result()
         self._replace_tool_result(
@@ -1998,30 +2052,26 @@ class ReActPattern(AgentPattern):
                 status="completed",
                 result=result,
                 settlement_status=settlement.status,
+                settlement_turn_id=getattr(runtime, "active_turn_id", None),
             )
-            await runtime.on_tool_end(tool_call=tool_call, result=result)
-            return
-
-        error = str(
-            settlement.error
-            or (result.get("error") if isinstance(result, dict) else result)
-        )
-        self._record_tool_call(
-            tool_call,
-            status="failed",
-            result=result,
-            error=error,
-            settlement_status=settlement.status,
-        )
-        if settlement.status in {"rejected", "dispatch_unknown"}:
-            # Neither outcome authorizes another attempt in this turn. A new
-            # external write must originate from a later user request.
-            self.force_final_answer_next = True
-        await runtime.on_tool_error(
-            tool_call=tool_call,
-            error=RuntimeError(error),
-            result=result,
-        )
+        else:
+            error = str(
+                settlement.error
+                or (result.get("error") if isinstance(result, dict) else result)
+            )
+            self._record_tool_call(
+                tool_call,
+                status="failed",
+                result=result,
+                error=error,
+                settlement_status=settlement.status,
+                settlement_turn_id=getattr(runtime, "active_turn_id", None),
+            )
+        # Recompute for every entry in a multi-interaction delivery batch.
+        self.force_final_answer_next = settlement.status in {
+            "rejected",
+            "dispatch_unknown",
+        }
 
     @staticmethod
     def _replace_tool_result(
@@ -2048,12 +2098,14 @@ class ReActPattern(AgentPattern):
                 f"{tool_call_id!r}; found {len(matching_indexes)}."
             )
 
-        context.add_tool_result(
+        replacement = context.add_tool_result(
             tool_name=tool_name,
             result=result,
             tool_call_id=tool_call_id,
         )
-        replacement = messages.pop()
+        if not messages or messages[-1] is not replacement:
+            raise RuntimeError("Execution context did not append the replacement result.")
+        messages.pop()
         messages[matching_indexes[0]] = replacement
 
     def _normalize_llm_response(self, response: Any) -> dict[str, Any]:
@@ -3837,18 +3889,17 @@ class ReActPattern(AgentPattern):
     ) -> dict[str, Any] | None:
         """Return the suppression envelope when this call repeats a completed write.
 
-        The comparison key is (turn_id, tool_name, args_hash), each side
+        The comparison key is (guard turn id, tool name, args hash), each side
         computed from the same post-transform ``tool_call`` that
         ``_record_tool_call`` hashes and ``_execute_tool`` executes — so two
         calls compare equal exactly when their executions would be identical.
-        The turn_id equality is what makes the guard strictly per-turn: the
-        runner stamps a fresh turn_id on every user message (initial and
-        injected), and ``active_turn_id`` is re-resolved from the latest user
-        message at each pattern start — so an explicit repeat requested in a
-        later turn always executes, while an intra-turn resume of the
-        checkpointed ledger keeps suppressing the replay. A call with no
-        stamped turn_id is never guarded: without a turn to scope to,
-        suppression could outlive a turn, so an unknowable turn fails open.
+        An ordinary completion uses its original ``turn_id``. A resumed
+        success uses ``settlement_turn_id``, the approval turn that received
+        that result. This keeps duplicate suppression active for subsequent
+        planning in the resumed turn without rewriting the original call's
+        identity or suppressing a new request in a later turn. A call with no
+        guard turn id is never guarded: without a turn to scope to, suppression
+        could outlive a turn, so an unknowable turn fails open.
 
         Serial execution makes the check-then-record window safe for guarded
         tools: they are non-idempotent by declaration, so
@@ -3876,7 +3927,12 @@ class ReActPattern(AgentPattern):
         for record in self.tool_ledger.values():
             if record.status != "completed":
                 continue
-            if record.turn_id != turn_id:
+            guard_turn_id = (
+                record.settlement_turn_id
+                if record.settlement_status == "succeeded"
+                else record.turn_id
+            )
+            if guard_turn_id != turn_id:
                 continue
             if record.tool_name != tool_name or record.args_hash != args_hash:
                 continue
@@ -4160,6 +4216,7 @@ class ReActPattern(AgentPattern):
         result: Any = None,
         error: str | None = None,
         settlement_status: str | None = None,
+        settlement_turn_id: str | None = None,
     ) -> None:
         tool_call_id = str(tool_call.get("id") or f"tool_call_{len(self.tool_ledger)}")
         args = self._tool_call_args_dict(tool_call)
@@ -4174,6 +4231,9 @@ class ReActPattern(AgentPattern):
             error=error,
             settlement_status=settlement_status,
             turn_id=self._tool_call_turn_id(tool_call),
+            settlement_turn_id=(
+                str(settlement_turn_id) if settlement_turn_id else None
+            ),
         )
 
     @staticmethod

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -74,6 +74,7 @@ from ....model.chat.exceptions import LLMToolProtocolError
 from ....model.chat.tool_protocol import get_tool_protocol_error
 from ....tools.adapters.vibe.interaction_types import INTERACTION_TYPES
 from ....tools.user_interaction import (
+    ToolInteractionSettlement,
     tool_result_waits_for_user,
     user_interaction_resume_callable,
 )
@@ -159,6 +160,10 @@ class ToolCallRecord:
     status: str
     result: Any = None
     error: str | None = None
+    # Terminal outcome supplied by a resumable tool callback. Kept separate
+    # from ``status`` so existing completed/failed ledger readers remain
+    # backward-compatible.
+    settlement_status: str | None = None
     # The durable turn the call ran in (see _with_runtime_turn_id). None when
     # the embedding provides no turn tracking, and for records restored from
     # checkpoints written before the field existed.
@@ -173,6 +178,7 @@ class ToolCallRecord:
             "status": self.status,
             "result": self.result,
             "error": self.error,
+            "settlement_status": self.settlement_status,
             "turn_id": self.turn_id,
         }
 
@@ -186,6 +192,11 @@ class ToolCallRecord:
             status=str(data.get("status", "pending")),
             result=data.get("result"),
             error=data.get("error"),
+            settlement_status=(
+                str(data["settlement_status"])
+                if data.get("settlement_status")
+                else None
+            ),
             turn_id=str(data["turn_id"]) if data.get("turn_id") else None,
         )
 
@@ -1900,20 +1911,150 @@ class ReActPattern(AgentPattern):
                 response=pending.get("response", ""),
             )
             if inspect.isawaitable(resumed):
-                await resumed
+                resumed = await resumed
 
-            # Keep the response retryable until the tool acknowledges delivery.
+            if isinstance(resumed, ToolInteractionSettlement):
+                await self._project_tool_interaction_settlement(
+                    pending=pending,
+                    settlement=resumed,
+                    context=context,
+                    runtime=runtime,
+                )
+
+            # Remove the response for the checkpoint, but restore it in memory
+            # if persistence fails. The last durable checkpoint still contains
+            # the response either way, and the host callback is required to
+            # replay its already-persisted settlement on a retry.
             self.pending_tool_interaction_responses.pop(0)
-            await runtime.checkpoint(
-                "tool_interaction_response_delivered",
-                context=context,
-                pattern=self,
-                metadata={
-                    "tool_name": tool_name,
-                    "tool_call_id": pending.get("tool_call_id", ""),
-                    "interaction_id": pending.get("interaction_id", ""),
-                },
+            try:
+                await runtime.checkpoint(
+                    "tool_interaction_response_delivered",
+                    context=context,
+                    pattern=self,
+                    metadata={
+                        "tool_name": tool_name,
+                        "tool_call_id": pending.get("tool_call_id", ""),
+                        "interaction_id": pending.get("interaction_id", ""),
+                        "settlement_status": (
+                            resumed.status
+                            if isinstance(resumed, ToolInteractionSettlement)
+                            else None
+                        ),
+                    },
+                )
+            except BaseException:
+                self.pending_tool_interaction_responses.insert(0, pending)
+                raise
+
+    async def _project_tool_interaction_settlement(
+        self,
+        *,
+        pending: dict[str, str],
+        settlement: ToolInteractionSettlement,
+        context: Any,
+        runtime: PatternRuntime,
+    ) -> None:
+        """Project a resumed outcome onto its original tool protocol slot."""
+
+        tool_call_id = str(pending.get("tool_call_id") or "")
+        record = self.tool_ledger.get(tool_call_id)
+        if record is None:
+            raise RuntimeError(
+                "Cannot settle resumed tool interaction without its original "
+                f"ledger record: {tool_call_id or '<missing>'}"
             )
+        pending_tool_name = str(pending.get("tool_name") or "")
+        if pending_tool_name != record.tool_name:
+            raise RuntimeError(
+                "Resumed tool interaction does not match its original ledger "
+                f"record: {pending_tool_name!r} != {record.tool_name!r}"
+            )
+        if record.status != "waiting_for_user" and (
+            record.settlement_status != settlement.status
+        ):
+            raise RuntimeError(
+                "Cannot overwrite a tool call that was not waiting for this "
+                f"settlement: {tool_call_id!r} is {record.status!r}."
+            )
+
+        result = settlement.projected_result()
+        self._replace_tool_result(
+            context=context,
+            tool_name=record.tool_name,
+            tool_call_id=record.tool_call_id,
+            result=result,
+        )
+        tool_call: dict[str, Any] = {
+            "id": record.tool_call_id,
+            "name": record.tool_name,
+            "args": copy.deepcopy(record.args),
+        }
+        if record.turn_id:
+            tool_call["turn_id"] = record.turn_id
+
+        if settlement.status == "succeeded":
+            self._record_tool_call(
+                tool_call,
+                status="completed",
+                result=result,
+                settlement_status=settlement.status,
+            )
+            await runtime.on_tool_end(tool_call=tool_call, result=result)
+            return
+
+        error = str(
+            settlement.error
+            or (result.get("error") if isinstance(result, dict) else result)
+        )
+        self._record_tool_call(
+            tool_call,
+            status="failed",
+            result=result,
+            error=error,
+            settlement_status=settlement.status,
+        )
+        if settlement.status in {"rejected", "dispatch_unknown"}:
+            # Neither outcome authorizes another attempt in this turn. A new
+            # external write must originate from a later user request.
+            self.force_final_answer_next = True
+        await runtime.on_tool_error(
+            tool_call=tool_call,
+            error=RuntimeError(error),
+            result=result,
+        )
+
+    @staticmethod
+    def _replace_tool_result(
+        *,
+        context: Any,
+        tool_name: str,
+        tool_call_id: str,
+        result: Any,
+    ) -> None:
+        """Replace the waiting observation without creating a second tool row."""
+
+        messages = getattr(context, "messages", None)
+        if not isinstance(messages, list):
+            raise RuntimeError("Execution context does not expose a message list.")
+        matching_indexes = [
+            index
+            for index, message in enumerate(messages)
+            if getattr(message, "role", None) == "tool"
+            and getattr(message, "tool_call_id", None) == tool_call_id
+        ]
+        if len(matching_indexes) != 1:
+            raise RuntimeError(
+                "Expected exactly one tool result for resumed tool call "
+                f"{tool_call_id!r}; found {len(matching_indexes)}."
+            )
+
+        context.add_tool_result(
+            tool_name=tool_name,
+            result=result,
+            tool_call_id=tool_call_id,
+        )
+        replacement = messages.pop()
+        messages[matching_indexes[0]] = replacement
 
     def _normalize_llm_response(self, response: Any) -> dict[str, Any]:
         if isinstance(response, str):
@@ -4018,6 +4159,7 @@ class ReActPattern(AgentPattern):
         status: str,
         result: Any = None,
         error: str | None = None,
+        settlement_status: str | None = None,
     ) -> None:
         tool_call_id = str(tool_call.get("id") or f"tool_call_{len(self.tool_ledger)}")
         args = self._tool_call_args_dict(tool_call)
@@ -4030,6 +4172,7 @@ class ReActPattern(AgentPattern):
             status=status,
             result=result,
             error=error,
+            settlement_status=settlement_status,
             turn_id=self._tool_call_turn_id(tool_call),
         )
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1936,7 +1936,9 @@ class ReActPattern(AgentPattern):
 
             ledger_before = copy.deepcopy(self.tool_ledger)
             messages = getattr(context, "messages", None)
-            messages_before = copy.deepcopy(messages) if isinstance(messages, list) else None
+            messages_before = (
+                copy.deepcopy(messages) if isinstance(messages, list) else None
+            )
             force_final_before = self.force_final_answer_next
             popped = False
             try:
@@ -2104,7 +2106,9 @@ class ReActPattern(AgentPattern):
             tool_call_id=tool_call_id,
         )
         if not messages or messages[-1] is not replacement:
-            raise RuntimeError("Execution context did not append the replacement result.")
+            raise RuntimeError(
+                "Execution context did not append the replacement result."
+            )
         messages.pop()
         messages[matching_indexes[0]] = replacement
 

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -880,6 +880,12 @@ class AgentRunner:
                     PREFERRED_INPUT_MODALITIES_METADATA_KEY,
                     None,
                 )
+            # A resumed checkpoint may carry stale or legacy caller-influenced
+            # values. The resume boundary supplies these two server-owned
+            # identities from the current task row and exact execution lease.
+            for key in ("task_source", "run_id"):
+                if key in metadata:
+                    context.metadata[key] = metadata[key]
             return
 
         current_metadata = dict(metadata)

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -33,7 +33,7 @@ from .config import (
     normalize_tool_allowlist,
     run_with_tool_runtime_cleanup,
 )
-from .connector_runtime import ConnectorRuntimeError
+from .connector_runtime import ConnectorRef, ConnectorRuntimeError
 from .output_filter_wrapper import OutputFilteredToolWrapper
 from .selection_spec import ToolSelectionSpec
 
@@ -1148,8 +1148,16 @@ class ToolFactory:
 
                     # Load MCP tools
                     if connections:
+                        connector_refs = {
+                            server_name: ConnectorRef("mcp", int(config["id"]))
+                            for server_name, config in configs_by_name.items()
+                            if isinstance(config.get("id"), int)
+                            and not isinstance(config.get("id"), bool)
+                            and int(config["id"]) > 0
+                        }
                         load_result = await load_mcp_tools_as_agent_tools(
                             connections,
+                            connector_refs=connector_refs,
                             sandbox=sandbox,
                         )  # type: ignore[arg-type]
                         normal_tools = list(load_result.tools)
@@ -1290,7 +1298,17 @@ class ToolFactory:
 
             # Load MCP tools
             try:
-                load_result = await load_mcp_tools_as_agent_tools(connections)
+                connector_refs = {
+                    server_name: ConnectorRef("mcp", int(config["id"]))
+                    for server_name, config in configs_by_name.items()
+                    if isinstance(config.get("id"), int)
+                    and not isinstance(config.get("id"), bool)
+                    and int(config["id"]) > 0
+                }
+                load_result = await load_mcp_tools_as_agent_tools(
+                    connections,
+                    connector_refs=connector_refs,
+                )
             except ConnectorRuntimeError:
                 raise
             except Exception as e:

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -53,6 +53,7 @@ from .sandboxed_tool.sandboxed_mcp_tool_helper import (
     load_sandboxed_mcp_tools,
     should_sandbox_mcp_connection,
 )
+from .mcp_approval_gate import gate_mcp_tools
 from .tool_naming_limits import MAX_AGENT_TOOL_NAME_LENGTH
 
 
@@ -2259,7 +2260,9 @@ async def load_mcp_tools_as_agent_tools(
                 server_tools = direct_result.tools
                 failures.extend(direct_result.failures)
 
-            agent_tools.extend(server_tools)
+            # Both direct adapters and sandbox wrappers reach this host-side
+            # boundary before any connector dispatch.
+            agent_tools.extend(gate_mcp_tools(server_tools, connection=connection))
             if server_tools:
                 loaded_servers.append(server_name)
             logger.info(f"Found {len(server_tools)} tools from server {server_name}")

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -44,16 +44,17 @@ from .connector_runtime import (
     RUNTIME_INPUT_CONTEXT,
     TARGET_MCP_META,
     TARGET_TOOL_ARGUMENTS,
+    ConnectorRef,
     binding_source_value,
     binding_target,
     connector_runtime_from_config,
     runtime_bindings_from_config,
 )
+from .mcp_approval_gate import gate_mcp_tools
 from .sandboxed_tool.sandboxed_mcp_tool_helper import (
     load_sandboxed_mcp_tools,
     should_sandbox_mcp_connection,
 )
-from .mcp_approval_gate import gate_mcp_tools
 from .tool_naming_limits import MAX_AGENT_TOOL_NAME_LENGTH
 
 
@@ -2124,6 +2125,7 @@ async def _load_server_tools_bounded(
 async def load_mcp_tools_as_agent_tools(
     connection_map: Dict[str, Connection],
     *,
+    connector_refs: Mapping[str, ConnectorRef] | None = None,
     name_prefix: str = "mcp_",
     visibility: Optional[ToolVisibility] = None,
     allow_users: Optional[List[str]] = None,
@@ -2133,6 +2135,9 @@ async def load_mcp_tools_as_agent_tools(
 
     Args:
         connection_map: Map of server names to connection configurations
+        connector_refs: Trusted persisted connector identities keyed by server
+            name. These stay outside transport mappings so sandbox guests never
+            receive host authorization identity.
         name_prefix: Prefix for tool names (default: "mcp_")
         visibility: Tool visibility setting
         allow_users: List of allowed user IDs
@@ -2262,7 +2267,13 @@ async def load_mcp_tools_as_agent_tools(
 
             # Both direct adapters and sandbox wrappers reach this host-side
             # boundary before any connector dispatch.
-            agent_tools.extend(gate_mcp_tools(server_tools, connection=connection))
+            agent_tools.extend(
+                gate_mcp_tools(
+                    server_tools,
+                    connection=connection,
+                    connector_ref=(connector_refs or {}).get(server_name),
+                )
+            )
             if server_tools:
                 loaded_servers.append(server_name)
             logger.info(f"Found {len(server_tools)} tools from server {server_name}")

--- a/src/xagent/core/tools/adapters/vibe/mcp_approval_gate.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_approval_gate.py
@@ -1,0 +1,503 @@
+"""Host-scoped approval boundary for deferred MCP calls.
+
+The module has no web or ORM dependencies. A host registers async hooks for
+one exact task source, and the MCP loader wraps both direct and sandboxed tools
+at their common host-side boundary. With no matching registration the wrapper
+is a transparent pass-through.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import json
+import logging
+import math
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from threading import RLock
+from typing import Any, Literal, Optional, Type
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from ...user_interaction import WAITING_FOR_USER_STATUS
+from .base import AbstractBaseTool, ToolMetadata
+from .connector_runtime import CONNECTOR_TYPE_MCP, ConnectorRef
+
+logger = logging.getLogger(__name__)
+
+GateDecisionValue = Literal["allow", "require_approval", "deny"]
+ExecutionPattern = Literal["react", "dag"]
+
+_GATE_FAILURE = {
+    "success": False,
+    "status": "error",
+    "error": "The connector approval gate is unavailable. The call was not sent.",
+}
+_UNSUPPORTED_PATTERN = {
+    "success": False,
+    "status": "denied",
+    "error": "Deferred MCP approval is not supported for this execution pattern.",
+}
+
+
+@dataclass(frozen=True)
+class ToolCallExecutionContext:
+    """Stable identity of the execution slot issuing one MCP call."""
+
+    task_source: str | None
+    task_id: str | None
+    run_id: str | None
+    turn_id: str | None
+    tool_call_id: str
+    pattern: ExecutionPattern
+    react_step_id: str | None = None
+    dag_step_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.tool_call_id:
+            raise ValueError("tool_call_id must not be empty")
+
+    def is_complete(self) -> bool:
+        """Whether the host has every identity needed for a durable decision."""
+
+        return bool(
+            self.task_source
+            and self.task_id
+            and self.run_id
+            and self.turn_id
+            and (
+                (self.pattern == "react" and self.react_step_id)
+                or (self.pattern == "dag" and self.dag_step_id)
+            )
+        )
+
+
+@dataclass(frozen=True)
+class GatedCall:
+    """Canonical, immutable snapshot presented to a host approval hook."""
+
+    connector_ref: ConnectorRef
+    tool_name: str
+    canonical_arguments_json: str
+    arguments_sha256: str
+    execution_context: ToolCallExecutionContext
+
+    @classmethod
+    def from_arguments(
+        cls,
+        *,
+        connector_ref: ConnectorRef,
+        tool_name: str,
+        arguments: Mapping[str, Any],
+        execution_context: ToolCallExecutionContext,
+    ) -> GatedCall:
+        canonical = json.dumps(
+            dict(arguments),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        decoded = json.loads(canonical)
+        if not isinstance(decoded, dict):
+            raise ValueError("MCP tool arguments must encode a JSON object")
+        return cls(
+            connector_ref=connector_ref,
+            tool_name=tool_name,
+            canonical_arguments_json=canonical,
+            arguments_sha256=hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+            execution_context=execution_context,
+        )
+
+    @property
+    def arguments(self) -> dict[str, Any]:
+        """Return a fresh deep copy of the canonical argument snapshot."""
+
+        return json.loads(self.canonical_arguments_json)
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Decision returned by the host before connector dispatch."""
+
+    decision: GateDecisionValue
+    interaction_id: str | None = None
+    message: str = ""
+
+    def __post_init__(self) -> None:
+        if self.decision not in {"allow", "require_approval", "deny"}:
+            raise ValueError(f"invalid gate decision: {self.decision!r}")
+        if self.decision == "require_approval" and not self.interaction_id:
+            raise ValueError("require_approval needs an interaction_id")
+
+    @classmethod
+    def allow(cls) -> GateDecision:
+        return cls(decision="allow")
+
+    @classmethod
+    def require_approval(
+        cls, interaction_id: str, *, message: str = ""
+    ) -> GateDecision:
+        return cls(
+            decision="require_approval",
+            interaction_id=interaction_id,
+            message=message,
+        )
+
+    @classmethod
+    def deny(cls, *, message: str = "") -> GateDecision:
+        return cls(decision="deny", message=message)
+
+
+GateHook = Callable[[GatedCall], Any]
+GateResumeHook = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class MCPApprovalGateRegistration:
+    """Opaque handle used to remove one exact scoped registration."""
+
+    task_source: str
+    registration_id: str
+
+
+@dataclass(frozen=True)
+class MCPApprovalReplayContext:
+    """Identity bound while an approved payload uses the normal connector path."""
+
+    interaction_id: str
+    arguments_sha256: str
+    execution_context: ToolCallExecutionContext
+
+
+@dataclass(frozen=True)
+class _RegisteredHooks:
+    handle: MCPApprovalGateRegistration
+    gate: GateHook
+    resume: GateResumeHook
+    timeout_seconds: float
+
+
+_REGISTRATIONS: dict[str, _RegisteredHooks] = {}
+_REGISTRATIONS_LOCK = RLock()
+_CURRENT_TOOL_CALL_CONTEXT: ContextVar[ToolCallExecutionContext | None] = ContextVar(
+    "xagent_mcp_gate_tool_call_context", default=None
+)
+_CURRENT_REPLAY_CONTEXT: ContextVar[MCPApprovalReplayContext | None] = ContextVar(
+    "xagent_mcp_gate_replay_context", default=None
+)
+
+
+def register_mcp_approval_gate(
+    *,
+    task_source: str,
+    gate: GateHook,
+    resume: GateResumeHook,
+    timeout_seconds: float = 10.0,
+) -> MCPApprovalGateRegistration:
+    """Register async hooks for one task source; duplicate scopes are refused."""
+
+    if (
+        not isinstance(task_source, str)
+        or not task_source
+        or task_source.strip() != task_source
+    ):
+        raise ValueError("task_source must be a non-empty trimmed string")
+    if not callable(gate) or not callable(resume):
+        raise TypeError("gate and resume hooks must be callable")
+    if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be finite and positive")
+    handle = MCPApprovalGateRegistration(task_source, str(uuid4()))
+    with _REGISTRATIONS_LOCK:
+        if task_source in _REGISTRATIONS:
+            raise RuntimeError(
+                f"an MCP approval gate is already registered for {task_source!r}"
+            )
+        _REGISTRATIONS[task_source] = _RegisteredHooks(
+            handle=handle,
+            gate=gate,
+            resume=resume,
+            timeout_seconds=float(timeout_seconds),
+        )
+    return handle
+
+
+def unregister_mcp_approval_gate(handle: MCPApprovalGateRegistration) -> bool:
+    """Remove only the registration identified by ``handle``."""
+
+    with _REGISTRATIONS_LOCK:
+        current = _REGISTRATIONS.get(handle.task_source)
+        if current is None or current.handle != handle:
+            return False
+        del _REGISTRATIONS[handle.task_source]
+        return True
+
+
+def _registration_for(task_source: str | None) -> _RegisteredHooks | None:
+    with _REGISTRATIONS_LOCK:
+        return _REGISTRATIONS.get(task_source) if task_source is not None else None
+
+
+def _has_registrations() -> bool:
+    with _REGISTRATIONS_LOCK:
+        return bool(_REGISTRATIONS)
+
+
+@contextmanager
+def bind_tool_call_execution_context(
+    context: ToolCallExecutionContext,
+) -> Iterator[None]:
+    """Bind one call identity across async hook and connector tasks."""
+
+    token = _CURRENT_TOOL_CALL_CONTEXT.set(context)
+    try:
+        yield
+    finally:
+        _CURRENT_TOOL_CALL_CONTEXT.reset(token)
+
+
+def current_tool_call_execution_context() -> ToolCallExecutionContext | None:
+    return _CURRENT_TOOL_CALL_CONTEXT.get()
+
+
+def current_mcp_approval_replay_context() -> MCPApprovalReplayContext | None:
+    return _CURRENT_REPLAY_CONTEXT.get()
+
+
+async def _call_async_hook(
+    hook: Callable[..., Any], timeout_seconds: float, /, *args: Any, **kwargs: Any
+) -> Any:
+    returned = hook(*args, **kwargs)
+    if not inspect.isawaitable(returned):
+        raise TypeError("MCP approval gate hooks must be async")
+    return await asyncio.wait_for(returned, timeout=timeout_seconds)
+
+
+def _connector_ref(connection: Mapping[str, Any]) -> ConnectorRef | None:
+    connector_id = connection.get("id")
+    if type(connector_id) is not int or connector_id <= 0:
+        return None
+    return ConnectorRef(CONNECTOR_TYPE_MCP, connector_id)
+
+
+class MCPApprovalGateTool(AbstractBaseTool):
+    """Gate an MCP tool before either direct or sandboxed dispatch."""
+
+    def __init__(
+        self,
+        target: AbstractBaseTool,
+        *,
+        connector_ref: ConnectorRef | None,
+    ) -> None:
+        self._target = target
+        self._connector_ref = connector_ref
+
+    @property
+    def target(self) -> AbstractBaseTool:
+        return self._target
+
+    @property
+    def name(self) -> str:
+        return self._target.name
+
+    @property
+    def description(self) -> str:
+        return self._target.description
+
+    @property
+    def tags(self) -> list[str]:
+        return self._target.tags
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return self._target.metadata
+
+    @property
+    def is_sandboxed(self) -> bool:
+        return bool(getattr(self._target, "is_sandboxed", False))
+
+    def args_type(self) -> Type[BaseModel]:
+        return self._target.args_type()
+
+    def return_type(self) -> Type[BaseModel]:
+        return self._target.return_type()
+
+    def state_type(self) -> Optional[Type[BaseModel]]:
+        return self._target.state_type()
+
+    def return_value_as_string(self, value: Any) -> str:
+        return self._target.return_value_as_string(value)
+
+    def is_async(self) -> bool:
+        return True
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        context = current_tool_call_execution_context()
+        registration = _registration_for(context.task_source if context else None)
+        if registration is None and not (context is None and _has_registrations()):
+            return self._target.run_json_sync(args)
+        raise RuntimeError(f"MCP tool {self.name} requires async approval evaluation")
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        context = current_tool_call_execution_context()
+        registration = _registration_for(context.task_source if context else None)
+        if registration is None:
+            if context is None and _has_registrations():
+                return dict(_GATE_FAILURE)
+            return await self._target.run_json_async(args)
+        if context is None or not context.is_complete() or self._connector_ref is None:
+            return dict(_GATE_FAILURE)
+
+        try:
+            call = GatedCall.from_arguments(
+                connector_ref=self._connector_ref,
+                tool_name=self.name,
+                arguments=args,
+                execution_context=context,
+            )
+            decision = await _call_async_hook(
+                registration.gate,
+                registration.timeout_seconds,
+                call,
+            )
+            if not isinstance(decision, GateDecision):
+                raise TypeError("gate hook returned an invalid decision")
+        except Exception:
+            logger.warning(
+                "MCP approval gate failed closed for tool=%s task_id=%s tool_call_id=%s",
+                self.name,
+                context.task_id,
+                context.tool_call_id,
+                exc_info=True,
+            )
+            return dict(_GATE_FAILURE)
+
+        if decision.decision == "allow":
+            return await self._target.run_json_async(call.arguments)
+        if decision.decision == "deny":
+            return {
+                "success": False,
+                "status": "denied",
+                "error": decision.message or "The connector call was denied.",
+            }
+        if context.pattern != "react":
+            return dict(_UNSUPPORTED_PATTERN)
+        return {
+            "success": False,
+            "status": WAITING_FOR_USER_STATUS,
+            "interaction_id": decision.interaction_id,
+            "message": decision.message or f"Approve running {self.name}?",
+            "message_type": "confirmation",
+            "interactions": [
+                {
+                    "type": "confirm",
+                    "field": "approve",
+                    "label": "Approve",
+                    "options": [
+                        {"label": "Approve", "value": "approve"},
+                        {"label": "Reject", "value": "reject"},
+                    ],
+                }
+            ],
+        }
+
+    async def resume_user_interaction(
+        self,
+        *,
+        interaction_id: str,
+        response: str,
+    ) -> Any:
+        context = current_tool_call_execution_context()
+        registration = _registration_for(context.task_source if context else None)
+        if registration is None:
+            if context is None and _has_registrations():
+                return dict(_GATE_FAILURE)
+            target_resume = getattr(self._target, "resume_user_interaction", None)
+            if not callable(target_resume):
+                return None
+            resumed = target_resume(interaction_id=interaction_id, response=response)
+            return await resumed if inspect.isawaitable(resumed) else resumed
+        if (
+            context is None
+            or not context.is_complete()
+            or self._connector_ref is None
+        ):
+            return dict(_GATE_FAILURE)
+
+        active = True
+        used = False
+
+        async def executor(arguments: Mapping[str, Any]) -> Any:
+            nonlocal used
+            if not active or used:
+                raise RuntimeError("approval replay executor is no longer available")
+            used = True
+            canonical = GatedCall.from_arguments(
+                connector_ref=self._connector_ref,
+                tool_name=self.name,
+                arguments=arguments,
+                execution_context=context,
+            )
+            replay = MCPApprovalReplayContext(
+                interaction_id=interaction_id,
+                arguments_sha256=canonical.arguments_sha256,
+                execution_context=context,
+            )
+            token = _CURRENT_REPLAY_CONTEXT.set(replay)
+            try:
+                return await self._target.run_json_async(canonical.arguments)
+            finally:
+                _CURRENT_REPLAY_CONTEXT.reset(token)
+
+        try:
+            return await _call_async_hook(
+                registration.resume,
+                registration.timeout_seconds,
+                interaction_id=interaction_id,
+                response=response,
+                connector_ref=self._connector_ref,
+                tool_name=self.name,
+                execution_context=context,
+                executor=executor,
+            )
+        except Exception:
+            logger.warning(
+                "MCP approval resume failed closed for tool=%s task_id=%s "
+                "tool_call_id=%s interaction_id=%s",
+                self.name,
+                context.task_id,
+                context.tool_call_id,
+                interaction_id,
+                exc_info=True,
+            )
+            return dict(_GATE_FAILURE)
+        finally:
+            active = False
+
+    async def setup(self, task_id: Optional[str] = None) -> None:
+        await self._target.setup(task_id)
+
+    async def teardown(self, task_id: Optional[str] = None) -> None:
+        await self._target.teardown(task_id)
+
+    async def save_state_json(self) -> Mapping[str, Any]:
+        return await self._target.save_state_json()
+
+    async def load_state_json(self, state: Mapping[str, Any]) -> None:
+        await self._target.load_state_json(state)
+
+
+def gate_mcp_tools(
+    tools: list[AbstractBaseTool],
+    *,
+    connection: Mapping[str, Any],
+) -> list[AbstractBaseTool]:
+    """Wrap tools where direct and sandboxed MCP transports converge."""
+
+    ref = _connector_ref(connection)
+    return [MCPApprovalGateTool(tool, connector_ref=ref) for tool in tools]

--- a/src/xagent/core/tools/adapters/vibe/mcp_approval_gate.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_approval_gate.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 
-from ...user_interaction import WAITING_FOR_USER_STATUS
+from ...user_interaction import WAITING_FOR_USER_STATUS, ToolInteractionSettlement
 from .base import AbstractBaseTool, ToolMetadata
 from .connector_runtime import ConnectorRef
 
@@ -42,14 +42,6 @@ _UNSUPPORTED_PATTERN = {
     "success": False,
     "status": "denied",
     "error": "Deferred MCP approval is not supported for this execution pattern.",
-}
-_DISPATCH_UNKNOWN = {
-    "success": False,
-    "status": "dispatch_unknown",
-    "error": (
-        "The connector call may have been sent, but its outcome could not be "
-        "confirmed. Do not retry it automatically."
-    ),
 }
 
 
@@ -475,19 +467,27 @@ class MCPApprovalGateTool(AbstractBaseTool):
         *,
         interaction_id: str,
         response: str,
-    ) -> Any:
+    ) -> ToolInteractionSettlement | None:
         context = current_tool_call_execution_context()
         registration = _registration_for(context.task_source if context else None)
         if registration is None:
             if (context is None or not context.task_source) and _has_registrations():
-                return dict(_GATE_FAILURE)
+                return ToolInteractionSettlement.failed(result=dict(_GATE_FAILURE))
             target_resume = getattr(self._target, "resume_user_interaction", None)
             if not callable(target_resume):
                 return None
             resumed = target_resume(interaction_id=interaction_id, response=response)
-            return await resumed if inspect.isawaitable(resumed) else resumed
+            resumed = await resumed if inspect.isawaitable(resumed) else resumed
+            if resumed is not None and not isinstance(
+                resumed, ToolInteractionSettlement
+            ):
+                raise TypeError(
+                    "resume_user_interaction must return "
+                    "ToolInteractionSettlement or None"
+                )
+            return resumed
         if context is None or not context.is_complete() or self._connector_ref is None:
-            return dict(_GATE_FAILURE)
+            return ToolInteractionSettlement.failed(result=dict(_GATE_FAILURE))
 
         connector_ref = self._connector_ref
         active = True
@@ -522,7 +522,7 @@ class MCPApprovalGateTool(AbstractBaseTool):
                 _CURRENT_REPLAY_CONTEXT.reset(token)
 
         try:
-            return await _call_resume_hook(
+            result = await _call_resume_hook(
                 registration.resume,
                 registration.timeout_seconds,
                 dispatch_started,
@@ -533,6 +533,11 @@ class MCPApprovalGateTool(AbstractBaseTool):
                 execution_context=context,
                 executor=executor,
             )
+            if not isinstance(result, ToolInteractionSettlement):
+                raise TypeError(
+                    "MCP approval resume hook must return ToolInteractionSettlement"
+                )
+            return result
         except Exception:
             logger.warning(
                 "MCP approval resume failed closed for tool=%s task_id=%s "
@@ -543,9 +548,14 @@ class MCPApprovalGateTool(AbstractBaseTool):
                 interaction_id,
                 exc_info=True,
             )
-            return dict(
-                _DISPATCH_UNKNOWN if dispatch_started.is_set() else _GATE_FAILURE
-            )
+            if dispatch_started.is_set():
+                return ToolInteractionSettlement.dispatch_unknown(
+                    error=(
+                        "The connector call may have reached the external system. "
+                        "Automatic retry is disabled."
+                    )
+                )
+            return ToolInteractionSettlement.failed(result=dict(_GATE_FAILURE))
         finally:
             active = False
 

--- a/src/xagent/core/tools/adapters/vibe/mcp_approval_gate.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_approval_gate.py
@@ -14,7 +14,7 @@ import inspect
 import json
 import logging
 import math
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 
 from ...user_interaction import WAITING_FOR_USER_STATUS
 from .base import AbstractBaseTool, ToolMetadata
-from .connector_runtime import CONNECTOR_TYPE_MCP, ConnectorRef
+from .connector_runtime import ConnectorRef
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,14 @@ _UNSUPPORTED_PATTERN = {
     "success": False,
     "status": "denied",
     "error": "Deferred MCP approval is not supported for this execution pattern.",
+}
+_DISPATCH_UNKNOWN = {
+    "success": False,
+    "status": "dispatch_unknown",
+    "error": (
+        "The connector call may have been sent, but its outcome could not be "
+        "confirmed. Do not retry it automatically."
+    ),
 }
 
 
@@ -118,7 +126,10 @@ class GatedCall:
     def arguments(self) -> dict[str, Any]:
         """Return a fresh deep copy of the canonical argument snapshot."""
 
-        return json.loads(self.canonical_arguments_json)
+        decoded: Any = json.loads(self.canonical_arguments_json)
+        if not isinstance(decoded, dict):
+            raise ValueError("canonical MCP arguments no longer encode an object")
+        return decoded
 
 
 @dataclass(frozen=True)
@@ -282,7 +293,48 @@ def _connector_ref(connection: Mapping[str, Any]) -> ConnectorRef | None:
     connector_id = connection.get("id")
     if type(connector_id) is not int or connector_id <= 0:
         return None
-    return ConnectorRef(CONNECTOR_TYPE_MCP, connector_id)
+    return ConnectorRef("mcp", connector_id)
+
+
+async def _call_resume_hook(
+    hook: Callable[..., Any],
+    timeout_seconds: float,
+    dispatch_started: asyncio.Event,
+    /,
+    **kwargs: Any,
+) -> Any:
+    """Bound only pre-dispatch resume policy; never cancel a started write."""
+
+    returned = hook(**kwargs)
+    if not inspect.isawaitable(returned):
+        raise TypeError("MCP approval gate hooks must be async")
+
+    hook_task = asyncio.ensure_future(returned)
+    dispatch_wait = asyncio.create_task(dispatch_started.wait())
+    try:
+        done, _ = await asyncio.wait(
+            {hook_task, dispatch_wait},
+            timeout=timeout_seconds,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if hook_task in done:
+            return hook_task.result()
+        if dispatch_wait in done or dispatch_started.is_set():
+            # The host has entered the one-shot executor. Connector latency is
+            # no longer approval-policy latency and must not be cancelled by
+            # the short gate deadline: cancellation cannot prove a remote
+            # write did not commit.
+            return await hook_task
+
+        hook_task.cancel()
+        try:
+            await hook_task
+        except asyncio.CancelledError:
+            pass
+        raise TimeoutError("MCP approval resume hook timed out before dispatch")
+    finally:
+        if not dispatch_wait.done():
+            dispatch_wait.cancel()
 
 
 class MCPApprovalGateTool(AbstractBaseTool):
@@ -315,7 +367,15 @@ class MCPApprovalGateTool(AbstractBaseTool):
 
     @property
     def metadata(self) -> ToolMetadata:
-        return self._target.metadata
+        metadata = self._target.metadata
+        if not _has_registrations():
+            return metadata
+        # ReAct fans one response out to every interaction paused in a
+        # concurrent batch. A gated tool must therefore revoke the scheduler's
+        # concurrency/idempotency declaration while any gate can be active.
+        return metadata.model_copy(
+            update={"read_only": False, "concurrency_safe": False}
+        )
 
     @property
     def is_sandboxed(self) -> bool:
@@ -339,7 +399,11 @@ class MCPApprovalGateTool(AbstractBaseTool):
     def run_json_sync(self, args: Mapping[str, Any]) -> Any:
         context = current_tool_call_execution_context()
         registration = _registration_for(context.task_source if context else None)
-        if registration is None and not (context is None and _has_registrations()):
+        if registration is None:
+            if (context is None or not context.task_source) and _has_registrations():
+                raise RuntimeError(
+                    f"MCP tool {self.name} requires async approval evaluation"
+                )
             return self._target.run_json_sync(args)
         raise RuntimeError(f"MCP tool {self.name} requires async approval evaluation")
 
@@ -347,7 +411,7 @@ class MCPApprovalGateTool(AbstractBaseTool):
         context = current_tool_call_execution_context()
         registration = _registration_for(context.task_source if context else None)
         if registration is None:
-            if context is None and _has_registrations():
+            if (context is None or not context.task_source) and _has_registrations():
                 return dict(_GATE_FAILURE)
             return await self._target.run_json_async(args)
         if context is None or not context.is_complete() or self._connector_ref is None:
@@ -415,22 +479,20 @@ class MCPApprovalGateTool(AbstractBaseTool):
         context = current_tool_call_execution_context()
         registration = _registration_for(context.task_source if context else None)
         if registration is None:
-            if context is None and _has_registrations():
+            if (context is None or not context.task_source) and _has_registrations():
                 return dict(_GATE_FAILURE)
             target_resume = getattr(self._target, "resume_user_interaction", None)
             if not callable(target_resume):
                 return None
             resumed = target_resume(interaction_id=interaction_id, response=response)
             return await resumed if inspect.isawaitable(resumed) else resumed
-        if (
-            context is None
-            or not context.is_complete()
-            or self._connector_ref is None
-        ):
+        if context is None or not context.is_complete() or self._connector_ref is None:
             return dict(_GATE_FAILURE)
 
+        connector_ref = self._connector_ref
         active = True
         used = False
+        dispatch_started = asyncio.Event()
 
         async def executor(arguments: Mapping[str, Any]) -> Any:
             nonlocal used
@@ -438,7 +500,7 @@ class MCPApprovalGateTool(AbstractBaseTool):
                 raise RuntimeError("approval replay executor is no longer available")
             used = True
             canonical = GatedCall.from_arguments(
-                connector_ref=self._connector_ref,
+                connector_ref=connector_ref,
                 tool_name=self.name,
                 arguments=arguments,
                 execution_context=context,
@@ -450,17 +512,23 @@ class MCPApprovalGateTool(AbstractBaseTool):
             )
             token = _CURRENT_REPLAY_CONTEXT.set(replay)
             try:
+                # The host resume hook must persist its EXECUTING/dispatch
+                # marker before awaiting this executor. From this point on,
+                # an exception is conservatively ambiguous unless the host
+                # returns a persisted known outcome.
+                dispatch_started.set()
                 return await self._target.run_json_async(canonical.arguments)
             finally:
                 _CURRENT_REPLAY_CONTEXT.reset(token)
 
         try:
-            return await _call_async_hook(
+            return await _call_resume_hook(
                 registration.resume,
                 registration.timeout_seconds,
+                dispatch_started,
                 interaction_id=interaction_id,
                 response=response,
-                connector_ref=self._connector_ref,
+                connector_ref=connector_ref,
                 tool_name=self.name,
                 execution_context=context,
                 executor=executor,
@@ -475,7 +543,9 @@ class MCPApprovalGateTool(AbstractBaseTool):
                 interaction_id,
                 exc_info=True,
             )
-            return dict(_GATE_FAILURE)
+            return dict(
+                _DISPATCH_UNKNOWN if dispatch_started.is_set() else _GATE_FAILURE
+            )
         finally:
             active = False
 
@@ -493,11 +563,12 @@ class MCPApprovalGateTool(AbstractBaseTool):
 
 
 def gate_mcp_tools(
-    tools: list[AbstractBaseTool],
+    tools: Sequence[AbstractBaseTool],
     *,
-    connection: Mapping[str, Any],
+    connection: Mapping[str, Any] | None = None,
+    connector_ref: ConnectorRef | None = None,
 ) -> list[AbstractBaseTool]:
     """Wrap tools where direct and sandboxed MCP transports converge."""
 
-    ref = _connector_ref(connection)
+    ref = connector_ref or _connector_ref(connection or {})
     return [MCPApprovalGateTool(tool, connector_ref=ref) for tool in tools]

--- a/src/xagent/core/tools/adapters/vibe/mcp_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_tools.py
@@ -99,7 +99,9 @@ def _build_mcp_load_summary(
             continue
 
         successful_tool_count += 1
-        source_server = getattr(tool, "source_server", None)
+        source_server = getattr(getattr(tool, "metadata", None), "source_server", None)
+        if source_server is None:
+            source_server = getattr(tool, "source_server", None)
         if type(source_server) is not str:
             continue
         key = normalize_mcp_server_name(source_server)

--- a/src/xagent/core/tools/user_interaction.py
+++ b/src/xagent/core/tools/user_interaction.py
@@ -2,11 +2,12 @@
 
 Tools opt into the control flow by returning a mapping whose ``status`` is
 ``waiting_for_user``.  The execution pattern presents the returned message,
-checkpoints, and stops the current run. After the user replies, the runtime asks
-the model to replan with the annotated response in context. Tools that keep
-server-owned interaction state may additionally implement
-``resume_user_interaction``; the runtime then delivers the reply to that exact
-suspended interaction before replanning.
+checkpoints, and stops the current run. After the user replies, tools that keep
+server-owned interaction state may implement ``resume_user_interaction``; the
+runtime then delivers the reply to that exact suspended interaction. Returning
+``ToolInteractionSettlement`` projects the terminal result onto the original
+tool call before the model continues. Returning ``None`` preserves the legacy
+replan behavior.
 
 The optional runtime capability keeps server-owned interaction state out of
 model-generated tool arguments and lets those tools decide how to interpret the
@@ -15,9 +16,120 @@ user's answer. Callback-less tools use the normal ReAct context and replan path.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Protocol, runtime_checkable
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Protocol, runtime_checkable
 
 WAITING_FOR_USER_STATUS = "waiting_for_user"
+ToolInteractionSettlementStatus = Literal[
+    "succeeded",
+    "rejected",
+    "failed",
+    "dispatch_unknown",
+]
+_TOOL_INTERACTION_SETTLEMENT_STATUSES = {
+    "succeeded",
+    "rejected",
+    "failed",
+    "dispatch_unknown",
+}
+_DEFAULT_SETTLEMENT_ERRORS = {
+    "rejected": "The user rejected the tool call.",
+    "failed": "The resumed tool call failed.",
+    "dispatch_unknown": (
+        "The tool call may have reached the external system. Automatic retry is "
+        "disabled; verify the external system before trying again."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ToolInteractionSettlement:
+    """Durable outcome returned when a suspended tool call is resumed.
+
+    Returning this value asks the execution pattern to replace the original
+    ``waiting_for_user`` observation with the terminal result. A callback that
+    returns ``None`` keeps the legacy behavior: delivery is acknowledged and
+    the model replans from the user's response.
+    """
+
+    status: ToolInteractionSettlementStatus
+    result: Any = None
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status not in _TOOL_INTERACTION_SETTLEMENT_STATUSES:
+            raise ValueError(f"Invalid tool interaction settlement: {self.status!r}")
+        if self.status == "succeeded" and isinstance(self.result, dict):
+            result_status = self.result.get("status")
+            if (
+                self.result.get("success") is False
+                or self.result.get("is_error") is True
+                or (
+                    isinstance(result_status, str)
+                    and result_status.strip().lower() == "error"
+                )
+            ):
+                raise ValueError(
+                    "A succeeded tool interaction settlement cannot carry a "
+                    "failed tool result."
+                )
+
+    @classmethod
+    def succeeded(cls, result: Any) -> ToolInteractionSettlement:
+        return cls(status="succeeded", result=result)
+
+    @classmethod
+    def rejected(
+        cls,
+        *,
+        result: Any = None,
+        error: str | None = None,
+    ) -> ToolInteractionSettlement:
+        return cls(status="rejected", result=result, error=error)
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        result: Any = None,
+        error: str | None = None,
+    ) -> ToolInteractionSettlement:
+        return cls(status="failed", result=result, error=error)
+
+    @classmethod
+    def dispatch_unknown(
+        cls,
+        *,
+        result: Any = None,
+        error: str | None = None,
+    ) -> ToolInteractionSettlement:
+        return cls(status="dispatch_unknown", result=result, error=error)
+
+    def projected_result(self) -> Any:
+        """Return the model-visible result with an unambiguous outcome."""
+
+        if self.status == "succeeded":
+            return self.result
+
+        result_error = (
+            self.result.get("error") if isinstance(self.result, dict) else None
+        )
+        error = self.error or result_error or _DEFAULT_SETTLEMENT_ERRORS[self.status]
+        if isinstance(self.result, dict):
+            return {
+                **self.result,
+                "success": False,
+                "status": self.status,
+                "error": error,
+            }
+        projected = {
+            "success": False,
+            "status": self.status,
+            "error": error,
+        }
+        if self.result is not None:
+            projected["result"] = self.result
+        return projected
 
 
 @runtime_checkable
@@ -30,7 +142,7 @@ class ResumableUserInteractionTool(Protocol):
         interaction_id: str,
         response: str,
     ) -> Any:
-        """Accept one user response identified by the suspended interaction."""
+        """Accept a response and optionally settle the suspended tool call."""
 
 
 def tool_result_waits_for_user(result: Any) -> bool:

--- a/src/xagent/core/tools/user_interaction.py
+++ b/src/xagent/core/tools/user_interaction.py
@@ -59,16 +59,19 @@ class ToolInteractionSettlement:
     def __post_init__(self) -> None:
         if self.status not in _TOOL_INTERACTION_SETTLEMENT_STATUSES:
             raise ValueError(f"Invalid tool interaction settlement: {self.status!r}")
-        if self.status == "succeeded" and isinstance(self.result, dict):
-            result_status = self.result.get("status")
-            if (
-                self.result.get("success") is False
-                or self.result.get("is_error") is True
-                or (
-                    isinstance(result_status, str)
-                    and result_status.strip().lower() == "error"
+        if self.status == "succeeded":
+            if self.result is None:
+                raise ValueError(
+                    "A succeeded tool interaction settlement needs a result."
                 )
-            ):
+            if tool_result_waits_for_user(self.result):
+                raise ValueError(
+                    "A succeeded tool interaction settlement cannot wait for user input."
+                )
+            # Deferred import avoids the agent.result -> tools import cycle.
+            from ..agent.result import tool_result_succeeded
+
+            if not tool_result_succeeded(self.result):
                 raise ValueError(
                     "A succeeded tool interaction settlement cannot carry a "
                     "failed tool result."
@@ -119,12 +122,12 @@ class ToolInteractionSettlement:
             return {
                 **self.result,
                 "success": False,
-                "status": self.status,
+                "settlement_status": self.status,
                 "error": error,
             }
         projected = {
             "success": False,
-            "status": self.status,
+            "settlement_status": self.status,
             "error": error,
         }
         if self.result is not None:
@@ -141,8 +144,13 @@ class ResumableUserInteractionTool(Protocol):
         *,
         interaction_id: str,
         response: str,
-    ) -> Any:
-        """Accept a response and optionally settle the suspended tool call."""
+    ) -> ToolInteractionSettlement | None:
+        """Accept a response and optionally settle the suspended tool call.
+
+        A host may invoke this callback again after a failed checkpoint or
+        process restart. Implementations that perform external work must
+        durably replay the same terminal settlement for the interaction.
+        """
 
 
 def tool_result_waits_for_user(result: Any) -> bool:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2837,10 +2837,15 @@ async def execute_task_background(
             actual_task_id = str(task_id)
             task_for_agent = llm_user_message or user_message
             agent_context = dict(context_dict)
-            agent_context.setdefault("task_source", snapshot.task.source)
+            # These are server-owned execution identities. WebSocket context
+            # is caller supplied and must never select an approval registry or
+            # impersonate another execution lease.
+            agent_context["task_source"] = snapshot.task.source
             run_id = task_lease.run_id if task_lease is not None else expected_run_id
             if run_id is not None:
-                agent_context.setdefault("run_id", run_id)
+                agent_context["run_id"] = run_id
+            else:
+                agent_context.pop("run_id", None)
             result = await agent_manager.execute_task(
                 agent_service=agent_service,
                 task=task_for_agent,
@@ -3392,6 +3397,7 @@ async def execute_resume_background(
     # forgets to pass its own run id would silently claim a lease under a
     # run nobody else knows about instead of failing loudly.
     expected_run_id: str | None = None,
+    trusted_task_source: str | None = None,
     resolved_execution_scope: Union[
         ExecutionScope, None, ExecutionScopeNotProvided
     ] = EXECUTION_SCOPE_NOT_PROVIDED,
@@ -3773,7 +3779,13 @@ async def execute_resume_background(
             bind_task_lease_context(lease),
         ):
             result = await run_while_task_lease_owned(
-                agent_service.resume_execution_by_id(str(task_id)),
+                agent_service.resume_execution_by_id(
+                    str(task_id),
+                    metadata={
+                        "task_source": trusted_task_source,
+                        "run_id": lease.run_id,
+                    },
+                ),
                 lease_heartbeat_task,
             )
 
@@ -5837,6 +5849,7 @@ class _WebSocketTaskRoutingSnapshot:
 
     task_id: int
     task_owner_user_id: int
+    task_source: str | None
     status: TaskStatus
     control_state: str | None
     run_id: str | None
@@ -5934,6 +5947,7 @@ def _load_websocket_task_routing_snapshot(
         _WebSocketTaskRoutingSnapshot(
             task_id=int(task.id),
             task_owner_user_id=int(task.user_id),
+            task_source=str(task.source) if task.source is not None else None,
             status=status,
             control_state=_task_control_state_value(task),
             run_id=_task_run_id(task),
@@ -6897,6 +6911,7 @@ async def _handle_chat_message_unserialized(
                             # is what a resume wants: those pointers are the
                             # anchor it is resuming from.
                             expected_run_id=handoff_snapshot.run_id,
+                            trusted_task_source=routing.task_source,
                             previous_task=previous_task,
                             resolved_execution_scope=resolved_execution_scope,
                             pending_user_message=(
@@ -9470,6 +9485,7 @@ async def _handle_resume_task_unserialized(
                         agent_service=agent_service,
                         task_owner_user_id=task_owner_user_id,
                         expected_run_id=resume_snapshot.run_id,
+                        trusted_task_source=task_fields.source,
                         previous_task=previous_task,
                         # Not `resolved_execution_scope`: that value is the
                         # off-turn downgrade used above to obtain

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2836,10 +2836,15 @@ async def execute_task_background(
             # Execute the next turn under the same task/thread id.
             actual_task_id = str(task_id)
             task_for_agent = llm_user_message or user_message
+            agent_context = dict(context_dict)
+            agent_context.setdefault("task_source", snapshot.task.source)
+            run_id = task_lease.run_id if task_lease is not None else expected_run_id
+            if run_id is not None:
+                agent_context.setdefault("run_id", run_id)
             result = await agent_manager.execute_task(
                 agent_service=agent_service,
                 task=task_for_agent,
-                context=context,
+                context=agent_context,
                 task_id=actual_task_id,
                 tracking_task_id=str(task_id),
                 db_session=None,

--- a/src/xagent/web/tools/mcp/linkedin.py
+++ b/src/xagent/web/tools/mcp/linkedin.py
@@ -234,7 +234,10 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             return [TextContent(type="text", text=r.text)]
 
         elif name == "create_post":
-            text = _sanitize_post_text(str(arguments.get("text") or ""))
+            # The caller owns the exact approved post text. Parentheses and
+            # backslashes are ordinary JSON string content and must not be
+            # rewritten before the LinkedIn REST request.
+            text = str(arguments.get("text") or "")
             image_path = (arguments.get("image_path") or "").strip()
             alt_text = str(arguments.get("altText") or "")
             author_urn = _get_author_urn(headers, proxies)

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -26,6 +26,7 @@ from xagent.core.agent.clarification import (
     ClarificationDraft,
     draft_from_waiting_request,
 )
+from xagent.core.agent.checkpoint import CheckpointPersistenceError
 from xagent.core.agent.context.enrichment import MEMORY_CONTEXT_METADATA_KEY
 from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_METADATA_KEY,
@@ -35,6 +36,7 @@ from xagent.core.agent.language import (
 from xagent.core.agent.pattern.base import RequiredToolCallError
 from xagent.core.agent.pattern.dag import dag as dag_module
 from xagent.core.agent.pattern.dag.dag import _DAGStepRuntime
+from xagent.core.agent.pattern.react import ReActPattern
 from xagent.core.agent.pattern.dag.plan_generator import (
     PLAN_GENERATION_REQUIRED_TOOL_MESSAGE,
     PlanLanguageMismatchError,
@@ -683,6 +685,60 @@ async def test_dag_step_runtime_forwards_llm_error_with_step_metadata() -> None:
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_dag_step_checkpoint_rolls_back_child_snapshot_on_failure() -> None:
+    class FailingRuntime(PatternRuntime):
+        async def checkpoint(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise CheckpointPersistenceError("checkpoint unavailable")
+
+    dag = DAGPattern(lambda **_: build_plan())
+    dag._set_active_step_context("creative", {"marker": "old-context"})
+    dag._set_active_step_pattern_state("creative", {"marker": "old-state"})
+    runtime = _DAGStepRuntime(
+        parent=FailingRuntime(),
+        dag_pattern=dag,
+        root_context=ExecutionContext(execution_id="dag-root"),
+        step_id="creative",
+    )
+
+    with pytest.raises(CheckpointPersistenceError, match="checkpoint unavailable"):
+        await runtime.checkpoint(
+            "tool_interaction_response_delivered",
+            context=ExecutionContext(execution_id="dag-root:creative"),
+            pattern=ReActPattern(),
+        )
+
+    assert dag.active_step_contexts["creative"] == {"marker": "old-context"}
+    assert dag.active_step_pattern_states["creative"] == {"marker": "old-state"}
+
+
+@pytest.mark.asyncio
+async def test_dag_step_does_not_convert_checkpoint_failure_into_step_failure(
+    monkeypatch,
+) -> None:
+    failure = CheckpointPersistenceError("checkpoint unavailable")
+
+    async def fail_run(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise failure
+
+    monkeypatch.setattr(ReActPattern, "run", fail_run)
+    dag = DAGPattern(lambda **_: build_plan())
+    step = PlanStep(id="creative", task="Create", tool_names=[])
+
+    with pytest.raises(CheckpointPersistenceError) as caught:
+        await dag._execute_step_impl(
+            step=step,
+            root_context=ExecutionContext(execution_id="dag-root"),
+            tools=[],
+            llm=object(),
+            runtime=PatternRuntime(),
+        )
+
+    assert caught.value is failure
+    assert step.status == "running"
+    assert "creative" in dag.active_step_ids
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -22,11 +22,11 @@ from xagent.core.agent import (
     PlanStep,
     PlanValidationError,
 )
+from xagent.core.agent.checkpoint import CheckpointPersistenceError
 from xagent.core.agent.clarification import (
     ClarificationDraft,
     draft_from_waiting_request,
 )
-from xagent.core.agent.checkpoint import CheckpointPersistenceError
 from xagent.core.agent.context.enrichment import MEMORY_CONTEXT_METADATA_KEY
 from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_METADATA_KEY,
@@ -36,11 +36,11 @@ from xagent.core.agent.language import (
 from xagent.core.agent.pattern.base import RequiredToolCallError
 from xagent.core.agent.pattern.dag import dag as dag_module
 from xagent.core.agent.pattern.dag.dag import _DAGStepRuntime
-from xagent.core.agent.pattern.react import ReActPattern
 from xagent.core.agent.pattern.dag.plan_generator import (
     PLAN_GENERATION_REQUIRED_TOOL_MESSAGE,
     PlanLanguageMismatchError,
 )
+from xagent.core.agent.pattern.react import ReActPattern
 from xagent.core.memory.core import MemoryNote as StoredMemoryNote
 from xagent.core.memory.core import MemoryResponse
 from xagent.core.model.chat.types import ChunkType, StreamChunk

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -7139,6 +7139,7 @@ async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() 
     record = restored_pattern.tool_ledger["original-publish-call"]
     assert record.status == "completed"
     assert record.settlement_status == "succeeded"
+    assert record.step_id
     assert record.result == {"success": True, "post_urn": "urn:li:share:123"}
     projected_messages = [
         message

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -39,8 +39,8 @@ from xagent.core.model.chat.tool_protocol import (
 )
 from xagent.core.model.chat.types import ChunkType, StreamChunk
 from xagent.core.tools.adapters.vibe.mcp_approval_gate import (
-    GateDecision,
     GatedCall,
+    GateDecision,
     current_tool_call_execution_context,
     gate_mcp_tools,
     register_mcp_approval_gate,

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -38,6 +38,14 @@ from xagent.core.model.chat.tool_protocol import (
     tool_protocol_error_response,
 )
 from xagent.core.model.chat.types import ChunkType, StreamChunk
+from xagent.core.tools.adapters.vibe.mcp_approval_gate import (
+    GateDecision,
+    GatedCall,
+    current_tool_call_execution_context,
+    gate_mcp_tools,
+    register_mcp_approval_gate,
+    unregister_mcp_approval_gate,
+)
 from xagent.core.tools.user_interaction import ToolInteractionSettlement
 
 
@@ -88,6 +96,66 @@ class FakeWorkspaceOutputTool:
 
     def args_type(self) -> type[BaseModel]:
         return EmptyArgs
+
+
+@pytest.mark.asyncio
+async def test_react_binds_exact_execution_identity_for_mcp_gate() -> None:
+    seen: list[GatedCall] = []
+
+    async def gate(call: GatedCall) -> GateDecision:
+        seen.append(call)
+        return GateDecision.deny()
+
+    async def resume(**_: Any) -> None:
+        raise AssertionError("resume must not run")
+
+    registration = register_mcp_approval_gate(
+        task_source="slack", gate=gate, resume=resume
+    )
+    try:
+        target = FakeTool()
+        target.name = "calculator"
+        (gated,) = gate_mcp_tools([target], connection={"id": 41})
+        context = ExecutionContext(
+            execution_id="task-248032",
+            metadata={"task_source": "slack", "run_id": "run-1"},
+        )
+        context.add_user_message("Publish.", metadata={"turn_id": "turn-1"})
+
+        result = await ReActPattern(max_iterations=2).run(
+            context=context,
+            tools=[gated],
+            llm=FakeLLM(
+                [
+                    {
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "function": {
+                                    "name": "calculator",
+                                    "arguments": '{"expression":"2+2"}',
+                                },
+                            }
+                        ]
+                    },
+                    {"content": "The connector call was denied.", "done": True},
+                ]
+            ),
+        )
+    finally:
+        unregister_mcp_approval_gate(registration)
+
+    assert result["success"] is True
+    assert target.calls == []
+    assert len(seen) == 1
+    execution = seen[0].execution_context
+    assert execution.task_source == "slack"
+    assert execution.task_id == "task-248032"
+    assert execution.run_id == "run-1"
+    assert execution.turn_id == "turn-1"
+    assert execution.tool_call_id == "call-1"
+    assert execution.pattern == "react"
+    assert execution.react_step_id
 
 
 class FakeWriteFileTool:
@@ -6779,6 +6847,7 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
                 description="Run an action after the user responds.",
             )
             self.resume_calls: list[dict[str, str]] = []
+            self.resume_context = None
             self.user_response: str | None = None
 
         def args_type(self) -> type[BaseModel]:
@@ -6790,6 +6859,7 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
             interaction_id: str,
             response: str,
         ) -> None:
+            self.resume_context = current_tool_call_execution_context()
             self.resume_calls.append(
                 {"interaction_id": interaction_id, "response": response}
             )
@@ -6934,6 +7004,9 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
     assert resumed_tool.resume_calls == [
         {"interaction_id": "interaction-1", "response": "Continue"}
     ]
+    assert resumed_tool.resume_context.react_step_id == (
+        pattern.tool_ledger["wait-call"].step_id
+    )
     assert resumed_mutation.calls == []
     assert resumed_pattern.pending_tool_interaction_responses == []
     response_metadata = next(

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -6985,15 +6985,13 @@ async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() 
             )
             return self.resume_result
 
-    first_tool = WaitingTool()
     first_context = ExecutionContext(execution_id="durable-interaction-task")
     first_context.add_user_message("Publish the approved post.")
     first_pattern = ReActPattern(max_iterations=3)
     first_runtime = PatternRuntime(execution_id="durable-interaction-task")
-
     waiting = await first_pattern.run(
         context=first_context,
-        tools=[first_tool],
+        tools=[WaitingTool()],
         llm=FakeLLM(
             [
                 {
@@ -7011,14 +7009,12 @@ async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() 
         ),
         runtime=first_runtime,
     )
-
     assert waiting["status"] == "waiting_for_user"
     checkpoint = next(
         checkpoint
         for checkpoint in reversed(first_runtime.checkpoints)
         if checkpoint["label"] == "waiting_for_user"
     )
-
     # Rebuild every runtime-owned object from the durable checkpoint.
     restored_context = ExecutionContext.from_dict(checkpoint["context"])
     restored_context.add_user_message("Approve")
@@ -7053,14 +7049,12 @@ async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() 
         execution_id="durable-interaction-task",
         tracer=tracer,
     )
-
     resumed = await restored_pattern.run(
         context=restored_context,
         tools=[resumed_tool],
         llm=resumed_llm,
         runtime=resumed_runtime,
     )
-
     assert resumed["success"] is True
     assert resumed_tool.run_calls == []
     assert resumed_tool.resume_calls == [
@@ -7082,10 +7076,9 @@ async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() 
     assert projected_messages[0].metadata["raw_result"] == record.result
     assert "urn:li:share:123" in str(resumed_llm.calls[0]["messages"])
     assert restored_pattern.pending_tool_interaction_responses == []
-    assert any(
-        event["event_type"] == "action_end_tool"
+    assert not any(
+        event["event_type"] in {"action_end_tool", "action_error_tool"}
         and event["data"].get("tool_call_id") == "original-publish-call"
-        and event["data"].get("result") == record.result
         for event in tracer.events
     )
 
@@ -7238,8 +7231,22 @@ async def test_pending_interaction_delivery_is_exact_and_retryable() -> None:
     ]
     pattern = ReActPattern()
     pattern.pending_tool_interaction_responses = list(pending)
+    for index in (1, 2):
+        pattern.tool_ledger[f"call-{index}"] = ToolCallRecord(
+            tool_call_id=f"call-{index}",
+            tool_name="approval_gate",
+            args={},
+            args_hash="stored-hash",
+            status="waiting_for_user",
+        )
     tool = ResumableTool()
     context = ExecutionContext(execution_id="interaction-delivery")
+    for index in (1, 2):
+        context.add_tool_result(
+            "approval_gate",
+            {"success": False, "status": "waiting_for_user"},
+            f"call-{index}",
+        )
     runtime = PatternRuntime(execution_id="interaction-delivery")
 
     with pytest.raises(RuntimeError, match="delivery failed"):
@@ -7276,7 +7283,6 @@ async def test_settled_interaction_remains_retryable_until_checkpoint_succeeds()
     settlement = ToolInteractionSettlement.succeeded(
         {"success": True, "post_urn": "urn:li:share:123"}
     )
-
     class ResumableTool:
         metadata = SimpleNamespace(
             name="approval_gate",
@@ -7317,15 +7323,15 @@ async def test_settled_interaction_remains_retryable_until_checkpoint_succeeds()
         "call-1",
     )
     tool = ResumableTool()
-
     with pytest.raises(RuntimeError, match="checkpoint unavailable"):
         await pattern._deliver_pending_tool_interaction_responses(
             tools=[tool],
             context=context,
             runtime=PatternRuntime(tracer=FailingCheckpointTracer()),
         )
-
     assert pattern.pending_tool_interaction_responses == [pending]
+    assert pattern.tool_ledger["call-1"].status == "waiting_for_user"
+    assert context.messages[0].metadata["raw_result"]["status"] == "waiting_for_user"
     assert (
         len(
             [
@@ -7342,7 +7348,6 @@ async def test_settled_interaction_remains_retryable_until_checkpoint_succeeds()
         context=context,
         runtime=PatternRuntime(),
     )
-
     assert tool.calls == 2
     assert pattern.pending_tool_interaction_responses == []
     assert pattern.tool_ledger["call-1"].result == settlement.result
@@ -7385,26 +7390,166 @@ async def test_non_successful_settlement_fails_the_original_tool_call(
         "call-1",
     )
     tracer = TraceEventRecorder()
-
     await pattern._deliver_pending_tool_interaction_responses(
         tools=[ResumableTool()],
         context=context,
         runtime=PatternRuntime(tracer=tracer),
     )
-
     record = pattern.tool_ledger["call-1"]
     assert record.status == "failed"
     assert record.settlement_status == status
     assert record.result["success"] is False
-    assert record.result["status"] == status
+    assert record.result["settlement_status"] == status
     assert pattern.force_final_answer_next is (
         status in {"rejected", "dispatch_unknown"}
     )
-    assert any(
-        event["event_type"] == "action_error_tool"
+    assert not any(
+        event["event_type"] in {"action_end_tool", "action_error_tool"}
         and event["data"].get("tool_call_id") == "call-1"
         for event in tracer.events
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "message", "expected_calls"),
+    [
+        ("missing_ledger", "without its original ledger", 0),
+        ("wrong_tool", "does not match its original ledger", 0),
+        ("not_waiting", "not waiting for user input", 0),
+        ("missing_result", "found 0", 0),
+        ("duplicate_result", "found 2", 0),
+        ("wrong_return", "must return ToolInteractionSettlement or None", 1),
+    ],
+)
+async def test_resume_target_is_validated_before_callback_or_projection(
+    case: str, message: str, expected_calls: int
+) -> None:
+    class ResumableTool:
+        metadata = SimpleNamespace(
+            name="approval_gate",
+            description="Resume a persisted interaction.",
+        )
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def resume_user_interaction(self, **_: str) -> Any:
+            self.calls += 1
+            return {"unexpected": True}
+
+    pattern = ReActPattern()
+    pending = {
+        "tool_name": "approval_gate",
+        "tool_call_id": "call-1",
+        "interaction_id": "interaction-1",
+        "response": "Approve",
+    }
+    pattern.pending_tool_interaction_responses = [pending]
+    if case != "missing_ledger":
+        pattern.tool_ledger["call-1"] = ToolCallRecord(
+            tool_call_id="call-1",
+            tool_name="different_tool" if case == "wrong_tool" else "approval_gate",
+            args={},
+            args_hash="stored-hash",
+            status="completed" if case == "not_waiting" else "waiting_for_user",
+        )
+    context = ExecutionContext(execution_id="invalid-resume-target")
+    if case not in {"missing_result"}:
+        context.add_tool_result(
+            "approval_gate",
+            {"success": False, "status": "waiting_for_user"},
+            "call-1",
+        )
+    if case == "duplicate_result":
+        context.add_tool_result(
+            "approval_gate",
+            {"success": False, "status": "waiting_for_user"},
+            "call-1",
+        )
+    tool = ResumableTool()
+    with pytest.raises((RuntimeError, TypeError), match=message):
+        await pattern._deliver_pending_tool_interaction_responses(
+            tools=[tool],
+            context=context,
+            runtime=PatternRuntime(),
+        )
+    assert tool.calls == expected_calls
+    assert pattern.pending_tool_interaction_responses == [pending]
+
+
+@pytest.mark.asyncio
+async def test_later_success_clears_an_earlier_terminal_batch_fence() -> None:
+    class ResumableTool:
+        metadata = SimpleNamespace(
+            name="approval_gate",
+            description="Resume persisted interactions.",
+        )
+
+        async def resume_user_interaction(self, *, interaction_id: str, **_: str) -> Any:
+            if interaction_id == "interaction-1":
+                return ToolInteractionSettlement.rejected()
+            return ToolInteractionSettlement.succeeded({"success": True})
+
+    pattern = ReActPattern()
+    context = ExecutionContext(execution_id="settlement-batch")
+    for index in (1, 2):
+        pattern.pending_tool_interaction_responses.append(
+            {
+                "tool_name": "approval_gate",
+                "tool_call_id": f"call-{index}",
+                "interaction_id": f"interaction-{index}",
+                "response": "Approve",
+            }
+        )
+        pattern.tool_ledger[f"call-{index}"] = ToolCallRecord(
+            tool_call_id=f"call-{index}",
+            tool_name="approval_gate",
+            args={},
+            args_hash="stored-hash",
+            status="waiting_for_user",
+        )
+        context.add_tool_result(
+            "approval_gate",
+            {"success": False, "status": "waiting_for_user"},
+            f"call-{index}",
+        )
+    await pattern._deliver_pending_tool_interaction_responses(
+        tools=[ResumableTool()],
+        context=context,
+        runtime=PatternRuntime(),
+    )
+    assert pattern.force_final_answer_next is False
+
+
+def test_resumed_success_guards_only_its_settlement_turn() -> None:
+    pattern = ReActPattern()
+    args = {"text": "approved"}
+    pattern.tool_ledger["original-call"] = ToolCallRecord(
+        tool_call_id="original-call",
+        tool_name="publish",
+        args=args,
+        args_hash=pattern._args_hash(args),
+        status="completed",
+        result={"success": True},
+        settlement_status="succeeded",
+        turn_id="original-turn",
+        settlement_turn_id="approval-turn",
+    )
+    tool = SimpleNamespace(
+        non_idempotent=True,
+        metadata=SimpleNamespace(name="publish"),
+    )
+    same_turn = pattern._suppressed_duplicate_write_result(
+        {"id": "new-call", "name": "publish", "args": args, "turn_id": "approval-turn"},
+        [tool],
+    )
+    later_turn = pattern._suppressed_duplicate_write_result(
+        {"id": "later-call", "name": "publish", "args": args, "turn_id": "later-turn"},
+        [tool],
+    )
+    assert same_turn["duplicate_write_suppressed"] is True
+    assert later_turn is None
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -38,6 +38,7 @@ from xagent.core.model.chat.tool_protocol import (
     tool_protocol_error_response,
 )
 from xagent.core.model.chat.types import ChunkType, StreamChunk
+from xagent.core.tools.user_interaction import ToolInteractionSettlement
 
 
 class CalculatorArgs(BaseModel):
@@ -6945,6 +6946,150 @@ async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_resumed_settlement_replaces_original_tool_result_after_rebuild() -> None:
+    class WaitingTool:
+        def __init__(self, *, resume_result: Any = None) -> None:
+            self.metadata = SimpleNamespace(
+                name="approval_gate",
+                description="Publish after explicit approval.",
+            )
+            self.resume_result = resume_result
+            self.run_calls: list[dict[str, Any]] = []
+            self.resume_calls: list[dict[str, str]] = []
+
+        def args_type(self) -> type[BaseModel]:
+            return CalculatorArgs
+
+        async def run_json_async(self, args: dict[str, Any]) -> Any:
+            self.run_calls.append(args)
+            if self.resume_result is not None:
+                raise AssertionError("resume must not execute a new tool call")
+            return {
+                "success": False,
+                "status": "waiting_for_user",
+                "interaction_id": "publish-interaction-1",
+                "message": "Publish this exact post?",
+                "message_type": "confirmation",
+                "interactions": [],
+            }
+
+        async def resume_user_interaction(
+            self,
+            *,
+            interaction_id: str,
+            response: str,
+        ) -> Any:
+            self.resume_calls.append(
+                {"interaction_id": interaction_id, "response": response}
+            )
+            return self.resume_result
+
+    first_tool = WaitingTool()
+    first_context = ExecutionContext(execution_id="durable-interaction-task")
+    first_context.add_user_message("Publish the approved post.")
+    first_pattern = ReActPattern(max_iterations=3)
+    first_runtime = PatternRuntime(execution_id="durable-interaction-task")
+
+    waiting = await first_pattern.run(
+        context=first_context,
+        tools=[first_tool],
+        llm=FakeLLM(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "id": "original-publish-call",
+                            "function": {
+                                "name": "approval_gate",
+                                "arguments": '{"expression":"publish"}',
+                            },
+                        }
+                    ]
+                }
+            ]
+        ),
+        runtime=first_runtime,
+    )
+
+    assert waiting["status"] == "waiting_for_user"
+    checkpoint = next(
+        checkpoint
+        for checkpoint in reversed(first_runtime.checkpoints)
+        if checkpoint["label"] == "waiting_for_user"
+    )
+
+    # Rebuild every runtime-owned object from the durable checkpoint.
+    restored_context = ExecutionContext.from_dict(checkpoint["context"])
+    restored_context.add_user_message("Approve")
+    restored_pattern = ReActPattern(max_iterations=3)
+    restored_pattern.load_state(checkpoint["pattern_state"])
+    resumed_tool = WaitingTool(
+        resume_result=ToolInteractionSettlement.succeeded(
+            {"success": True, "post_urn": "urn:li:share:123"}
+        )
+    )
+    resumed_llm = FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "final-call",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": (
+                                '{"response_language":"English",'
+                                '"answer":"Published.",'
+                                '"outcome":"completed"}'
+                            ),
+                        },
+                    }
+                ]
+            }
+        ]
+    )
+    tracer = TraceEventRecorder()
+    resumed_runtime = PatternRuntime(
+        execution_id="durable-interaction-task",
+        tracer=tracer,
+    )
+
+    resumed = await restored_pattern.run(
+        context=restored_context,
+        tools=[resumed_tool],
+        llm=resumed_llm,
+        runtime=resumed_runtime,
+    )
+
+    assert resumed["success"] is True
+    assert resumed_tool.run_calls == []
+    assert resumed_tool.resume_calls == [
+        {
+            "interaction_id": "publish-interaction-1",
+            "response": "Approve",
+        }
+    ]
+    record = restored_pattern.tool_ledger["original-publish-call"]
+    assert record.status == "completed"
+    assert record.settlement_status == "succeeded"
+    assert record.result == {"success": True, "post_urn": "urn:li:share:123"}
+    projected_messages = [
+        message
+        for message in restored_context.messages
+        if message.role == "tool" and message.tool_call_id == "original-publish-call"
+    ]
+    assert len(projected_messages) == 1
+    assert projected_messages[0].metadata["raw_result"] == record.result
+    assert "urn:li:share:123" in str(resumed_llm.calls[0]["messages"])
+    assert restored_pattern.pending_tool_interaction_responses == []
+    assert any(
+        event["event_type"] == "action_end_tool"
+        and event["data"].get("tool_call_id") == "original-publish-call"
+        and event["data"].get("result") == record.result
+        for event in tracer.events
+    )
+
+
 @pytest.mark.parametrize("waiting_request", [None, [], "malformed"])
 def test_tool_interaction_response_queue_ignores_malformed_requests(
     waiting_request: Any,
@@ -7122,6 +7267,144 @@ async def test_pending_interaction_delivery_is_exact_and_retryable() -> None:
         "response": "Reject second",
     }
     assert pattern.pending_tool_interaction_responses == []
+
+
+@pytest.mark.asyncio
+async def test_settled_interaction_remains_retryable_until_checkpoint_succeeds() -> (
+    None
+):
+    settlement = ToolInteractionSettlement.succeeded(
+        {"success": True, "post_urn": "urn:li:share:123"}
+    )
+
+    class ResumableTool:
+        metadata = SimpleNamespace(
+            name="approval_gate",
+            description="Resume a persisted interaction.",
+        )
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def resume_user_interaction(self, **_: str) -> Any:
+            self.calls += 1
+            return settlement
+
+    class FailingCheckpointTracer:
+        async def checkpoint(self, **_: Any) -> None:
+            raise RuntimeError("checkpoint unavailable")
+
+    pending = {
+        "tool_name": "approval_gate",
+        "tool_call_id": "call-1",
+        "interaction_id": "interaction-1",
+        "response": "Approve",
+    }
+    pattern = ReActPattern()
+    pattern.pending_tool_interaction_responses = [pending]
+    pattern.tool_ledger["call-1"] = ToolCallRecord(
+        tool_call_id="call-1",
+        tool_name="approval_gate",
+        args={"expression": "publish"},
+        args_hash="stored-hash",
+        status="waiting_for_user",
+        result={"status": "waiting_for_user"},
+    )
+    context = ExecutionContext(execution_id="interaction-retry")
+    context.add_tool_result(
+        "approval_gate",
+        {"success": False, "status": "waiting_for_user"},
+        "call-1",
+    )
+    tool = ResumableTool()
+
+    with pytest.raises(RuntimeError, match="checkpoint unavailable"):
+        await pattern._deliver_pending_tool_interaction_responses(
+            tools=[tool],
+            context=context,
+            runtime=PatternRuntime(tracer=FailingCheckpointTracer()),
+        )
+
+    assert pattern.pending_tool_interaction_responses == [pending]
+    assert (
+        len(
+            [
+                message
+                for message in context.messages
+                if message.tool_call_id == "call-1"
+            ]
+        )
+        == 1
+    )
+
+    await pattern._deliver_pending_tool_interaction_responses(
+        tools=[tool],
+        context=context,
+        runtime=PatternRuntime(),
+    )
+
+    assert tool.calls == 2
+    assert pattern.pending_tool_interaction_responses == []
+    assert pattern.tool_ledger["call-1"].result == settlement.result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["rejected", "failed", "dispatch_unknown"])
+async def test_non_successful_settlement_fails_the_original_tool_call(
+    status: str,
+) -> None:
+    class ResumableTool:
+        metadata = SimpleNamespace(
+            name="approval_gate",
+            description="Resume a persisted interaction.",
+        )
+
+        async def resume_user_interaction(self, **_: str) -> Any:
+            return ToolInteractionSettlement(status=status)  # type: ignore[arg-type]
+
+    pattern = ReActPattern()
+    pattern.pending_tool_interaction_responses = [
+        {
+            "tool_name": "approval_gate",
+            "tool_call_id": "call-1",
+            "interaction_id": "interaction-1",
+            "response": "Reject",
+        }
+    ]
+    pattern.tool_ledger["call-1"] = ToolCallRecord(
+        tool_call_id="call-1",
+        tool_name="approval_gate",
+        args={},
+        args_hash="stored-hash",
+        status="waiting_for_user",
+    )
+    context = ExecutionContext(execution_id="terminal-interaction")
+    context.add_tool_result(
+        "approval_gate",
+        {"success": False, "status": "waiting_for_user"},
+        "call-1",
+    )
+    tracer = TraceEventRecorder()
+
+    await pattern._deliver_pending_tool_interaction_responses(
+        tools=[ResumableTool()],
+        context=context,
+        runtime=PatternRuntime(tracer=tracer),
+    )
+
+    record = pattern.tool_ledger["call-1"]
+    assert record.status == "failed"
+    assert record.settlement_status == status
+    assert record.result["success"] is False
+    assert record.result["status"] == status
+    assert pattern.force_final_answer_next is (
+        status in {"rejected", "dispatch_unknown"}
+    )
+    assert any(
+        event["event_type"] == "action_error_tool"
+        and event["data"].get("tool_call_id") == "call-1"
+        for event in tracer.events
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -7283,6 +7283,7 @@ async def test_settled_interaction_remains_retryable_until_checkpoint_succeeds()
     settlement = ToolInteractionSettlement.succeeded(
         {"success": True, "post_urn": "urn:li:share:123"}
     )
+
     class ResumableTool:
         metadata = SimpleNamespace(
             name="approval_gate",
@@ -7486,7 +7487,9 @@ async def test_later_success_clears_an_earlier_terminal_batch_fence() -> None:
             description="Resume persisted interactions.",
         )
 
-        async def resume_user_interaction(self, *, interaction_id: str, **_: str) -> Any:
+        async def resume_user_interaction(
+            self, *, interaction_id: str, **_: str
+        ) -> Any:
             if interaction_id == "interaction-1":
                 return ToolInteractionSettlement.rejected()
             return ToolInteractionSettlement.succeeded({"success": True})

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -1139,6 +1139,29 @@ def test_merge_context_metadata_restored_clears_absent_modality_key(
     assert context.metadata["execution_type"] == "checkpointed"
 
 
+def test_merge_context_metadata_restored_overlays_execution_identity(
+    tmp_path: Path,
+) -> None:
+    runner = AgentRunner(
+        agent=Agent(name="writer", patterns=[StatefulPattern()]),
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    context = ExecutionContext(execution_id="exec-trusted-identity")
+    context.metadata.update(
+        {"task_source": "spoofed", "run_id": "stale", "other": "checkpointed"}
+    )
+
+    runner._merge_context_metadata(
+        context,
+        {"task_source": "slack", "run_id": "run-current"},
+        restored=True,
+    )
+
+    assert context.metadata["task_source"] == "slack"
+    assert context.metadata["run_id"] == "run-current"
+    assert context.metadata["other"] == "checkpointed"
+
+
 @pytest.mark.asyncio
 async def test_runner_empty_resume_metadata_preserves_non_modality_metadata(
     tmp_path: Path,

--- a/tests/core/tools/adapters/vibe/test_mcp_approval_gate.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_approval_gate.py
@@ -10,10 +10,10 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
-from xagent.core.tools.adapters.vibe.base import AbstractBaseTool
+from xagent.core.tools.adapters.vibe.base import AbstractBaseTool, ToolMetadata
 from xagent.core.tools.adapters.vibe.mcp_approval_gate import (
-    GateDecision,
     GatedCall,
+    GateDecision,
     ToolCallExecutionContext,
     bind_tool_call_execution_context,
     current_mcp_approval_replay_context,
@@ -28,10 +28,21 @@ class _Args(BaseModel):
 
 
 class _Target(AbstractBaseTool):
-    def __init__(self, *, sandboxed: bool = False) -> None:
+    def __init__(
+        self, *, sandboxed: bool = False, concurrency_safe: bool = False
+    ) -> None:
         self.calls: list[dict[str, Any]] = []
         self.is_sandboxed = sandboxed
         self.replay_contexts: list[Any] = []
+        self._metadata = ToolMetadata(
+            name=self.name,
+            concurrency_safe=concurrency_safe,
+            read_only=concurrency_safe,
+        )
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return self._metadata
 
     @property
     def name(self) -> str:
@@ -57,7 +68,9 @@ class _Target(AbstractBaseTool):
         return {"success": True, "arguments": dict(args)}
 
 
-def _context(*, task_source: str = "slack", pattern: str = "react") -> ToolCallExecutionContext:
+def _context(
+    *, task_source: str = "slack", pattern: str = "react"
+) -> ToolCallExecutionContext:
     return ToolCallExecutionContext(
         task_source=task_source,
         task_id="248032",
@@ -79,7 +92,9 @@ def registrations() -> list[Any]:
 
 
 def _register(registrations: list[Any], gate: Any, resume: Any, **kwargs: Any) -> None:
-    handle = register_mcp_approval_gate(task_source="slack", gate=gate, resume=resume, **kwargs)
+    handle = register_mcp_approval_gate(
+        task_source="slack", gate=gate, resume=resume, **kwargs
+    )
     registrations.append(handle)
 
 
@@ -114,6 +129,40 @@ async def test_registration_only_applies_to_its_task_source(
 
     assert result["success"] is True
     assert target.calls == [{"text": "web call"}]
+
+
+@pytest.mark.asyncio
+async def test_missing_source_fails_closed_when_any_gate_is_registered(
+    registrations: list[Any],
+) -> None:
+    _register(registrations, lambda _: None, _unused_resume)
+    target = _Target()
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+    missing_source = replace(_context(), task_source="")
+
+    with bind_tool_call_execution_context(missing_source):
+        result = await tool.run_json_async({"text": "must not publish"})
+        with pytest.raises(RuntimeError, match="requires async approval"):
+            tool.run_json_sync({"text": "must not publish"})
+
+    assert result["status"] == "error"
+    assert target.calls == []
+
+
+def test_registered_gate_revokes_concurrency_metadata(
+    registrations: list[Any],
+) -> None:
+    target = _Target(concurrency_safe=True)
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+    assert tool.metadata.concurrency_safe is True
+    assert tool.metadata.read_only is True
+
+    _register(registrations, lambda _: None, _unused_resume)
+
+    assert tool.metadata.concurrency_safe is False
+    assert tool.metadata.read_only is False
+    assert target.metadata.concurrency_safe is True
+    assert target.metadata.read_only is True
 
 
 @pytest.mark.asyncio
@@ -184,14 +233,19 @@ async def test_canonical_snapshot_is_deep_and_drives_allowed_dispatch(
 
     canonical = '{"image":{"path":"/tmp/a.png"},"text":"内容 A"}'
     assert seen[0].canonical_arguments_json == canonical
-    assert seen[0].arguments_sha256 == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    assert (
+        seen[0].arguments_sha256
+        == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    )
     assert seen[0].arguments == json.loads(canonical)
     assert target.calls == [json.loads(canonical)]
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("failure", ["exception", "timeout", "sync", "invalid"])
-async def test_gate_failures_never_dispatch(registrations: list[Any], failure: str) -> None:
+async def test_gate_failures_never_dispatch(
+    registrations: list[Any], failure: str
+) -> None:
     if failure == "exception":
 
         async def gate(_: GatedCall) -> GateDecision:
@@ -246,7 +300,9 @@ async def test_pause_is_refused_for_dag_execution(registrations: list[Any]) -> N
 
 
 @pytest.mark.asyncio
-async def test_resume_uses_one_ephemeral_executor_for_host_payload(registrations: list[Any]) -> None:
+async def test_resume_uses_one_ephemeral_executor_for_host_payload(
+    registrations: list[Any],
+) -> None:
     frozen = {"text": "approved", "image": {"file_id": "file-1"}}
     second_error: list[str] = []
 
@@ -298,6 +354,60 @@ async def test_resume_hook_failures_never_dispatch(registrations: list[Any]) -> 
 
     assert result["status"] == "error"
     assert target.calls == []
+
+
+@pytest.mark.asyncio
+async def test_resume_timeout_does_not_cancel_a_started_dispatch(
+    registrations: list[Any],
+) -> None:
+    completed = asyncio.Event()
+
+    class SlowTarget(_Target):
+        async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+            await asyncio.sleep(0.02)
+            completed.set()
+            return await super().run_json_async(args)
+
+    async def resume(*, executor: Any, **_: Any) -> Any:
+        return await executor({"text": "approved"})
+
+    _register(registrations, lambda _: None, resume, timeout_seconds=0.001)
+    target = SlowTarget()
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+
+    with bind_tool_call_execution_context(_context()):
+        result = await tool.resume_user_interaction(
+            interaction_id="interaction-1", response="approve"
+        )
+
+    assert completed.is_set()
+    assert result["success"] is True
+    assert target.calls == [{"text": "approved"}]
+
+
+@pytest.mark.asyncio
+async def test_unhandled_failure_after_dispatch_is_reported_as_unknown(
+    registrations: list[Any],
+) -> None:
+    class FailingTarget(_Target):
+        async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+            self.calls.append(dict(args))
+            raise RuntimeError("connection lost after request write")
+
+    async def resume(*, executor: Any, **_: Any) -> Any:
+        return await executor({"text": "approved"})
+
+    _register(registrations, lambda _: None, resume)
+    target = FailingTarget()
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+
+    with bind_tool_call_execution_context(_context()):
+        result = await tool.resume_user_interaction(
+            interaction_id="interaction-1", response="approve"
+        )
+
+    assert result["status"] == "dispatch_unknown"
+    assert target.calls == [{"text": "approved"}]
 
 
 def test_registration_is_scoped_and_not_last_writer_wins(

--- a/tests/core/tools/adapters/vibe/test_mcp_approval_gate.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_approval_gate.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import replace
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from xagent.core.tools.adapters.vibe.base import AbstractBaseTool
+from xagent.core.tools.adapters.vibe.mcp_approval_gate import (
+    GateDecision,
+    GatedCall,
+    ToolCallExecutionContext,
+    bind_tool_call_execution_context,
+    current_mcp_approval_replay_context,
+    gate_mcp_tools,
+    register_mcp_approval_gate,
+    unregister_mcp_approval_gate,
+)
+
+
+class _Args(BaseModel):
+    text: str = ""
+
+
+class _Target(AbstractBaseTool):
+    def __init__(self, *, sandboxed: bool = False) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.is_sandboxed = sandboxed
+        self.replay_contexts: list[Any] = []
+
+    @property
+    def name(self) -> str:
+        return "mcp_LinkedIn_create_post"
+
+    @property
+    def description(self) -> str:
+        return "Create a post."
+
+    def args_type(self) -> type[BaseModel]:
+        return _Args
+
+    def return_type(self) -> type[BaseModel]:
+        return BaseModel
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        self.calls.append(dict(args))
+        return {"success": True}
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        self.calls.append(dict(args))
+        self.replay_contexts.append(current_mcp_approval_replay_context())
+        return {"success": True, "arguments": dict(args)}
+
+
+def _context(
+    *, task_source: str = "slack", pattern: str = "react"
+) -> ToolCallExecutionContext:
+    return ToolCallExecutionContext(
+        task_source=task_source,
+        task_id="248032",
+        run_id="run-1",
+        turn_id="turn-1",
+        tool_call_id="call-1",
+        pattern=pattern,  # type: ignore[arg-type]
+        react_step_id="react-1",
+        dag_step_id="dag-1" if pattern == "dag" else None,
+    )
+
+
+@pytest.fixture
+def registrations() -> list[Any]:
+    handles: list[Any] = []
+    yield handles
+    for handle in reversed(handles):
+        unregister_mcp_approval_gate(handle)
+
+
+def _register(registrations: list[Any], gate: Any, resume: Any, **kwargs: Any) -> None:
+    registrations.append(
+        register_mcp_approval_gate(
+            task_source="slack", gate=gate, resume=resume, **kwargs
+        )
+    )
+
+
+async def _unused_resume(**_: Any) -> None:
+    raise AssertionError("resume hook should not run")
+
+
+@pytest.mark.asyncio
+async def test_no_matching_hook_preserves_legacy_execution() -> None:
+    target = _Target()
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+
+    result = await tool.run_json_async({"text": "publish"})
+
+    assert result["success"] is True
+    assert target.calls == [{"text": "publish"}]
+
+
+@pytest.mark.asyncio
+async def test_registration_only_applies_to_its_task_source(
+    registrations: list[Any],
+) -> None:
+    async def gate(_: GatedCall) -> GateDecision:
+        raise AssertionError("another task source must not reach this hook")
+
+    _register(registrations, gate, _unused_resume)
+    target = _Target()
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+
+    with bind_tool_call_execution_context(_context(task_source="web")):
+        result = await tool.run_json_async({"text": "web call"})
+
+    assert result["success"] is True
+    assert target.calls == [{"text": "web call"}]
+
+
+@pytest.mark.asyncio
+async def test_matching_gate_requires_complete_execution_and_connector_identity(
+    registrations: list[Any],
+) -> None:
+    async def gate(_: GatedCall) -> GateDecision:
+        raise AssertionError("incomplete identity must fail before the hook")
+
+    _register(registrations, gate, _unused_resume)
+    incomplete = replace(_context(), run_id=None)
+
+    for connection in ({"id": 41}, {"transport": "oauth"}):
+        target = _Target()
+        (tool,) = gate_mcp_tools([target], connection=connection)
+        context = incomplete if connection.get("id") else _context()
+        with bind_tool_call_execution_context(context):
+            result = await tool.run_json_async({"text": "must not publish"})
+        assert result["status"] == "error"
+        assert target.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sandboxed", [False, True], ids=["direct", "sandbox"])
+async def test_approval_stops_both_transports_before_dispatch(
+    registrations: list[Any], sandboxed: bool
+) -> None:
+    seen: list[GatedCall] = []
+
+    async def gate(call: GatedCall) -> GateDecision:
+        seen.append(call)
+        return GateDecision.require_approval("interaction-1", message="Publish?")
+
+    _register(registrations, gate, _unused_resume)
+    target = _Target(sandboxed=sandboxed)
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+
+    with bind_tool_call_execution_context(_context()):
+        result = await tool.run_json_async({"text": "approved text"})
+
+    assert result["status"] == "waiting_for_user"
+    assert result["interaction_id"] == "interaction-1"
+    assert target.calls == []
+    assert seen[0].connector_ref.to_wire() == {
+        "connector_type": "mcp",
+        "connector_id": 41,
+    }
+
+
+@pytest.mark.asyncio
+async def test_canonical_snapshot_is_deep_and_drives_allowed_dispatch(
+    registrations: list[Any],
+) -> None:
+    original = {"text": "内容 A", "image": {"path": "/tmp/a.png"}}
+    seen: list[GatedCall] = []
+
+    async def gate(call: GatedCall) -> GateDecision:
+        seen.append(call)
+        original["image"]["path"] = "/tmp/changed.png"
+        return GateDecision.allow()
+
+    _register(registrations, gate, _unused_resume)
+    target = _Target()
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+
+    with bind_tool_call_execution_context(_context()):
+        await tool.run_json_async(original)
+
+    canonical = '{"image":{"path":"/tmp/a.png"},"text":"内容 A"}'
+    assert seen[0].canonical_arguments_json == canonical
+    assert (
+        seen[0].arguments_sha256
+        == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    )
+    assert seen[0].arguments == json.loads(canonical)
+    assert target.calls == [json.loads(canonical)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["exception", "timeout", "sync", "invalid"])
+async def test_gate_failures_never_dispatch(
+    registrations: list[Any], failure: str
+) -> None:
+    if failure == "exception":
+
+        async def gate(_: GatedCall) -> GateDecision:
+            raise RuntimeError("database unavailable")
+
+    elif failure == "timeout":
+
+        async def gate(_: GatedCall) -> GateDecision:
+            await asyncio.sleep(1)
+            return GateDecision.allow()
+
+    elif failure == "sync":
+
+        def gate(_: GatedCall) -> GateDecision:
+            return GateDecision.allow()
+
+    else:
+
+        async def gate(_: GatedCall) -> Any:
+            return "allow"
+
+    _register(
+        registrations,
+        gate,
+        _unused_resume,
+        timeout_seconds=0.001 if failure == "timeout" else 1,
+    )
+    target = _Target()
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+
+    with bind_tool_call_execution_context(_context()):
+        result = await tool.run_json_async({"text": "must not publish"})
+
+    assert result["status"] == "error"
+    assert target.calls == []
+
+
+@pytest.mark.asyncio
+async def test_pause_is_refused_for_dag_execution(
+    registrations: list[Any],
+) -> None:
+    async def gate(_: GatedCall) -> GateDecision:
+        return GateDecision.require_approval("orphan")
+
+    _register(registrations, gate, _unused_resume)
+    target = _Target()
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+
+    with bind_tool_call_execution_context(_context(pattern="dag")):
+        result = await tool.run_json_async({"text": "must not publish"})
+
+    assert result["status"] == "denied"
+    assert target.calls == []
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_one_ephemeral_executor_for_host_payload(
+    registrations: list[Any],
+) -> None:
+    frozen = {"text": "approved", "image": {"file_id": "file-1"}}
+    second_error: list[str] = []
+
+    async def gate(_: GatedCall) -> GateDecision:
+        return GateDecision.require_approval("interaction-1")
+
+    async def resume(*, executor: Any, **_: Any) -> Any:
+        result = await executor(frozen)
+        with pytest.raises(RuntimeError, match="no longer available") as exc:
+            await executor(frozen)
+        second_error.append(str(exc.value))
+        return result
+
+    _register(registrations, gate, resume)
+    target = _Target()
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+
+    with bind_tool_call_execution_context(_context()):
+        paused = await tool.run_json_async({"text": "approved"})
+        result = await tool.resume_user_interaction(
+            interaction_id=paused["interaction_id"], response="approve"
+        )
+
+    assert result["success"] is True
+    assert target.calls == [frozen]
+    replay = target.replay_contexts[0]
+    assert replay.interaction_id == "interaction-1"
+    assert replay.execution_context.tool_call_id == "call-1"
+    assert current_mcp_approval_replay_context() is None
+    assert second_error
+
+
+@pytest.mark.asyncio
+async def test_resume_hook_failures_never_dispatch(
+    registrations: list[Any],
+) -> None:
+    async def gate(_: GatedCall) -> GateDecision:
+        return GateDecision.require_approval("interaction-1")
+
+    async def resume(**_: Any) -> Any:
+        raise RuntimeError("ledger unavailable")
+
+    _register(registrations, gate, resume)
+    target = _Target()
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+
+    with bind_tool_call_execution_context(_context()):
+        result = await tool.resume_user_interaction(
+            interaction_id="interaction-1", response="approve"
+        )
+
+    assert result["status"] == "error"
+    assert target.calls == []
+
+
+def test_registration_is_scoped_and_not_last_writer_wins(
+    registrations: list[Any],
+) -> None:
+    registrations.append(
+        register_mcp_approval_gate(
+            task_source="slack", gate=lambda _: None, resume=lambda **_: None
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="already registered"):
+        register_mcp_approval_gate(
+            task_source="slack", gate=lambda _: None, resume=lambda **_: None
+        )

--- a/tests/core/tools/adapters/vibe/test_mcp_approval_gate.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_approval_gate.py
@@ -21,6 +21,7 @@ from xagent.core.tools.adapters.vibe.mcp_approval_gate import (
     register_mcp_approval_gate,
     unregister_mcp_approval_gate,
 )
+from xagent.core.tools.user_interaction import ToolInteractionSettlement
 
 
 class _Args(BaseModel):
@@ -69,7 +70,7 @@ class _Target(AbstractBaseTool):
 
 
 def _context(
-    *, task_source: str = "slack", pattern: str = "react"
+    *, task_source: str | None = "slack", pattern: str = "react"
 ) -> ToolCallExecutionContext:
     return ToolCallExecutionContext(
         task_source=task_source,
@@ -132,13 +133,14 @@ async def test_registration_only_applies_to_its_task_source(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("task_source", [None, ""])
 async def test_missing_source_fails_closed_when_any_gate_is_registered(
-    registrations: list[Any],
+    registrations: list[Any], task_source: str | None
 ) -> None:
     _register(registrations, lambda _: None, _unused_resume)
     target = _Target()
     (tool,) = gate_mcp_tools([target], connection={"id": 41})
-    missing_source = replace(_context(), task_source="")
+    missing_source = replace(_context(), task_source=task_source)
 
     with bind_tool_call_execution_context(missing_source):
         result = await tool.run_json_async({"text": "must not publish"})
@@ -146,6 +148,26 @@ async def test_missing_source_fails_closed_when_any_gate_is_registered(
             tool.run_json_sync({"text": "must not publish"})
 
     assert result["status"] == "error"
+    assert target.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task_source", [None, ""])
+async def test_missing_source_resume_fails_closed_when_any_gate_is_registered(
+    registrations: list[Any], task_source: str | None
+) -> None:
+    _register(registrations, lambda _: None, _unused_resume)
+    target = _Target()
+    (tool,) = gate_mcp_tools([target], connection={"id": 41})
+
+    with bind_tool_call_execution_context(replace(_context(), task_source=task_source)):
+        settlement = await tool.resume_user_interaction(
+            interaction_id="interaction-1", response="approve"
+        )
+
+    assert settlement is not None
+    assert settlement.status == "failed"
+    assert settlement.projected_result()["status"] == "error"
     assert target.calls == []
 
 
@@ -309,12 +331,12 @@ async def test_resume_uses_one_ephemeral_executor_for_host_payload(
     async def gate(_: GatedCall) -> GateDecision:
         return GateDecision.require_approval("interaction-1")
 
-    async def resume(*, executor: Any, **_: Any) -> Any:
+    async def resume(*, executor: Any, **_: Any) -> ToolInteractionSettlement:
         result = await executor(frozen)
         with pytest.raises(RuntimeError, match="no longer available") as exc:
             await executor(frozen)
         second_error.append(str(exc.value))
-        return result
+        return ToolInteractionSettlement.succeeded(result)
 
     _register(registrations, gate, resume)
     target = _Target()
@@ -326,7 +348,8 @@ async def test_resume_uses_one_ephemeral_executor_for_host_payload(
             interaction_id=paused["interaction_id"], response="approve"
         )
 
-    assert result["success"] is True
+    assert result.status == "succeeded"
+    assert result.projected_result()["success"] is True
     assert target.calls == [frozen]
     replay = target.replay_contexts[0]
     assert replay.interaction_id == "interaction-1"
@@ -352,7 +375,8 @@ async def test_resume_hook_failures_never_dispatch(registrations: list[Any]) -> 
             interaction_id="interaction-1", response="approve"
         )
 
-    assert result["status"] == "error"
+    assert result.status == "failed"
+    assert result.projected_result()["status"] == "error"
     assert target.calls == []
 
 
@@ -368,8 +392,9 @@ async def test_resume_timeout_does_not_cancel_a_started_dispatch(
             completed.set()
             return await super().run_json_async(args)
 
-    async def resume(*, executor: Any, **_: Any) -> Any:
-        return await executor({"text": "approved"})
+    async def resume(*, executor: Any, **_: Any) -> ToolInteractionSettlement:
+        result = await executor({"text": "approved"})
+        return ToolInteractionSettlement.succeeded(result)
 
     _register(registrations, lambda _: None, resume, timeout_seconds=0.001)
     target = SlowTarget()
@@ -381,7 +406,8 @@ async def test_resume_timeout_does_not_cancel_a_started_dispatch(
         )
 
     assert completed.is_set()
-    assert result["success"] is True
+    assert result.status == "succeeded"
+    assert result.projected_result()["success"] is True
     assert target.calls == [{"text": "approved"}]
 
 
@@ -394,8 +420,9 @@ async def test_unhandled_failure_after_dispatch_is_reported_as_unknown(
             self.calls.append(dict(args))
             raise RuntimeError("connection lost after request write")
 
-    async def resume(*, executor: Any, **_: Any) -> Any:
-        return await executor({"text": "approved"})
+    async def resume(*, executor: Any, **_: Any) -> ToolInteractionSettlement:
+        result = await executor({"text": "approved"})
+        return ToolInteractionSettlement.succeeded(result)
 
     _register(registrations, lambda _: None, resume)
     target = FailingTarget()
@@ -406,7 +433,7 @@ async def test_unhandled_failure_after_dispatch_is_reported_as_unknown(
             interaction_id="interaction-1", response="approve"
         )
 
-    assert result["status"] == "dispatch_unknown"
+    assert result.status == "dispatch_unknown"
     assert target.calls == [{"text": "approved"}]
 
 

--- a/tests/core/tools/adapters/vibe/test_mcp_approval_gate.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_approval_gate.py
@@ -57,9 +57,7 @@ class _Target(AbstractBaseTool):
         return {"success": True, "arguments": dict(args)}
 
 
-def _context(
-    *, task_source: str = "slack", pattern: str = "react"
-) -> ToolCallExecutionContext:
+def _context(*, task_source: str = "slack", pattern: str = "react") -> ToolCallExecutionContext:
     return ToolCallExecutionContext(
         task_source=task_source,
         task_id="248032",
@@ -81,11 +79,8 @@ def registrations() -> list[Any]:
 
 
 def _register(registrations: list[Any], gate: Any, resume: Any, **kwargs: Any) -> None:
-    registrations.append(
-        register_mcp_approval_gate(
-            task_source="slack", gate=gate, resume=resume, **kwargs
-        )
-    )
+    handle = register_mcp_approval_gate(task_source="slack", gate=gate, resume=resume, **kwargs)
+    registrations.append(handle)
 
 
 async def _unused_resume(**_: Any) -> None:
@@ -189,19 +184,14 @@ async def test_canonical_snapshot_is_deep_and_drives_allowed_dispatch(
 
     canonical = '{"image":{"path":"/tmp/a.png"},"text":"内容 A"}'
     assert seen[0].canonical_arguments_json == canonical
-    assert (
-        seen[0].arguments_sha256
-        == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
-    )
+    assert seen[0].arguments_sha256 == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     assert seen[0].arguments == json.loads(canonical)
     assert target.calls == [json.loads(canonical)]
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("failure", ["exception", "timeout", "sync", "invalid"])
-async def test_gate_failures_never_dispatch(
-    registrations: list[Any], failure: str
-) -> None:
+async def test_gate_failures_never_dispatch(registrations: list[Any], failure: str) -> None:
     if failure == "exception":
 
         async def gate(_: GatedCall) -> GateDecision:
@@ -240,9 +230,7 @@ async def test_gate_failures_never_dispatch(
 
 
 @pytest.mark.asyncio
-async def test_pause_is_refused_for_dag_execution(
-    registrations: list[Any],
-) -> None:
+async def test_pause_is_refused_for_dag_execution(registrations: list[Any]) -> None:
     async def gate(_: GatedCall) -> GateDecision:
         return GateDecision.require_approval("orphan")
 
@@ -258,9 +246,7 @@ async def test_pause_is_refused_for_dag_execution(
 
 
 @pytest.mark.asyncio
-async def test_resume_uses_one_ephemeral_executor_for_host_payload(
-    registrations: list[Any],
-) -> None:
+async def test_resume_uses_one_ephemeral_executor_for_host_payload(registrations: list[Any]) -> None:
     frozen = {"text": "approved", "image": {"file_id": "file-1"}}
     second_error: list[str] = []
 
@@ -294,9 +280,7 @@ async def test_resume_uses_one_ephemeral_executor_for_host_payload(
 
 
 @pytest.mark.asyncio
-async def test_resume_hook_failures_never_dispatch(
-    registrations: list[Any],
-) -> None:
+async def test_resume_hook_failures_never_dispatch(registrations: list[Any]) -> None:
     async def gate(_: GatedCall) -> GateDecision:
         return GateDecision.require_approval("interaction-1")
 

--- a/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
@@ -43,7 +43,8 @@ async def test_stalled_server_times_out_and_other_servers_still_load(monkeypatch
         }
     )
 
-    assert result.tools == (healthy_tool,)
+    assert len(result.tools) == 1
+    assert result.tools[0].target is healthy_tool
     assert result.loaded_servers == ("healthy",)
     assert len(result.failures) == 1
     assert result.failures[0].server_name == "stalled"

--- a/tests/core/tools/test_mcp_database_integration.py
+++ b/tests/core/tools/test_mcp_database_integration.py
@@ -442,6 +442,14 @@ class TestToolFactoryMCPIntegration:
         call_args = mock_load_mcp.call_args
         connections_arg = call_args[0][0]  # First positional argument
         assert sample_stdio_config["name"] in connections_arg
+        connector_refs = call_args.kwargs["connector_refs"]
+        persisted_server = (
+            test_db.query(MCPServer).filter_by(name=sample_stdio_config["name"]).one()
+        )
+        assert connector_refs[sample_stdio_config["name"]].to_wire() == {
+            "connector_type": "mcp",
+            "connector_id": persisted_server.id,
+        }
 
     @patch("xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools")
     async def test_create_mcp_tools_exposes_unavailable_oauth_and_loads_other_servers(

--- a/tests/core/tools/test_mcp_sandbox_integration.py
+++ b/tests/core/tools/test_mcp_sandbox_integration.py
@@ -127,7 +127,8 @@ class TestLoadMcpToolsAsAgentTools:
                 sandbox=sandbox,
             )
 
-        assert result.tools == (wrapped_tool,)
+        assert len(result.tools) == 1
+        assert result.tools[0].target is wrapped_tool
         assert result.loaded_servers == ("demo",)
         assert result.failures == ()
         mock_list.assert_awaited_once_with(sandbox, connection)
@@ -162,7 +163,8 @@ class TestLoadMcpToolsAsAgentTools:
                 sandbox=MagicMock(),
             )
 
-        assert result.tools == (direct_tool,)
+        assert len(result.tools) == 1
+        assert result.tools[0].target is direct_tool
         assert result.loaded_servers == ("demo",)
         assert result.failures == ()
         mock_direct.assert_awaited_once()
@@ -266,7 +268,8 @@ class TestLoadMcpToolsAsAgentTools:
                 {"demo": connection}, sandbox=sandbox
             )
 
-        assert result.tools == (wrapped_tool,)
+        assert len(result.tools) == 1
+        assert result.tools[0].target is wrapped_tool
         assert result.loaded_servers == ("demo",)
         assert len(result.failures) == 1
         assert result.failures[0].phase is MCPFailurePhase.SANDBOX_TOOL_WRAP

--- a/tests/core/tools/test_user_interaction.py
+++ b/tests/core/tools/test_user_interaction.py
@@ -44,6 +44,26 @@ def test_successful_settlement_rejects_a_failed_tool_result() -> None:
         ToolInteractionSettlement.succeeded({"success": False, "error": "failed"})
 
 
+@pytest.mark.parametrize(
+    "result, message",
+    [
+        (None, "needs a result"),
+        ({"status": "waiting_for_user"}, "cannot wait for user input"),
+    ],
+)
+def test_successful_settlement_rejects_non_terminal_results(
+    result, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        ToolInteractionSettlement.succeeded(result)
+
+
+def test_successful_settlement_uses_the_canonical_failure_classifier() -> None:
+    result = {"status": " error "}
+
+    assert ToolInteractionSettlement.succeeded(result).result is result
+
+
 @pytest.mark.parametrize("status", ["rejected", "failed", "dispatch_unknown"])
 def test_non_successful_settlement_has_an_unambiguous_failure_shape(
     status: str,
@@ -52,7 +72,7 @@ def test_non_successful_settlement_has_an_unambiguous_failure_shape(
 
     assert settlement.projected_result() == {
         "success": False,
-        "status": status,
+        "settlement_status": status,
         "error": {
             "rejected": "The user rejected the tool call.",
             "failed": "The resumed tool call failed.",
@@ -63,6 +83,15 @@ def test_non_successful_settlement_has_an_unambiguous_failure_shape(
         }[status],
         "detail": "safe",
     }
+
+
+def test_failed_settlement_preserves_a_tool_specific_status() -> None:
+    settlement = ToolInteractionSettlement.failed(
+        result={"status": "cancelled_by_policy"}
+    )
+
+    assert settlement.projected_result()["status"] == "cancelled_by_policy"
+    assert settlement.projected_result()["settlement_status"] == "failed"
 
 
 def test_settlement_rejects_an_unknown_status() -> None:

--- a/tests/core/tools/test_user_interaction.py
+++ b/tests/core/tools/test_user_interaction.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 from xagent.core.tools.user_interaction import (
+    ToolInteractionSettlement,
     tool_result_waits_for_user,
     user_interaction_resume_callable,
 )
@@ -26,3 +29,42 @@ def test_resume_capability_detection() -> None:
 
     assert callable(user_interaction_resume_callable(Resumable()))
     assert user_interaction_resume_callable(object()) is None
+
+
+def test_successful_settlement_preserves_the_tool_result() -> None:
+    result = {"success": True, "post_urn": "urn:li:share:123"}
+
+    settlement = ToolInteractionSettlement.succeeded(result)
+
+    assert settlement.projected_result() is result
+
+
+def test_successful_settlement_rejects_a_failed_tool_result() -> None:
+    with pytest.raises(ValueError, match="cannot carry a failed tool result"):
+        ToolInteractionSettlement.succeeded({"success": False, "error": "failed"})
+
+
+@pytest.mark.parametrize("status", ["rejected", "failed", "dispatch_unknown"])
+def test_non_successful_settlement_has_an_unambiguous_failure_shape(
+    status: str,
+) -> None:
+    settlement = ToolInteractionSettlement(status=status, result={"detail": "safe"})  # type: ignore[arg-type]
+
+    assert settlement.projected_result() == {
+        "success": False,
+        "status": status,
+        "error": {
+            "rejected": "The user rejected the tool call.",
+            "failed": "The resumed tool call failed.",
+            "dispatch_unknown": (
+                "The tool call may have reached the external system. Automatic retry "
+                "is disabled; verify the external system before trying again."
+            ),
+        }[status],
+        "detail": "safe",
+    }
+
+
+def test_settlement_rejects_an_unknown_status() -> None:
+    with pytest.raises(ValueError, match="Invalid tool interaction settlement"):
+        ToolInteractionSettlement(status="unknown")  # type: ignore[arg-type]

--- a/tests/web/api/test_execute_task_background_snapshot_passthrough.py
+++ b/tests/web/api/test_execute_task_background_snapshot_passthrough.py
@@ -224,6 +224,7 @@ async def test_snapshot_path_skips_task_and_user_queries() -> None:
                 agent_manager=agent_manager,
                 task_owner_user_id=1,
                 task_setup_snapshot=snapshot,
+                expected_run_id="run-snapshot",
             )
         except Exception:
             # Downstream finalize stubs may raise; the query counts
@@ -244,6 +245,9 @@ async def test_snapshot_path_skips_task_and_user_queries() -> None:
     ]
     assert forwarded_snapshot is snapshot
     assert forwarded_snapshot.task.source == "trigger"
+    forwarded_context = agent_manager.execute_task.await_args.kwargs["context"]
+    assert forwarded_context["task_source"] == "trigger"
+    assert forwarded_context["run_id"] == "run-snapshot"
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_execute_task_background_snapshot_passthrough.py
+++ b/tests/web/api/test_execute_task_background_snapshot_passthrough.py
@@ -220,7 +220,7 @@ async def test_snapshot_path_skips_task_and_user_queries() -> None:
             await execute_task_background(
                 task_id=42,
                 user_message="hi",
-                context={},
+                context={"task_source": "spoofed", "run_id": "spoofed-run"},
                 agent_manager=agent_manager,
                 task_owner_user_id=1,
                 task_setup_snapshot=snapshot,

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -97,6 +97,7 @@ def _bg_patches(db: Any) -> list[Any]:
             user_id=1,
             status=TaskStatus.RUNNING,
             agent_id=None,
+            source=None,
         ),
         runtime_user=SimpleNamespace(id=1, is_admin=False),
         agent=None,
@@ -356,6 +357,7 @@ async def test_bg_turn_resolves_scope_before_loading_snapshot_off_loop() -> None
                 user_id=1,
                 status=TaskStatus.RUNNING,
                 agent_id=None,
+                source=None,
             ),
             runtime_user=SimpleNamespace(id=1, is_admin=False),
             agent=None,
@@ -411,8 +413,9 @@ async def test_resumed_turn_re_resolves_scope() -> None:
     seen: dict[str, Any] = {}
     agent_service = MagicMock()
 
-    async def _resume(task_id: str) -> dict:
+    async def _resume(task_id: str, *, metadata: dict[str, Any]) -> dict:
         seen["scope_at_resume"] = get_execution_scope()
+        assert metadata == {"task_source": None, "run_id": "scope-run"}
         return {"status": "completed", "success": True, "output": "ok"}
 
     agent_service.resume_execution_by_id = AsyncMock(side_effect=_resume)
@@ -550,7 +553,9 @@ async def test_resume_background_adopts_preacquired_lease_without_reacquiring() 
 
     acquire.assert_not_called()
     start_heartbeat.assert_not_called()
-    agent_service.resume_execution_by_id.assert_awaited_once_with("42")
+    agent_service.resume_execution_by_id.assert_awaited_once_with(
+        "42", metadata={"task_source": None, "run_id": "run-a"}
+    )
     assert heartbeat_task.done()
 
 
@@ -584,6 +589,7 @@ async def test_resume_handler_resolves_scope_once_off_loop_for_agent_lookup() ->
             control_state="paused",
             run_id="run-a",
             state_version=3,
+            source=None,
         ),
         runtime_user=SimpleNamespace(id=1, is_admin=False),
     )
@@ -604,7 +610,9 @@ async def test_resume_handler_resolves_scope_once_off_loop_for_agent_lookup() ->
         ResumeReservationOutcome.RESERVED
     )
     transition = AsyncMock(
-        return_value=SimpleNamespace(run_id="run-a", status=TaskStatus.PAUSED)
+        return_value=SimpleNamespace(
+            run_id="run-a", status=TaskStatus.PAUSED, state_version=4
+        )
     )
 
     with _Patches(
@@ -685,6 +693,7 @@ async def test_resume_survives_a_scope_authority_mismatch() -> None:
             control_state="paused",
             run_id="run-a",
             state_version=3,
+            source=None,
         ),
         runtime_user=SimpleNamespace(id=1, is_admin=False),
     )
@@ -716,7 +725,7 @@ async def test_resume_survives_a_scope_authority_mismatch() -> None:
                 "xagent.web.api.websocket.task_execution_controller.transition",
                 new=AsyncMock(
                     return_value=SimpleNamespace(
-                        run_id="run-a", status=TaskStatus.PAUSED
+                        run_id="run-a", status=TaskStatus.PAUSED, state_version=4
                     )
                 ),
             ),
@@ -1809,7 +1818,8 @@ async def test_resume_lease_loss_cancels_execution_without_stale_side_effects() 
         async def interrupt_reason_for_quota(self) -> None:
             return None
 
-    async def resume(_task_id: str) -> dict[str, Any]:
+    async def resume(_task_id: str, *, metadata: dict[str, Any]) -> dict[str, Any]:
+        assert metadata == {"task_source": None, "run_id": "run-a"}
         resume_started.set()
         try:
             await asyncio.Event().wait()
@@ -1861,7 +1871,9 @@ async def test_resume_lease_loss_cancels_execution_without_stale_side_effects() 
         )
 
     assert resume_cancelled.is_set()
-    agent_service.resume_execution_by_id.assert_awaited_once_with("42")
+    agent_service.resume_execution_by_id.assert_awaited_once_with(
+        "42", metadata={"task_source": None, "run_id": "run-a"}
+    )
     finalize.assert_not_called()
     settle.assert_not_called()
     assert [

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, TypeVar
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import create_engine
@@ -4230,7 +4230,9 @@ async def test_deferred_injection_marker_failure_does_not_abort_resume(
             delivery_client_message_id="deferred-marker-turn",
         )
 
-    agent.resume_execution_by_id.assert_awaited_once_with(str(task.id))
+    agent.resume_execution_by_id.assert_awaited_once_with(
+        str(task.id), metadata={"task_source": None, "run_id": ANY}
+    )
     accepted = [
         call.args[0]
         for call in ws_manager.send_personal_message.call_args_list
@@ -4311,7 +4313,9 @@ async def test_deferred_injection_marker_cancellation_does_not_abort_resume(
             delivery_client_message_id="deferred-marker-cancel-turn",
         )
 
-    agent.resume_execution_by_id.assert_awaited_once_with(str(task.id))
+    agent.resume_execution_by_id.assert_awaited_once_with(
+        str(task.id), metadata={"task_source": None, "run_id": ANY}
+    )
     accepted = [
         call.args[0]
         for call in ws_manager.send_personal_message.call_args_list
@@ -4410,7 +4414,9 @@ async def test_deferred_injection_close_failure_does_not_abort_resume(
             delivery_client_message_id="deferred-close-failure-turn",
         )
 
-    agent.resume_execution_by_id.assert_awaited_once_with(str(task.id))
+    agent.resume_execution_by_id.assert_awaited_once_with(
+        str(task.id), metadata={"task_source": None, "run_id": ANY}
+    )
     assert len(observed_close_calls) == 1
     called_task_id, called_run_id, live_run_id = observed_close_calls[0]
     assert called_task_id == int(task.id)
@@ -4686,7 +4692,9 @@ async def test_deferred_injection_close_cancellation_does_not_abort_resume(
             delivery_client_message_id="deferred-close-cancel-turn",
         )
 
-    agent.resume_execution_by_id.assert_awaited_once_with(str(task.id))
+    agent.resume_execution_by_id.assert_awaited_once_with(
+        str(task.id), metadata={"task_source": None, "run_id": ANY}
+    )
     assert len(observed_close_calls) == 1
     called_task_id, called_run_id, live_run_id = observed_close_calls[0]
     assert called_task_id == int(task.id)

--- a/tests/web/tools/test_linkedin_mcp.py
+++ b/tests/web/tools/test_linkedin_mcp.py
@@ -20,15 +20,6 @@ class MockResponse:
             raise RuntimeError(self.text or f"HTTP {self.status_code}")
 
 
-def test_sanitize_post_text_escapes_ascii_parentheses():
-    text = "🤖 Claude (Anthropic) — Prompt-to-prototype thinking"
-
-    assert (
-        linkedin._sanitize_post_text(text)
-        == "🤖 Claude \\(Anthropic\\) — Prompt-to-prototype thinking"
-    )
-
-
 @pytest.mark.asyncio
 async def test_create_post_schema_accepts_optional_image_path():
     tools = await linkedin.list_tools()
@@ -58,13 +49,14 @@ async def test_create_post_without_image_keeps_text_only_flow(monkeypatch):
     monkeypatch.setattr(linkedin.requests, "post", mock_post)
     monkeypatch.setattr(linkedin.requests, "put", mock_put)
 
-    result = await linkedin.call_tool("create_post", {"text": "hello"})
+    approved_text = "Unicode: 你好 (approved) \\ literal"
+    result = await linkedin.call_tool("create_post", {"text": approved_text})
 
     assert result[0].text == "Post created successfully! URN: urn:li:share:post-1"
     mock_put.assert_not_called()
     assert mock_post.call_count == 1
     post_body = mock_post.call_args.kwargs["json"]
-    assert post_body["commentary"] == "hello"
+    assert post_body["commentary"] == approved_text
     assert "content" not in post_body
 
 


### PR DESCRIPTION
## Summary

- add a host-scoped async approval gate at the common direct and sandboxed MCP boundary
- bind canonical arguments and trusted task, run, turn, tool-call, and ReAct step identities across fresh and resumed execution
- fail closed on missing identity, hook exceptions, invalid return types, and unsupported DAG pauses
- preserve connector identity outside guest transport serialization and revoke unsafe concurrent execution metadata
- distinguish bounded pre-dispatch policy timeouts from durable post-dispatch `dispatch_unknown` settlements
- resume approved calls through a one-use executor that preserves the original connector authorization and error path
- preserve approved LinkedIn post text verbatim

## Dependency

This PR is stacked on #2283 so resumed connector outcomes use its structured settlement contract. The dedicated integration thread will rebuild the final X1+X2 draft from the published heads.

Tracks xorbitsai/xagent-saas#976.

## Verification

- 536 focused tests passed across the approval gate, ReAct, DAG, runner, MCP factory/database/sandbox seams, WebSocket identity bridge, user interaction, and LinkedIn tool
- ruff check and format, mypy, isort, codespell, whitespace, and EOF hooks passed on all changed X2 files
- mutation checks proved the missing-source fail-closed guard, durable `dispatch_unknown` settlement, and ReAct step-ID preservation regressions detect their respective fixes
- local diff review and full stacked-PR blocker review found no remaining blocker
