### PR TITLE
fix(memory): preserve Arrow metadata when adding scope columns

### DIFF
--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -306,6 +306,14 @@ class LanceDBMemoryStore(MemoryStore):
         Unlike the vector rebuild, this preserves the existing ``vector`` column
         as-is (no re-embedding) — it only projects ``user_id`` / ``scope_dims``
         out of each row's metadata JSON.
+
+        Schema- and field-level Arrow metadata is preserved: the output table
+        is rebuilt with an explicit schema that reuses every pre-existing
+        field verbatim (type and field metadata) and carries over the
+        schema-level metadata. Any identity metadata already present on the
+        schema or fields is therefore preserved verbatim; no identity
+        metadata is synthesized, copied from elsewhere, or validated when
+        absent.
         """
         columns: dict[str, Any] = {
             name: existing.column(name) for name in existing.schema.names
@@ -317,7 +325,14 @@ class LanceDBMemoryStore(MemoryStore):
         user_ids, scope_dims = self._derive_scope_arrays(metadata_column)
         columns[USER_ID_COLUMN] = user_ids
         columns[SCOPE_DIMS_COLUMN] = scope_dims
-        return pa.table(columns)
+        fields: list[Any] = []
+        for name, column in columns.items():
+            if name in existing.schema.names:
+                fields.append(existing.schema.field(name))
+            else:
+                fields.append(pa.field(name, column.type))
+        schema = pa.schema(fields, metadata=existing.schema.metadata)
+        return pa.table(columns, schema=schema)
 
     def _ensure_scope_columns(self, conn: Any) -> None:
         """Promote user_id + scope_dims to real columns on an existing table (#822).

--- a/tests/core/memory/test_lancedb_migration.py
+++ b/tests/core/memory/test_lancedb_migration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import tempfile
 
@@ -276,3 +277,66 @@ def test_add_record_without_embedding_into_vector_table(temp_db_dir):
     assert {"withvec", "novec"} <= ids
     # The vector-less row still round-trips through get().
     assert store.get("novec").success
+
+
+def test_add_scope_columns_preserves_arrow_metadata(temp_db_dir):
+    """_add_scope_columns keeps schema/field metadata and back-fills scope columns.
+
+    Builds an Arrow table whose schema carries schema-level metadata and whose
+    ``id`` field carries field metadata, then runs the additive migration
+    directly. The old ``pa.table(columns)`` reconstruction dropped both, so
+    the metadata assertions below fail on the pre-fix implementation.
+    """
+    store = _store(temp_db_dir, None)
+    schema_metadata = {b"custom-key": b"custom-value"}
+    id_field_metadata = {b"field-key": b"field-value"}
+    fields = [
+        pa.field("id", pa.string(), metadata=id_field_metadata),
+        pa.field("text", pa.string()),
+        pa.field("metadata", pa.string()),
+        pa.field("vector", pa.list_(pa.float32(), 2)),
+    ]
+    schema = pa.schema(fields, metadata=schema_metadata)
+    metadata_row = json.dumps({"user_id": 7, "execution_scope_d1": "x"})
+    existing = pa.table(
+        {
+            "id": pa.array(["a", "b"], pa.string()),
+            "text": pa.array(["alpha", "beta"], pa.string()),
+            "metadata": pa.array([metadata_row, "{}"], pa.string()),
+            "vector": pa.array(
+                [[0.1, 0.2], [0.3, 0.4]], pa.list_(pa.float32(), 2)
+            ),
+        },
+        schema=schema,
+    )
+
+    migrated = store._add_scope_columns(existing)
+
+    # Schema- and field-level metadata survive the additive migration.
+    assert migrated.schema.metadata == existing.schema.metadata
+    assert migrated.schema.field("id").metadata == existing.schema.field(
+        "id"
+    ).metadata
+    # Existing column data is unchanged; the vector column is preserved as-is.
+    assert migrated.column("id").to_pylist() == ["a", "b"]
+    assert migrated.column("text").to_pylist() == ["alpha", "beta"]
+    assert migrated.column("metadata").to_pylist() == [metadata_row, "{}"]
+    assert migrated.column("vector").to_pylist() == existing.column(
+        "vector"
+    ).to_pylist()
+    # The derived scope columns are present with correct types and values.
+    assert "user_id" in migrated.schema.names
+    assert "scope_dims" in migrated.schema.names
+    assert migrated.schema.field("user_id").type == pa.int64()
+    assert migrated.schema.field("scope_dims").type == pa.list_(pa.string())
+    assert migrated.column("user_id").to_pylist() == [7, None]
+    assert migrated.column("scope_dims").to_pylist() == [["d1=x"], []]
+    # Column order: existing columns in order, then user_id, then scope_dims.
+    assert migrated.schema.names == [
+        "id",
+        "text",
+        "metadata",
+        "vector",
+        "user_id",
+        "scope_dims",
+    ]


### PR DESCRIPTION
## Description

Fixes #2296. `LanceDBMemoryStore._add_scope_columns` rebuilt the Arrow table with `pa.table(columns)`, which preserves column data but drops schema-level and per-field Arrow metadata during the additive `user_id`/`scope_dims` migration. This preserves the metadata so operational/diagnostic annotations on the schema or fields survive the migration.

**What**

- `_add_scope_columns` now rebuilds the output with an explicit schema: every pre-existing column reuses `existing.schema.field(name)` (type + field metadata verbatim), the two new columns get plain `pa.field` entries, and `pa.schema(fields, metadata=existing.schema.metadata)` carries over schema-level metadata.
- Column order is unchanged (existing columns then `user_id`, `scope_dims`); the `vector` column is preserved as-is; no re-embedding, no new dependencies.
- Identity metadata (when present) is preserved verbatim; nothing is synthesized, copied from elsewhere, or validated. `_build_migrated_table` is intentionally untouched (per the issue's scope).

**Why**

The migration runs whenever a table lacks `user_id`/`scope_dims` (e.g. tables created before the scope-column layout). The old reconstruction silently discarded any schema/field metadata attached by other lifecycle code, breaking non-data annotations downstream readers rely on.

**Tests**

- New `test_add_scope_columns_preserves_arrow_metadata` in `tests/core/memory/test_lancedb_migration.py` covers: schema metadata survival, field metadata survival, unchanged existing column data, preserved `vector` column, correct derived `user_id`/`scope_dims` types and values, and column order.
- `pytest tests/core/memory/test_lancedb_migration.py -q -p no:warnings` → 10/10 pass.
- Mutation check: reverting the fix to the old `pa.table(columns)` makes the new test fail (`schema.metadata` is `None`, field metadata missing); restoring the fix turns it green — the test genuinely guards the fix.

**Note**

`tests/core/memory/test_lancedb_admission.py::test_create_and_recreate_use_typed_vectors_and_canonical_identity` fails with a `RuntimeError` inside `lancedb/db.py:1939`; reproduced on clean `main` @ `eb87d93` without these changes — a LanceDB environment/version issue in an unrelated code path.

Fixes #2296