### PR TITLE
fix(web): stamp terminal task_error frames with the cancel-path state tuple

### DIFF
--- a/src/xagent/web/services/external_task_cancel.py
+++ b/src/xagent/web/services/external_task_cancel.py
@@ -429,15 +429,29 @@ def _finalize_external_cancel_sync(
         _invalidate_task_cache_after_commit(task_id)
 
 
-async def _broadcast_external_cancel_terminal_event(task_id: int) -> None:
+async def _broadcast_external_cancel_terminal_event(
+    task_id: int,
+    *,
+    run_id: str | None = None,
+    state_version: int | None = None,
+    control_state: str | None = None,
+) -> None:
     from .task_events import publish_task_event
     from .task_execution import create_terminal_task_error_event
+
+    if state_version is None or control_state is None:
+        run_id = None
+        state_version = None
+        control_state = None
 
     try:
         await publish_task_event(
             create_terminal_task_error_event(
                 task_id,
                 EXTERNAL_TURN_INTERRUPTED_MESSAGE,
+                run_id=run_id,
+                state_version=state_version,
+                control_state=control_state,
             ),
             task_id,
         )
@@ -485,4 +499,9 @@ async def cancel_external_task_unserialized(
                 turn_id=turn_id,
             )
         )
-    await _broadcast_external_cancel_terminal_event(task_id)
+    await _broadcast_external_cancel_terminal_event(
+        task_id,
+        run_id=expected_run_id,
+        state_version=expected_state_version + 1,
+        control_state=TaskControlState.FAILED.value,
+    )

--- a/src/xagent/web/services/task_execution.py
+++ b/src/xagent/web/services/task_execution.py
@@ -199,6 +199,9 @@ def create_terminal_task_error_event(
     message: str,
     *,
     code: str | None = None,
+    run_id: str | None = None,
+    state_version: int | None = None,
+    control_state: str | None = None,
 ) -> dict[str, Any]:
     """Shape an error event after the exact lease owner commits FAILED.
 
@@ -256,6 +259,12 @@ def create_terminal_task_error_event(
     }
     if code is not None:
         event["code"] = code
+    if run_id is not None:
+        event["task"]["run_id"] = run_id
+    if state_version is not None:
+        event["task"]["state_version"] = state_version
+    if control_state is not None:
+        event["task"]["control_state"] = control_state
     return event
 
 

--- a/tests/web/api/test_external_task_cancel.py
+++ b/tests/web/api/test_external_task_cancel.py
@@ -38,6 +38,7 @@ from xagent.web.services.external_task_cancel import (
     EXTERNAL_CANCEL_NOT_APPLIED_MESSAGE,
     EXTERNAL_CANCEL_WAIT_SECONDS,
     EXTERNAL_TURN_INTERRUPTED_MESSAGE,
+    _broadcast_external_cancel_terminal_event,
     cancel_external_task_unserialized,
 )
 from xagent.web.services.task_command_terminal_events import (
@@ -1444,3 +1445,70 @@ async def test_cancel_rejects_an_unknown_scope(
     assert untouched.status == TaskStatus.RUNNING
     assert untouched.state_version == 4
     assert untouched.error_message is None
+
+
+@pytest.mark.asyncio
+async def test_external_cancel_terminal_frame_survives_row_deletion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The terminal frame carries its own state tuple past row deletion.
+
+    The finalize commits run/version ``run-external``/5 FAILED, then the
+    Task row disappears before anyone reads it back. The broadcast frame
+    must still parse through ``_event_task_control_state`` with no DB
+    snapshot, or the client's version gate drops the turn's terminal frame.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="terminal frame survives row deletion",
+    )
+    manager = _broadcast_manager(monkeypatch)
+    monkeypatch.setattr(
+        task_execution_service.background_task_manager,
+        "cancel_task",
+        AsyncMock(return_value=MagicMock(requested=False)),
+    )
+
+    await cancel_external_task_unserialized(
+        task_id=task_id,
+        agent_id=agent_id,
+        expected_run_id="run-external",
+        expected_state_version=4,
+    )
+
+    payloads = _broadcast_payloads(manager)
+    assert [payload["type"] for payload in payloads] == ["task_error"]
+    db = _direct_db_session()
+    try:
+        db.query(Task).filter(Task.id == task_id).delete()
+        db.commit()
+    finally:
+        db.close()
+
+    state = websocket_api._event_task_control_state(payloads[0])
+    assert state is not None
+    assert state["run_id"] == "run-external"
+    assert state["state_version"] == 5
+    assert state["control_state"] == TaskControlState.FAILED.value
+    assert state["status"] == TaskStatus.FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_broadcast_partial_tuple_emits_no_tuple(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A half-supplied tuple is dropped whole, matching the gate's contract."""
+    manager = _broadcast_manager(monkeypatch)
+
+    await _broadcast_external_cancel_terminal_event(
+        424242,
+        control_state=TaskControlState.FAILED.value,
+    )
+
+    payloads = _broadcast_payloads(manager)
+    assert len(payloads) == 1
+    assert websocket_api._event_task_control_state(payloads[0]) is None
+    assert "state_version" not in payloads[0]["task"]
+    assert "control_state" not in payloads[0]["task"]


### PR DESCRIPTION
Fixes #2274

## What / Why

A terminal \`task_error\` emitted by the external cancel path carries no \`run_id\` / \`state_version\` / \`control_state\`, so when the Task row is deleted between the cancel's commit and the broadcast, \`_with_current_task_control_state\` falls back to a DB snapshot lookup that returns \`None\` — the frame goes out unversioned and the client's version gate drops it. The turn's terminal frame never renders; the page keeps showing an in-progress turn.

The gate's versioned-event contract is shared (replay protection); the fix belongs on the producer, which already holds the tuple.

## How

- \`create_terminal_task_error_event\` accepts optional \`run_id\` / \`state_version\` / \`control_state\` (all \`None\` by default → byte-identical frames for existing call sites).
- \`_broadcast_external_cancel_terminal_event\` threads them through; a partial tuple is dropped whole to match \`_event_task_control_state\`'s all-or-nothing contract.
- \`cancel_external_task_unserialized\` passes the tuple the finalize already commits (\`state_version = expected + 1\`, \`control_state = failed\`), making the frame self-describing — the snapshot lookup is never consulted for this frame.

No client change, no gate change, no behaviour change for any other producer.

## Tests

- \`test_external_cancel_terminal_frame_survives_row_deletion\`: full cancel → Task row deleted → frame still parses through \`_event_task_control_state\` (\`run-external\` / 5 / failed) with no DB snapshot. **Mutation check**: removing the state-field writes makes this test fail (verified).
- \`test_broadcast_partial_tuple_emits_no_tuple\`: half-supplied tuple → no tuple emitted.

Local: 62 passed (test_external_task_cancel + test_terminal_task_error_event + test_task_deletion_rows); neighbours test_task_command_terminal_events green (postgres-gated skips pre-existing).