### PR TITLE
enh(frontend): give ClarificationForm's onSend a typed failure contract

### DIFF
--- a/frontend/src/components/build/agent-builder-chat.test.tsx
+++ b/frontend/src/components/build/agent-builder-chat.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { ClarificationOnSend } from "@/components/chat/clarification-delivery"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
@@ -103,7 +104,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
     traceEvents,
   }: {
     content?: React.ReactNode
-    onSendInteraction?: (text: string, files?: File[]) => Promise<void> | void
+    onSendInteraction?: ClarificationOnSend
     processStatus?: string
     traceEvents?: unknown[]
   }) => {
@@ -127,16 +128,24 @@ vi.mock("@/components/chat/ChatMessage", () => ({
         data-process-status={processStatus || ""}
         data-trace-count={traceEvents?.length ?? 0}
       >
+        {/* Rendered so the rollback tests can tell the surviving row apart
+            from the optimistic bubbles it is supposed to have removed. */}
+        <div>{content}</div>
         <button
           type="button"
           onClick={async () => {
             try {
               await onSendInteraction("upload this", [
                 new File(["data"], "data.txt", { type: "text/plain" }),
-              ])
+              ], {})
               setStatus("resolved")
-            } catch {
-              setStatus("rejected")
+            } catch (error) {
+              // Surface the declared delivery contract (#1485): the form
+              // probes `disposition` off whatever this callback rejects with.
+              const disposition = (error as { disposition?: unknown })?.disposition
+              setStatus(
+                `rejected:${typeof disposition === "string" ? disposition : "untyped"}`,
+              )
             }
           }}
         >
@@ -279,8 +288,46 @@ describe("AgentBuilderChat", () => {
     })
 
     await waitFor(() => {
-      expect(screen.getByText("rejected")).toBeInTheDocument()
+      // The upload failed before anything reached the agent, and the typed
+      // failure must say so - "not_sent" is what lets ClarificationForm tell
+      // the visitor a resubmit is safe.
+      expect(screen.getByText("rejected:not_sent")).toBeInTheDocument()
     })
+    // The resubmit that hint invites must not stack a duplicate answer: both
+    // optimistic bubbles (user + assistant placeholder) are rolled back,
+    // leaving only the initial greeting.
+    expect(screen.getAllByTestId("chat-message")).toHaveLength(1)
+    expect(screen.getAllByTestId("chat-message")[0]).toHaveTextContent(
+      "builds.configForm.chat.initialMessage"
+    )
+  })
+
+  it("rolls back both optimistic bubbles when the connection setup throws", async () => {
+    apiRequestMock.mockResolvedValueOnce(
+      successfulUploadResponse([{ file_id: "file-1", filename: "data.txt" }])
+    )
+    class ThrowingWebSocket {
+      static OPEN = 1
+      constructor(_url: string) {
+        throw new Error("SecurityError: insecure WebSocket")
+      }
+    }
+    globalThis.WebSocket = ThrowingWebSocket as unknown as typeof WebSocket
+
+    renderBuilderChat()
+    fireEvent.click(await screen.findByText("send-file-interaction"))
+
+    // Nothing reached the wire, so the interaction rejects as not_sent and
+    // the transcript returns to just the greeting - a hinted resubmit must
+    // not find a stranded answer bubble or blank placeholder.
+    await waitFor(() => {
+      expect(screen.getByText("rejected:not_sent")).toBeInTheDocument()
+    })
+    expect(screen.getAllByTestId("chat-message")).toHaveLength(1)
+    expect(screen.getAllByTestId("chat-message")[0]).toHaveTextContent(
+      "builds.configForm.chat.initialMessage"
+    )
+    expect(MockWebSocket.instances.flatMap((ws) => ws.sentMessages)).toEqual([])
   })
 
   it.each([

--- a/frontend/src/components/build/agent-builder-chat.test.tsx
+++ b/frontend/src/components/build/agent-builder-chat.test.tsx
@@ -327,7 +327,6 @@ describe("AgentBuilderChat", () => {
     expect(screen.getAllByTestId("chat-message")[0]).toHaveTextContent(
       "builds.configForm.chat.initialMessage"
     )
-    expect(MockWebSocket.instances.flatMap((ws) => ws.sentMessages)).toEqual([])
   })
 
   it.each([

--- a/frontend/src/components/build/agent-builder-chat.tsx
+++ b/frontend/src/components/build/agent-builder-chat.tsx
@@ -15,6 +15,10 @@ import { useI18n } from "@/contexts/i18n-context"
 import { toast } from "@/components/ui/sonner"
 import { getBrandingFromEnv } from "@/lib/branding"
 import { normalizeUploadFileIds } from "@/lib/upload-file-ids"
+import {
+  createClarificationSendFailure,
+  type ClarificationSendMetadata,
+} from "@/components/chat/clarification-delivery"
 
 import { Interaction } from "@/contexts/app-context-chat"
 
@@ -142,7 +146,7 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
     }
   }, [messages])
 
-  const handleSendMessage = useCallback(async (text: string, files?: File[], metadata?: any) => {
+  const handleSendMessage = useCallback(async (text: string, files?: File[], metadata?: ClarificationSendMetadata) => {
     if ((!text.trim() && (!files || files.length === 0)) || isLoading) return false
 
     let displayMessage: string | React.ReactNode = text || t("chatPage.clarification.uploadedFiles")
@@ -236,7 +240,10 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
         console.error("Failed to upload files", err);
         toast.error(err instanceof Error ? err.message : "Failed to upload files");
         setIsLoading(false);
-        setMessages(prev => prev.slice(0, -1));
+        // Nothing was sent, so the optimistic user bubble comes back out with
+        // the assistant placeholder - otherwise a resubmit (which the form's
+        // "not sent" hint now invites) shows the same answer twice.
+        setMessages(prev => prev.slice(0, -2));
         return false;
       }
     } else if (metadata?.url) {
@@ -514,6 +521,11 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
       console.error(error)
       toast.error(t("builds.configForm.chat.errorInit") || "Failed to initialize connection.")
       setIsLoading(false)
+      // Same rollback as the upload failure above: nothing was sent, so both
+      // optimistic bubbles come back out - the "not sent" hint invites a
+      // resubmit that must not stack a duplicate answer over a blank
+      // placeholder.
+      setMessages(prev => prev.slice(0, -2))
       return false
     }
     return true
@@ -553,7 +565,15 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
               onSendInteraction={async (text, files, meta) => {
                 const didSend = await handleSendMessage(text, files, meta)
                 if (!didSend) {
-                  throw new Error("Failed to send interaction")
+                  // Every false return means the payload never went out -
+                  // empty input, a send already in flight, upload failure, or
+                  // a connection setup throw - so "not_sent" is accurate and
+                  // the visitor can resubmit safely. The message is a
+                  // developer diagnostic, so it stays non-user-facing.
+                  throw createClarificationSendFailure(
+                    "Failed to send interaction",
+                    "not_sent",
+                  )
                 }
               }}
             />

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/button";
 import { normalizeTimestampMs } from "@/lib/time-utils";
 import { FileChip } from "./FileChip";
 import { ClarificationForm } from "./clarification-form";
+import type { ClarificationOnSend } from "./clarification-delivery";
 import { isStoppedTraceProcessStatus, resolveTraceProcessStatus } from "@/lib/trace-process-status";
 import {
   TaskRuntimeMessageMetadataExtension,
@@ -94,7 +95,7 @@ export interface ChatMessageProps {
   showEmptyStatus?: boolean;
   onOpenExecutionPlan?: () => void;
   onAgentExecutionClick?: (execution: AgentExecutionSummary) => void;
-  onSendInteraction?: (message: string, files?: File[], metadata?: any) => Promise<void> | void;
+  onSendInteraction?: ClarificationOnSend;
   contextBadges?: Array<{
     kind: "computer_use";
     label: string;

--- a/frontend/src/components/chat/clarification-delivery.test.ts
+++ b/frontend/src/components/chat/clarification-delivery.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { MessageDeliveryError } from "@/hooks/use-websocket"
+import {
+  createClarificationSendFailure,
+  readSendDisposition,
+  readSendErrorCode,
+  readSendReason,
+} from "./clarification-delivery"
+
+describe("clarification-delivery readers", () => {
+  it("reads every contract field off a real MessageDeliveryError", () => {
+    const error = new MessageDeliveryError(
+      "A previous guidance message is still being applied.",
+      "outcome_unknown",
+      { retryWithNewId: true, userFacing: true, errorCode: "guidance_in_progress" },
+    )
+
+    expect(readSendDisposition(error)).toBe("outcome_unknown")
+    expect(readSendReason(error)).toBe(
+      "A previous guidance message is still being applied.",
+    )
+    expect(readSendErrorCode(error)).toBe("guidance_in_progress")
+  })
+
+  it("the factory's product satisfies the same readers", () => {
+    const failure = createClarificationSendFailure("Failed to send interaction", "not_sent")
+
+    expect(readSendDisposition(failure)).toBe("not_sent")
+    expect(readSendReason(failure)).toBe("")
+    expect(readSendErrorCode(failure)).toBeNull()
+  })
+})

--- a/frontend/src/components/chat/clarification-delivery.ts
+++ b/frontend/src/components/chat/clarification-delivery.ts
@@ -29,21 +29,21 @@ export type ClarificationOnSend = (
  * The discriminated failure a send path rejects with — its shape is derived
  * from use-websocket's MessageDeliveryError (a type-only import, so this
  * still has no runtime dependency on the websocket hook). Deriving via Pick
- * means renaming or removing one of these four fields on the class fails
+ * means renaming or removing one of these fields on the class fails
  * type-check here; it does not notice fields *added* to the class, and the
  * readers below stay deliberately structural (they take `unknown`).
  */
 export type ClarificationSendFailure = Error & Pick<
   MessageDeliveryError,
-  "disposition" | "userFacing" | "errorCode" | "retryWithNewId"
+  "disposition" | "userFacing" | "errorCode"
 >
 
 /**
  * Every caller so far wants the same defaults: non-user-facing (the message
- * is a developer diagnostic), no error code, and keep the delivery identity.
- * Should a provider ever need different values, the type above declares all
- * four fields, so they can be set on the returned error - or this can grow
- * an options argument again at that point.
+ * is a developer diagnostic) and no error code.
+ * Should a provider ever need different values, the type above declares
+ * them, so they can be set on the returned error - or this can grow an
+ * options argument again at that point.
  */
 export const createClarificationSendFailure = (
   message: string,
@@ -55,7 +55,6 @@ export const createClarificationSendFailure = (
   disposition,
   userFacing: false,
   errorCode: null,
-  retryWithNewId: false,
 })
 
 const asRecord = (error: unknown): Record<string, unknown> | null =>

--- a/frontend/src/components/chat/clarification-delivery.ts
+++ b/frontend/src/components/chat/clarification-delivery.ts
@@ -49,6 +49,9 @@ export const createClarificationSendFailure = (
   message: string,
   disposition: MessageDeliveryDisposition,
 ): ClarificationSendFailure => Object.assign(new Error(message), {
+  // Named like MessageDeliveryError so a console.error of either one says
+  // which side of the contract produced it.
+  name: "ClarificationSendFailure",
   disposition,
   userFacing: false,
   errorCode: null,

--- a/frontend/src/components/chat/clarification-delivery.ts
+++ b/frontend/src/components/chat/clarification-delivery.ts
@@ -1,0 +1,105 @@
+import type { MessageDeliveryDisposition, MessageDeliveryError } from "@/hooks/use-websocket"
+import type { TranslationKey } from "@/i18n/translations"
+import { readClientErrorCode, type ClientErrorCode } from "@/lib/client-errors"
+
+/**
+ * The delivery contract shared by ClarificationForm's two send paths (#1485).
+ *
+ * The internal path (AppContext.sendMessage) and any injected `onSend`
+ * provider are held to the same shape: a failed send rejects with a
+ * discriminated failure the form can act on. Failures are still probed
+ * structurally rather than by `instanceof`, because a provider's rejection
+ * need not be an `Error` subclass — the contract is the fields, not the
+ * class.
+ */
+
+/** Metadata a clarification answer travels with. */
+export interface ClarificationSendMetadata {
+  request_id?: string
+  url?: string
+}
+
+export type ClarificationOnSend = (
+  message: string,
+  files: File[],
+  metadata: ClarificationSendMetadata,
+) => Promise<void> | void
+
+/**
+ * The discriminated failure a send path rejects with — its shape is derived
+ * from use-websocket's MessageDeliveryError (a type-only import, so this
+ * still has no runtime dependency on the websocket hook). Deriving via Pick
+ * means renaming or removing one of these four fields on the class fails
+ * type-check here; it does not notice fields *added* to the class, and the
+ * readers below stay deliberately structural (they take `unknown`).
+ */
+export type ClarificationSendFailure = Error & Pick<
+  MessageDeliveryError,
+  "disposition" | "userFacing" | "errorCode" | "retryWithNewId"
+>
+
+/**
+ * Every caller so far wants the same defaults: non-user-facing (the message
+ * is a developer diagnostic), no error code, and keep the delivery identity.
+ * Should a provider ever need different values, the type above declares all
+ * four fields, so they can be set on the returned error - or this can grow
+ * an options argument again at that point.
+ */
+export const createClarificationSendFailure = (
+  message: string,
+  disposition: MessageDeliveryDisposition,
+): ClarificationSendFailure => Object.assign(new Error(message), {
+  disposition,
+  userFacing: false,
+  errorCode: null,
+  retryWithNewId: false,
+})
+
+const asRecord = (error: unknown): Record<string, unknown> | null =>
+  typeof error === "object" && error !== null ? error as Record<string, unknown> : null
+
+/**
+ * Delivery failures carry whether the turn definitely never reached the agent.
+ * Plain errors (local validation, unexpected throws) carry nothing, and are
+ * left unqualified rather than guessed at: telling a visitor to resubmit a
+ * turn that may have landed is worse than saying nothing.
+ */
+export const readSendDisposition = (error: unknown): MessageDeliveryDisposition | null => {
+  const disposition = asRecord(error)?.disposition
+  return disposition === "not_sent"
+    || disposition === "rejected"
+    || disposition === "outcome_unknown"
+    ? disposition
+    : null
+}
+
+/**
+ * Only the reasons the sender can act on — the backend's rejection text — are
+ * shown as-is. Connection plumbing messages stay behind the localized string:
+ * they are English diagnostics, and a widget visitor is not the audience for
+ * them. Nothing new becomes displayable through an arbitrary provider either
+ * way — `userFacing` still has to be set.
+ */
+export const readSendReason = (error: unknown): string => {
+  const record = asRecord(error)
+  if (record?.userFacing !== true) return ""
+  const message = record.message
+  return typeof message === "string" ? message.trim() : ""
+}
+
+export const readSendErrorCode = (error: unknown): ClientErrorCode | null =>
+  readClientErrorCode(asRecord(error)?.errorCode)
+
+/**
+ * The hint that belongs with a disposition, as a key rather than a translated
+ * string: the toast needs it once at failure time, while the persistent alert
+ * has to re-resolve it on every render so a locale switch is not stuck behind
+ * whatever language was active when the send failed.
+ */
+export const sendHintKey = (
+  disposition: MessageDeliveryDisposition | null,
+): TranslationKey | null => disposition === "outcome_unknown"
+  ? "chatPage.clarification.sendOutcomeUnknown"
+  : disposition === "not_sent" || disposition === "rejected"
+    ? "chatPage.clarification.sendNotSent"
+    : null

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -66,6 +66,7 @@ vi.mock("@/contexts/auth-context", () => ({
 }))
 
 import { ClarificationForm } from "./clarification-form"
+import { createClarificationSendFailure } from "./clarification-delivery"
 
 // Every describe in this file gets the identity translate back, so a locale
 // swapped by one test cannot leak into a suite added below it.
@@ -594,6 +595,26 @@ describe("ClarificationForm delivery failures", () => {
         { description: "chatPage.clarification.sendNotSent" },
       )
     })
+  })
+
+  it("never shows the builder's internal diagnostic to the visitor", async () => {
+    // agent-builder-chat.tsx's onSendInteraction throws this exact failure as
+    // a developer diagnostic (#1485) - it must never reach the visitor.
+    const onSend = vi.fn().mockRejectedValue(
+      createClarificationSendFailure("Failed to send interaction", "not_sent"),
+    )
+
+    await submitAnswer(onSend)
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "chatPage.clarification.sendError",
+        { description: "chatPage.clarification.sendNotSent" },
+      )
+    })
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("chatPage.clarification.sendError")
+    expect(alert).not.toHaveTextContent("Failed to send interaction")
   })
 
   it("re-renders the visible failure in the new locale", async () => {

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -14,12 +14,15 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { ChevronDown, ChevronRight, MessageSquare, Upload, File as FileIcon, X, Globe } from "lucide-react"
 import { ConnectAppsField } from "./connect-apps-field"
 import type { MessageDeliveryDisposition } from "@/hooks/use-websocket"
-import type { TranslationKey } from "@/i18n/translations"
+import { clientErrorTranslationKey, type ClientErrorCode } from "@/lib/client-errors"
 import {
-  clientErrorTranslationKey,
-  readClientErrorCode,
-  type ClientErrorCode,
-} from "@/lib/client-errors"
+  readSendDisposition,
+  readSendErrorCode,
+  readSendReason,
+  sendHintKey,
+  type ClarificationOnSend,
+  type ClarificationSendMetadata,
+} from "./clarification-delivery"
 
 interface ClarificationFormProps {
   message?: string
@@ -28,7 +31,12 @@ interface ClarificationFormProps {
   requestId?: string
   active?: boolean
   filesDisabled?: boolean
-  onSend?: (message: string, files?: File[], metadata?: any) => Promise<void> | void
+  /**
+   * Injected send path (e.g. the agent builder chat). Held to the delivery
+   * contract in clarification-delivery.ts: it rejects with the same
+   * discriminated failure shape as the internal path (#1485).
+   */
+  onSend?: ClarificationOnSend
 }
 
 const FILE_ACTION_VALUE_RE = /(^|[-_\s])(upload|file)(?=$|[-_\s])/i
@@ -52,67 +60,6 @@ const isFileActionSelection = (
 ): boolean => option
   ? isFileActionOption(option)
   : isFileActionValue(value)
-
-/**
- * Delivery failures carry whether the turn definitely never reached the agent.
- * Plain errors (local validation, unexpected throws) carry nothing, and are
- * left unqualified rather than guessed at: telling a visitor to resubmit a
- * turn that may have landed is worse than saying nothing. Errors are probed
- * structurally rather than by `instanceof`, because the `onSend` branch's
- * failures come from arbitrary builder callbacks (see #1485).
- */
-const readSendDisposition = (error: unknown): MessageDeliveryDisposition | null => {
-  if (typeof error !== "object" || error === null || !("disposition" in error)) {
-    return null
-  }
-  const disposition = (error as { disposition: unknown }).disposition
-  return disposition === "not_sent"
-    || disposition === "rejected"
-    || disposition === "outcome_unknown"
-    ? disposition
-    : null
-}
-
-/**
- * Only the reasons the sender can act on — the backend's rejection text — are
- * shown as-is. Connection plumbing messages stay behind the localized string:
- * they are English diagnostics, and a widget visitor is not the audience for
- * them.
- *
- * The message is probed structurally for the same reason the disposition is:
- * an `onSend` callback's rejection need not be an `Error` instance. Nothing
- * new becomes displayable either way — `userFacing` still has to be set.
- */
-const readSendReason = (error: unknown): string => {
-  if (
-    typeof error !== "object"
-    || error === null
-    || (error as { userFacing?: unknown }).userFacing !== true
-  ) {
-    return ""
-  }
-  const message = (error as { message?: unknown }).message
-  return typeof message === "string" ? message.trim() : ""
-}
-
-const readSendErrorCode = (error: unknown): ClientErrorCode | null => {
-  if (typeof error !== "object" || error === null) return null
-  return readClientErrorCode((error as { errorCode?: unknown }).errorCode)
-}
-
-/**
- * The hint that belongs with a disposition, as a key rather than a translated
- * string: the toast needs it once at failure time, while the persistent alert
- * has to re-resolve it on every render so a locale switch is not stuck behind
- * whatever language was active when the send failed.
- */
-const sendHintKey = (
-  disposition: MessageDeliveryDisposition | null,
-): TranslationKey | null => disposition === "outcome_unknown"
-  ? "chatPage.clarification.sendOutcomeUnknown"
-  : disposition === "not_sent" || disposition === "rejected"
-    ? "chatPage.clarification.sendNotSent"
-    : null
 
 // Interaction types that are "live widgets" reflecting external state (e.g.
 // useMcpApps()'s connection state), not a question with an answer to submit
@@ -291,7 +238,7 @@ export function ClarificationForm({
   const handleSubmit = async () => {
     const submittedRequestId = requestId
     // Construct the message
-    const metadata: any = requestId ? { request_id: requestId } : {}
+    const metadata: ClarificationSendMetadata = requestId ? { request_id: requestId } : {}
     const lines = normalizedInteractions.flatMap(interaction => {
       const value = formState[interaction.field]
 


### PR DESCRIPTION
Part of #1485. Replaces #2175.

## What

`ClarificationForm`'s injected `onSend` path gets the declared failure contract the internal path already had.

- **New `frontend/src/components/chat/clarification-delivery.ts`** — the contract in one place: the typed `ClarificationOnSend` signature, typed `ClarificationSendMetadata`, a discriminated failure shape derived from `use-websocket`'s `MessageDeliveryError` via `Pick` (a type-only import, so no runtime dependency on the websocket hook — and renaming one of those four fields on the class now fails type-check here), a factory for providers, and the structural readers moved out of `ClarificationForm` unchanged. They stay structural on purpose: a provider's rejection need not be an `Error` subclass.
- **`ClarificationForm`, `ChatMessage`, `AgentBuilderChat` are typed against it**, and `metadata?: any` is gone from all three signatures. The form is a net deletion here — the private helpers move out.
- **The builder rejects with a typed `not_sent` failure** instead of a plain `Error`. Every one of its `false` returns happens before anything reaches the websocket, so `not_sent` is accurate and the form can tell the visitor a resubmit is safe.
- **Both builder paths that pushed optimistic bubbles before failing now roll them back** (upload failure, connection setup throw). This rides along because it is what makes the new `not_sent` claim true: without it the resubmit the hint invites stacks a duplicate answer over a blank placeholder.

## Why this shape

This is a re-cut of #2175, which grew from 573 to ~1050 changed lines over four review rounds. Splitting by which concern actually drew fire: the contract typing produced **zero** blocking findings across all four rounds, while the delivery-identity work produced three and the builder's WebSocket delivery semantics produced one. This PR is the zero-blocker slice, and it answers #1485's first proposed fix on its own.

Shape: 327 changed lines, 137 of them in the two new files; the rest is small edits across four existing leaf files, with no hub touched.

## Explicitly out of scope (tracked)

- **#2289** — the delivery identity (form owning one `clientMessageId` per unresolved answer, plus its round-boundary, reconnect and file-answer edge cases). This is #1485's second proposed fix; the work is implemented and reviewed on the preserved branch.
- **#2290** — `AgentBuilderChat` reporting a send as delivered before the payload leaves the socket. Pre-existing on `main` (identical `return true` after registering `onopen`); real answer loss against a refused backend.
- **#2288** — the optimistic-bubble rollback this PR adds is positional (`slice(0, -2)`); id-based removal is the follow-up.
- **#2251** — the backend never mints a per-round `request_id`, which is what forces the frontend proxies in #2289.
- **#2174** — unifying this contract with `MessageDeliveryError` and `ChatInput`'s inline probes into one home; also where the reviewer's suggestion to relocate this module under `lib/` belongs, and where `ClarificationSendMetadata.url` being builder-specific is noted.
- **#2173** — `PROVIDER_DISPLAY_NAMES` is missing the `salesforce` builtin provider, so `connect-apps-field.test.tsx` fails on a clean `main`. Unrelated to this diff; it is the only failure in the full frontend suite on this branch.

## Verification

- `vitest`: targeted suites 67/67; full frontend suite 2922/2923 with the single pre-existing #2173 failure.
- `tsc --noEmit` clean. `eslint` adds no new problems and removes four `no-explicit-any` errors across the three retyped files.
- New tests: the readers round-trip a real `MessageDeliveryError`; the form never shows the builder's raw diagnostic to a visitor; the builder's rejection carries `not_sent`; and both rollback paths restore the transcript to just the greeting.

## Review history

All prior review feedback on #2175 that applies to this slice is already folded in: the factory is verb-named, its unused options bag is gone, the failure type is derived rather than hand-declared, and the readers share one guard.
