### PR TITLE
ref(frontend): remove dead user-message frame handlers

### DIFF
--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -2919,23 +2919,6 @@ export function AppProvider({
     }
 
     switch (message.type) {
-      case "chat":
-        const chatData = message as any
-        const messageContent = chatData.message || ""
-
-        if (!isDuplicateMessageForViewedTask(messageContent, 'user-message')) {
-          dispatch({
-            type: "ADD_MESSAGE",
-            payload: {
-              id: generateMessageId("msg-user"),
-              role: "user",
-              content: messageContent,
-              timestamp: message.timestamp?.toString() || Date.now().toString(),
-            }
-          })
-        }
-        break
-
       case "trace_event":
         const traceEventData = (message.data ?? {}) as any
 
@@ -5400,20 +5383,6 @@ export function AppProvider({
             dispatch({ type: "ADD_TRACE_EVENT", payload: traceEventData })
           }
         }
-        break
-
-      case "chat_message":
-        console.trace('Original message:', JSON.stringify(message), 'Handler: handleMessage (chat_message)')
-        const messageData = message.data as any
-        dispatch({
-          type: "ADD_MESSAGE",
-          payload: {
-            id: `msg-${messageData.id}`,
-            role: messageData.role,
-            content: messageData.content,
-            timestamp: messageData.timestamp,
-          },
-        })
         break
 
       case "task_completed":


### PR DESCRIPTION
## What

Removes the two dead, content-collapsible `role: "user"` dispatch handlers from `frontend/src/contexts/app-context-chat.tsx`:

- `case "chat":` — dispatched `ADD_MESSAGE` with `id: generateMessageId("msg-user")` / `role: "user"`.
- `case "chat_message":` — dispatched `ADD_MESSAGE` with `` id: \`msg-${messageData.id}\` `` / `role: messageData.role`.

## Why

Issue #2252's preflight proved neither frame type has a producer:

- `"type": "chat"` appears twice in the backend and neither is an outbound frame (`src/xagent/web/api/websocket.py:10488` builds a JSON string re-inserted into LLM history; `:10740` builds an inbound dict on the preview path).
- `"type": "chat_message"` has no producer anywhere; the only matching backend string is an `event_id` inside a `trace_event` frame, not a frame type.

They were the last two `role: "user"` sites where distinct turns sharing text could still merge into one bubble. Deleting them removes that latent collapse risk; the issue's preferred fix is deletion, not hardening.

## How verified

- Diff is exactly 31 deleted lines in one file — both `case` blocks, nothing else (no formatting churn, no new deps).
- `tsc --noEmit` passes.
- Full frontend suite: `2925 passed / 2926` (158 files). The single failure — `connect-apps-field.test.tsx` `PROVIDER_DISPLAY_NAMES` missing `Salesforce` — reproduces identically on the pre-change file state (pre-existing on main, unrelated to this change).
- `grep` confirms no remaining `case "chat"` / `case "chat_message"` in the file.

Fixes #2252