### PR TITLE
feat(calendar): detect scheduling conflicts before booking or moving events

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.svg,*.png,*.jpg,*.jpeg,*.gif,*.ico,*.webp,pyproject.toml,*node_modules*,uploads/,generated_db_for_test/,memory_store/,data/lancedb/,**/package-lock.json
-ignore-words-list = fo,nd,te,hav,hte,wil,clol,loove,assertIn,ser,mis,pres,wit,asend,createable
+ignore-words-list = fo,nd,te,hav,hte,wil,clol,loove,assertIn,ser,mis,pres,wit,asend,createable,fle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,11 @@ dependencies = [
   "matplotlib>=3.5.0",
   "google-auth-oauthlib>=1.2.0",
   "google-api-python-client>=2.145.0",
+  # zoneinfo's IANA timezone database - stdlib zoneinfo relies on the OS's
+  # tz data, which minimal container images may not ship; this guarantees
+  # it's present regardless of platform (calendar/outlook conflict-check
+  # timezone math needs real zone offsets, not just zone names).
+  "tzdata>=2024.1",
   "boxlite>=0.6.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "boxlite>=0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
   "filelock>=3.0.0",

--- a/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
+++ b/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
@@ -1,0 +1,128 @@
+"""add calendar.freebusy to the Google Calendar connector's OAuth scope
+
+The scheduling-conflict check added to the calendar connector's create/update
+tools calls Google's ``freebusy.query`` endpoint to check attendees'
+availability. That endpoint is not authorized by ``.../auth/calendar.events``
+alone (per Google's own Calendar API scope reference) - it needs one of
+``calendar``, ``calendar.readonly``, ``calendar.freebusy``, or
+``calendar.events.freebusy``. ``calendar.freebusy`` is the minimal addition
+that covers it without also granting broader calendar read access.
+
+For a builtin app, the scope actually requested at authorize time is sourced
+live from ``builtin_mcp_registry.py``, not from this table -- this migration
+only converges the persisted ``public_mcp_apps.oauth_scopes`` row so
+``validate_builtin_public_mcp_apps`` stops reporting drift against that
+registry value on an already-seeded database.
+
+Unlike the earlier narrowing migration (20260817_narrow_google_calendar_scope),
+this one WIDENS the scope: an already-issued ``user_oauth`` grant only has
+the narrower ``calendar.events`` scope and does not automatically pick up
+the new one. Existing users must reconnect the Google Calendar connector
+before attendee free/busy checks stop 403ing for them; this migration does
+not (and cannot) retroactively fix already-issued tokens.
+
+Revision ID: 20260907_add_calendar_freebusy_scope
+Revises: 370740d9125a
+Create Date: 2026-09-07
+
+"""
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260907_add_calendar_freebusy_scope"
+down_revision: Union[str, None] = "370740d9125a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+)
+
+APP_ID = "google-calendar"
+OLD_SCOPES = ("https://www.googleapis.com/auth/calendar.events",)
+NEW_SCOPES = (
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+)
+
+
+def _columns_present(
+    bind: sa.engine.Connection, table_name: str, required_columns: set[str]
+) -> bool:
+    """Whether ``table_name`` exists and has all of ``required_columns``.
+
+    Used by _set_calendar_scopes(), the online path upgrade() and
+    downgrade() both call: this migration must be a no-op (not an error)
+    against a database mid-way through a schema this old, or an admin's
+    reduced-schema table, rather than assume a table shape that matches
+    only the current model.
+    """
+    inspector = sa.inspect(bind)
+    if table_name not in set(inspector.get_table_names()):
+        return False
+    columns = {column["name"] for column in inspector.get_columns(table_name)}
+    return required_columns.issubset(columns)
+
+
+def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str) -> object:
+    # Match the online sa.JSON binding contract: values are stored as JSON,
+    # not as a bare SQL string literal, on every supported dialect.
+    serialized_literal = op.inline_literal(json.dumps(scopes))
+    if dialect_name == "postgresql":
+        return sa.cast(serialized_literal, sa.JSON())
+    return serialized_literal
+
+
+def _set_calendar_scopes_offline(scopes: Sequence[str]) -> None:
+    dialect_name = op.get_context().dialect.name
+    statement = (
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
+        .values(oauth_scopes=_offline_scopes_literal(scopes, dialect_name))
+    )
+    op.execute(statement)
+
+
+def _set_calendar_scopes(scopes: Sequence[str]) -> None:
+    """Write ``scopes`` to the google-calendar row's oauth_scopes column.
+
+    oauth_scopes is in admin_mcp's _BUILTIN_PROTECTED_FIELDS, so an operator
+    can never have customized it via the admin PATCH endpoint -- safe to
+    overwrite unconditionally, with no prior-value check, in both
+    directions. Online-only: the caller has already handled the offline
+    (``--sql``) path, since there's no live ``bind`` to use here otherwise.
+    """
+    bind = op.get_bind()
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=scopes)
+    )
+
+
+def upgrade() -> None:
+    # Offline (--sql) generation has a MockConnection, so reflection is
+    # unavailable -- emit the unconditional UPDATE instead of inspecting.
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(NEW_SCOPES)
+        return
+
+    _set_calendar_scopes(NEW_SCOPES)
+
+
+def downgrade() -> None:
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(OLD_SCOPES)
+        return
+
+    _set_calendar_scopes(OLD_SCOPES)

--- a/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
+++ b/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
@@ -22,7 +22,7 @@ before attendee free/busy checks stop 403ing for them; this migration does
 not (and cannot) retroactively fix already-issued tokens.
 
 Revision ID: 20260907_add_calendar_freebusy_scope
-Revises: 370740d9125a
+Revises: 20260909_seed_shopify_mcp_app
 Create Date: 2026-09-07
 
 """
@@ -34,7 +34,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260907_add_calendar_freebusy_scope"
-down_revision: Union[str, None] = "370740d9125a"
+down_revision: Union[str, None] = "20260909_seed_shopify_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py
+++ b/src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py
@@ -1,8 +1,10 @@
 """add calendar.calendars.readonly to the Google Calendar connector's OAuth scope
 
 The all-day conflict-check path calls Google's ``calendars.get`` endpoint (via
-``_primary_calendar_timezone``) to widen an all-day boundary using the primary
-calendar's own configured timezone. That endpoint is not authorized by
+``_primary_calendar_info``) to widen an all-day boundary using the primary
+calendar's own configured timezone (the same call also resolves the
+connected account's own address, used to tell whether the caller is
+actually a given event's organizer). That endpoint is not authorized by
 ``.../auth/calendar.events`` or ``.../auth/calendar.freebusy`` (per Google's
 own Calendar API scope reference for ``calendars.get``) -- it needs one of
 ``calendar``, ``calendar.readonly``, ``calendar.app.created``,

--- a/src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py
+++ b/src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py
@@ -1,0 +1,137 @@
+"""add calendar.calendars.readonly to the Google Calendar connector's OAuth scope
+
+The all-day conflict-check path calls Google's ``calendars.get`` endpoint (via
+``_primary_calendar_timezone``) to widen an all-day boundary using the primary
+calendar's own configured timezone. That endpoint is not authorized by
+``.../auth/calendar.events`` or ``.../auth/calendar.freebusy`` (per Google's
+own Calendar API scope reference for ``calendars.get``) -- it needs one of
+``calendar``, ``calendar.readonly``, ``calendar.app.created``,
+``calendar.calendars``, or ``calendar.calendars.readonly``.
+``calendar.calendars.readonly`` is the minimal addition that covers it
+without also granting event read access beyond what ``calendar.events``
+already does.
+
+For a builtin app, the scope actually requested at authorize time is sourced
+live from ``builtin_mcp_registry.py``, not from this table -- this migration
+only converges the persisted ``public_mcp_apps.oauth_scopes`` row so
+``validate_builtin_public_mcp_apps`` stops reporting drift against that
+registry value on an already-seeded database.
+
+Like 20260907_add_calendar_freebusy_scope, this WIDENS the scope: an
+already-issued ``user_oauth`` grant does not automatically pick up the new
+scope. Existing users must reconnect the Google Calendar connector before
+all-day conflict checks stop 403ing for them; this migration does not (and
+cannot) retroactively fix already-issued tokens. Unlike the freebusy gap,
+which degraded to "attendee unchecked but still books", the calendar.py
+caller now rejects the write outright on this missing-scope signal rather
+than silently proceeding (see google_calendar_update_events).
+
+Revision ID: 20260909_add_calendar_calendars_readonly_scope
+Revises: 20260907_add_calendar_freebusy_scope
+Create Date: 2026-09-09
+
+"""
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260909_add_calendar_calendars_readonly_scope"
+down_revision: Union[str, None] = "20260907_add_calendar_freebusy_scope"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+)
+
+APP_ID = "google-calendar"
+OLD_SCOPES = (
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+)
+NEW_SCOPES = (
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+    "https://www.googleapis.com/auth/calendar.calendars.readonly",
+)
+
+
+def _columns_present(
+    bind: sa.engine.Connection, table_name: str, required_columns: set[str]
+) -> bool:
+    """Whether ``table_name`` exists and has all of ``required_columns``.
+
+    Used by _set_calendar_scopes(), the online path upgrade() and
+    downgrade() both call: this migration must be a no-op (not an error)
+    against a database mid-way through a schema this old, or an admin's
+    reduced-schema table, rather than assume a table shape that matches
+    only the current model.
+    """
+    inspector = sa.inspect(bind)
+    if table_name not in set(inspector.get_table_names()):
+        return False
+    columns = {column["name"] for column in inspector.get_columns(table_name)}
+    return required_columns.issubset(columns)
+
+
+def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str) -> object:
+    # Match the online sa.JSON binding contract: values are stored as JSON,
+    # not as a bare SQL string literal, on every supported dialect.
+    serialized_literal = op.inline_literal(json.dumps(scopes))
+    if dialect_name == "postgresql":
+        return sa.cast(serialized_literal, sa.JSON())
+    return serialized_literal
+
+
+def _set_calendar_scopes_offline(scopes: Sequence[str]) -> None:
+    dialect_name = op.get_context().dialect.name
+    statement = (
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
+        .values(oauth_scopes=_offline_scopes_literal(scopes, dialect_name))
+    )
+    op.execute(statement)
+
+
+def _set_calendar_scopes(scopes: Sequence[str]) -> None:
+    """Write ``scopes`` to the google-calendar row's oauth_scopes column.
+
+    oauth_scopes is in admin_mcp's _BUILTIN_PROTECTED_FIELDS, so an operator
+    can never have customized it via the admin PATCH endpoint -- safe to
+    overwrite unconditionally, with no prior-value check, in both
+    directions. Online-only: the caller has already handled the offline
+    (``--sql``) path, since there's no live ``bind`` to use here otherwise.
+    """
+    bind = op.get_bind()
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=scopes)
+    )
+
+
+def upgrade() -> None:
+    # Offline (--sql) generation has a MockConnection, so reflection is
+    # unavailable -- emit the unconditional UPDATE instead of inspecting.
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(NEW_SCOPES)
+        return
+
+    _set_calendar_scopes(NEW_SCOPES)
+
+
+def downgrade() -> None:
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(OLD_SCOPES)
+        return
+
+    _set_calendar_scopes(OLD_SCOPES)

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -480,7 +480,11 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "transport": "oauth",
             "provider_name": "google",
             "category": "Scheduling",
-            "oauth_scopes": ["https://www.googleapis.com/auth/calendar.events"],
+            "oauth_scopes": [
+                "https://www.googleapis.com/auth/calendar.events",
+                "https://www.googleapis.com/auth/calendar.freebusy",
+                "https://www.googleapis.com/auth/calendar.calendars.readonly",
+            ],
             "is_visible_in_connector": True,
             "launch_config": {
                 "command": "python",

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -938,11 +938,6 @@ def google_calendar_update_events(
             # assuming caller==organizer, as an earlier version did)
             # catches that case rather than silently checking - and
             # excluding from freebusy - the wrong person's calendar.
-            caller_is_organizer = True
-            if organizer_email_lower is not None:
-                caller_is_organizer = (
-                    primary_calendar_info()[0].lower() == organizer_email_lower
-                )
             # A newly-added organizer is checked via the organizer path
             # (events.list, which can actually exclude this event by id/
             # recurringEventId) rather than freebusy - without also
@@ -957,6 +952,17 @@ def google_calendar_update_events(
             # (the overwhelmingly common case), and this must still
             # trigger then, same as before this identity fix.
             organizer_needs_verification = window_changed or organizer_newly_added
+            # Gated on organizer_needs_verification too - caller_is_organizer
+            # is only ever consulted below when the organizer needs
+            # (re)verifying at all, so a metadata-only edit (summary/
+            # description/location, no window or attendee change) on an
+            # event with an explicit organizer field must not pay for
+            # this API call when nothing downstream would use its result.
+            caller_is_organizer = True
+            if organizer_needs_verification and organizer_email_lower is not None:
+                caller_is_organizer = (
+                    primary_calendar_info()[0].lower() == organizer_email_lower
+                )
             # Only actually query "primary" for the organizer's own
             # conflicts when the caller genuinely IS the organizer -
             # otherwise "primary" is someone else's calendar entirely,

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -803,6 +803,26 @@ def google_calendar_update_events(
         # calendar entirely, in the specific case where the organizer's
         # own email was the only thing making a raw set non-empty.
         organizer_email = (event.get("organizer") or {}).get("email")
+        if organizer_email is None and added_attendees:
+            # Google omits the top-level `organizer` field whenever the
+            # organizer is just the calendar owner (the overwhelmingly
+            # common case) - the caller's own resolved address (from the
+            # same calendars().get(calendarId="primary") already used
+            # for caller_is_organizer/all-day widening below) IS the
+            # organizer then. Only resolved when there's a newly-added
+            # attendee to check this against - a retained attendee's
+            # delta-segment query never re-scans the event's OLD window
+            # (where their own footprint would live), so it can't
+            # self-conflict regardless of this exclusion, and a
+            # metadata-only edit has no attendee to need it for at all.
+            # Without this, adding the caller's OWN address as a "new"
+            # attendee on an event with no explicit organizer field
+            # would never be excluded from the freebusy batch below and
+            # would always find this very event's own busy block on
+            # their calendar - the exact self-conflict class this
+            # exclusion exists to prevent for the explicit-organizer-
+            # field case already.
+            organizer_email = primary_calendar_info()[0]
         # None never equals a real address's lowercased form, so this
         # filter is a no-op (keeps everything) when there's no organizer
         # email to exclude - same effect as branching on `organizer_email`
@@ -997,6 +1017,37 @@ def google_calendar_update_events(
             # the case that stops `_merge_scope_error` from re-raising).
             pending_scope_error: InsufficientScopeError | None = None
 
+            def _run_and_accumulate(
+                time_min: str, time_max: str, attendees: list[str], *, check_org: bool
+            ) -> bool:
+                """Runs one _find_conflicts call, folding its result (or,
+                on a scope error, whatever it had already confirmed) into
+                the shared all_conflicts/unchecked_attendees accumulators.
+                Returns True on a scope error, so a segment loop can stop
+                attempting further segments (every remaining one would
+                hit the same error) - a `for/break`, not a re-raise,
+                since the OTHER accumulation block below must still get
+                its own chance to run regardless.
+                """
+                nonlocal pending_scope_error
+                try:
+                    conflicts, unchecked = _find_conflicts(
+                        service,
+                        time_min,
+                        time_max,
+                        attendees,
+                        exclude_event_id=event_id,
+                        check_organizer=check_org,
+                    )
+                    all_conflicts.extend(conflicts)
+                    unchecked_attendees.extend(unchecked)
+                    return False
+                except InsufficientScopeError as exc:
+                    all_conflicts.extend(exc.conflicts)
+                    unchecked_attendees.extend(exc.unchecked_attendees)
+                    pending_scope_error = exc
+                    return True
+
             # A newly-added attendee has no footprint on this event
             # at all, so the FULL effective window is safe (and
             # necessary) to check for them - same call also covers
@@ -1004,21 +1055,12 @@ def google_calendar_update_events(
             # by window, so `window_changed` alone (not a
             # disjoint-move test) decides whether to re-check them.
             if check_organizer or attendees_to_check:
-                try:
-                    conflicts, unchecked = _find_conflicts(
-                        service,
-                        effective_start,
-                        effective_end,
-                        attendees_to_check,
-                        exclude_event_id=event_id,
-                        check_organizer=check_organizer,
-                    )
-                    all_conflicts.extend(conflicts)
-                    unchecked_attendees.extend(unchecked)
-                except InsufficientScopeError as exc:
-                    all_conflicts.extend(exc.conflicts)
-                    unchecked_attendees.extend(exc.unchecked_attendees)
-                    pending_scope_error = exc
+                _run_and_accumulate(
+                    effective_start,
+                    effective_end,
+                    attendees_to_check,
+                    check_org=check_organizer,
+                )
 
             # A retained attendee's own busy block for THIS event
             # covers the entire OLD window - querying that overlap
@@ -1036,24 +1078,15 @@ def google_calendar_update_events(
                     effective_start_key,
                     effective_end_key,
                 ):
-                    try:
-                        conflicts, unchecked = _find_conflicts(
-                            service,
-                            seg_start.isoformat(),
-                            seg_end.isoformat(),
-                            existing_attendees_to_check,
-                            exclude_event_id=event_id,
-                            check_organizer=False,
-                        )
-                        all_conflicts.extend(conflicts)
-                        unchecked_attendees.extend(unchecked)
-                    except InsufficientScopeError as exc:
-                        all_conflicts.extend(exc.conflicts)
-                        unchecked_attendees.extend(exc.unchecked_attendees)
-                        pending_scope_error = exc
-                        # Every remaining segment would hit this same
-                        # scope error too - nothing left to gain by
-                        # attempting them.
+                    hit_scope_error = _run_and_accumulate(
+                        seg_start.isoformat(),
+                        seg_end.isoformat(),
+                        existing_attendees_to_check,
+                        check_org=False,
+                    )
+                    # Every remaining segment would hit this same scope
+                    # error too - nothing left to gain by attempting them.
+                    if hit_scope_error:
                         break
 
             # A both-sides-widened window produces two delta segments

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -739,6 +739,11 @@ def google_calendar_update_events(
     -- rather than failing loudly; only pass it once the user has actually confirmed they want to
     proceed without checking, not as a blanket way to route around an unrelated error. Editing other
     fields (summary, description, location) without moving the event is never blocked.
+    Moving the time or adding an attendee on a recurring event's own master (not a single occurrence)
+    is refused outright rather than checked, since only that one occurrence's window can be verified
+    here, not every occurrence the series will generate. Update a single occurrence directly by its
+    own event id instead, or pass ignore_conflicts=True once the user has confirmed they've verified
+    every occurrence themselves.
     attendees is a list of email addresses to add to the event; attendees already on the event are
     kept, and there is no way to remove an attendee through this parameter. Adding attendees does
     not, by itself, email anyone; set notify_attendees=True to have Google Calendar send a native
@@ -802,6 +807,42 @@ def google_calendar_update_events(
         # off whether anything is *actually* new, not just whether
         # `attendees` was given at all.
         added_attendees = _attendees_to_add(attendees, existing_attendee_emails)
+
+        if (
+            event.get("recurrence")
+            and not ignore_conflicts
+            and (bool(start_time) or bool(end_time) or added_attendees)
+        ):
+            # A recurring MASTER event's `recurrence` field (its RRULE/
+            # EXRULE/RDATE/EXDATE lines) is only present on the master
+            # itself - an individual occurrence carries `recurringEventId`
+            # instead (see the exclusion logic in _find_conflicts) and is
+            # unaffected by this check. Moving the master's time, or
+            # adding an attendee, affects EVERY occurrence the series
+            # generates, but the conflict check below only evaluates the
+            # single window this call computes (in effect, just the
+            # master's own occurrence) - there is no logic here to expand
+            # and check each future occurrence the recurrence rule would
+            # produce. Silently succeeding could let a real conflict on
+            # some LATER occurrence through completely unchecked. Refuse
+            # outright rather than give a false "no conflict" answer for
+            # the whole series - a metadata-only edit (no start_time/
+            # end_time/attendees change) is unaffected, and updating a
+            # single occurrence directly by its own event id is too (that
+            # event carries recurringEventId, not recurrence).
+            raise ValueError(
+                "This event is part of a recurring series (it has its "
+                "own recurrence rule) - moving it or adding an attendee "
+                "can only be conflict-checked against the single "
+                "occurrence this call computes, not every occurrence the "
+                "series will generate, so this write was refused rather "
+                "than risk missing a real conflict on a later date. "
+                "Update a single occurrence directly using its own event "
+                "id instead of the series' id, make a metadata-only edit "
+                "(summary/description/location) instead, or pass "
+                "ignore_conflicts=True only once the user has explicitly "
+                "confirmed they've verified every occurrence themselves."
+            )
 
         # The organizer's own calendar is checked separately, via
         # check_organizer (events.list, excluded by id/recurringEventId) -

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -789,9 +789,14 @@ def google_calendar_update_events(
         # filtered out) and `check_organizer` alone wouldn't have been
         # true for an unmoved window, so no conflict check would run for
         # them at all, silently missing a real conflict on their calendar.
-        organizer_newly_added = organizer_email_lower is not None and any(
-            a.lower() == organizer_email_lower for a in added_attendees
-        )
+        # Recovered as a length comparison rather than a separate scan -
+        # `added_attendees` is already case-insensitively deduplicated
+        # (via normalize_addresses), so at most one entry can match
+        # `organizer_email_lower` - which also keeps this fact and
+        # `attendees_to_check`'s own filtering from drifting apart (both
+        # the timezone-lookup gate below and the organizer-check gate
+        # further down must account for this consistently).
+        organizer_newly_added = len(attendees_to_check) != len(added_attendees)
 
         existing_is_all_day = "date" in (event.get("start") or {}) or "date" in (
             event.get("end") or {}
@@ -810,22 +815,29 @@ def google_calendar_update_events(
             )
 
         # The calendar's own timezone is only needed to widen an all-day
-        # boundary (see _event_boundary) so a moved window or a genuinely
-        # new attendee gets checked against the right absolute instant -
-        # fetch it lazily so a plain timed-event update, or a
-        # summary/location/description-only edit of an all-day event that
-        # never touches its window or attendees, doesn't pay for an extra
-        # API call (or a scope-403 that would otherwise block an edit
-        # that never needed timezone precision at all) it has no use for.
-        # Keyed off `added_attendees` (genuinely new), not the raw
-        # `attendees` argument - naming only addresses already on the
-        # event adds nothing to check, and a resubmission that never
-        # moves the window makes any retained attendee's delta segment
-        # trivially empty regardless of timezone precision (both sides
-        # of that comparison fall back to the same assumption
-        # consistently), so neither actually needs the real zone either.
+        # boundary (see _event_boundary) so a moved window, a genuinely
+        # new attendee, or the organizer-calendar check gets checked
+        # against the right absolute instant - fetch it lazily so a
+        # plain timed-event update, or a summary/location/description-
+        # only edit of an all-day event that never touches its window or
+        # attendees, doesn't pay for an extra API call (or a scope-403
+        # that would otherwise block an edit that never needed timezone
+        # precision at all) it has no use for. `organizer_newly_added`
+        # is included alongside `attendees_to_check` (genuinely new,
+        # organizer excluded) since it independently triggers
+        # `check_organizer` below, which also needs a correctly-widened
+        # window - omitting it here would run that check against a
+        # wrong-timezone (UTC-defaulted) boundary instead of failing
+        # loudly or skipping it. A resubmission that never moves the
+        # window makes any retained attendee's delta segment trivially
+        # empty regardless of timezone precision (both sides of that
+        # comparison fall back to the same assumption consistently), so
+        # that case alone still doesn't need the real zone.
         needs_real_calendar_timezone = existing_is_all_day and (
-            bool(start_time) or bool(end_time) or bool(attendees_to_check)
+            bool(start_time)
+            or bool(end_time)
+            or bool(attendees_to_check)
+            or organizer_newly_added
         )
         try:
             calendar_timezone = (
@@ -878,15 +890,27 @@ def google_calendar_update_events(
             # freebusy path for them.
             check_organizer = window_changed or organizer_newly_added
             all_conflicts: list[dict[str, Any]] = []
+            # Tracks the most recent InsufficientScopeError seen across
+            # EITHER block below, re-raised only once both blocks have
+            # had their chance to run and nothing was confirmed by
+            # either. The two blocks check disjoint attendee sets (newly
+            # added vs. retained), so one block hitting a scope error
+            # must not skip the other - otherwise a retained attendee's
+            # delta-segment check would silently never run at all
+            # (neither confirmed as conflicting nor reported as
+            # unchecked) whenever the first block happens to fail with
+            # an already-confirmed conflict in hand (which is exactly
+            # the case that stops `_merge_scope_error` from re-raising).
+            pending_scope_error: InsufficientScopeError | None = None
 
-            try:
-                # A newly-added attendee has no footprint on this event
-                # at all, so the FULL effective window is safe (and
-                # necessary) to check for them - same call also covers
-                # the organizer, who's excluded by event id rather than
-                # by window, so `window_changed` alone (not a
-                # disjoint-move test) decides whether to re-check them.
-                if check_organizer or attendees_to_check:
+            # A newly-added attendee has no footprint on this event
+            # at all, so the FULL effective window is safe (and
+            # necessary) to check for them - same call also covers
+            # the organizer, who's excluded by event id rather than
+            # by window, so `window_changed` alone (not a
+            # disjoint-move test) decides whether to re-check them.
+            if check_organizer or attendees_to_check:
+                try:
                     conflicts, unchecked = _find_conflicts(
                         service,
                         effective_start,
@@ -897,23 +921,28 @@ def google_calendar_update_events(
                     )
                     all_conflicts.extend(conflicts)
                     unchecked_attendees.extend(unchecked)
+                except InsufficientScopeError as exc:
+                    all_conflicts.extend(exc.conflicts)
+                    unchecked_attendees.extend(exc.unchecked_attendees)
+                    pending_scope_error = exc
 
-                # A retained attendee's own busy block for THIS event
-                # covers the entire OLD window - querying that overlap
-                # can't tell "busy because of this event" from a real
-                # conflict. Only the portion of the new window that's
-                # genuinely new territory (window_delta_segments - empty
-                # for an unchanged/shrunk window, up to two segments for
-                # a partial nudge that extends past the old window on one
-                # or both sides, or the whole new window for a fully
-                # disjoint move) can hide a real conflict for them.
-                if existing_attendees_to_check:
-                    for seg_start, seg_end in _window_delta_segments(
-                        existing_start_key,
-                        existing_end_key,
-                        effective_start_key,
-                        effective_end_key,
-                    ):
+            # A retained attendee's own busy block for THIS event
+            # covers the entire OLD window - querying that overlap
+            # can't tell "busy because of this event" from a real
+            # conflict. Only the portion of the new window that's
+            # genuinely new territory (window_delta_segments - empty
+            # for an unchanged/shrunk window, up to two segments for
+            # a partial nudge that extends past the old window on one
+            # or both sides, or the whole new window for a fully
+            # disjoint move) can hide a real conflict for them.
+            if existing_attendees_to_check:
+                for seg_start, seg_end in _window_delta_segments(
+                    existing_start_key,
+                    existing_end_key,
+                    effective_start_key,
+                    effective_end_key,
+                ):
+                    try:
                         conflicts, unchecked = _find_conflicts(
                             service,
                             seg_start.isoformat(),
@@ -924,10 +953,17 @@ def google_calendar_update_events(
                         )
                         all_conflicts.extend(conflicts)
                         unchecked_attendees.extend(unchecked)
-            except InsufficientScopeError as exc:
-                all_conflicts, unchecked_attendees = _merge_scope_error(
-                    exc, all_conflicts, unchecked_attendees
-                )
+                    except InsufficientScopeError as exc:
+                        all_conflicts.extend(exc.conflicts)
+                        unchecked_attendees.extend(exc.unchecked_attendees)
+                        pending_scope_error = exc
+                        # Every remaining segment would hit this same
+                        # scope error too - nothing left to gain by
+                        # attempting them.
+                        break
+
+            if pending_scope_error is not None and not all_conflicts:
+                raise pending_scope_error
 
             if all_conflicts:
                 return _conflict_response(

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -595,9 +595,15 @@ def google_calendar_create_events(
     """
     requested_conference = False
     try:
-        _reject_reversed_window(start_time, end_time)
+        # Checked before reject_reversed_window (which stays permissive,
+        # not diagnostic, on a mismatched-awareness pair): two NAIVE
+        # values that also happen to be reversed compare just fine (no
+        # TypeError, so reject_reversed_window doesn't defer to this
+        # check) and would otherwise surface the generic "must be after"
+        # message instead of this more specific, actionable one.
         _require_offset_datetime(start_time, "start_time")
         _require_offset_datetime(end_time, "end_time")
+        _reject_reversed_window(start_time, end_time)
         service = get_calendar_service()
         normalized_attendees = _normalize_addresses(attendees) if attendees else []
 
@@ -742,6 +748,51 @@ def google_calendar_update_events(
         # `attendees` was given at all.
         added_attendees = _attendees_to_add(attendees, existing_attendee_emails)
 
+        # The organizer's own calendar is checked separately, via
+        # check_organizer (events.list, excluded by id/recurringEventId) -
+        # freebusy.query has no concept of "exclude this event", so if the
+        # organizer's own email also shows up among the attendees being
+        # freebusy-checked (just added now, or already on the event from
+        # an earlier call), that query would always find this very
+        # event's own busy block on their calendar and report a false
+        # self-conflict. Excluded only from the freebusy-checked copies
+        # below, never from `added_attendees` itself - a caller that
+        # explicitly asked to add the organizer as an attendee must still
+        # have them actually written to the event. Computed this early
+        # (alongside added_attendees, rather than right before use) so
+        # both the timezone-lookup gate and the organizer-check gate
+        # below can key off the POST-filter attendee sets, not the raw
+        # ones - gating off the raw sets would trigger an unnecessary
+        # timezone lookup, or (worse) skip checking the organizer's
+        # calendar entirely, in the specific case where the organizer's
+        # own email was the only thing making a raw set non-empty.
+        organizer_email = (event.get("organizer") or {}).get("email")
+        # None never equals a real address's lowercased form, so this
+        # filter is a no-op (keeps everything) when there's no organizer
+        # email to exclude - same effect as branching on `organizer_email`
+        # explicitly, without a duplicated ternary.
+        organizer_email_lower = organizer_email.lower() if organizer_email else None
+        attendees_to_check = [
+            a for a in added_attendees if a.lower() != organizer_email_lower
+        ]
+        existing_attendees_to_check = [
+            a for a in existing_attendees_raw if a.lower() != organizer_email_lower
+        ]
+        # Whether the organizer's own email was itself one of the
+        # genuinely-new additions (filtered out of attendees_to_check
+        # above) - if so, their availability still needs verifying, just
+        # via the organizer-calendar path (which can actually exclude
+        # this event) rather than freebusy (which can't). Without this,
+        # adding ONLY the organizer as a new attendee - with the window
+        # otherwise unchanged - would skip checking their calendar
+        # entirely: `attendees_to_check` ends up empty (organizer
+        # filtered out) and `check_organizer` alone wouldn't have been
+        # true for an unmoved window, so no conflict check would run for
+        # them at all, silently missing a real conflict on their calendar.
+        organizer_newly_added = organizer_email_lower is not None and any(
+            a.lower() == organizer_email_lower for a in added_attendees
+        )
+
         existing_is_all_day = "date" in (event.get("start") or {}) or "date" in (
             event.get("end") or {}
         )
@@ -774,7 +825,7 @@ def google_calendar_update_events(
         # of that comparison fall back to the same assumption
         # consistently), so neither actually needs the real zone either.
         needs_real_calendar_timezone = existing_is_all_day and (
-            bool(start_time) or bool(end_time) or bool(added_attendees)
+            bool(start_time) or bool(end_time) or bool(attendees_to_check)
         )
         try:
             calendar_timezone = (
@@ -814,32 +865,18 @@ def google_calendar_update_events(
             existing_end_key,
         )
 
-        # The organizer's own calendar is already checked above via
-        # check_organizer (events.list, excluded by id/recurringEventId) -
-        # freebusy.query has no concept of "exclude this event", so if the
-        # organizer's own email also shows up among the attendees being
-        # freebusy-checked (just added now, or already on the event from
-        # an earlier call), that query would always find this very
-        # event's own busy block on their calendar and report a false
-        # self-conflict. Excluded only from the freebusy-checked copies
-        # below, never from `added_attendees` itself - a caller that
-        # explicitly asked to add the organizer as an attendee must still
-        # have them actually written to the event.
-        organizer_email = (event.get("organizer") or {}).get("email")
-        attendees_to_check = (
-            [a for a in added_attendees if a.lower() != organizer_email.lower()]
-            if organizer_email
-            else added_attendees
-        )
-        existing_attendees_to_check = (
-            [a for a in existing_attendees_raw if a.lower() != organizer_email.lower()]
-            if organizer_email
-            else existing_attendees_raw
-        )
-
         unchecked_attendees: list[str] = []
         if not ignore_conflicts and effective_start and effective_end:
-            check_organizer = window_changed
+            # A newly-added organizer is checked via the organizer path
+            # (events.list, which can actually exclude this event by id/
+            # recurringEventId) rather than freebusy - without also
+            # triggering it here, adding ONLY the organizer as a new
+            # attendee on an otherwise-unmoved event would leave
+            # `attendees_to_check` empty (organizer filtered out above)
+            # and `window_changed` false, skipping their calendar
+            # entirely instead of just skipping the self-conflicting
+            # freebusy path for them.
+            check_organizer = window_changed or organizer_newly_added
             all_conflicts: list[dict[str, Any]] = []
 
             try:

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -802,26 +802,40 @@ def google_calendar_update_events(
         # timezone lookup, or (worse) skip checking the organizer's
         # calendar entirely, in the specific case where the organizer's
         # own email was the only thing making a raw set non-empty.
-        organizer_email = (event.get("organizer") or {}).get("email")
-        if organizer_email is None and added_attendees:
-            # Google omits the top-level `organizer` field whenever the
-            # organizer is just the calendar owner (the overwhelmingly
-            # common case) - the caller's own resolved address (from the
-            # same calendars().get(calendarId="primary") already used
-            # for caller_is_organizer/all-day widening below) IS the
-            # organizer then. Only resolved when there's a newly-added
-            # attendee to check this against - a retained attendee's
-            # delta-segment query never re-scans the event's OLD window
+        organizer = event.get("organizer") or {}
+        organizer_email = organizer.get("email")
+        # Google's own documented signal for "is the organizer this
+        # connected account" (per the Events resource: "Whether the
+        # organizer corresponds to the calendar on which this copy of
+        # the event appears") - reading it directly here is more
+        # reliable than comparing email strings (no case-folding to get
+        # wrong) and, in the common case where it's present, needs no
+        # extra API call at all for identity purposes. None only when
+        # the whole `organizer` object is absent or lacks this field -
+        # not actually documented to happen for a self-organized event,
+        # but handled the same as "assume self" purely as a defensive
+        # fallback, not because it's expected in practice.
+        organizer_self = organizer.get("self")
+        if organizer_email is None and organizer_self is not False and added_attendees:
+            # Whether via organizer.self=True or a wholly-missing
+            # organizer object/field, the caller is (or is assumed to
+            # be) the organizer here - but neither case gives us an
+            # actual email to exclude from the freebusy batch below.
+            # Resolved via the same calendars().get(calendarId="primary")
+            # already used for caller_is_organizer/all-day widening
+            # below (the closure caches it, so this never fetches
+            # twice). Only resolved when there's a newly-added attendee
+            # to check this against - a retained attendee's delta-
+            # segment query never re-scans the event's OLD window
             # (where their own footprint would live), so it can't
             # self-conflict regardless of this exclusion, and a
             # metadata-only edit has no attendee to need it for at all.
             # Without this, adding the caller's OWN address as a "new"
-            # attendee on an event with no explicit organizer field
-            # would never be excluded from the freebusy batch below and
-            # would always find this very event's own busy block on
-            # their calendar - the exact self-conflict class this
-            # exclusion exists to prevent for the explicit-organizer-
-            # field case already.
+            # attendee on such an event would never be excluded from
+            # the freebusy batch and would always find this very
+            # event's own busy block on their calendar - the exact
+            # self-conflict class this exclusion exists to prevent for
+            # the known-organizer-email case already.
             organizer_email = primary_calendar_info()[0]
         # None never equals a real address's lowercased form, so this
         # filter is a no-op (keeps everything) when there's no organizer
@@ -966,23 +980,28 @@ def google_calendar_update_events(
             # `attendees_to_check` empty (organizer filtered out above)
             # and `window_changed` false, skipping their calendar
             # entirely instead of just skipping the self-conflicting
-            # freebusy path for them. Independent of whether an explicit
-            # `organizer` field is even present on the event - Google
-            # omits it whenever the organizer is just the calendar owner
-            # (the overwhelmingly common case), and this must still
-            # trigger then, same as before this identity fix.
+            # freebusy path for them. Independent of whether the
+            # organizer's own identity is resolvable at all - even an
+            # event with no organizer info whatsoever must still trigger
+            # this the same as before this identity fix.
             organizer_needs_verification = window_changed or organizer_newly_added
             # Gated on organizer_needs_verification too - caller_is_organizer
             # is only ever consulted below when the organizer needs
             # (re)verifying at all, so a metadata-only edit (summary/
             # description/location, no window or attendee change) on an
             # event with an explicit organizer field must not pay for
-            # this API call when nothing downstream would use its result.
+            # an API call when nothing downstream would use its result.
             caller_is_organizer = True
-            if organizer_needs_verification and organizer_email_lower is not None:
-                caller_is_organizer = (
-                    primary_calendar_info()[0].lower() == organizer_email_lower
-                )
+            if organizer_needs_verification:
+                if organizer_self is not None:
+                    # The documented, direct signal - no email
+                    # comparison (and its case-folding risk) or extra
+                    # API call needed when Google already told us.
+                    caller_is_organizer = organizer_self
+                elif organizer_email_lower is not None:
+                    caller_is_organizer = (
+                        primary_calendar_info()[0].lower() == organizer_email_lower
+                    )
             # Only actually query "primary" for the organizer's own
             # conflicts when the caller genuinely IS the organizer -
             # otherwise "primary" is someone else's calendar entirely,

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -2,13 +2,26 @@ import json
 import logging
 import os
 import uuid
+from datetime import datetime
 from typing import Any
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build  # type: ignore
+from googleapiclient.errors import HttpError  # type: ignore
 from mcp.server.fastmcp import FastMCP
 
+from .utils import InsufficientScopeError
+from .utils import attendees_to_add as _attendees_to_add
+from .utils import calendar_day_bounds as _calendar_day_bounds
+from .utils import conflict_response as _conflict_response
+from .utils import datetime_key_for_comparison as _datetime_key_for_comparison
+from .utils import merge_scope_error as _merge_scope_error
+from .utils import normalize_addresses as _normalize_addresses
+from .utils import offset_datetime_string as _offset_datetime_string
+from .utils import reject_reversed_window as _reject_reversed_window
 from .utils import setup_proxy_env, success_with_capped_dict
+from .utils import unchecked_extra as _unchecked_extra
+from .utils import window_delta_segments as _window_delta_segments
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("calendar-mcp")
@@ -17,6 +30,294 @@ logger = logging.getLogger("calendar-mcp")
 setup_proxy_env()
 
 mcp = FastMCP("calendar-mcp")
+
+# freebusy.query accepts at most this many calendars per call
+# (Google's calendarExpansionMax).
+_MAX_ATTENDEES_PER_FREEBUSY_QUERY = 50
+
+
+def _is_insufficient_scope_error(exc: Any) -> bool:
+    """Whether `exc` is specifically "the access token doesn't have the
+    scope this call needs", not just any 403.
+
+    Google's error body can carry this reason on either of two fields,
+    and both show up in practice: the legacy `error.errors[].reason ==
+    "insufficientPermissions"`, and a newer `error.details[].reason ==
+    "ACCESS_TOKEN_SCOPE_INSUFFICIENT"` (an ErrorInfo entry) that a real
+    Calendar API 403 for this exact case carries ALONGSIDE the legacy
+    one, not instead of it. `HttpError._get_reason` picks one field per
+    a fixed priority order (`detail` > `details` > `errors` > `message`)
+    to build `exc.error_details`/`str(exc)` - when both are present,
+    `details` wins and the legacy reason string is dropped entirely from
+    the formatted message. So a plain substring check on `str(exc)` can
+    silently stop matching real scope errors the moment Google's backend
+    starts including both. Check the parsed body directly instead of
+    trusting which one HttpError's own formatting happens to surface.
+    """
+    try:
+        data = json.loads(exc.content.decode("utf-8"))
+    except (ValueError, AttributeError):
+        return False
+    error = data.get("error") if isinstance(data, dict) else None
+    if not isinstance(error, dict):
+        return False
+    for field, reason in (
+        ("errors", "insufficientPermissions"),
+        ("details", "ACCESS_TOKEN_SCOPE_INSUFFICIENT"),
+    ):
+        entries = error.get(field)
+        if not isinstance(entries, list):
+            # A real Google error body always shapes these as arrays -
+            # this is defensive against a malformed/unexpected body,
+            # which is exactly the "can't tell" case this function
+            # already treats as False elsewhere (e.g. non-JSON content).
+            continue
+        for entry in entries:
+            if isinstance(entry, dict) and entry.get("reason") == reason:
+                return True
+    return False
+
+
+def _find_conflicts(
+    service: Any,
+    time_min: str,
+    time_max: str,
+    attendees: list[str],
+    *,
+    exclude_event_id: str | None = None,
+    check_organizer: bool = True,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Check the organizer's own calendar (when check_organizer) plus each
+    attendee's free/busy for anything overlapping [time_min, time_max).
+
+    Delegates the actual interval-overlap comparison to the Google Calendar
+    API's timeMin/timeMax semantics rather than parsing/normalizing the
+    timestamps locally, so this can't reproduce a timezone-comparison bug.
+
+    Free/busy has no concept of "exclude this event": it only returns raw
+    busy time ranges, so a query against a window an attendee is *already*
+    busy for (because that's the very event being updated) can't be told
+    apart from a genuine conflict here. Callers that aren't moving the event
+    to a new window must restrict `attendees` to only the newly-added ones
+    (see google_calendar_update_events) rather than relying on this function
+    to exclude the event's own footprint on attendee calendars.
+
+    Returns (conflicts, unchecked_attendees). A missing-scope 403 covering
+    the whole call raises `InsufficientScopeError` (carrying whatever was
+    already confirmed in `conflicts`/`unchecked_attendees` before the
+    error) instead of degrading to unchecked and returning normally -
+    that's OUR OWN credential's problem, not a per-attendee visibility
+    gap, and writing an event whose availability was never actually
+    checked would defeat the point of this feature. Every entry that
+    does end up in `unchecked_attendees` on a normal return is the
+    self-explanatory kind (absent from the response, or its own
+    per-attendee error).
+    """
+    conflicts: list[dict[str, Any]] = []
+    unchecked_attendees: list[str] = []
+
+    if check_organizer:
+        organizer_events = (
+            service.events()
+            .list(
+                calendarId="primary",
+                timeMin=time_min,
+                timeMax=time_max,
+                singleEvents=True,
+                orderBy="startTime",
+            )
+            .execute()
+            .get("items")
+            or []
+        )
+        for item in organizer_events:
+            if item.get("status") == "cancelled":
+                continue
+            if item.get("transparency") == "transparent":
+                continue
+            if exclude_event_id and item.get("id") == exclude_event_id:
+                continue
+            # NOTE: declining an invite (attendees[].responseStatus ==
+            # "declined" for the organizer's own self entry) is NOT used
+            # as a busy/free signal here - Google's own Events docs treat
+            # responseStatus and transparency as independent fields, with
+            # no documented guarantee that declining clears transparency
+            # to "transparent". An earlier version of this check skipped
+            # declined events outright, which silently treated a
+            # still-opaque declined event as free and permitted a real
+            # double booking. `transparency` above is the one field
+            # Google actually documents as the busy/free predicate.
+            start = item.get("start") or {}
+            end = item.get("end") or {}
+            conflicts.append(
+                {
+                    "calendar": "organizer",
+                    "summary": item.get("summary") or "(no title)",
+                    "start": start.get("dateTime") or start.get("date"),
+                    "end": end.get("dateTime") or end.get("date"),
+                }
+            )
+
+    # freebusy.query caps the number of calendars per call
+    # (Google's calendarExpansionMax) - chunk rather than giving up on the
+    # whole batch, so a large invite list still gets everyone it can check
+    # only. `range(0, 0, N)` is empty, so this is also just a no-op loop
+    # when `attendees` is empty.
+    for offset in range(0, len(attendees), _MAX_ATTENDEES_PER_FREEBUSY_QUERY):
+        batch = attendees[offset : offset + _MAX_ATTENDEES_PER_FREEBUSY_QUERY]
+        try:
+            freebusy = (
+                service.freebusy()
+                .query(
+                    body={
+                        "timeMin": time_min,
+                        "timeMax": time_max,
+                        "items": [{"id": email} for email in batch],
+                    }
+                )
+                .execute()
+            )
+        except HttpError as exc:
+            if exc.resp.status == 403 and _is_insufficient_scope_error(exc):
+                # This connection's OAuth token predates the
+                # calendar.freebusy scope (see the
+                # 20260907_add_calendar_freebusy_scope migration) and
+                # hasn't been reconnected yet. This is OUR OWN
+                # credential's problem, not a per-attendee visibility gap
+                # (e.g. a specific attendee's calendar being unreadable,
+                # which genuinely can't be fixed and still degrades to
+                # unchecked below) - proceeding to write an event whose
+                # availability was never actually checked would defeat
+                # the entire point of this feature, so reject instead of
+                # silently booking over a possible conflict. Carrying
+                # `conflicts` (e.g. an organizer conflict already found
+                # above, before this batch ever ran) lets a caller still
+                # report it rather than silently discarding a known
+                # problem just because this later, unrelated check also
+                # failed.
+                raise InsufficientScopeError(
+                    "Missing the calendar.freebusy permission needed to "
+                    "check attendee availability - reconnect the Google "
+                    "Calendar connector to grant it, or pass "
+                    "ignore_conflicts=true if the user has confirmed "
+                    "they want to proceed without this check.",
+                    conflicts,
+                    # Every attendee from this failed batch onward is
+                    # unchecked - every remaining batch would hit this
+                    # same scope error too, so there's nothing left to
+                    # gain by attempting them.
+                    unchecked_attendees + attendees[offset:],
+                ) from exc
+            raise
+
+        # Google's own calendarList entries are case-normalized; be
+        # defensive in case freebusy echoes calendar ids back
+        # differently from how the caller supplied them, rather than
+        # silently dropping a real conflict/error for that attendee.
+        calendars = {
+            key.lower(): value
+            for key, value in (freebusy.get("calendars") or {}).items()
+        }
+        for email in batch:
+            if email.lower() not in calendars:
+                # Not even present in the response - can't tell
+                # whether they're free, so don't silently report them
+                # as clear.
+                unchecked_attendees.append(email)
+                continue
+            info = calendars[email.lower()] or {}
+            if info.get("errors"):
+                unchecked_attendees.append(email)
+                continue
+            for busy in info.get("busy") or []:
+                conflicts.append(
+                    {
+                        "calendar": email,
+                        "summary": None,
+                        "start": busy.get("start"),
+                        "end": busy.get("end"),
+                    }
+                )
+
+    return conflicts, unchecked_attendees
+
+
+def _primary_calendar_timezone(service: Any) -> str:
+    """The primary calendar's own configured IANA timezone (falls back to
+    UTC if somehow absent - Google's Calendar resource always carries a
+    timeZone, so this is a defensive last resort, not the expected path).
+
+    Needs the calendar.calendars.readonly scope (see the
+    20260909_add_calendar_calendars_readonly_scope migration) - neither
+    calendar.events nor calendar.freebusy authorizes calendars.get, per
+    Google's own scope reference for that endpoint.
+    """
+    try:
+        calendar = service.calendars().get(calendarId="primary").execute()
+    except HttpError as exc:
+        if exc.resp.status == 403 and _is_insufficient_scope_error(exc):
+            # This connection's OAuth token predates the
+            # calendar.calendars.readonly scope. Without the calendar's
+            # own timezone, an all-day boundary can't be safely widened
+            # for the conflict check that's about to run - reject rather
+            # than silently guessing (e.g. defaulting to UTC), which
+            # could misjudge the query window by the calendar's real
+            # UTC offset.
+            raise ValueError(
+                "Missing the calendar.calendars.readonly permission "
+                "needed to look up the calendar's timezone for this "
+                "all-day event - reconnect the Google Calendar "
+                "connector to grant it, or pass ignore_conflicts=true "
+                "if the user has confirmed they want to proceed without "
+                "this check."
+            ) from exc
+        raise
+    return calendar.get("timeZone") or "UTC"
+
+
+def _event_boundary(field: dict[str, Any] | None, tz_name: str) -> str | None:
+    """Return a RFC3339 timestamp usable as a freebusy/events.list time
+    bound for one side (start or end) of an event.
+
+    Google represents a timed event's boundary as {"dateTime": ...} and an
+    all-day event's as {"date": "YYYY-MM-DD"} - timeMin/timeMax require a
+    full RFC3339 timestamp with a zone offset, so a bare date needs
+    widening.
+
+    A timed boundary's `dateTime` USUALLY already carries its own zone
+    offset, but Google's own EventDateTime docs are explicit that this
+    isn't guaranteed: "A time zone offset is required unless a time zone
+    is explicitly specified in timeZone" - a client (including one that
+    isn't this tool) can legally write an offsetless `dateTime` paired
+    with a sibling `timeZone` field instead. Comparing that offsetless
+    string as if it were self-describing would compare naive against
+    aware for what could be the same instant, defeating the overlap math
+    this whole module exists to get right - so it must be resolved
+    against its own `timeZone` (falling back to the calendar's default,
+    `tz_name`, only if this specific field is missing one).
+
+    An all-day event's date is a day on the *calendar's own* calendar, not
+    a UTC day - `tz_name` must be that calendar's configured timezone, not
+    a hardcoded UTC, or the widened boundary is off by the calendar's own
+    UTC offset. All-day events already store both start.date and end.date
+    as the correct (exclusive-end) calendar-day range, so no day-arithmetic
+    is needed here - just giving each date its own midnight in tz_name.
+    """
+    field = field or {}
+    date_time: str | None = field.get("dateTime")
+    if date_time:
+        try:
+            is_naive = datetime.fromisoformat(date_time).tzinfo is None
+        except ValueError:
+            return date_time  # malformed - pass through unchanged, as before
+        if not is_naive:
+            return date_time
+        return _offset_datetime_string(date_time, field.get("timeZone") or tz_name)
+    date_value: str | None = field.get("date")
+    if date_value:
+        start, _ = _calendar_day_bounds(date_value, tz_name)
+        return start
+    return None
 
 
 def get_calendar_service() -> Any:
@@ -87,41 +388,6 @@ def _add_conference_request(event: dict[str, Any]) -> None:
             "conferenceSolutionKey": {"type": "hangoutsMeet"},
         }
     }
-
-
-def _merge_attendees(event: dict[str, Any], attendees: list[str] | None) -> None:
-    """Add attendees to the event without dropping ones already on it.
-
-    Matching against existing attendees (and within the new list) is
-    case-/whitespace-insensitive, since `Alice@Example.com` and
-    `alice@example.com` are the same mailbox and would otherwise be added
-    as a redundant duplicate.
-    """
-    if not attendees:
-        return
-    existing = event.get("attendees") or []
-    existing_emails = {
-        email.strip().lower()
-        for a in existing
-        if isinstance(a, dict) and (email := a.get("email"))
-    }
-
-    seen = set()
-    new_attendees = []
-    for email in attendees:
-        if not email:
-            continue
-        normalized = email.strip()
-        if not normalized:
-            continue
-        key = normalized.lower()
-        if key in existing_emails or key in seen:
-            continue
-        seen.add(key)
-        new_attendees.append({"email": normalized})
-
-    if new_attendees:
-        event["attendees"] = existing + new_attendees
 
 
 def _create_request_status_code(conference_data: dict[str, Any]) -> str | None:
@@ -232,7 +498,7 @@ def _error_message(exc: Exception, requested_conference: bool) -> str:
     return message
 
 
-def _event_response(event: dict[str, Any]) -> str:
+def _event_response(event: dict[str, Any], **extra_fields: Any) -> str:
     conference_data = event.get("conferenceData") or {}
 
     hangout_link = event.get("hangoutLink")
@@ -274,7 +540,8 @@ def _event_response(event: dict[str, Any]) -> str:
     # capping never has to reason about them.
     response = json.loads(success_with_capped_dict("event", event))
     response.update(extra)
-    return json.dumps(response)
+    response.update(extra_fields)
+    return json.dumps(response, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -284,16 +551,20 @@ def google_calendar_create_events(
     end_time: str,
     description: str | None = None,
     location: str | None = None,
-    attendees: list[str] | None = None,
+    attendees: list[str] | str | None = None,
     notify_attendees: bool = False,
     add_google_meet: bool = False,
+    ignore_conflicts: bool = False,
 ) -> str:
     """
     Create a new event in Google Calendar.
     start_time and end_time must be RFC3339 formatted (e.g., '2024-01-01T10:00:00Z' or '2024-01-01T10:00:00-07:00').
-    attendees is a list of email addresses to add to the event. Adding attendees does not, by
-    itself, email them; set notify_attendees=True to have Google Calendar send them a native
-    invite immediately. Confirm the recipient list with the user before setting notify_attendees=True.
+    attendees, if given, are checked for scheduling conflicts together with the organizer's own
+    calendar; a conflict returns status="conflict" instead of creating the event. Pass
+    ignore_conflicts=True to create it anyway once the user has explicitly confirmed a conflict is
+    fine. Adding attendees does not, by itself, email them; set notify_attendees=True to have Google
+    Calendar send them a native invite immediately. Confirm the recipient list with the user before
+    setting notify_attendees=True.
     Set add_google_meet=True to attach a real Google Meet video-conference link to the event. The
     link is returned as hangout_link once Google finishes provisioning it; if it isn't ready yet the
     response includes conference_status instead (e.g. "pending") — call google_calendar_get_event
@@ -305,7 +576,25 @@ def google_calendar_create_events(
     """
     requested_conference = False
     try:
+        _reject_reversed_window(start_time, end_time)
         service = get_calendar_service()
+        normalized_attendees = _normalize_addresses(attendees) if attendees else []
+
+        unchecked_attendees: list[str] = []
+        if not ignore_conflicts:
+            try:
+                conflicts, unchecked_attendees = _find_conflicts(
+                    service, start_time, end_time, normalized_attendees
+                )
+            except InsufficientScopeError as exc:
+                conflicts, unchecked_attendees = _merge_scope_error(exc, [], [])
+            if conflicts:
+                return _conflict_response(
+                    conflicts,
+                    unchecked_attendees,
+                    start_time,
+                    end_time,
+                )
 
         event: dict[str, Any] = {
             "summary": summary,
@@ -321,7 +610,10 @@ def google_calendar_create_events(
             event["description"] = description
         if location:
             event["location"] = location
-        _merge_attendees(event, attendees)
+        if normalized_attendees:
+            event["attendees"] = [
+                {"email": address} for address in normalized_attendees
+            ]
         requested_conference = _apply_conference_request(event, add_google_meet)
 
         request = service.events().insert(
@@ -330,7 +622,7 @@ def google_calendar_create_events(
             **_api_call_kwargs(event, notify_attendees),
         )
         created_event = request.execute()
-        return _event_response(created_event)
+        return _event_response(created_event, **_unchecked_extra(unchecked_attendees))
 
     except Exception as e:
         logger.error(f"Error creating event: {e}")
@@ -364,13 +656,18 @@ def google_calendar_update_events(
     end_time: str | None = None,
     description: str | None = None,
     location: str | None = None,
-    attendees: list[str] | None = None,
+    attendees: list[str] | str | None = None,
     notify_attendees: bool = False,
     add_google_meet: bool = False,
+    ignore_conflicts: bool = False,
 ) -> str:
     """
     Update an existing event in Google Calendar.
     start_time and end_time must be RFC3339 formatted if provided.
+    If the update moves the event to a new time, or adds attendees, that change is checked for
+    conflicts the same way google_calendar_create_events is; pass ignore_conflicts=True to skip the
+    check once the user has explicitly confirmed a conflict is fine. Editing other fields (summary,
+    description, location) without moving the event is never blocked.
     attendees is a list of email addresses to add to the event; attendees already on the event are
     kept, and there is no way to remove an attendee through this parameter. Adding attendees does
     not, by itself, email anyone; set notify_attendees=True to have Google Calendar send a native
@@ -395,6 +692,151 @@ def google_calendar_update_events(
         # First get the existing event
         event = service.events().get(calendarId="primary", eventId=event_id).execute()
 
+        existing_is_all_day = "date" in (event.get("start") or {}) or "date" in (
+            event.get("end") or {}
+        )
+        if existing_is_all_day and bool(start_time) != bool(end_time):
+            # The existing event's start/end are {"date": ...}; writing
+            # only one of start_time/end_time would overwrite just that
+            # side with {"dateTime": ...} while the other side keeps its
+            # {"date": ...} shape - Google rejects a body mixing the two
+            # formats between an event's start and end.
+            raise ValueError(
+                "Existing event is all-day (uses date-only start/end); "
+                "updating only one of start_time/end_time would mix "
+                "date-only and dateTime formats. Pass both start_time and "
+                "end_time together."
+            )
+
+        # The calendar's own timezone is only needed to widen an all-day
+        # boundary (see _event_boundary) so a moved window or an
+        # added/retained attendee gets checked against the right absolute
+        # instant - fetch it lazily so a plain timed-event update, or a
+        # summary/location/description-only edit of an all-day event that
+        # never touches its window or attendees, doesn't pay for an extra
+        # API call (or a scope-403 that would otherwise block an edit
+        # that never needed timezone precision at all) it has no use for.
+        needs_real_calendar_timezone = existing_is_all_day and (
+            bool(start_time) or bool(end_time) or bool(attendees)
+        )
+        try:
+            calendar_timezone = (
+                _primary_calendar_timezone(service)
+                if needs_real_calendar_timezone
+                else "UTC"
+            )
+        except ValueError:
+            if not ignore_conflicts:
+                raise
+            # ignore_conflicts=True means the caller has already decided
+            # the conflict check doesn't need to run - a missing-scope
+            # 403 here would only ever be surfaced by that check (or by
+            # the reversed-window sanity check below, which is fine to
+            # run a little less precisely against UTC than to block a
+            # write the caller explicitly opted out of checking).
+            calendar_timezone = "UTC"
+        existing_start = _event_boundary(event.get("start"), calendar_timezone)
+        existing_end = _event_boundary(event.get("end"), calendar_timezone)
+        effective_start = start_time or existing_start
+        effective_end = end_time or existing_end
+        if (start_time or end_time) and effective_start and effective_end:
+            # Only worth checking when this call is actually about to
+            # write a (possibly partly-existing) window - an
+            # attendees/summary-only edit that never moves either
+            # boundary would otherwise re-validate the event's
+            # already-stored, unchanged start/end and could reject an
+            # unrelated field edit over pre-existing data this call
+            # never touches.
+            _reject_reversed_window(effective_start, effective_end)
+        existing_start_key = _datetime_key_for_comparison(existing_start)
+        existing_end_key = _datetime_key_for_comparison(existing_end)
+        effective_start_key = _datetime_key_for_comparison(effective_start)
+        effective_end_key = _datetime_key_for_comparison(effective_end)
+        window_changed = (effective_start_key, effective_end_key) != (
+            existing_start_key,
+            existing_end_key,
+        )
+
+        existing_attendees_raw = [
+            a["email"]
+            for a in (event.get("attendees") or [])
+            if isinstance(a, dict) and a.get("email")
+        ]
+        existing_attendee_emails = {
+            address.lower() for address in existing_attendees_raw
+        }
+        # attendees only ever ADDS: there's no way to remove an existing
+        # attendee through this parameter (matching this tool's own
+        # docstring). `added_attendees` (genuinely new) and
+        # `existing_attendees_raw` (retained) are checked separately
+        # below - a retained attendee only needs checking against the
+        # portion of a moved window that's actually new territory, while
+        # a newly-added one needs the whole effective window checked.
+        added_attendees = _attendees_to_add(attendees, existing_attendee_emails)
+
+        unchecked_attendees: list[str] = []
+        if not ignore_conflicts and effective_start and effective_end:
+            check_organizer = window_changed
+            all_conflicts: list[dict[str, Any]] = []
+
+            try:
+                # A newly-added attendee has no footprint on this event
+                # at all, so the FULL effective window is safe (and
+                # necessary) to check for them - same call also covers
+                # the organizer, who's excluded by event id rather than
+                # by window, so `window_changed` alone (not a
+                # disjoint-move test) decides whether to re-check them.
+                if check_organizer or added_attendees:
+                    conflicts, unchecked = _find_conflicts(
+                        service,
+                        effective_start,
+                        effective_end,
+                        added_attendees,
+                        exclude_event_id=event_id,
+                        check_organizer=check_organizer,
+                    )
+                    all_conflicts.extend(conflicts)
+                    unchecked_attendees.extend(unchecked)
+
+                # A retained attendee's own busy block for THIS event
+                # covers the entire OLD window - querying that overlap
+                # can't tell "busy because of this event" from a real
+                # conflict. Only the portion of the new window that's
+                # genuinely new territory (window_delta_segments - empty
+                # for an unchanged/shrunk window, up to two segments for
+                # a partial nudge that extends past the old window on one
+                # or both sides, or the whole new window for a fully
+                # disjoint move) can hide a real conflict for them.
+                if existing_attendees_raw:
+                    for seg_start, seg_end in _window_delta_segments(
+                        existing_start_key,
+                        existing_end_key,
+                        effective_start_key,
+                        effective_end_key,
+                    ):
+                        conflicts, unchecked = _find_conflicts(
+                            service,
+                            seg_start.isoformat(),
+                            seg_end.isoformat(),
+                            existing_attendees_raw,
+                            exclude_event_id=event_id,
+                            check_organizer=False,
+                        )
+                        all_conflicts.extend(conflicts)
+                        unchecked_attendees.extend(unchecked)
+            except InsufficientScopeError as exc:
+                all_conflicts, unchecked_attendees = _merge_scope_error(
+                    exc, all_conflicts, unchecked_attendees
+                )
+
+            if all_conflicts:
+                return _conflict_response(
+                    all_conflicts,
+                    unchecked_attendees,
+                    effective_start,
+                    effective_end,
+                )
+
         if summary:
             event["summary"] = summary
         if start_time:
@@ -405,7 +847,14 @@ def google_calendar_update_events(
             event["description"] = description
         if location:
             event["location"] = location
-        _merge_attendees(event, attendees)
+        if added_attendees:
+            # Only append the newly-added attendees - existing entries are
+            # left completely untouched (dict identity and all), so their
+            # RSVP state (responseStatus, optional, comment, ...) is never
+            # at risk of being clobbered by a re-submission.
+            event["attendees"] = (event.get("attendees") or []) + [
+                {"email": address} for address in added_attendees
+            ]
         requested_conference = _apply_conference_request(event, add_google_meet)
 
         request = service.events().update(
@@ -415,7 +864,7 @@ def google_calendar_update_events(
             **_api_call_kwargs(event, notify_attendees),
         )
         updated_event = request.execute()
-        return _event_response(updated_event)
+        return _event_response(updated_event, **_unchecked_extra(unchecked_attendees))
 
     except Exception as e:
         logger.error(f"Error updating event: {e}")

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -1081,15 +1081,34 @@ def google_calendar_update_events(
                 and organizer_needs_verification
                 and not caller_is_organizer
             ):
-                # The real organizer's own copy of this event would
-                # self-conflict via freebusy (same problem
-                # attendees_to_check's exclusion above avoids), and we
-                # have no calendarId to query their actual calendar
-                # directly (only "primary", which is the caller's) - so
-                # there is no available mechanism to actually verify
-                # them. Report as unchecked rather than silently treating
-                # them as clear.
-                unchecked_attendees.append(organizer_email)
+                if window_changed:
+                    # freebusy.query accepts any calendar/email id, not
+                    # just "primary" - the real organizer's calendar CAN
+                    # be checked this way, same as any other attendee.
+                    # Their own copy of this event already occupies the
+                    # OLD window regardless of whether they're also
+                    # listed as an attendee (they've always been the
+                    # organizer), so - exactly like a retained attendee -
+                    # only the delta segments beyond that old window are
+                    # safe to check without self-conflicting on their own
+                    # unrelated busy block for this same event.
+                    existing_attendees_to_check = existing_attendees_to_check + [
+                        organizer_email
+                    ]
+                else:
+                    # window_changed is False here only because
+                    # organizer_newly_added forced organizer_needs_
+                    # verification - the window itself never moved, so
+                    # window_delta_segments would find no new territory
+                    # at all to check them against. Unlike the
+                    # caller_is_organizer path (which excludes by event
+                    # id via events.list and so can safely re-scan the
+                    # whole unchanged window), freebusy has no id-based
+                    # exclusion - there is genuinely no way to verify an
+                    # unchanged window for them without risking a
+                    # self-conflict. Report as unchecked rather than
+                    # silently treating them as clear.
+                    unchecked_attendees.append(organizer_email)
             all_conflicts: list[dict[str, Any]] = []
             # Tracks the most recent InsufficientScopeError seen across
             # EITHER block below, re-raised only once both blocks have

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -217,9 +217,9 @@ def _find_conflicts(
                 raise InsufficientScopeError(
                     "Missing the calendar.freebusy permission needed to "
                     "check attendee availability - reconnect the Google "
-                    "Calendar connector to grant it, or pass "
-                    "ignore_conflicts=true if the user has confirmed "
-                    "they want to proceed without this check.",
+                    "Calendar connector to grant it. This is a missing "
+                    "permission on our own credential, not a real "
+                    "scheduling conflict to route around.",
                     conflicts,
                     # Every attendee from this failed batch onward is
                     # unchecked - every remaining batch would hit this
@@ -261,9 +261,15 @@ def _find_conflicts(
     return conflicts, unchecked_attendees
 
 
-def _primary_calendar_timezone(service: Any) -> str:
-    """The primary calendar's own configured IANA timezone (falls back to
-    UTC if somehow absent - Google's Calendar resource always carries a
+def _primary_calendar_info(service: Any) -> tuple[str, str]:
+    """The connected account's own (email, timezone) for its primary
+    calendar - a single calendars().get(calendarId="primary") call serves
+    both needs: `id` is the connected account's own address (used to tell
+    whether the authenticated caller is actually a given event's
+    organizer, since "primary" always means the caller's own calendar,
+    never an arbitrary other attendee's or organizer's), and `timeZone`
+    is the calendar's configured IANA zone, falling back to UTC if
+    somehow absent (Google's Calendar resource always carries a
     timeZone, so this is a defensive last resort, not the expected path).
 
     Needs the calendar.calendars.readonly scope (see the
@@ -277,21 +283,30 @@ def _primary_calendar_timezone(service: Any) -> str:
         if exc.resp.status == 403 and _is_insufficient_scope_error(exc):
             # This connection's OAuth token predates the
             # calendar.calendars.readonly scope. Without the calendar's
-            # own timezone, an all-day boundary can't be safely widened
-            # for the conflict check that's about to run - reject rather
-            # than silently guessing (e.g. defaulting to UTC), which
-            # could misjudge the query window by the calendar's real
-            # UTC offset.
-            raise ValueError(
+            # own identity/timezone, neither an all-day boundary nor a
+            # different-organizer conflict check can be safely resolved -
+            # reject rather than silently guessing (e.g. defaulting to
+            # UTC, or assuming the caller is the organizer), either of
+            # which could misjudge the query window or silently skip a
+            # real conflict.
+            # Raised as InsufficientScopeError (a ValueError subclass, so
+            # existing `except ValueError` call sites still catch it
+            # unchanged) rather than a bare ValueError, for consistency
+            # with every other scope-error site in this module - nothing
+            # has been confirmed by this helper itself, so both
+            # accumulator args are empty.
+            raise InsufficientScopeError(
                 "Missing the calendar.calendars.readonly permission "
-                "needed to look up the calendar's timezone for this "
-                "all-day event - reconnect the Google Calendar "
-                "connector to grant it, or pass ignore_conflicts=true "
-                "if the user has confirmed they want to proceed without "
-                "this check."
+                "needed to look up the calendar's own identity/timezone "
+                "for this update - reconnect the Google Calendar "
+                "connector to grant it. This is a missing permission on "
+                "our own credential, not a real scheduling conflict to "
+                "route around.",
+                [],
+                [],
             ) from exc
         raise
-    return calendar.get("timeZone") or "UTC"
+    return calendar.get("id") or "", calendar.get("timeZone") or "UTC"
 
 
 def _event_boundary(field: dict[str, Any] | None, tz_name: str) -> str | None:
@@ -730,6 +745,21 @@ def google_calendar_update_events(
             _require_offset_datetime(end_time, "end_time")
         service = get_calendar_service()
 
+        # Lazily fetched and cached (as a one-element list, mutated
+        # rather than rebound, so the closure needs no `nonlocal`) - this
+        # single calendars().get(calendarId="primary") call resolves both
+        # the connected account's own identity (needed below to tell
+        # whether the caller is actually this event's organizer) and its
+        # timezone (needed further down only for an all-day boundary),
+        # so a call site that only needs one doesn't force a redundant
+        # second round-trip when the other site already fetched it.
+        primary_calendar_cache: list[tuple[str, str]] = []
+
+        def primary_calendar_info() -> tuple[str, str]:
+            if not primary_calendar_cache:
+                primary_calendar_cache.append(_primary_calendar_info(service))
+            return primary_calendar_cache[0]
+
         # First get the existing event
         event = service.events().get(calendarId="primary", eventId=event_id).execute()
 
@@ -847,10 +877,18 @@ def google_calendar_update_events(
         )
         try:
             calendar_timezone = (
-                _primary_calendar_timezone(service)
-                if needs_real_calendar_timezone
-                else "UTC"
+                primary_calendar_info()[1] if needs_real_calendar_timezone else "UTC"
             )
+            # _event_boundary can itself raise ValueError (via
+            # resolve_zoneinfo) when a stored event's own dateTime is
+            # offsetless and its sibling timeZone field is unresolvable -
+            # kept inside this same try so that case is governed by
+            # ignore_conflicts too, not just a bad calendar_timezone
+            # lookup. Otherwise a malformed event would hard-fail this
+            # call even when the caller explicitly opted out of the
+            # check the docstring says this guards.
+            existing_start = _event_boundary(event.get("start"), calendar_timezone)
+            existing_end = _event_boundary(event.get("end"), calendar_timezone)
         except ValueError:
             if not ignore_conflicts:
                 raise
@@ -859,10 +897,14 @@ def google_calendar_update_events(
             # 403 here would only ever be surfaced by that check (or by
             # the reversed-window sanity check below, which is fine to
             # run a little less precisely against UTC than to block a
-            # write the caller explicitly opted out of checking).
+            # write the caller explicitly opted out of checking). Leaving
+            # the existing boundaries unresolved (None) is safe: the
+            # conflict-check block below is itself gated on `not
+            # ignore_conflicts`, and the write payload only ever uses the
+            # caller-supplied start_time/end_time, never these.
             calendar_timezone = "UTC"
-        existing_start = _event_boundary(event.get("start"), calendar_timezone)
-        existing_end = _event_boundary(event.get("end"), calendar_timezone)
+            existing_start = None
+            existing_end = None
         effective_start = start_time or existing_start
         effective_end = end_time or existing_end
         if (start_time or end_time) and effective_start and effective_end:
@@ -885,6 +927,22 @@ def google_calendar_update_events(
 
         unchecked_attendees: list[str] = []
         if not ignore_conflicts and effective_start and effective_end:
+            # check_organizer queries calendarId="primary", which is
+            # always the AUTHENTICATED CALLER's own calendar - not
+            # necessarily this event's organizer. Google copies an event
+            # onto every attendee's own calendar too, and a guest with
+            # edit permission (guestsCanModify) can call this tool on an
+            # event they didn't organize; event["organizer"]["email"]
+            # would then differ from the caller's own address. Comparing
+            # against the calendar's own resolved identity (rather than
+            # assuming caller==organizer, as an earlier version did)
+            # catches that case rather than silently checking - and
+            # excluding from freebusy - the wrong person's calendar.
+            caller_is_organizer = True
+            if organizer_email_lower is not None:
+                caller_is_organizer = (
+                    primary_calendar_info()[0].lower() == organizer_email_lower
+                )
             # A newly-added organizer is checked via the organizer path
             # (events.list, which can actually exclude this event by id/
             # recurringEventId) rather than freebusy - without also
@@ -893,8 +951,32 @@ def google_calendar_update_events(
             # `attendees_to_check` empty (organizer filtered out above)
             # and `window_changed` false, skipping their calendar
             # entirely instead of just skipping the self-conflicting
-            # freebusy path for them.
-            check_organizer = window_changed or organizer_newly_added
+            # freebusy path for them. Independent of whether an explicit
+            # `organizer` field is even present on the event - Google
+            # omits it whenever the organizer is just the calendar owner
+            # (the overwhelmingly common case), and this must still
+            # trigger then, same as before this identity fix.
+            organizer_needs_verification = window_changed or organizer_newly_added
+            # Only actually query "primary" for the organizer's own
+            # conflicts when the caller genuinely IS the organizer -
+            # otherwise "primary" is someone else's calendar entirely,
+            # and mislabeling their busy blocks as the organizer's would
+            # be actively wrong, not just incomplete.
+            check_organizer = organizer_needs_verification and caller_is_organizer
+            if (
+                organizer_email
+                and organizer_needs_verification
+                and not caller_is_organizer
+            ):
+                # The real organizer's own copy of this event would
+                # self-conflict via freebusy (same problem
+                # attendees_to_check's exclusion above avoids), and we
+                # have no calendarId to query their actual calendar
+                # directly (only "primary", which is the caller's) - so
+                # there is no available mechanism to actually verify
+                # them. Report as unchecked rather than silently treating
+                # them as clear.
+                unchecked_attendees.append(organizer_email)
             all_conflicts: list[dict[str, Any]] = []
             # Tracks the most recent InsufficientScopeError seen across
             # EITHER block below, re-raised only once both blocks have
@@ -967,6 +1049,38 @@ def google_calendar_update_events(
                         # scope error too - nothing left to gain by
                         # attempting them.
                         break
+
+            # A both-sides-widened window produces two delta segments
+            # (the new territory on each side), both checked against the
+            # SAME existing_attendees_to_check list - an attendee who's
+            # unverifiable for a reason unrelated to which segment ran
+            # (absent from every freebusy response, or their own
+            # per-attendee error) would otherwise land in
+            # unchecked_attendees once per segment. Dedup both
+            # accumulators once, after every block above has had its
+            # chance to contribute, rather than per-block (which would
+            # miss a duplicate straddling the organizer/attendee split).
+            deduped_unchecked: list[str] = []
+            seen_unchecked: set[str] = set()
+            for attendee in unchecked_attendees:
+                if attendee not in seen_unchecked:
+                    seen_unchecked.add(attendee)
+                    deduped_unchecked.append(attendee)
+            unchecked_attendees = deduped_unchecked
+
+            deduped_conflicts: list[dict[str, Any]] = []
+            seen_conflicts: set[tuple[Any, Any, Any, Any]] = set()
+            for conflict in all_conflicts:
+                conflict_key = (
+                    conflict.get("calendar"),
+                    conflict.get("summary"),
+                    conflict.get("start"),
+                    conflict.get("end"),
+                )
+                if conflict_key not in seen_conflicts:
+                    seen_conflicts.add(conflict_key)
+                    deduped_conflicts.append(conflict)
+            all_conflicts = deduped_conflicts
 
             if pending_scope_error is not None and not all_conflicts:
                 raise pending_scope_error

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -10,6 +10,7 @@ from googleapiclient.discovery import build  # type: ignore
 from googleapiclient.errors import HttpError  # type: ignore
 from mcp.server.fastmcp import FastMCP
 
+from ....config import get_tool_max_output_length
 from .utils import InsufficientScopeError
 from .utils import attendees_to_add as _attendees_to_add
 from .utils import calendar_day_bounds as _calendar_day_bounds
@@ -576,9 +577,27 @@ def _event_response(
     # capping never has to reason about them.
     response = json.loads(success_with_capped_dict("event", event))
     response.update(extra)
-    if unchecked_attendees:
-        response["unchecked_attendees"] = unchecked_attendees
-    return json.dumps(response, ensure_ascii=False)
+    if not unchecked_attendees:
+        return json.dumps(response, ensure_ascii=False)
+
+    # unchecked_attendees is appended AFTER the event has already been
+    # capped to fit the output budget, so it needs its own check - an
+    # attendee list has no documented maximum, and a whole-batch scope
+    # error or a large invite list can leave most of it unchecked. Without
+    # this, a long enough list could push the final response back over
+    # budget with nothing left to shrink it, unlike conflict_response's
+    # payload (which caps both of its own list fields for the same
+    # reason).
+    response["unchecked_attendees"] = unchecked_attendees
+    max_output_length = get_tool_max_output_length()
+    encoded = json.dumps(response, ensure_ascii=False)
+    remaining_unchecked = unchecked_attendees
+    while remaining_unchecked and len(encoded) > max_output_length:
+        remaining_unchecked = remaining_unchecked[: len(remaining_unchecked) // 2]
+        response["unchecked_attendees"] = remaining_unchecked
+        response["truncated"] = True
+        encoded = json.dumps(response, ensure_ascii=False)
+    return encoded
 
 
 @mcp.tool()

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -803,6 +803,14 @@ def google_calendar_update_events(
         # calendar entirely, in the specific case where the organizer's
         # own email was the only thing making a raw set non-empty.
         organizer = event.get("organizer") or {}
+        # The organizer's REAL, event-provided email only - never
+        # backfilled. Used later for the identity-fallback comparison
+        # and for naming the organizer in `unchecked_attendees`; a
+        # backfilled guess has no business appearing in either (the
+        # identity question is already answered directly by
+        # organizer_self whenever a backfill would apply, and reporting
+        # a *guessed* address to the caller as "the organizer" would be
+        # actively misleading).
         organizer_email = organizer.get("email")
         # Google's own documented signal for "is the organizer this
         # connected account" (per the Events resource: "Whether the
@@ -816,7 +824,15 @@ def google_calendar_update_events(
         # but handled the same as "assume self" purely as a defensive
         # fallback, not because it's expected in practice.
         organizer_self = organizer.get("self")
-        if organizer_email is None and organizer_self is not False and added_attendees:
+        # The address actually excluded from the freebusy-checked
+        # attendee lists below - separate from organizer_email because
+        # this one MAY fall back to the caller's own resolved address
+        # when the real organizer email is missing. Conflating the two
+        # would make the later identity-fallback comparison compare a
+        # backfilled value against itself (always trivially True,
+        # answering nothing) instead of a real, independent check.
+        exclude_email = organizer_email
+        if exclude_email is None and organizer_self is not False and added_attendees:
             # Whether via organizer.self=True or a wholly-missing
             # organizer object/field, the caller is (or is assumed to
             # be) the organizer here - but neither case gives us an
@@ -836,18 +852,37 @@ def google_calendar_update_events(
             # event's own busy block on their calendar - the exact
             # self-conflict class this exclusion exists to prevent for
             # the known-organizer-email case already.
-            organizer_email = primary_calendar_info()[0]
+            try:
+                exclude_email = primary_calendar_info()[0]
+            except InsufficientScopeError:
+                if not ignore_conflicts:
+                    raise
+                # ignore_conflicts=True means the caller has already
+                # decided the conflict check doesn't need to run - a
+                # missing-scope 403 here would only ever be surfaced by
+                # that check (which is skipped entirely below when
+                # ignore_conflicts is set), so leaving exclude_email
+                # unresolved is safe: nothing downstream that consults
+                # it runs in that case either. Without this, a token
+                # missing calendar.calendars.readonly would hard-fail
+                # this call even though the caller explicitly opted out
+                # of the check the docstring says this guards.
         # None never equals a real address's lowercased form, so this
-        # filter is a no-op (keeps everything) when there's no organizer
-        # email to exclude - same effect as branching on `organizer_email`
+        # filter is a no-op (keeps everything) when there's no address
+        # to exclude - same effect as branching on `exclude_email`
         # explicitly, without a duplicated ternary.
-        organizer_email_lower = organizer_email.lower() if organizer_email else None
+        exclude_email_lower = exclude_email.lower() if exclude_email else None
         attendees_to_check = [
-            a for a in added_attendees if a.lower() != organizer_email_lower
+            a for a in added_attendees if a.lower() != exclude_email_lower
         ]
         existing_attendees_to_check = [
-            a for a in existing_attendees_raw if a.lower() != organizer_email_lower
+            a for a in existing_attendees_raw if a.lower() != exclude_email_lower
         ]
+        # None never equals a real address's lowercased form either -
+        # used below only for the identity-fallback comparison and for
+        # naming the organizer in unchecked_attendees, both of which
+        # need the REAL email, not exclude_email's backfilled guess.
+        organizer_email_lower = organizer_email.lower() if organizer_email else None
         # Whether the organizer's own email was itself one of the
         # genuinely-new additions (filtered out of attendees_to_check
         # above) - if so, their availability still needs verifying, just
@@ -862,7 +897,7 @@ def google_calendar_update_events(
         # Recovered as a length comparison rather than a separate scan -
         # `added_attendees` is already case-insensitively deduplicated
         # (via normalize_addresses), so at most one entry can match
-        # `organizer_email_lower` - which also keeps this fact and
+        # `exclude_email_lower` - which also keeps this fact and
         # `attendees_to_check`'s own filtering from drifting apart (both
         # the timezone-lookup gate below and the organizer-check gate
         # further down must account for this consistently).

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -19,8 +19,8 @@ from .utils import merge_scope_error as _merge_scope_error
 from .utils import normalize_addresses as _normalize_addresses
 from .utils import offset_datetime_string as _offset_datetime_string
 from .utils import reject_reversed_window as _reject_reversed_window
+from .utils import require_offset_datetime as _require_offset_datetime
 from .utils import setup_proxy_env, success_with_capped_dict
-from .utils import unchecked_extra as _unchecked_extra
 from .utils import window_delta_segments as _window_delta_segments
 
 logging.basicConfig(level=logging.INFO)
@@ -135,7 +135,20 @@ def _find_conflicts(
                 continue
             if item.get("transparency") == "transparent":
                 continue
-            if exclude_event_id and item.get("id") == exclude_event_id:
+            # A recurring event's instances (from singleEvents=True
+            # expansion) carry their OWN id, never the master's - e.g.
+            # "<masterId>_<recurrenceStamp>" - so excluding only by `id`
+            # never matches when `exclude_event_id` names the master
+            # itself (the normal way to address a recurring series).
+            # `recurringEventId` is the field Google's own Events
+            # resource documents as reporting the master's id on each
+            # instance; without also checking it, rescheduling or adding
+            # an attendee to a recurring event's master would report the
+            # event as conflicting with its own instances.
+            if exclude_event_id and exclude_event_id in (
+                item.get("id"),
+                item.get("recurringEventId"),
+            ):
                 continue
             # NOTE: declining an invite (attendees[].responseStatus ==
             # "declined" for the organizer's own self entry) is NOT used
@@ -498,7 +511,9 @@ def _error_message(exc: Exception, requested_conference: bool) -> str:
     return message
 
 
-def _event_response(event: dict[str, Any], **extra_fields: Any) -> str:
+def _event_response(
+    event: dict[str, Any], unchecked_attendees: list[str] | None = None
+) -> str:
     conference_data = event.get("conferenceData") or {}
 
     hangout_link = event.get("hangoutLink")
@@ -540,7 +555,8 @@ def _event_response(event: dict[str, Any], **extra_fields: Any) -> str:
     # capping never has to reason about them.
     response = json.loads(success_with_capped_dict("event", event))
     response.update(extra)
-    response.update(extra_fields)
+    if unchecked_attendees:
+        response["unchecked_attendees"] = unchecked_attendees
     return json.dumps(response, ensure_ascii=False)
 
 
@@ -562,7 +578,10 @@ def google_calendar_create_events(
     attendees, if given, are checked for scheduling conflicts together with the organizer's own
     calendar; a conflict returns status="conflict" instead of creating the event. Pass
     ignore_conflicts=True to create it anyway once the user has explicitly confirmed a conflict is
-    fine. Adding attendees does not, by itself, email them; set notify_attendees=True to have Google
+    fine. This also skips the whole check outright (not just the conflict result) whenever it can't
+    run at all -- e.g. a connector token missing a needed OAuth scope -- rather than failing loudly;
+    only pass it once the user has actually confirmed they want to proceed without checking, not as a
+    blanket way to route around an unrelated error. Adding attendees does not, by itself, email them; set notify_attendees=True to have Google
     Calendar send them a native invite immediately. Confirm the recipient list with the user before
     setting notify_attendees=True.
     Set add_google_meet=True to attach a real Google Meet video-conference link to the event. The
@@ -577,6 +596,8 @@ def google_calendar_create_events(
     requested_conference = False
     try:
         _reject_reversed_window(start_time, end_time)
+        _require_offset_datetime(start_time, "start_time")
+        _require_offset_datetime(end_time, "end_time")
         service = get_calendar_service()
         normalized_attendees = _normalize_addresses(attendees) if attendees else []
 
@@ -622,7 +643,7 @@ def google_calendar_create_events(
             **_api_call_kwargs(event, notify_attendees),
         )
         created_event = request.execute()
-        return _event_response(created_event, **_unchecked_extra(unchecked_attendees))
+        return _event_response(created_event, unchecked_attendees=unchecked_attendees)
 
     except Exception as e:
         logger.error(f"Error creating event: {e}")
@@ -666,8 +687,12 @@ def google_calendar_update_events(
     start_time and end_time must be RFC3339 formatted if provided.
     If the update moves the event to a new time, or adds attendees, that change is checked for
     conflicts the same way google_calendar_create_events is; pass ignore_conflicts=True to skip the
-    check once the user has explicitly confirmed a conflict is fine. Editing other fields (summary,
-    description, location) without moving the event is never blocked.
+    check once the user has explicitly confirmed a conflict is fine. This also skips the whole check
+    outright (not just the conflict result) whenever it can't run at all -- e.g. a connector token
+    missing a needed OAuth scope, including the one needed to widen an all-day event's own boundary
+    -- rather than failing loudly; only pass it once the user has actually confirmed they want to
+    proceed without checking, not as a blanket way to route around an unrelated error. Editing other
+    fields (summary, description, location) without moving the event is never blocked.
     attendees is a list of email addresses to add to the event; attendees already on the event are
     kept, and there is no way to remove an attendee through this parameter. Adding attendees does
     not, by itself, email anyone; set notify_attendees=True to have Google Calendar send a native
@@ -687,10 +712,35 @@ def google_calendar_update_events(
     """
     requested_conference = False
     try:
+        if start_time is not None:
+            _require_offset_datetime(start_time, "start_time")
+        if end_time is not None:
+            _require_offset_datetime(end_time, "end_time")
         service = get_calendar_service()
 
         # First get the existing event
         event = service.events().get(calendarId="primary", eventId=event_id).execute()
+
+        existing_attendees_raw = [
+            a["email"]
+            for a in (event.get("attendees") or [])
+            if isinstance(a, dict) and a.get("email")
+        ]
+        existing_attendee_emails = {
+            address.lower() for address in existing_attendees_raw
+        }
+        # attendees only ever ADDS: there's no way to remove an existing
+        # attendee through this parameter (matching this tool's own
+        # docstring). `added_attendees` (genuinely new) and
+        # `existing_attendees_raw` (retained) are checked separately
+        # below - a retained attendee only needs checking against the
+        # portion of a moved window that's actually new territory, while
+        # a newly-added one needs the whole effective window checked.
+        # Computed this early (rather than right before its first use)
+        # specifically so the all-day timezone-lookup gate below can key
+        # off whether anything is *actually* new, not just whether
+        # `attendees` was given at all.
+        added_attendees = _attendees_to_add(attendees, existing_attendee_emails)
 
         existing_is_all_day = "date" in (event.get("start") or {}) or "date" in (
             event.get("end") or {}
@@ -709,15 +759,22 @@ def google_calendar_update_events(
             )
 
         # The calendar's own timezone is only needed to widen an all-day
-        # boundary (see _event_boundary) so a moved window or an
-        # added/retained attendee gets checked against the right absolute
-        # instant - fetch it lazily so a plain timed-event update, or a
+        # boundary (see _event_boundary) so a moved window or a genuinely
+        # new attendee gets checked against the right absolute instant -
+        # fetch it lazily so a plain timed-event update, or a
         # summary/location/description-only edit of an all-day event that
         # never touches its window or attendees, doesn't pay for an extra
         # API call (or a scope-403 that would otherwise block an edit
         # that never needed timezone precision at all) it has no use for.
+        # Keyed off `added_attendees` (genuinely new), not the raw
+        # `attendees` argument - naming only addresses already on the
+        # event adds nothing to check, and a resubmission that never
+        # moves the window makes any retained attendee's delta segment
+        # trivially empty regardless of timezone precision (both sides
+        # of that comparison fall back to the same assumption
+        # consistently), so neither actually needs the real zone either.
         needs_real_calendar_timezone = existing_is_all_day and (
-            bool(start_time) or bool(end_time) or bool(attendees)
+            bool(start_time) or bool(end_time) or bool(added_attendees)
         )
         try:
             calendar_timezone = (
@@ -757,22 +814,28 @@ def google_calendar_update_events(
             existing_end_key,
         )
 
-        existing_attendees_raw = [
-            a["email"]
-            for a in (event.get("attendees") or [])
-            if isinstance(a, dict) and a.get("email")
-        ]
-        existing_attendee_emails = {
-            address.lower() for address in existing_attendees_raw
-        }
-        # attendees only ever ADDS: there's no way to remove an existing
-        # attendee through this parameter (matching this tool's own
-        # docstring). `added_attendees` (genuinely new) and
-        # `existing_attendees_raw` (retained) are checked separately
-        # below - a retained attendee only needs checking against the
-        # portion of a moved window that's actually new territory, while
-        # a newly-added one needs the whole effective window checked.
-        added_attendees = _attendees_to_add(attendees, existing_attendee_emails)
+        # The organizer's own calendar is already checked above via
+        # check_organizer (events.list, excluded by id/recurringEventId) -
+        # freebusy.query has no concept of "exclude this event", so if the
+        # organizer's own email also shows up among the attendees being
+        # freebusy-checked (just added now, or already on the event from
+        # an earlier call), that query would always find this very
+        # event's own busy block on their calendar and report a false
+        # self-conflict. Excluded only from the freebusy-checked copies
+        # below, never from `added_attendees` itself - a caller that
+        # explicitly asked to add the organizer as an attendee must still
+        # have them actually written to the event.
+        organizer_email = (event.get("organizer") or {}).get("email")
+        attendees_to_check = (
+            [a for a in added_attendees if a.lower() != organizer_email.lower()]
+            if organizer_email
+            else added_attendees
+        )
+        existing_attendees_to_check = (
+            [a for a in existing_attendees_raw if a.lower() != organizer_email.lower()]
+            if organizer_email
+            else existing_attendees_raw
+        )
 
         unchecked_attendees: list[str] = []
         if not ignore_conflicts and effective_start and effective_end:
@@ -786,12 +849,12 @@ def google_calendar_update_events(
                 # the organizer, who's excluded by event id rather than
                 # by window, so `window_changed` alone (not a
                 # disjoint-move test) decides whether to re-check them.
-                if check_organizer or added_attendees:
+                if check_organizer or attendees_to_check:
                     conflicts, unchecked = _find_conflicts(
                         service,
                         effective_start,
                         effective_end,
-                        added_attendees,
+                        attendees_to_check,
                         exclude_event_id=event_id,
                         check_organizer=check_organizer,
                     )
@@ -807,7 +870,7 @@ def google_calendar_update_events(
                 # a partial nudge that extends past the old window on one
                 # or both sides, or the whole new window for a fully
                 # disjoint move) can hide a real conflict for them.
-                if existing_attendees_raw:
+                if existing_attendees_to_check:
                     for seg_start, seg_end in _window_delta_segments(
                         existing_start_key,
                         existing_end_key,
@@ -818,7 +881,7 @@ def google_calendar_update_events(
                             service,
                             seg_start.isoformat(),
                             seg_end.isoformat(),
-                            existing_attendees_raw,
+                            existing_attendees_to_check,
                             exclude_event_id=event_id,
                             check_organizer=False,
                         )
@@ -864,7 +927,7 @@ def google_calendar_update_events(
             **_api_call_kwargs(event, notify_attendees),
         )
         updated_event = request.execute()
-        return _event_response(updated_event, **_unchecked_extra(unchecked_attendees))
+        return _event_response(updated_event, unchecked_attendees=unchecked_attendees)
 
     except Exception as e:
         logger.error(f"Error updating event: {e}")

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -117,19 +117,25 @@ def _find_conflicts(
     unchecked_attendees: list[str] = []
 
     if check_organizer:
-        organizer_events = (
-            service.events()
-            .list(
-                calendarId="primary",
-                timeMin=time_min,
-                timeMax=time_max,
-                singleEvents=True,
-                orderBy="startTime",
+        organizer_events: list[dict[str, Any]] = []
+        page_token: str | None = None
+        while True:
+            page = (
+                service.events()
+                .list(
+                    calendarId="primary",
+                    timeMin=time_min,
+                    timeMax=time_max,
+                    singleEvents=True,
+                    orderBy="startTime",
+                    pageToken=page_token,
+                )
+                .execute()
             )
-            .execute()
-            .get("items")
-            or []
-        )
+            organizer_events.extend(page.get("items") or [])
+            page_token = page.get("nextPageToken")
+            if not page_token:
+                break
         for item in organizer_events:
             if item.get("status") == "cancelled":
                 continue

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -854,19 +854,26 @@ def google_calendar_update_events(
             # the known-organizer-email case already.
             try:
                 exclude_email = primary_calendar_info()[0]
-            except InsufficientScopeError:
+            except (InsufficientScopeError, HttpError):
+                # Not just the recognized missing-scope case -
+                # _primary_calendar_info re-raises any OTHER HttpError
+                # from calendars().get() unchanged (rate limiting, a
+                # transient 5xx, an unrelated 403), and that's still
+                # "this lookup couldn't run" every bit as much as a
+                # missing scope is.
                 if not ignore_conflicts:
                     raise
                 # ignore_conflicts=True means the caller has already
-                # decided the conflict check doesn't need to run - a
-                # missing-scope 403 here would only ever be surfaced by
-                # that check (which is skipped entirely below when
-                # ignore_conflicts is set), so leaving exclude_email
-                # unresolved is safe: nothing downstream that consults
-                # it runs in that case either. Without this, a token
-                # missing calendar.calendars.readonly would hard-fail
-                # this call even though the caller explicitly opted out
-                # of the check the docstring says this guards.
+                # decided the conflict check doesn't need to run - this
+                # lookup failing for ANY reason here would only ever be
+                # surfaced by that check (which is skipped entirely
+                # below when ignore_conflicts is set), so leaving
+                # exclude_email unresolved is safe: nothing downstream
+                # that consults it runs in that case either. Without
+                # this, any failure of this lookup - not just a missing
+                # scope - would hard-fail a call the caller explicitly
+                # opted out of the check the docstring says this
+                # guards.
         # None never equals a real address's lowercased form, so this
         # filter is a no-op (keeps everything) when there's no address
         # to exclude - same effect as branching on `exclude_email`
@@ -958,19 +965,26 @@ def google_calendar_update_events(
             # check the docstring says this guards.
             existing_start = _event_boundary(event.get("start"), calendar_timezone)
             existing_end = _event_boundary(event.get("end"), calendar_timezone)
-        except ValueError:
+        except (ValueError, HttpError):
+            # Not just the recognized missing-scope ValueError (or a
+            # malformed-event ValueError from _event_boundary) - a bare
+            # HttpError here means _primary_calendar_info hit some OTHER
+            # failure (rate limiting, a transient 5xx, an unrelated 403)
+            # that it re-raises unchanged rather than converting, and
+            # that's still "this lookup couldn't run" too.
             if not ignore_conflicts:
                 raise
             # ignore_conflicts=True means the caller has already decided
-            # the conflict check doesn't need to run - a missing-scope
-            # 403 here would only ever be surfaced by that check (or by
-            # the reversed-window sanity check below, which is fine to
-            # run a little less precisely against UTC than to block a
-            # write the caller explicitly opted out of checking). Leaving
-            # the existing boundaries unresolved (None) is safe: the
-            # conflict-check block below is itself gated on `not
-            # ignore_conflicts`, and the write payload only ever uses the
-            # caller-supplied start_time/end_time, never these.
+            # the conflict check doesn't need to run - this lookup
+            # failing for ANY reason here would only ever be surfaced by
+            # that check (or by the reversed-window sanity check below,
+            # which is fine to run a little less precisely against UTC
+            # than to block a write the caller explicitly opted out of
+            # checking). Leaving the existing boundaries unresolved
+            # (None) is safe: the conflict-check block below is itself
+            # gated on `not ignore_conflicts`, and the write payload only
+            # ever uses the caller-supplied start_time/end_time, never
+            # these.
             calendar_timezone = "UTC"
             existing_start = None
             existing_end = None

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -217,16 +217,21 @@ def conflict_response(
     that point the write is already correctly blocked by the known
     conflict, so being honest about who else couldn't be checked is safe.
 
-    `conflicts` is uncapped input (an organizer with a busy shared
-    calendar, or a wide window, can turn up far more overlapping events
-    than a caller needs to see) - unlike every other response path here,
-    which routes through `success_with_capped_dict`, this shape has
-    multiple top-level fields under a non-"success" status that function
-    doesn't support, so the payload is capped locally instead: only
-    `conflicts` (the one field that can actually grow large) is halved,
-    repeatedly, until the JSON fits `get_tool_max_output_length()` -
-    small fields like `hint`/`unchecked_attendees` are left untouched as
-    long as there's a bigger field left to shrink first.
+    `conflicts` and `unchecked_attendees` are both uncapped input (an
+    organizer with a busy shared calendar or a wide window can turn up
+    far more overlapping events than a caller needs to see; a missing-
+    scope error partway through a large invite list can likewise mark
+    an entire remaining batch unchecked) - unlike every other response
+    path here, which routes through `success_with_capped_dict`, this
+    shape has multiple top-level fields under a non-"success" status
+    that function doesn't support, so the payload is capped locally
+    instead: whichever of `conflicts`/`unchecked_attendees` is currently
+    larger (by its own serialized size) is halved each step, so a
+    single real conflict isn't fully dropped just to make room for a
+    still-oversized `unchecked_attendees` list (unconditionally halving
+    `conflicts` first would zero out a 1-item list in a single step,
+    regardless of whether that was actually necessary) - the small
+    `hint` field is never touched.
     """
     payload: dict[str, Any] = {
         "status": "conflict",
@@ -240,16 +245,31 @@ def conflict_response(
             "ignore_conflicts=true after the user has explicitly confirmed "
             "they still want this slot."
         ),
+        # Always present (not just when truncation actually happens),
+        # matching every other capped response path in this package
+        # (see success_with_capped_dict) - a caller that learned
+        # "truncated is always in the payload" from those shouldn't have
+        # to special-case this one.
+        "truncated": False,
     }
     response = json.dumps(payload, ensure_ascii=False)
     max_output_length = get_tool_max_output_length()
     if len(response) <= max_output_length:
         return response
 
-    remaining = conflicts
-    while remaining and len(response) > max_output_length:
-        remaining = remaining[: len(remaining) // 2]
-        payload["conflicts"] = remaining
+    remaining_conflicts = conflicts
+    remaining_unchecked = unchecked_attendees
+    while (remaining_conflicts or remaining_unchecked) and len(
+        response
+    ) > max_output_length:
+        conflicts_size = len(json.dumps(remaining_conflicts, ensure_ascii=False))
+        unchecked_size = len(json.dumps(remaining_unchecked, ensure_ascii=False))
+        if remaining_conflicts and conflicts_size >= unchecked_size:
+            remaining_conflicts = remaining_conflicts[: len(remaining_conflicts) // 2]
+        else:
+            remaining_unchecked = remaining_unchecked[: len(remaining_unchecked) // 2]
+        payload["conflicts"] = remaining_conflicts
+        payload["unchecked_attendees"] = remaining_unchecked
         payload["truncated"] = True
         response = json.dumps(payload, ensure_ascii=False)
     return response

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -216,8 +216,19 @@ def conflict_response(
     may pass that error's own `unchecked_attendees` through here too - at
     that point the write is already correctly blocked by the known
     conflict, so being honest about who else couldn't be checked is safe.
+
+    `conflicts` is uncapped input (an organizer with a busy shared
+    calendar, or a wide window, can turn up far more overlapping events
+    than a caller needs to see) - unlike every other response path here,
+    which routes through `success_with_capped_dict`, this shape has
+    multiple top-level fields under a non-"success" status that function
+    doesn't support, so the payload is capped locally instead: only
+    `conflicts` (the one field that can actually grow large) is halved,
+    repeatedly, until the JSON fits `get_tool_max_output_length()` -
+    small fields like `hint`/`unchecked_attendees` are left untouched as
+    long as there's a bigger field left to shrink first.
     """
-    payload = {
+    payload: dict[str, Any] = {
         "status": "conflict",
         "message": f"{len(conflicts)} existing event(s) overlap {start} - {end}",
         "conflicts": conflicts,
@@ -230,16 +241,18 @@ def conflict_response(
             "they still want this slot."
         ),
     }
-    return json.dumps(payload, ensure_ascii=False)
+    response = json.dumps(payload, ensure_ascii=False)
+    max_output_length = get_tool_max_output_length()
+    if len(response) <= max_output_length:
+        return response
 
-
-def unchecked_extra(unchecked_attendees: list[str]) -> dict[str, Any]:
-    """Extra fields for a status="success" envelope when some attendees
-    ended up unchecked - empty (nothing to add) when there's nothing to
-    report."""
-    if not unchecked_attendees:
-        return {}
-    return {"unchecked_attendees": unchecked_attendees}
+    remaining = conflicts
+    while remaining and len(response) > max_output_length:
+        remaining = remaining[: len(remaining) // 2]
+        payload["conflicts"] = remaining
+        payload["truncated"] = True
+        response = json.dumps(payload, ensure_ascii=False)
+    return response
 
 
 def attendees_were_given(attendees: list[str] | str | None) -> bool:
@@ -359,127 +372,39 @@ def reject_reversed_window(start_value: str, end_value: str) -> None:
         return
 
 
-# Microsoft Graph timeZone values come in two shapes depending on how/where
-# an event was created: IANA names (e.g. "Asia/Singapore", which Graph also
-# accepts on write) and legacy Windows names (e.g. "Pacific Standard Time",
-# from desktop Outlook or an Exchange org defaulting to them). zoneinfo only
-# understands the former. This is the standard (CLDR) Windows-to-IANA
-# mapping, restricted to the zone list Graph's own dateTimeTimeZone docs
-# enumerate as supported - not exhaustive of every Windows zone that has
-# ever existed, but covers every zone Graph itself claims to support.
-_WINDOWS_TO_IANA: dict[str, str] = {
-    "UTC": "UTC",
-    "GMT Standard Time": "Europe/London",
-    "Greenwich Standard Time": "Atlantic/Reykjavik",
-    "W. Europe Standard Time": "Europe/Berlin",
-    "Central Europe Standard Time": "Europe/Budapest",
-    "Central European Standard Time": "Europe/Warsaw",
-    "Romance Standard Time": "Europe/Paris",
-    "E. Europe Standard Time": "Europe/Bucharest",
-    "GTB Standard Time": "Europe/Bucharest",
-    "FLE Standard Time": "Europe/Kyiv",
-    "Turkey Standard Time": "Europe/Istanbul",
-    "Russian Standard Time": "Europe/Moscow",
-    "Kaliningrad Standard Time": "Europe/Kaliningrad",
-    "Arabic Standard Time": "Asia/Baghdad",
-    "Syria Standard Time": "Asia/Damascus",
-    "Arab Standard Time": "Asia/Riyadh",
-    "Israel Standard Time": "Asia/Jerusalem",
-    "Jordan Standard Time": "Asia/Amman",
-    "Middle East Standard Time": "Asia/Beirut",
-    "Egypt Standard Time": "Africa/Cairo",
-    "South Africa Standard Time": "Africa/Johannesburg",
-    "E. Africa Standard Time": "Africa/Nairobi",
-    "Mauritius Standard Time": "Indian/Mauritius",
-    "Iran Standard Time": "Asia/Tehran",
-    "Arabian Standard Time": "Asia/Dubai",
-    "Azerbaijan Standard Time": "Asia/Baku",
-    "Georgian Standard Time": "Asia/Tbilisi",
-    "Caucasus Standard Time": "Asia/Yerevan",
-    "Afghanistan Standard Time": "Asia/Kabul",
-    "Pakistan Standard Time": "Asia/Karachi",
-    "West Asia Standard Time": "Asia/Tashkent",
-    "India Standard Time": "Asia/Kolkata",
-    "Sri Lanka Standard Time": "Asia/Colombo",
-    "Nepal Standard Time": "Asia/Kathmandu",
-    "Central Asia Standard Time": "Asia/Almaty",
-    "Bangladesh Standard Time": "Asia/Dhaka",
-    "Ekaterinburg Standard Time": "Asia/Yekaterinburg",
-    "Myanmar Standard Time": "Asia/Yangon",
-    "SE Asia Standard Time": "Asia/Bangkok",
-    "Novosibirsk Standard Time": "Asia/Novosibirsk",
-    "China Standard Time": "Asia/Shanghai",
-    "North Asia Standard Time": "Asia/Krasnoyarsk",
-    "Singapore Standard Time": "Asia/Singapore",
-    "Taipei Standard Time": "Asia/Taipei",
-    "Ulaanbaatar Standard Time": "Asia/Ulaanbaatar",
-    "North Asia East Standard Time": "Asia/Irkutsk",
-    "W. Australia Standard Time": "Australia/Perth",
-    "Tokyo Standard Time": "Asia/Tokyo",
-    "Korea Standard Time": "Asia/Seoul",
-    "Cen. Australia Standard Time": "Australia/Adelaide",
-    "AUS Central Standard Time": "Australia/Darwin",
-    "E. Australia Standard Time": "Australia/Brisbane",
-    "AUS Eastern Standard Time": "Australia/Sydney",
-    "West Pacific Standard Time": "Pacific/Port_Moresby",
-    "Tasmania Standard Time": "Australia/Hobart",
-    "Yakutsk Standard Time": "Asia/Yakutsk",
-    "Central Pacific Standard Time": "Pacific/Guadalcanal",
-    "Vladivostok Standard Time": "Asia/Vladivostok",
-    "New Zealand Standard Time": "Pacific/Auckland",
-    "Fiji Standard Time": "Pacific/Fiji",
-    "Magadan Standard Time": "Asia/Magadan",
-    "Tonga Standard Time": "Pacific/Tongatapu",
-    "Samoa Standard Time": "Pacific/Apia",
-    "Line Islands Standard Time": "Pacific/Kiritimati",
-    "Dateline Standard Time": "Etc/GMT+12",
-    "Hawaiian Standard Time": "Pacific/Honolulu",
-    "Alaskan Standard Time": "America/Anchorage",
-    "Pacific Standard Time (Mexico)": "America/Santa_Isabel",
-    "Pacific Standard Time": "America/Los_Angeles",
-    "US Mountain Standard Time": "America/Phoenix",
-    "Mountain Standard Time (Mexico)": "America/Chihuahua",
-    "Mountain Standard Time": "America/Denver",
-    "Central America Standard Time": "America/Guatemala",
-    "Central Standard Time": "America/Chicago",
-    "Central Standard Time (Mexico)": "America/Mexico_City",
-    "Canada Central Standard Time": "America/Regina",
-    "SA Pacific Standard Time": "America/Bogota",
-    "Eastern Standard Time": "America/New_York",
-    "US Eastern Standard Time": "America/Indiana/Indianapolis",
-    "Venezuela Standard Time": "America/Caracas",
-    "Paraguay Standard Time": "America/Asuncion",
-    "Atlantic Standard Time": "America/Halifax",
-    "Central Brazilian Standard Time": "America/Cuiaba",
-    "SA Western Standard Time": "America/La_Paz",
-    "Pacific SA Standard Time": "America/Santiago",
-    "Newfoundland Standard Time": "America/St_Johns",
-    "E. South America Standard Time": "America/Sao_Paulo",
-    "Argentina Standard Time": "America/Argentina/Buenos_Aires",
-    "SA Eastern Standard Time": "America/Cayenne",
-    "Greenland Standard Time": "America/Godthab",
-    "Montevideo Standard Time": "America/Montevideo",
-    "Bahia Standard Time": "America/Bahia",
-    "Azores Standard Time": "Atlantic/Azores",
-    "Cape Verde Standard Time": "Atlantic/Cape_Verde",
-    "Morocco Standard Time": "Africa/Casablanca",
-    "Namibia Standard Time": "Africa/Windhoek",
-    "W. Central Africa Standard Time": "Africa/Lagos",
-}
+def require_offset_datetime(value: str, field_name: str) -> None:
+    """Raise ValueError when `value` parses to a real instant but doesn't
+    carry a UTC offset or "Z" suffix.
 
+    A caller-supplied boundary that's naive isn't just non-compliant with
+    the documented RFC3339 contract: this module's own internal instants
+    (e.g. an existing event's boundary via `_event_boundary`) are always
+    offset-bearing, so a naive value compared against one raises
+    `TypeError` deep inside a downstream comparison (see
+    `window_delta_segments`'s aware-vs-naive guard) - which conservatively
+    falls back to using the naive value as-is, so it eventually reaches
+    the provider API's timeMin/timeMax and fails there with an opaque
+    error instead of this clear, actionable one.
 
-def resolve_zone_name(name: str) -> str:
-    """Map a Graph timeZone value to a name zoneinfo can load.
-
-    Returns the input unchanged when it isn't a recognized legacy Windows
-    zone name - it's then assumed to already be IANA-shaped, which
-    zoneinfo can load directly.
+    Silent (no-op) when `value` doesn't parse to a real instant at all -
+    that's a different failure a caller will already hit downstream with
+    its own clear error, not this function's job to preempt.
     """
-    return _WINDOWS_TO_IANA.get(name, name)
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return
+    if parsed.tzinfo is None:
+        raise ValueError(
+            f"{field_name} ({value!r}) must include a UTC offset or 'Z' "
+            "suffix (RFC3339), e.g. '2026-08-27T10:00:00+00:00' or "
+            "'2026-08-27T10:00:00Z'."
+        )
 
 
 def resolve_zoneinfo(name: str) -> ZoneInfo:
-    """Resolve a Graph timeZone value (Windows or IANA) to a real
+    """Resolve a Google Calendar timeZone value (an IANA Time Zone
+    Database name, per Google's own EventDateTime docs) to a real
     ``ZoneInfo``, for use anywhere a working zone is required (not just a
     best-effort comparison) - e.g. attaching a real UTC offset to a naive
     datetime string.
@@ -490,10 +415,10 @@ def resolve_zoneinfo(name: str) -> ZoneInfo:
     helper exists to prevent.
     """
     try:
-        return ZoneInfo(resolve_zone_name(name))
+        return ZoneInfo(name)
     except (ZoneInfoNotFoundError, ValueError) as exc:
         raise ValueError(
-            f"Timezone {name!r} isn't a recognized IANA or Windows zone name."
+            f"Timezone {name!r} isn't a recognized IANA zone name."
         ) from exc
 
 

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -2,10 +2,65 @@ import json
 import os
 import re
 import urllib.request
+from datetime import date, datetime, time, timedelta
 from typing import Any
 from urllib.parse import quote
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ....config import get_tool_max_output_length
+
+
+class InsufficientScopeError(ValueError):
+    """Raised by a connector's ``_find_conflicts`` on a whole-batch
+    missing-scope error (see that function's own docstring for why this
+    is raised at all rather than degrading to unchecked).
+
+    Carries whatever ``conflicts``/``unchecked_attendees`` had already
+    been confirmed before the error - a caller accumulating results
+    across multiple ``_find_conflicts`` calls for one create/update (e.g.
+    one call for newly-added attendees, another per delta segment for
+    retained attendees) needs this to still report an already-confirmed
+    real conflict (found before the error, in this call or an earlier
+    one) instead of silently discarding it just because a *later*,
+    unrelated check also hit the same scope problem. Reporting a known
+    conflict is always safe regardless of what else couldn't be checked;
+    only the "nothing confirmed yet, can't tell if this is safe" case
+    should still reject the write outright.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        conflicts: list[dict[str, Any]],
+        unchecked_attendees: list[str],
+    ) -> None:
+        super().__init__(message)
+        self.conflicts = conflicts
+        self.unchecked_attendees = unchecked_attendees
+
+
+def merge_scope_error(
+    exc: InsufficientScopeError,
+    conflicts: list[dict[str, Any]],
+    unchecked_attendees: list[str],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Fold an `InsufficientScopeError` caught mid-accumulation into the
+    running `conflicts`/`unchecked_attendees` a connector's create/update
+    tool is building up (potentially across more than one `_find_conflicts`
+    call) - merging the error's own already-confirmed findings in first, so
+    a real conflict found before the error is never lost regardless of
+    which of possibly several calls actually raised.
+
+    Re-raises `exc` itself (preserving its original traceback/cause) when
+    the merged `conflicts` is still empty: nothing was confirmed yet, so
+    there is no already-known problem safe to report instead of rejecting
+    the write outright.
+    """
+    conflicts = [*conflicts, *exc.conflicts]
+    unchecked_attendees = [*unchecked_attendees, *exc.unchecked_attendees]
+    if not conflicts:
+        raise exc
+    return conflicts, unchecked_attendees
 
 
 def require_clean_identifier(value: str, field_name: str) -> str:
@@ -116,6 +171,453 @@ def success_with_capped_dict(field_name: str, data: Any) -> str:
         truncated = True
         response = _build(working, truncated)
     return response
+
+
+def normalize_addresses(addresses: list[str] | str) -> list[str]:
+    """Split/strip a comma-separated string or list of email addresses into a
+    clean list, dropping anything blank and case-insensitive duplicates
+    (keeping the first casing seen - email addresses are case-insensitive,
+    so a caller passing the same person twice with different casing, e.g.
+    from a human-written invite list, must not become two separate
+    attendee entries downstream)."""
+    if isinstance(addresses, str):
+        raw = [address.strip() for address in addresses.split(",") if address.strip()]
+    else:
+        raw = [address.strip() for address in addresses if address and address.strip()]
+    seen: set[str] = set()
+    deduped = []
+    for address in raw:
+        key = address.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(address)
+    return deduped
+
+
+def conflict_response(
+    conflicts: list[dict[str, Any]],
+    unchecked_attendees: list[str],
+    start: str,
+    end: str,
+) -> str:
+    """Build the status="conflict" envelope a calendar-writing MCP tool
+    returns instead of creating/updating an event, so the calling agent
+    reports the conflict to the user rather than silently double-booking.
+
+    `unchecked_attendees` is usually the self-explanatory kind (an
+    attendee absent from the provider's response, or its own per-attendee
+    error) - a missing-OAuth-scope 403 covering the whole call is instead
+    raised as `InsufficientScopeError` before ever reaching here, since
+    writing an event whose availability could never actually be checked
+    would defeat the point of this feature. The one exception: a caller
+    that catches `InsufficientScopeError` because `conflicts` was already
+    non-empty (a real conflict was confirmed before the scope error hit)
+    may pass that error's own `unchecked_attendees` through here too - at
+    that point the write is already correctly blocked by the known
+    conflict, so being honest about who else couldn't be checked is safe.
+    """
+    payload = {
+        "status": "conflict",
+        "message": f"{len(conflicts)} existing event(s) overlap {start} - {end}",
+        "conflicts": conflicts,
+        "unchecked_attendees": unchecked_attendees,
+        "hint": (
+            "Do not retry with the same time slot. Report these conflicts to "
+            "the user and ask them to pick a different time or confirm they "
+            "want to proceed anyway. Only call this tool again with "
+            "ignore_conflicts=true after the user has explicitly confirmed "
+            "they still want this slot."
+        ),
+    }
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def unchecked_extra(unchecked_attendees: list[str]) -> dict[str, Any]:
+    """Extra fields for a status="success" envelope when some attendees
+    ended up unchecked - empty (nothing to add) when there's nothing to
+    report."""
+    if not unchecked_attendees:
+        return {}
+    return {"unchecked_attendees": unchecked_attendees}
+
+
+def attendees_were_given(attendees: list[str] | str | None) -> bool:
+    """Whether `attendees` was actually provided by the caller for an
+    update, treating an empty string the same as not-provided at all -
+    matching every other optional field's truthy convention here (and the
+    create path's own check) - rather than as "clear every attendee".
+    That's still expressible, just via an explicit empty list: `[]` is a
+    deliberate, differently-typed value that must keep working."""
+    return attendees is not None and attendees != ""
+
+
+def attendees_to_add(
+    attendees: list[str] | str | None, existing_attendee_emails: set[str]
+) -> list[str]:
+    """The newly-added addresses from an update's `attendees` argument,
+    normalized and deduped, that aren't already in
+    `existing_attendee_emails` - what actually needs writing when
+    `attendees` only ever adds attendees and never removes any. Returns
+    [] for anything `attendees_were_given` treats as not-provided (None,
+    ""), matching its own convention, as well as for a caller-supplied
+    list/string that turns out to name only people already on the event.
+    """
+    if not attendees_were_given(attendees):
+        return []
+    assert attendees is not None  # narrows for mypy; attendees_were_given implies this
+    return [
+        address
+        for address in normalize_addresses(attendees)
+        if address.lower() not in existing_attendee_emails
+    ]
+
+
+_OVERLONG_FRACTIONAL_SECONDS = re.compile(r"(\.\d{6})\d+")
+
+
+def datetime_key_for_comparison(value: str | None) -> datetime | str | None:
+    """Return a value suitable for equality-comparing two datetime strings
+    that may be written in different but equivalent formats.
+
+    A caller re-submitting the same instant it just read back from an API
+    (or a value it typed by hand) can differ in formatting alone - "Z" vs
+    "+00:00", a different (but equal-instant) zone offset, missing vs
+    present fractional seconds - while meaning the same moment. Comparing
+    such strings directly treats a same-instant resubmission as a real
+    change, which for a scheduling-conflict check means re-querying (and,
+    worse, misjudging self-conflicts against) a window that never actually
+    moved.
+
+    Parses to a `datetime` and returns it: two aware datetimes compare
+    equal when they denote the same instant regardless of differing zone
+    offsets, which a string/isoformat() comparison would not catch. Two
+    naive datetimes (Outlook's dateTime values, which carry no offset of
+    their own) compare directly, which is correct since both sides here
+    always come from the same source. An aware value never equals a naive
+    one, which is fine - these are simply never the same source's values
+    (never worse than the plain-string comparison this replaces).
+
+    Returns the original value unchanged if it doesn't parse (None stays
+    None, and a genuinely malformed value still compares by raw string,
+    same as before this normalization existed - never worse, never a
+    crash).
+
+    Outlook commonly reports 7-digit (100-nanosecond) fractional seconds
+    (e.g. ".0000000"), one more digit than a `datetime` microsecond can
+    hold. `fromisoformat`'s tolerance for that is a CPython-version detail
+    the caller shouldn't need to know about, so any fractional-seconds run
+    longer than 6 digits is truncated to 6 before parsing, rather than
+    relying on the current interpreter to accept (and correctly truncate)
+    the extra digits itself.
+    """
+    if value is None:
+        return None
+    normalized = value
+    if normalized[-1:] in ("Z", "z"):
+        # Only the trailing UTC marker, not a blanket .replace("Z", ...) -
+        # a naive str.replace would also touch a "Z"/"z" anywhere else in
+        # the string, which happens to never occur in a valid ISO
+        # datetime today but is needless coupling to that happening to
+        # stay true.
+        normalized = normalized[:-1] + "+00:00"
+    normalized = _OVERLONG_FRACTIONAL_SECONDS.sub(r"\1", normalized)
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return value
+
+
+def reject_reversed_window(start_value: str, end_value: str) -> None:
+    """Raise ValueError when `end_value` is not after `start_value` - an
+    event window's basic ordering sanity, checked before forwarding it to
+    the provider API as-is (both on create, and on update's effective
+    window regardless of ignore_conflicts - this isn't a conflict-check
+    decision a caller can opt out of).
+
+    Deliberately permissive when either side doesn't parse to a real,
+    comparable instant (stays silent rather than rejecting) - matching
+    this module's other datetime comparisons, which treat "can't tell"
+    as "don't block", not "assume invalid". That includes the case where
+    both sides parse but one is offset-aware and the other naive (e.g. a
+    ``Z``-suffixed value alongside a naive one): Python raises
+    ``TypeError`` comparing those with ``<=`` even though both are real
+    ``datetime`` instances, so the ``isinstance`` check alone isn't
+    enough to guarantee a safe comparison - see ``window_delta_segments``,
+    which guards the identical hazard the same way.
+    """
+    start_key = datetime_key_for_comparison(start_value)
+    end_key = datetime_key_for_comparison(end_value)
+    if not (isinstance(start_key, datetime) and isinstance(end_key, datetime)):
+        return
+    try:
+        if end_key <= start_key:
+            raise ValueError(
+                f"end ({end_value!r}) must be after start ({start_value!r})."
+            )
+    except TypeError:
+        return
+
+
+# Microsoft Graph timeZone values come in two shapes depending on how/where
+# an event was created: IANA names (e.g. "Asia/Singapore", which Graph also
+# accepts on write) and legacy Windows names (e.g. "Pacific Standard Time",
+# from desktop Outlook or an Exchange org defaulting to them). zoneinfo only
+# understands the former. This is the standard (CLDR) Windows-to-IANA
+# mapping, restricted to the zone list Graph's own dateTimeTimeZone docs
+# enumerate as supported - not exhaustive of every Windows zone that has
+# ever existed, but covers every zone Graph itself claims to support.
+_WINDOWS_TO_IANA: dict[str, str] = {
+    "UTC": "UTC",
+    "GMT Standard Time": "Europe/London",
+    "Greenwich Standard Time": "Atlantic/Reykjavik",
+    "W. Europe Standard Time": "Europe/Berlin",
+    "Central Europe Standard Time": "Europe/Budapest",
+    "Central European Standard Time": "Europe/Warsaw",
+    "Romance Standard Time": "Europe/Paris",
+    "E. Europe Standard Time": "Europe/Bucharest",
+    "GTB Standard Time": "Europe/Bucharest",
+    "FLE Standard Time": "Europe/Kyiv",
+    "Turkey Standard Time": "Europe/Istanbul",
+    "Russian Standard Time": "Europe/Moscow",
+    "Kaliningrad Standard Time": "Europe/Kaliningrad",
+    "Arabic Standard Time": "Asia/Baghdad",
+    "Syria Standard Time": "Asia/Damascus",
+    "Arab Standard Time": "Asia/Riyadh",
+    "Israel Standard Time": "Asia/Jerusalem",
+    "Jordan Standard Time": "Asia/Amman",
+    "Middle East Standard Time": "Asia/Beirut",
+    "Egypt Standard Time": "Africa/Cairo",
+    "South Africa Standard Time": "Africa/Johannesburg",
+    "E. Africa Standard Time": "Africa/Nairobi",
+    "Mauritius Standard Time": "Indian/Mauritius",
+    "Iran Standard Time": "Asia/Tehran",
+    "Arabian Standard Time": "Asia/Dubai",
+    "Azerbaijan Standard Time": "Asia/Baku",
+    "Georgian Standard Time": "Asia/Tbilisi",
+    "Caucasus Standard Time": "Asia/Yerevan",
+    "Afghanistan Standard Time": "Asia/Kabul",
+    "Pakistan Standard Time": "Asia/Karachi",
+    "West Asia Standard Time": "Asia/Tashkent",
+    "India Standard Time": "Asia/Kolkata",
+    "Sri Lanka Standard Time": "Asia/Colombo",
+    "Nepal Standard Time": "Asia/Kathmandu",
+    "Central Asia Standard Time": "Asia/Almaty",
+    "Bangladesh Standard Time": "Asia/Dhaka",
+    "Ekaterinburg Standard Time": "Asia/Yekaterinburg",
+    "Myanmar Standard Time": "Asia/Yangon",
+    "SE Asia Standard Time": "Asia/Bangkok",
+    "Novosibirsk Standard Time": "Asia/Novosibirsk",
+    "China Standard Time": "Asia/Shanghai",
+    "North Asia Standard Time": "Asia/Krasnoyarsk",
+    "Singapore Standard Time": "Asia/Singapore",
+    "Taipei Standard Time": "Asia/Taipei",
+    "Ulaanbaatar Standard Time": "Asia/Ulaanbaatar",
+    "North Asia East Standard Time": "Asia/Irkutsk",
+    "W. Australia Standard Time": "Australia/Perth",
+    "Tokyo Standard Time": "Asia/Tokyo",
+    "Korea Standard Time": "Asia/Seoul",
+    "Cen. Australia Standard Time": "Australia/Adelaide",
+    "AUS Central Standard Time": "Australia/Darwin",
+    "E. Australia Standard Time": "Australia/Brisbane",
+    "AUS Eastern Standard Time": "Australia/Sydney",
+    "West Pacific Standard Time": "Pacific/Port_Moresby",
+    "Tasmania Standard Time": "Australia/Hobart",
+    "Yakutsk Standard Time": "Asia/Yakutsk",
+    "Central Pacific Standard Time": "Pacific/Guadalcanal",
+    "Vladivostok Standard Time": "Asia/Vladivostok",
+    "New Zealand Standard Time": "Pacific/Auckland",
+    "Fiji Standard Time": "Pacific/Fiji",
+    "Magadan Standard Time": "Asia/Magadan",
+    "Tonga Standard Time": "Pacific/Tongatapu",
+    "Samoa Standard Time": "Pacific/Apia",
+    "Line Islands Standard Time": "Pacific/Kiritimati",
+    "Dateline Standard Time": "Etc/GMT+12",
+    "Hawaiian Standard Time": "Pacific/Honolulu",
+    "Alaskan Standard Time": "America/Anchorage",
+    "Pacific Standard Time (Mexico)": "America/Santa_Isabel",
+    "Pacific Standard Time": "America/Los_Angeles",
+    "US Mountain Standard Time": "America/Phoenix",
+    "Mountain Standard Time (Mexico)": "America/Chihuahua",
+    "Mountain Standard Time": "America/Denver",
+    "Central America Standard Time": "America/Guatemala",
+    "Central Standard Time": "America/Chicago",
+    "Central Standard Time (Mexico)": "America/Mexico_City",
+    "Canada Central Standard Time": "America/Regina",
+    "SA Pacific Standard Time": "America/Bogota",
+    "Eastern Standard Time": "America/New_York",
+    "US Eastern Standard Time": "America/Indiana/Indianapolis",
+    "Venezuela Standard Time": "America/Caracas",
+    "Paraguay Standard Time": "America/Asuncion",
+    "Atlantic Standard Time": "America/Halifax",
+    "Central Brazilian Standard Time": "America/Cuiaba",
+    "SA Western Standard Time": "America/La_Paz",
+    "Pacific SA Standard Time": "America/Santiago",
+    "Newfoundland Standard Time": "America/St_Johns",
+    "E. South America Standard Time": "America/Sao_Paulo",
+    "Argentina Standard Time": "America/Argentina/Buenos_Aires",
+    "SA Eastern Standard Time": "America/Cayenne",
+    "Greenland Standard Time": "America/Godthab",
+    "Montevideo Standard Time": "America/Montevideo",
+    "Bahia Standard Time": "America/Bahia",
+    "Azores Standard Time": "Atlantic/Azores",
+    "Cape Verde Standard Time": "Atlantic/Cape_Verde",
+    "Morocco Standard Time": "Africa/Casablanca",
+    "Namibia Standard Time": "Africa/Windhoek",
+    "W. Central Africa Standard Time": "Africa/Lagos",
+}
+
+
+def resolve_zone_name(name: str) -> str:
+    """Map a Graph timeZone value to a name zoneinfo can load.
+
+    Returns the input unchanged when it isn't a recognized legacy Windows
+    zone name - it's then assumed to already be IANA-shaped, which
+    zoneinfo can load directly.
+    """
+    return _WINDOWS_TO_IANA.get(name, name)
+
+
+def resolve_zoneinfo(name: str) -> ZoneInfo:
+    """Resolve a Graph timeZone value (Windows or IANA) to a real
+    ``ZoneInfo``, for use anywhere a working zone is required (not just a
+    best-effort comparison) - e.g. attaching a real UTC offset to a naive
+    datetime string.
+
+    Raises ``ValueError`` rather than silently defaulting to UTC when the
+    name can't be resolved: a wrong silent guess here is exactly the class
+    of bug (a query or write running in the wrong real-world window) this
+    helper exists to prevent.
+    """
+    try:
+        return ZoneInfo(resolve_zone_name(name))
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise ValueError(
+            f"Timezone {name!r} isn't a recognized IANA or Windows zone name."
+        ) from exc
+
+
+def offset_datetime_string(value: str, tz_name: str) -> str:
+    """Combine a naive datetime string (no embedded UTC offset - Outlook's
+    dateTimeTimeZone.dateTime is always this shape, paired with a separate
+    timeZone field) with its zone name into an offset-bearing ISO 8601
+    string.
+
+    Needed anywhere a naive value has to be sent to an API that (unlike
+    Outlook's own structured ``{"dateTime", "timeZone"}`` request bodies)
+    takes a single datetime string and infers UTC when it carries no
+    offset of its own. Graph's own docs for List calendarView's
+    startDateTime/endDateTime query parameters say exactly this: they're
+    "interpreted using the timezone offset specified in the value" and
+    "aren't impacted by the value of the Prefer ... header" - a naive
+    value there is silently read as UTC regardless of what timezone the
+    caller actually meant.
+
+    Raises ``ValueError`` (via ``resolve_zoneinfo``) rather than falling
+    back to UTC when ``tz_name`` can't be resolved - and also raises if
+    ``value`` turns out to already carry its own offset/``Z``, rather
+    than silently relabeling those same clock digits with `tz_name`'s
+    offset instead of converting them (``.replace(tzinfo=...)`` changes
+    what zone a datetime is interpreted in without changing the instant
+    it names, e.g. turning "10:00 UTC" into "10:00 <tz_name>" - a real
+    shift, not a no-op, whenever the two offsets differ). No public tool
+    parameter is documented as requiring a naive value, so a caller
+    passing one with an offset already attached is a real, reachable
+    input here, not just a theoretical one.
+    """
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is not None:
+        raise ValueError(
+            f"{value!r} already carries a UTC offset; pass a naive "
+            "datetime string (no trailing 'Z' or +HH:MM) together with "
+            "its timezone name instead of embedding an offset in both."
+        )
+    return parsed.replace(tzinfo=resolve_zoneinfo(tz_name)).isoformat()
+
+
+def calendar_day_bounds(
+    date_value: str, tz_name: str, *, days: int = 1
+) -> tuple[str, str]:
+    """Return (start, end) offset-bearing ISO instants spanning ``days``
+    full calendar day(s) starting at ``date_value``'s date, in ``tz_name``.
+
+    ``date_value`` may be a bare "YYYY-MM-DD" or a full datetime string
+    (only its date component is used). Used to widen an all-day event's
+    (or an all-day toggle's) boundary into a real queryable window: an
+    all-day event occupies the *calendar's own* day, not a UTC day, so a
+    hardcoded "T00:00:00Z" is only correct for a UTC calendar.
+    """
+    zone = resolve_zoneinfo(tz_name)
+    day: date = datetime.fromisoformat(date_value).date()
+    start = datetime.combine(day, time.min, tzinfo=zone)
+    end = start + timedelta(days=days)
+    return start.isoformat(), end.isoformat()
+
+
+def window_delta_segments(
+    existing_start: datetime | str | None,
+    existing_end: datetime | str | None,
+    new_start: datetime | str | None,
+    new_end: datetime | str | None,
+) -> list[tuple[datetime, datetime]]:
+    """The portion(s) of the half-open [new_start, new_end) window that
+    fall OUTSIDE [existing_start, existing_end) - the only territory an
+    attendee already on the event needs a fresh free/busy check against.
+
+    An attendee already on the event will always show this very event's
+    own busy block for any instant inside the OLD window - querying that
+    overlap can't distinguish "busy because of this event" from a real
+    conflict, the exact self-conflict bug this function exists to avoid.
+    But a window can move in a way that's neither identical/subset (no
+    new territory at all) nor fully disjoint (the whole new window is new
+    territory) - a partial nudge like 10:00-10:30 -> 10:15-10:45 makes
+    10:30-10:45 new territory while 10:15-10:30 is still old ground, and
+    checking the retained attendee only over the confirmed-safe old
+    portion (or not at all) would silently miss a genuine conflict
+    sitting in that new segment. This computes exactly that new territory
+    so the caller can check retained attendees against precisely it,
+    while newly-added attendees (who have no footprint on this event at
+    all) still get the FULL new window checked regardless of any of this
+    - they need every instant in it verified, delta or not.
+
+    Returns:
+    - ``[]`` when the new window is confirmed to add no territory beyond
+      the old one (identical or a subset) - nothing new for a retained
+      attendee to be checked against.
+    - Up to two disjoint segments when the new window extends past the
+      old one's start, end, or both (e.g. extending a meeting on both
+      sides in one call).
+    - The whole ``[new_start, new_end)`` as a single segment when the two
+      windows are confirmed to not overlap at all (matching "moved
+      somewhere completely disjoint -> check the whole thing"), OR when
+      any value isn't a real, mutually-comparable ``datetime`` (parsing
+      failure, or one side aware and the other naive) - "can't confirm
+      the delta is smaller than the whole window" must never silently
+      shrink what gets checked, so treat it as needing the full window.
+    - ``[]`` in the same can't-tell scenario if there's no valid new
+      window at all to fall back to (``new_start``/``new_end`` themselves
+      aren't real instants) - there is nothing meaningful to check.
+    """
+    if not (isinstance(new_start, datetime) and isinstance(new_end, datetime)):
+        return []
+    if not (
+        isinstance(existing_start, datetime) and isinstance(existing_end, datetime)
+    ):
+        return [(new_start, new_end)]
+    try:
+        fully_disjoint = new_end <= existing_start or new_start >= existing_end
+        if fully_disjoint:
+            return [(new_start, new_end)]
+        segments = []
+        if new_start < existing_start:
+            segments.append((new_start, existing_start))
+        if new_end > existing_end:
+            segments.append((existing_end, new_end))
+        return segments
+    except TypeError:
+        # Real datetimes that still can't be compared (aware vs. naive) -
+        # same "can't confirm smaller than the whole window" fallback.
+        return [(new_start, new_end)]
 
 
 def clamp_limit(limit: int, *, max_limit: int) -> int:

--- a/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
+++ b/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
@@ -374,4 +374,4 @@ def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
     assert migration.revision == "20260907_add_calendar_freebusy_scope"
-    assert migration.down_revision == "370740d9125a"
+    assert migration.down_revision == "20260909_seed_shopify_mcp_app"

--- a/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
+++ b/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
@@ -1,4 +1,4 @@
-"""Tests for narrowing the Google Calendar connector's OAuth scope."""
+"""Tests for adding calendar.freebusy to the Google Calendar connector's scope."""
 
 import importlib.util
 import json
@@ -13,16 +13,19 @@ from alembic.operations import Operations
 
 MIGRATION_PATH = (
     Path(__file__).parent.parent.parent
-    / "src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py"
+    / "src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py"
 )
 
-OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
-NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+OLD_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+NEW_SCOPES = [
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+]
 
 
 def _load_migration_module():
     spec = importlib.util.spec_from_file_location(
-        "narrow_google_calendar_scope_migration", MIGRATION_PATH
+        "add_calendar_freebusy_scope_migration", MIGRATION_PATH
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -49,9 +52,7 @@ def _scopes_by_app_id(connection, table: sa.Table) -> dict[str, object]:
     return {row.app_id: row.oauth_scopes for row in rows}
 
 
-def test_upgrade_narrows_google_calendar_scope_without_touching_other_apps(
-    tmp_path,
-) -> None:
+def test_upgrade_adds_freebusy_scope_without_touching_other_apps(tmp_path) -> None:
     migration = _load_migration_module()
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     metadata = sa.MetaData()
@@ -149,7 +150,7 @@ def test_upgrade_skips_when_oauth_scopes_column_is_absent() -> None:
     assert stored["app_id"] == "google-calendar"
 
 
-def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
+def test_downgrade_restores_the_events_only_scope(tmp_path) -> None:
     migration = _load_migration_module()
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     metadata = sa.MetaData()
@@ -171,7 +172,7 @@ def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
     assert scopes["google-calendar"] == OLD_SCOPES
 
 
-def test_downgrade_restores_the_full_calendar_scope_without_touching_other_apps(
+def test_downgrade_restores_the_events_only_scope_without_touching_other_apps(
     tmp_path,
 ) -> None:
     migration = _load_migration_module()
@@ -198,6 +199,56 @@ def test_downgrade_restores_the_full_calendar_scope_without_touching_other_apps(
     assert scopes["gmail"] == ["gmail-scope"]
 
 
+def test_upgrade_downgrade_upgrade_converges_on_the_new_scope(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+
+
+def test_upgrade_after_downgrade_does_not_touch_other_apps(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            [
+                {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+                {"app_id": "gmail", "oauth_scopes": ["gmail-scope"]},
+            ],
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+    assert scopes["gmail"] == ["gmail-scope"]
+
+
 def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     migration = _load_migration_module()
     output = StringIO()
@@ -213,7 +264,7 @@ def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    assert "calendar.events" in sql
+    assert "calendar.freebusy" in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -264,13 +315,11 @@ def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    # "auth/calendar" alone is a substring of both OLD_SCOPES and NEW_SCOPES
-    # ("auth/calendar.events"), so it can't distinguish which one was
-    # emitted; assert the narrower scope is absent to catch a swapped
-    # OLD_SCOPES/NEW_SCOPES argument in downgrade()'s
-    # _set_calendar_scopes_offline() call.
-    assert "auth/calendar" in sql
-    assert "calendar.events" not in sql
+    # Assert the freebusy scope is absent, not just present-or-absent by
+    # accident, to catch a swapped OLD_SCOPES/NEW_SCOPES argument in
+    # downgrade()'s _set_calendar_scopes_offline() call.
+    assert "calendar.events" in sql
+    assert "calendar.freebusy" not in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -306,18 +355,15 @@ def test_offline_sqlite_downgrade_round_trips_json_scope_value() -> None:
     assert json.loads(stored[0]) == OLD_SCOPES
 
 
-def test_migration_fields_match_this_files_expectations() -> None:
-    # This migration has since been superseded by
-    # 20260907_add_calendar_freebusy_scope, which adds calendar.freebusy on
-    # top of what this one set - so migration.NEW_SCOPES is no longer
-    # expected to equal the live registry value; that comparison now lives
-    # in the newer migration's own test instead.
-    #
-    # This file's own OLD_SCOPES/NEW_SCOPES (used throughout the tests
-    # above) are a separate copy of the migration's constants, not a
-    # reference to them -- if the migration's values ever changed without
-    # this file's copy following, every test above would keep passing
-    # against a stale expectation instead of failing loudly.
+def test_migration_fields_match_this_files_constants() -> None:
+    """This migration is no longer the last word on the google-calendar
+    scope (20260909_add_calendar_calendars_readonly_scope widens it
+    further) - checking against the *live* registry belongs on the most
+    recent scope-widening migration's own test, not here. This just
+    guards against this file's own OLD_SCOPES/NEW_SCOPES (used throughout
+    the tests above) silently drifting from the migration's real
+    constants, which are a separate copy, not a reference.
+    """
     migration = _load_migration_module()
 
     assert list(migration.OLD_SCOPES) == OLD_SCOPES
@@ -327,5 +373,5 @@ def test_migration_fields_match_this_files_expectations() -> None:
 def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
-    assert migration.revision == "20260817_narrow_google_calendar_scope"
-    assert migration.down_revision == "20260825_add_slack_channels_join_scope"
+    assert migration.revision == "20260907_add_calendar_freebusy_scope"
+    assert migration.down_revision == "370740d9125a"

--- a/tests/alembic/test_20260909_add_calendar_calendars_readonly_scope.py
+++ b/tests/alembic/test_20260909_add_calendar_calendars_readonly_scope.py
@@ -1,4 +1,5 @@
-"""Tests for narrowing the Google Calendar connector's OAuth scope."""
+"""Tests for adding calendar.calendars.readonly to the Google Calendar
+connector's scope."""
 
 import importlib.util
 import json
@@ -13,16 +14,23 @@ from alembic.operations import Operations
 
 MIGRATION_PATH = (
     Path(__file__).parent.parent.parent
-    / "src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py"
+    / "src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py"
 )
 
-OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
-NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+OLD_SCOPES = [
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+]
+NEW_SCOPES = [
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+    "https://www.googleapis.com/auth/calendar.calendars.readonly",
+]
 
 
 def _load_migration_module():
     spec = importlib.util.spec_from_file_location(
-        "narrow_google_calendar_scope_migration", MIGRATION_PATH
+        "add_calendar_calendars_readonly_scope_migration", MIGRATION_PATH
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -49,7 +57,7 @@ def _scopes_by_app_id(connection, table: sa.Table) -> dict[str, object]:
     return {row.app_id: row.oauth_scopes for row in rows}
 
 
-def test_upgrade_narrows_google_calendar_scope_without_touching_other_apps(
+def test_upgrade_adds_calendars_readonly_scope_without_touching_other_apps(
     tmp_path,
 ) -> None:
     migration = _load_migration_module()
@@ -149,7 +157,7 @@ def test_upgrade_skips_when_oauth_scopes_column_is_absent() -> None:
     assert stored["app_id"] == "google-calendar"
 
 
-def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
+def test_downgrade_restores_the_freebusy_only_scope(tmp_path) -> None:
     migration = _load_migration_module()
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     metadata = sa.MetaData()
@@ -171,7 +179,7 @@ def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
     assert scopes["google-calendar"] == OLD_SCOPES
 
 
-def test_downgrade_restores_the_full_calendar_scope_without_touching_other_apps(
+def test_downgrade_restores_the_freebusy_only_scope_without_touching_other_apps(
     tmp_path,
 ) -> None:
     migration = _load_migration_module()
@@ -198,6 +206,29 @@ def test_downgrade_restores_the_full_calendar_scope_without_touching_other_apps(
     assert scopes["gmail"] == ["gmail-scope"]
 
 
+def test_upgrade_downgrade_upgrade_converges_on_the_new_scope(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+
+
 def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     migration = _load_migration_module()
     output = StringIO()
@@ -213,7 +244,7 @@ def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    assert "calendar.events" in sql
+    assert "calendar.calendars.readonly" in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -264,13 +295,11 @@ def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    # "auth/calendar" alone is a substring of both OLD_SCOPES and NEW_SCOPES
-    # ("auth/calendar.events"), so it can't distinguish which one was
-    # emitted; assert the narrower scope is absent to catch a swapped
-    # OLD_SCOPES/NEW_SCOPES argument in downgrade()'s
-    # _set_calendar_scopes_offline() call.
-    assert "auth/calendar" in sql
-    assert "calendar.events" not in sql
+    # Assert the calendars.readonly scope is absent, not just present-or-
+    # absent by accident, to catch a swapped OLD_SCOPES/NEW_SCOPES argument
+    # in downgrade()'s _set_calendar_scopes_offline() call.
+    assert "calendar.freebusy" in sql
+    assert "calendar.calendars.readonly" not in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -306,20 +335,22 @@ def test_offline_sqlite_downgrade_round_trips_json_scope_value() -> None:
     assert json.loads(stored[0]) == OLD_SCOPES
 
 
-def test_migration_fields_match_this_files_expectations() -> None:
-    # This migration has since been superseded by
-    # 20260907_add_calendar_freebusy_scope, which adds calendar.freebusy on
-    # top of what this one set - so migration.NEW_SCOPES is no longer
-    # expected to equal the live registry value; that comparison now lives
-    # in the newer migration's own test instead.
-    #
-    # This file's own OLD_SCOPES/NEW_SCOPES (used throughout the tests
-    # above) are a separate copy of the migration's constants, not a
-    # reference to them -- if the migration's values ever changed without
-    # this file's copy following, every test above would keep passing
-    # against a stale expectation instead of failing loudly.
-    migration = _load_migration_module()
+def test_migration_fields_match_registry() -> None:
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
 
+    migration = _load_migration_module()
+    registry_row = next(
+        row
+        for row in get_builtin_public_mcp_app_rows()
+        if row["app_id"] == "google-calendar"
+    )
+
+    assert list(migration.NEW_SCOPES) == registry_row["oauth_scopes"]
+    # This file's own OLD_SCOPES/NEW_SCOPES (used throughout the tests above)
+    # are a separate copy of the migration's constants, not a reference to
+    # them -- if the migration's values ever changed without this file's
+    # copy following, every test above would keep passing against a stale
+    # expectation instead of failing loudly.
     assert list(migration.OLD_SCOPES) == OLD_SCOPES
     assert list(migration.NEW_SCOPES) == NEW_SCOPES
 
@@ -327,5 +358,5 @@ def test_migration_fields_match_this_files_expectations() -> None:
 def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
-    assert migration.revision == "20260817_narrow_google_calendar_scope"
-    assert migration.down_revision == "20260825_add_slack_channels_join_scope"
+    assert migration.revision == "20260909_add_calendar_calendars_readonly_scope"
+    assert migration.down_revision == "20260907_add_calendar_freebusy_scope"

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1120,6 +1120,47 @@ def test_create_events_rejects_a_reversed_window(fake_service):
     assert fake_service._events.insert_calls == []
 
 
+def test_create_events_rejects_an_offsetless_start_time(fake_service):
+    """Regression test: an offsetless start_time compared naive-against-
+    aware deep inside a downstream comparison would previously fall
+    through to Google's own freebusy/events.list APIs (which require an
+    RFC3339 offset on timeMin/timeMax) and fail there with an opaque
+    error, instead of this clear, actionable one raised up front."""
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00",  # no offset
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "start_time" in result["message"]
+    assert fake_service._events.insert_calls == []
+
+
+def test_update_events_rejects_an_offsetless_start_time(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00",  # no offset
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "start_time" in result["message"]
+    assert fake_service._events.update_calls == []
+    assert fake_service._freebusy.query_calls == []
+
+
 def test_update_events_excludes_the_event_being_moved_from_its_own_conflicts(
     fake_service,
 ):
@@ -1144,6 +1185,47 @@ def test_update_events_excludes_the_event_being_moved_from_its_own_conflicts(
     result = json.loads(
         calendar.google_calendar_update_events(
             event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["Board sync"]
+
+
+def test_update_events_excludes_a_recurring_events_own_instances_from_its_conflicts(
+    fake_service,
+):
+    """Regression test: events.list(singleEvents=True) expands a recurring
+    event into instances that carry their OWN id
+    ("<masterId>_<recurrenceStamp>"), never the master's - rescheduling
+    the master itself (the normal way to address a recurring series)
+    must not report it as conflicting with its own instances just
+    because `id` alone never matches `exclude_event_id`. recurringEventId
+    is the field that actually names the master on each instance."""
+    fake_service._events._get_result = {
+        "id": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+    }
+    fake_service._events._list_result = {
+        "items": [
+            {
+                "id": "series-1_20260827T010000Z",
+                "recurringEventId": "series-1",
+                "summary": "Weekly sync (this instance)",
+                "status": "confirmed",
+                "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+                "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+            },
+            _confirmed_event(event_id="other-1", summary="Board sync"),
+        ]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1",
             start_time="2026-08-27T10:00:00+08:00",
             end_time="2026-08-27T10:30:00+08:00",
         )
@@ -1223,6 +1305,50 @@ def test_update_events_same_window_only_checks_newly_added_attendee(fake_service
         for item in call["body"]["items"]
     }
     assert queried_emails == {"new@example.com"}
+
+
+def test_update_events_adding_the_organizer_as_an_attendee_does_not_self_conflict(
+    fake_service,
+):
+    """Regression test: freebusy.query has no concept of "exclude this
+    event", unlike the organizer-calendar path (excluded by id/
+    recurringEventId). Adding the organizer's own email as a "new"
+    attendee would otherwise be checked via freebusy and always find
+    this very event's own busy block on their calendar - the organizer's
+    own availability is already covered by the organizer-calendar check,
+    so they must be excluded from the freebusy batch."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "me@example.com"},
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "me@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._freebusy.query_calls == []
 
 
 def test_update_events_treats_existing_attendee_case_insensitively(fake_service):
@@ -2197,19 +2323,23 @@ def test_update_events_respects_sibling_timezone_on_an_offsetless_datetime(
     that offsetless value as if it belonged to some other zone (e.g. the
     calendar's, or UTC) would misjudge a same-instant resubmission as a
     real time change and run the organizer check against the event's own
-    now-"moved" window."""
+    now-"moved" window. The sibling zone here (Asia/Singapore, +08:00) is
+    deliberately NOT the code's own UTC fallback, so this only passes if
+    the sibling timeZone field is actually read rather than ignored -
+    falling back to UTC would compute a different instant and treat this
+    resubmission as a real move."""
     fake_service._events._get_result = {
         "id": "self-1",
-        "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
-        "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+        "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "Asia/Singapore"},
+        "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "Asia/Singapore"},
         "attendees": [{"email": "existing@example.com"}],
     }
 
     result = json.loads(
         calendar.google_calendar_update_events(
             event_id="self-1",
-            start_time="2026-08-27T10:00:00+08:00",  # same instant, different offset
-            end_time="2026-08-27T10:30:00+08:00",
+            start_time="2026-08-27T02:00:00+08:00",  # same instant, explicit offset
+            end_time="2026-08-27T02:30:00+08:00",
             location="Room 4",
         )
     )
@@ -2281,6 +2411,40 @@ def test_update_events_missing_scope_still_reports_an_already_confirmed_conflict
     assert result["status"] == "conflict"
     assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
     assert result["unchecked_attendees"] == ["outsider@gmail.com"]
+
+
+def test_update_events_missing_scope_on_retained_attendees_still_reports_the_first_calls_conflict(
+    fake_service,
+):
+    """Regression test for the multi-call accumulation path specifically
+    (as opposed to a single _find_conflicts call's own internal one): a
+    real conflict found by the FIRST call (organizer, via events.list,
+    which needs no extra scope) must survive being merged with a SECOND,
+    separate call's InsufficientScopeError (the retained-attendee delta
+    segment, via freebusy.query) at google_calendar_update_events' own
+    accumulation layer - not just within a single _find_conflicts call."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert result["unchecked_attendees"] == ["existing@example.com"]
 
 
 def test_update_events_missing_scope_can_be_bypassed_with_ignore_conflicts(

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1588,6 +1588,76 @@ def test_update_events_organizer_self_false_needs_no_identity_api_call(
     assert fake_service._calendars.get_calls == []
 
 
+def test_update_events_organizer_self_false_with_no_email_still_checks_the_new_attendee(
+    fake_service,
+):
+    """Regression test: organizer.self=False with no organizer.email at
+    all must NOT trigger the "backfill organizer_email to the caller's
+    own address" fallback - that fallback exists for the "no organizer
+    info whatsoever" case, and backfilling here would wrongly exclude a
+    genuinely different, newly-added attendee ("me@example.com" - the
+    caller's own address, added as an ordinary attendee to someone
+    else's event) from the freebusy batch, silently skipping a real
+    conflict check for them."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"self": False},
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {"calendars": {"me@example.com": {"busy": []}}}
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    queried_emails = {
+        item["id"]
+        for call in fake_service._freebusy.query_calls
+        for item in call["body"]["items"]
+    }
+    assert queried_emails == {"me@example.com"}
+    assert fake_service._calendars.get_calls == []
+
+
+def test_update_events_missing_scope_on_the_organizer_backfill_is_skipped_with_ignore_conflicts(
+    fake_service,
+):
+    """Regression test: the organizer-email backfill (resolving the
+    caller's own address when the event has no organizer info at all)
+    calls the same calendars().get(calendarId="primary") endpoint as the
+    all-day-timezone lookup, and must respect ignore_conflicts the same
+    way that sibling call site already does - a token missing
+    calendar.calendars.readonly must not hard-fail a call the caller
+    explicitly opted out of checking."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        # No "organizer" field at all - triggers the backfill attempt.
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
 def test_update_events_organizer_self_true_needs_no_identity_api_call(
     fake_service,
 ):
@@ -1665,15 +1735,17 @@ def test_update_events_treats_existing_attendee_case_insensitively(fake_service)
     with different casing must still be recognized as "already there" -
     otherwise it's treated as newly-added, gets checked against the
     unchanged window, and always self-conflicts on its own busy block for
-    this very event. Uses mismatched casing on BOTH sides (the event's own
-    stored casing, and the caller's resubmitted casing) - a fixture using
-    lowercase on the stored side alone can't tell a correct fold from a
-    mutation that drops .lower() on just that side."""
+    this very event. Uses two DIFFERENT non-canonical casings (neither one
+    plain-lowercase, and the two not equal to each other without folding)
+    on the stored side vs. the resubmitted side - a fixture where either
+    side happens to already be lowercase can't tell a correct fold on
+    that side from a mutation that drops .lower() on it specifically,
+    since a dropped .lower() on an already-lowercase value is invisible."""
     fake_service._events._get_result = {
         "id": "self-1",
         "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
         "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
-        "attendees": [{"email": "Old@Example.com"}],
+        "attendees": [{"email": "OLD@EXAMPLE.COM"}],
     }
     fake_service._freebusy = FakeFreebusy(
         {
@@ -1697,7 +1769,7 @@ def test_update_events_treats_existing_attendee_case_insensitively(fake_service)
     result = json.loads(
         calendar.google_calendar_update_events(
             event_id="self-1",
-            attendees=["old@example.com", "new@example.com"],
+            attendees=["Old@Example.Com", "new@example.com"],
         )
     )
 

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1139,6 +1139,29 @@ def test_create_events_rejects_an_offsetless_start_time(fake_service):
     assert fake_service._events.insert_calls == []
 
 
+def test_create_events_prefers_the_offset_error_over_the_reversed_window_one(
+    fake_service,
+):
+    """Regression test: two NAIVE values that also happen to be reversed
+    compare just fine (no TypeError, so reject_reversed_window's
+    permissive aware-vs-naive handling never kicks in) and would
+    otherwise raise the generic "must be after" message before the more
+    specific, actionable offset error ever got a chance to run - offset
+    validation must happen first."""
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:30:00",  # naive AND reversed
+            end_time="2026-08-27T10:00:00",  # naive
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "start_time" in result["message"]
+    assert "offset" in result["message"]
+    assert fake_service._events.insert_calls == []
+
+
 def test_update_events_rejects_an_offsetless_start_time(fake_service):
     fake_service._events._get_result = {
         "id": "self-1",
@@ -1348,6 +1371,43 @@ def test_update_events_adding_the_organizer_as_an_attendee_does_not_self_conflic
     )
 
     assert result["status"] == "success"
+    assert fake_service._freebusy.query_calls == []
+    # The organizer's own calendar must still have been checked - just via
+    # the id/recurringEventId-excluding events.list path instead of the
+    # self-conflicting freebusy one - not skipped outright.
+    assert len(fake_service._events.list_calls) == 1
+
+
+def test_update_events_adding_the_organizer_as_an_attendee_still_catches_a_real_conflict(
+    fake_service,
+):
+    """Regression test: excluding the organizer from the freebusy batch
+    must not also skip checking their calendar altogether. Before this
+    fix, adding ONLY the organizer as a new attendee (window otherwise
+    unchanged) left both `attendees_to_check` empty (organizer filtered
+    out) and `check_organizer` false (window unchanged), so a genuinely
+    different conflicting event on the organizer's own calendar was
+    silently missed entirely."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "me@example.com"},
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1", summary="Board sync")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["Board sync"]
     assert fake_service._freebusy.query_calls == []
 
 

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -833,6 +833,11 @@ class FakeEvents:
         update_result: dict[str, Any] | None = None,
     ):
         self._list_result = list_result if list_result is not None else {"items": []}
+        # Keyed by the request's own pageToken (None for the first page) -
+        # lets a test simulate a multi-page events.list response instead
+        # of always returning the same page regardless of pageToken. Only
+        # used when set; _list_result covers every single-page test.
+        self._list_results_by_page_token: dict[str | None, dict[str, Any]] | None = None
         self._get_result = get_result or {}
         self._insert_result = insert_result or {"id": "created"}
         self._update_result = update_result or {"id": "updated"}
@@ -842,6 +847,8 @@ class FakeEvents:
 
     def list(self, **kwargs: Any) -> _Exec:
         self.list_calls.append(kwargs)
+        if self._list_results_by_page_token is not None:
+            return _Exec(self._list_results_by_page_token[kwargs.get("pageToken")])
         return _Exec(self._list_result)
 
     def get(self, **kwargs: Any) -> _Exec:
@@ -994,6 +1001,33 @@ def test_create_events_detects_organizer_conflict_same_timezone(fake_service):
     assert len(result["conflicts"]) == 1
     assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
     assert fake_service._events.insert_calls == []
+
+
+def test_create_events_follows_pagination_to_find_a_conflict_on_a_later_page(
+    fake_service,
+):
+    """Regression test: events.list() caps a single response at a limited
+    page size and signals more with nextPageToken - stopping after the
+    first page (as an earlier version of this check did) would silently
+    place a busy event on a later page outside the check entirely,
+    letting a real conflict through undetected."""
+    fake_service._events._list_results_by_page_token = {
+        None: {"items": [], "nextPageToken": "page-2"},
+        "page-2": {"items": [_confirmed_event(event_id="other-1")]},
+    }
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    page_tokens = [call.get("pageToken") for call in fake_service._events.list_calls]
+    assert page_tokens == [None, "page-2"]
 
 
 def test_create_events_ignores_transparent_organizer_event(fake_service):

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1553,6 +1553,71 @@ def test_update_events_on_someone_elses_event_reports_the_real_organizer_uncheck
     assert fake_service._freebusy.query_calls == []
 
 
+def test_update_events_organizer_self_false_needs_no_identity_api_call(
+    fake_service,
+):
+    """Regression test: Google's own organizer.self field ("Whether the
+    organizer corresponds to the calendar on which this copy of the
+    event appears") directly answers caller_is_organizer - when present,
+    no calendars().get(calendarId="primary") call is needed at all for
+    identity purposes, unlike the email-comparison fallback this uses
+    when organizer.self is absent."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "boss@example.com"}],
+        "organizer": {"email": "boss@example.com", "self": False},
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["boss@example.com"]
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+    # The whole point: organizer.self answered caller_is_organizer
+    # directly, so the connected account's own identity never needed
+    # looking up via calendars().get() at all.
+    assert fake_service._calendars.get_calls == []
+
+
+def test_update_events_organizer_self_true_needs_no_identity_api_call(
+    fake_service,
+):
+    """Companion to the test above: organizer.self=True must resolve
+    caller_is_organizer without an identity API call either, and let the
+    organizer-calendar check run normally."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "me@example.com", "self": True},
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["1:1 with Hazel"]
+    assert fake_service._calendars.get_calls == []
+
+
 def test_update_events_on_someone_elses_event_still_catches_another_attendees_conflict(
     fake_service,
 ):

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1690,6 +1690,36 @@ def test_update_events_non_scope_error_on_the_organizer_backfill_is_also_skipped
     assert len(fake_service._events.update_calls) == 1
 
 
+def test_update_events_missing_scope_on_the_organizer_backfill_rejects_the_write_by_default(
+    fake_service,
+):
+    """Companion to the two tests above: without ignore_conflicts, a
+    missing-scope failure on the organizer-email backfill must reject
+    the write outright, same as its two sibling calendars().get() call
+    sites (the all-day-timezone lookup and the identity-fallback
+    comparison) already do - not silently proceed as if the caller had
+    opted out of the check."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        # No "organizer" field at all - triggers the backfill attempt.
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
 def test_update_events_organizer_self_true_needs_no_identity_api_call(
     fake_service,
 ):

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1,7 +1,11 @@
 import copy
 import json
 import re
+from typing import Any
 from unittest.mock import Mock
+
+import pytest
+from googleapiclient.errors import HttpError
 
 from xagent.web.tools.mcp import calendar
 from xagent.web.tools.mcp import utils as mcp_utils
@@ -34,8 +38,16 @@ def _fake_service(execute_result: dict, existing_event: dict | None = None):
             )
         )
     )
+    # These Meet-focused tests don't exercise the scheduling-conflict
+    # check (that's the other half of this file's test suite) - stub the
+    # organizer/attendee queries it always runs (unless ignore_conflicts)
+    # to report "no conflicts" so it doesn't block on an un-mocked Mock.
+    events.list = Mock(return_value=Mock(execute=Mock(return_value={"items": []})))
     service = Mock()
     service.events.return_value = events
+    service.freebusy.return_value = Mock(
+        query=Mock(return_value=Mock(execute=Mock(return_value={"calendars": {}})))
+    )
     return service
 
 
@@ -801,3 +813,1530 @@ def test_event_response_does_not_truncate_a_small_event(monkeypatch):
 
     assert result["status"] == "success"
     assert result["truncated"] is False
+
+
+class _Exec:
+    def __init__(self, result: dict[str, Any]):
+        self._result = result
+
+    def execute(self) -> dict[str, Any]:
+        return self._result
+
+
+class FakeEvents:
+    def __init__(
+        self,
+        *,
+        list_result: dict[str, Any] | None = None,
+        get_result: dict[str, Any] | None = None,
+        insert_result: dict[str, Any] | None = None,
+        update_result: dict[str, Any] | None = None,
+    ):
+        self._list_result = list_result if list_result is not None else {"items": []}
+        self._get_result = get_result or {}
+        self._insert_result = insert_result or {"id": "created"}
+        self._update_result = update_result or {"id": "updated"}
+        self.list_calls: list[dict[str, Any]] = []
+        self.insert_calls: list[dict[str, Any]] = []
+        self.update_calls: list[dict[str, Any]] = []
+
+    def list(self, **kwargs: Any) -> _Exec:
+        self.list_calls.append(kwargs)
+        return _Exec(self._list_result)
+
+    def get(self, **kwargs: Any) -> _Exec:
+        return _Exec(self._get_result)
+
+    def insert(self, **kwargs: Any) -> _Exec:
+        self.insert_calls.append(kwargs)
+        return _Exec(self._insert_result)
+
+    def update(self, **kwargs: Any) -> _Exec:
+        self.update_calls.append(kwargs)
+        return _Exec(self._update_result)
+
+
+class _FakeHttpResp:
+    def __init__(self, status: int):
+        self.status = status
+        self.reason = "error"
+
+
+def _insufficient_scope_error() -> HttpError:
+    """A real Google API 403 for this case carries the reason on BOTH the
+    legacy `errors[].reason` field and a newer `details[].reason`
+    ErrorInfo entry at once - not one or the other. `HttpError`'s own
+    `_get_reason()` picks `details` over `errors` whenever both are
+    present, dropping the legacy reason from `str(exc)` entirely, which
+    is exactly what makes a naive `"insufficientPermissions" in str(exc)`
+    substring check unreliable (see `_is_insufficient_scope_error`)."""
+    return HttpError(
+        _FakeHttpResp(403),
+        (
+            b'{"error": {"code": 403, '
+            b'"message": "Request had insufficient authentication scopes.", '
+            b'"errors": [{"message": "Insufficient Permission", '
+            b'"domain": "global", "reason": "insufficientPermissions"}], '
+            b'"status": "PERMISSION_DENIED", '
+            b'"details": [{"@type": "type.googleapis.com/google.rpc.ErrorInfo", '
+            b'"reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT", '
+            b'"domain": "googleapis.com", '
+            b'"metadata": {"service": "calendar-json.googleapis.com", '
+            b'"method": "calendar.v3.Freebusy.Query"}}]}}'
+        ),
+    )
+
+
+def _legacy_only_insufficient_scope_error() -> HttpError:
+    """Older/less-instrumented responses may still carry only the legacy
+    field - must keep matching this shape too, not just the dual one."""
+    return HttpError(
+        _FakeHttpResp(403),
+        (
+            b'{"error": {"errors": [{"reason": "insufficientPermissions"}], '
+            b'"message": "Request had insufficient authentication scopes."}}'
+        ),
+    )
+
+
+class FakeFreebusy:
+    def __init__(
+        self,
+        result: dict[str, Any] | None = None,
+        *,
+        raise_error: Exception | None = None,
+    ):
+        self._result = result or {"calendars": {}}
+        self._raise_error = raise_error
+        self.query_calls: list[dict[str, Any]] = []
+
+    def query(self, **kwargs: Any) -> _Exec:
+        self.query_calls.append(kwargs)
+        if self._raise_error is not None:
+            raise self._raise_error
+        return _Exec(self._result)
+
+
+class FakeCalendars:
+    def __init__(self, timezone: str = "UTC", *, raise_error: Exception | None = None):
+        self._timezone = timezone
+        self._raise_error = raise_error
+        self.get_calls: list[dict[str, Any]] = []
+
+    def get(self, **kwargs: Any) -> _Exec:
+        self.get_calls.append(kwargs)
+        if self._raise_error is not None:
+            raise self._raise_error
+        return _Exec({"timeZone": self._timezone})
+
+
+class FakeService:
+    def __init__(
+        self,
+        events: FakeEvents | None = None,
+        freebusy: FakeFreebusy | None = None,
+        calendars: FakeCalendars | None = None,
+    ):
+        self._events = events or FakeEvents()
+        self._freebusy = freebusy or FakeFreebusy()
+        self._calendars = calendars or FakeCalendars()
+
+    def events(self) -> FakeEvents:
+        return self._events
+
+    def freebusy(self) -> FakeFreebusy:
+        return self._freebusy
+
+    def calendars(self) -> FakeCalendars:
+        return self._calendars
+
+
+@pytest.fixture
+def fake_service(monkeypatch):
+    service = FakeService()
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+    return service
+
+
+def _confirmed_event(
+    event_id="existing-1",
+    summary="1:1 with Hazel",
+    transparency=None,
+    status="confirmed",
+):
+    event: dict[str, Any] = {
+        "id": event_id,
+        "summary": summary,
+        "status": status,
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+    }
+    if transparency:
+        event["transparency"] = transparency
+    return event
+
+
+def test_create_events_detects_organizer_conflict_same_timezone(fake_service):
+    """Reproduces the reported bug: booking a slot that overlaps an existing
+    event, both in the same timezone, must be caught rather than silently
+    created."""
+    fake_service._events._list_result = {"items": [_confirmed_event()]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert len(result["conflicts"]) == 1
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert fake_service._events.insert_calls == []
+
+
+def test_create_events_ignores_transparent_organizer_event(fake_service):
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(transparency="transparent")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.insert_calls) == 1
+
+
+def test_create_events_ignores_cancelled_organizer_event(fake_service):
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(status="cancelled")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_create_events_detects_attendee_freebusy_conflict(fake_service):
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "chelsea@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "chelsea@example.com"
+    assert fake_service._events.insert_calls == []
+
+
+def test_create_events_unchecked_attendee_does_not_block_creation(fake_service):
+    """An attendee whose calendar can't be queried (external/unshared) must
+    not block booking — only be surfaced so Toby can say so."""
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "outsider@gmail.com": {"errors": [{"reason": "notFound"}]},
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
+    insert_call = fake_service._events.insert_calls[0]
+    assert insert_call["body"]["attendees"] == [{"email": "outsider@gmail.com"}]
+    # notify_attendees defaults to False - adding an attendee never emails
+    # them without the caller explicitly opting in.
+    assert insert_call["sendUpdates"] == "none"
+
+
+def test_create_events_ignore_conflicts_skips_the_check_entirely(fake_service):
+    fake_service._events._list_result = {"items": [_confirmed_event()]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert len(fake_service._events.insert_calls) == 1
+
+
+def test_create_events_rejects_a_reversed_window(fake_service):
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:30:00+08:00",
+            end_time="2026-08-27T10:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after" in result["message"]
+    assert fake_service._events.list_calls == []
+    assert fake_service._events.insert_calls == []
+
+
+def test_update_events_excludes_the_event_being_moved_from_its_own_conflicts(
+    fake_service,
+):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+    }
+    fake_service._events._list_result = {
+        "items": [
+            {
+                "id": "self-1",
+                "summary": "old slot",
+                "status": "confirmed",
+                "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+                "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+            },
+            _confirmed_event(event_id="other-1", summary="Board sync"),
+        ]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["Board sync"]
+
+
+def test_update_events_metadata_only_edit_never_checks_conflicts(fake_service):
+    """A pure metadata edit (no time/attendee change) must never run the
+    conflict check at all - not just tolerate it, since even running the
+    check would spuriously self-conflict against the event's own attendees
+    (see the two tests below)."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "chelsea@example.com"}],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="New Title",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+    assert fake_service._events.update_calls[0]["sendUpdates"] == "none"
+
+
+def test_update_events_same_window_only_checks_newly_added_attendee(fake_service):
+    """Adding an attendee without moving the event must only check the new
+    attendee's free/busy - checking an existing attendee against the
+    unchanged window would always find the event's own busy block on their
+    calendar and falsely report a conflict."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "old@example.com"}],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "old@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+                "new@example.com": {"busy": []},
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["old@example.com", "new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    queried_emails = {
+        item["id"]
+        for call in fake_service._freebusy.query_calls
+        for item in call["body"]["items"]
+    }
+    assert queried_emails == {"new@example.com"}
+
+
+def test_update_events_treats_existing_attendee_case_insensitively(fake_service):
+    """Regression test for a review finding: an existing attendee re-passed
+    with different casing must still be recognized as "already there" -
+    otherwise it's treated as newly-added, gets checked against the
+    unchanged window, and always self-conflicts on its own busy block for
+    this very event."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "old@example.com"}],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                # This event's own busy block on the existing attendee's
+                # calendar - present so the test would fail with a false
+                # "conflict" if the case-insensitive exclusion regressed.
+                "old@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+                "new@example.com": {"busy": []},
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["Old@Example.com", "new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    queried_emails = {
+        item["id"]
+        for call in fake_service._freebusy.query_calls
+        for item in call["body"]["items"]
+    }
+    assert queried_emails == {"new@example.com"}
+
+
+def test_update_events_reports_original_casing_in_conflicts(fake_service):
+    """Regression test: falling back to the event's existing attendees (no
+    attendees param passed) while moving the time must report a conflict
+    using the originally-stored casing, not the lowercased form used
+    internally for the case-insensitive membership check."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "John.Smith@Example.com"}],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "john.smith@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "John.Smith@Example.com"
+
+
+def test_update_events_moving_time_checks_organizer_and_all_attendees(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert len(fake_service._events.list_calls) == 1
+    queried_emails = {
+        item["id"]
+        for call in fake_service._freebusy.query_calls
+        for item in call["body"]["items"]
+    }
+    assert queried_emails == {"existing@example.com"}
+
+
+def test_update_events_rejects_a_reversed_window(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:30:00+08:00",
+            end_time="2026-08-27T10:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after" in result["message"]
+    assert fake_service._events.list_calls == []
+    assert fake_service._events.update_calls == []
+
+
+def test_freebusy_lookup_is_case_insensitive(fake_service):
+    """Not confirmed against real Google API behavior, but the lookup should
+    be defensive either way: a case-mismatched key must not silently
+    swallow a real conflict."""
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "Chelsea@Example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_organizer_events_list_tolerates_null_items(fake_service):
+    """Regression test for a review finding: the API can return an explicit
+    "items": null instead of omitting the key, which must not crash the
+    tool with a TypeError."""
+    fake_service._events._list_result = {"items": None}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_freebusy_tolerates_null_calendars(fake_service):
+    """Regression test for a review finding: freebusy.query can return an
+    explicit "calendars": null, which must not crash the tool with an
+    AttributeError."""
+    fake_service._freebusy = FakeFreebusy({"calendars": None})
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_update_events_ignore_conflicts_skips_the_check(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+    }
+    fake_service._events._list_result = {"items": [_confirmed_event()]}
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_organizer_declined_but_opaque_event_is_still_a_conflict(fake_service):
+    """Google documents `responseStatus` and `transparency` as independent
+    fields with no guaranteed link - declining an invite doesn't reliably
+    clear its transparency, so a still-opaque declined event must still be
+    treated as busy rather than assumed free."""
+    event = _confirmed_event()
+    event["attendees"] = [
+        {"email": "me@example.com", "self": True, "responseStatus": "declined"}
+    ]
+    fake_service._events._list_result = {"items": [event]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_organizer_declined_and_transparent_event_is_not_a_conflict(fake_service):
+    event = _confirmed_event(transparency="transparent")
+    event["attendees"] = [
+        {"email": "me@example.com", "self": True, "responseStatus": "declined"}
+    ]
+    fake_service._events._list_result = {"items": [event]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_organizer_accepted_event_is_still_a_conflict(fake_service):
+    event = _confirmed_event()
+    event["attendees"] = [
+        {"email": "me@example.com", "self": True, "responseStatus": "accepted"}
+    ]
+    fake_service._events._list_result = {"items": [event]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_freebusy_batch_over_limit_is_chunked_into_multiple_calls(fake_service):
+    """Regression test: an over-limit attendee list must be split into
+    multiple <=50-sized freebusy.query calls and the results merged,
+    rather than giving up on checking anyone at all."""
+    attendees = [f"person{i}@example.com" for i in range(51)]
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "person0@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+                "person50@example.com": {"busy": []},
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="All hands",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=attendees,
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "person0@example.com"
+    batch_sizes = sorted(
+        len(call["body"]["items"]) for call in fake_service._freebusy.query_calls
+    )
+    assert batch_sizes == [1, 50]
+
+
+def test_freebusy_missing_scope_rejects_the_write(fake_service):
+    """A whole-batch 403 means our own credential/scope is insufficient,
+    not that a particular attendee's calendar is merely invisible - proceed
+    would silently skip the entire conflict check, defeating the feature.
+    The write must be rejected rather than degraded to unchecked."""
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.insert_calls == []
+
+
+def test_freebusy_missing_scope_rejects_the_write_even_with_ignore_conflicts_false(
+    fake_service,
+):
+    """`ignore_conflicts` is the caller's explicit escape hatch - without it,
+    a scope-insufficient 403 must reject rather than silently proceed."""
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+            ignore_conflicts=False,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert fake_service._events.insert_calls == []
+
+
+def test_freebusy_missing_scope_can_be_bypassed_with_ignore_conflicts(fake_service):
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.insert_calls) == 1
+
+
+def test_freebusy_missing_scope_still_reports_an_already_confirmed_conflict(
+    fake_service,
+):
+    """Regression test: a real conflict already confirmed before the scope
+    error hit (here, the organizer's own calendar, which doesn't need the
+    freebusy scope at all) must not be silently discarded just because a
+    later, unrelated attendee check then hit the same missing-scope 403 -
+    reporting a known conflict is always safe, and blindly rejecting
+    instead would tell the caller to retry with ignore_conflicts=true,
+    which would then book straight over the real conflict nobody ever
+    mentioned."""
+    fake_service._events._list_result = {"items": [_confirmed_event()]}
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert result["unchecked_attendees"] == ["chelsea@example.com"]
+    assert fake_service._events.insert_calls == []
+
+
+def test_freebusy_missing_scope_legacy_only_body_still_rejects(fake_service):
+    """The dual-format body is what a real Calendar API 403 actually
+    carries, but a response with only the legacy `errors[]` field must
+    still be recognized - not just the newer `details[]` shape."""
+    fake_service._freebusy = FakeFreebusy(
+        raise_error=_legacy_only_insufficient_scope_error()
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert fake_service._events.insert_calls == []
+
+
+def test_is_insufficient_scope_error_matches_details_only_body():
+    """Regression test for the actual bug: HttpError._get_reason() prefers
+    `details` over `errors` whenever a response carries both, dropping
+    "insufficientPermissions" from str(exc) entirely - a plain substring
+    check on str(exc) would miss this. Must check the parsed body's
+    fields directly instead."""
+    details_only = HttpError(
+        _FakeHttpResp(403),
+        (b'{"error": {"details": [{"reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT"}]}}'),
+    )
+    assert calendar._is_insufficient_scope_error(details_only) is True
+
+
+def test_is_insufficient_scope_error_rejects_unrelated_403():
+    other = HttpError(
+        _FakeHttpResp(403),
+        b'{"error": {"errors": [{"reason": "forbiddenForNonOrganizer"}]}}',
+    )
+    assert calendar._is_insufficient_scope_error(other) is False
+
+
+def test_is_insufficient_scope_error_tolerates_malformed_body():
+    malformed = HttpError(_FakeHttpResp(403), b"not json")
+    assert calendar._is_insufficient_scope_error(malformed) is False
+
+
+def test_is_insufficient_scope_error_tolerates_non_list_error_fields():
+    """Regression test: valid JSON whose "errors"/"details" field is
+    present but isn't an array (e.g. a boolean/object, from a malformed
+    or unexpected error body) must not crash - `x or []` treats a truthy
+    non-list value as itself, and iterating a non-iterable raises
+    TypeError; must fall through to "can't tell, so False" instead."""
+    non_list_fields = HttpError(
+        _FakeHttpResp(403), b'{"error": {"errors": true, "details": 42}}'
+    )
+    assert calendar._is_insufficient_scope_error(non_list_fields) is False
+
+
+def test_freebusy_other_http_errors_still_propagate(fake_service):
+    other_error = HttpError(_FakeHttpResp(500), b'{"error": {"message": "boom"}}')
+    fake_service._freebusy = FakeFreebusy(raise_error=other_error)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+
+
+def test_freebusy_attendee_absent_from_response_is_marked_unchecked(fake_service):
+    """An attendee simply missing from calendars (no entry at all, not even
+    an "errors" key) must not be silently reported as free."""
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["ghost@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["ghost@example.com"]
+
+
+def test_update_events_checks_conflicts_for_an_all_day_event(fake_service):
+    """Regression test: an all-day event stores its bounds under "date", not
+    "dateTime" - previously existing_start/existing_end came back None for
+    it, so the whole conflict check (and thus adding attendees) silently
+    skipped, even though sendUpdates="all" would still fire real invites.
+
+    Adding an attendee without moving the (all-day) window only checks the
+    newly-added attendee, same as the timed-event case - so this asserts
+    the freebusy query actually ran, with the date widened into a valid
+    RFC3339 bound, rather than an organizer-side conflict.
+    """
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "new@example.com": {
+                    "busy": [
+                        {"start": "2026-08-27T09:00:00Z", "end": "2026-08-27T10:00:00Z"}
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["timeMin"] == "2026-08-27T00:00:00+00:00"
+    assert query_call["body"]["timeMax"] == "2026-08-28T00:00:00+00:00"
+
+
+def test_update_events_rejects_single_boundary_change_on_an_all_day_event(
+    fake_service,
+):
+    """Regression test: an all-day event's start/end are {"date": ...} -
+    writing only one of start_time/end_time would overwrite just that side
+    with {"dateTime": ...} while the other side keeps its {"date": ...}
+    shape, which Google rejects as a malformed mixed body. Must fail
+    loudly with an actionable message instead of sending that request."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "all-day" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_allows_replacing_both_boundaries_on_an_all_day_event(
+    fake_service,
+):
+    """Both start_time and end_time together are a full, unambiguous
+    replacement of an all-day event's bounds, so this must succeed."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {"items": []}
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_update_events_widens_all_day_boundary_in_the_calendars_own_timezone(
+    fake_service,
+):
+    """Regression test: an all-day event's date is a day on the
+    *calendar's own* calendar, not a UTC day - hardcoding "T00:00:00Z"
+    shifts the queried window by the calendar's own UTC offset instead of
+    asking what timezone the calendar is actually configured in."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(timezone="Asia/Singapore")
+    fake_service._freebusy = FakeFreebusy(
+        {"calendars": {"new@example.com": {"busy": []}}}
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["timeMin"] == "2026-08-27T00:00:00+08:00"
+    assert query_call["body"]["timeMax"] == "2026-08-28T00:00:00+08:00"
+    assert fake_service._calendars.get_calls  # actually looked it up
+
+
+def test_update_events_calendar_timezone_lookup_missing_scope_rejects_the_write(
+    fake_service,
+):
+    """The calendars.get call needed to widen an all-day boundary needs its
+    own calendar.calendars.readonly scope - a token that predates that
+    migration must reject the write outright, same as a missing
+    freebusy scope, rather than silently guessing at UTC."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_summary_only_edit_of_all_day_event_never_looks_up_calendar_timezone(
+    fake_service,
+):
+    """Regression test: a summary/location/description-only edit of an
+    all-day event never moves its window or touches attendees, so it has
+    no use for the calendar's real timezone - looking it up anyway would
+    needlessly block this benign edit behind a calendar.calendars.readonly
+    scope-403 for every pre-migration token, a far bigger blast radius
+    than the migration's stated purpose (all-day conflict checks)."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="Renamed",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls == []
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_calendar_timezone_lookup_missing_scope_falls_back_with_ignore_conflicts(
+    fake_service,
+):
+    """ignore_conflicts is the caller's explicit escape hatch - it must not
+    be defeated by an unrelated all-day-timezone-lookup failure; the
+    write still proceeds, just without a real calendar timezone."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_timed_event_never_looks_up_calendar_timezone(fake_service):
+    """The calendar-timezone lookup is only needed to widen an all-day
+    boundary - a plain timed-event update must not pay for it."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="self-1", summary="Renamed")
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls == []
+
+
+def test_update_events_partial_overlap_nudge_only_checks_the_new_delta_segment(
+    fake_service,
+):
+    """Regression test: nudging a meeting to a window that still overlaps
+    its old one (e.g. 10:00-10:30 -> 10:15-10:45) must only check existing
+    attendees against the genuinely new sliver (10:30-10:45) - the
+    retained 10:15-10:30 overlap still contains this event's own busy
+    block on their calendars, which isn't a real conflict. Checking the
+    delta segment (rather than skipping the check outright) still catches
+    a real conflict that happens to land in the newly-added time."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {"items": []}
+    # The fake, unlike the real freebusy.query endpoint, doesn't filter its
+    # configured busy blocks down to the requested [timeMin, timeMax) - so
+    # this leaves it empty and instead asserts directly on the query's
+    # timeMin/timeMax below. That's the actual behavior under our control;
+    # Google's own server is responsible for only returning busy blocks
+    # that overlap whatever window we send it.
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:15:00+08:00",
+            end_time="2026-08-27T10:45:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._freebusy.query_calls) == 1
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["timeMin"] == "2026-08-27T10:30:00+08:00"
+    assert query_call["body"]["timeMax"] == "2026-08-27T10:45:00+08:00"
+
+
+def test_update_events_partial_overlap_nudge_still_catches_a_real_conflict(
+    fake_service,
+):
+    """The delta segment isn't just a smaller no-op window - a genuine
+    conflict that only exists in the newly-added time must still be
+    caught."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "existing@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:35:00+08:00",
+                            "end": "2026-08-27T10:40:00+08:00",
+                        }
+                    ]
+                },
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:15:00+08:00",
+            end_time="2026-08-27T10:45:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "existing@example.com"
+
+
+def test_update_events_disjoint_move_checks_existing_attendees(fake_service):
+    """The counterpart to the partial-overlap test: moving to a window
+    that's completely disjoint from the old one IS safe to check every
+    existing attendee against, since this event's own busy block can't
+    show up in a window it doesn't occupy."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "existing@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T14:00:00+08:00",
+                            "end": "2026-08-27T14:30:00+08:00",
+                        }
+                    ]
+                },
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "existing@example.com"
+
+
+def test_update_events_empty_string_attendees_is_treated_as_not_provided(
+    fake_service,
+):
+    """Regression test: an accidental empty string (a stray default from a
+    template, or an LLM passing "" instead of omitting the argument) must
+    not be treated as a genuine attendees argument - attendees only ever
+    adds people, so there'd be nothing to add either way, but this
+    confirms the event's existing attendee data is left alone rather than
+    triggering any attendee-processing path at all."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com", "responseStatus": "accepted"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="self-1", attendees="")
+    )
+
+    assert result["status"] == "success"
+    update_call = fake_service._events.update_calls[0]
+    assert update_call["body"]["attendees"] == [
+        {"email": "existing@example.com", "responseStatus": "accepted"}
+    ]
+    assert update_call["sendUpdates"] == "none"
+
+
+def test_update_events_preserves_attendee_rsvp_state_on_resubmission(fake_service):
+    """Re-passing the same attendee list must not wipe responseStatus etc.
+    by replacing the whole array with bare {"email": ...} objects."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [
+            {
+                "email": "existing@example.com",
+                "responseStatus": "accepted",
+                "comment": "looking forward to it",
+            }
+        ],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["existing@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    update_call = fake_service._events.update_calls[0]
+    assert update_call["body"]["attendees"] == [
+        {
+            "email": "existing@example.com",
+            "responseStatus": "accepted",
+            "comment": "looking forward to it",
+        }
+    ]
+    # Byte-identical resubmission is not a real change - no notification.
+    assert update_call["sendUpdates"] == "none"
+
+
+def test_update_events_treats_equivalent_timestamp_formats_as_unchanged(
+    fake_service,
+):
+    """A same-instant resubmission written in a different (but equivalent)
+    format must not be treated as a real time change - that would run the
+    organizer check on the same window and self-conflict."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T02:00:00+00:00"},
+        "end": {"dateTime": "2026-08-27T02:30:00+00:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",  # same instant, "Z"-free offset form
+            end_time="2026-08-27T10:30:00+08:00",
+            location="Room 4",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+    assert fake_service._events.update_calls[0]["sendUpdates"] == "none"
+
+
+def test_update_events_summary_only_edit_never_revalidates_the_existing_window(
+    fake_service,
+):
+    """Regression test: an update that never touches start_time/end_time
+    isn't about to write any window at all, so it must not re-validate
+    the event's already-stored start/end - a zero-duration or malformed
+    pre-existing window (e.g. from another client/tool) would otherwise
+    reject an unrelated summary edit that never asked to change the
+    time."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:00:00+08:00"},  # zero-duration
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="Renamed",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_update_events_respects_sibling_timezone_on_an_offsetless_datetime(
+    fake_service,
+):
+    """Regression test: Google's own docs say dateTime "may" omit its
+    offset when a sibling timeZone field is present instead - treating
+    that offsetless value as if it belonged to some other zone (e.g. the
+    calendar's, or UTC) would misjudge a same-instant resubmission as a
+    real time change and run the organizer check against the event's own
+    now-"moved" window."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+        "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",  # same instant, different offset
+            end_time="2026-08-27T10:30:00+08:00",
+            location="Room 4",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+    assert fake_service._events.update_calls[0]["sendUpdates"] == "none"
+
+
+def test_update_events_missing_scope_rejects_the_write(fake_service):
+    """A whole-batch 403 while checking the newly-added attendee is our own
+    credential's problem, not a per-attendee visibility gap - with nothing
+    else already confirmed, the write must be rejected outright."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_missing_scope_still_reports_an_already_confirmed_conflict(
+    fake_service,
+):
+    """Regression test: a real conflict already confirmed before the scope
+    error hit (here, the organizer's own calendar, which doesn't need the
+    freebusy scope at all) must not be silently discarded just because a
+    later, unrelated attendee check then hit the same missing-scope 403 -
+    reporting a known conflict is always safe, and blindly rejecting
+    instead would tell the caller to retry with ignore_conflicts=true,
+    which would then book straight over the real conflict nobody ever
+    mentioned."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
+
+
+def test_update_events_missing_scope_can_be_bypassed_with_ignore_conflicts(
+    fake_service,
+):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_conflict_response_still_reports_unchecked_attendees(
+    fake_service,
+):
+    """A conflict found via one source (the organizer's own calendar) must
+    not suppress unchecked_attendees info for a different attendee whose
+    calendar couldn't be read (absent from the freebusy response, a
+    per-attendee gap rather than a whole-batch 403) - a caller acting on
+    the conflict still needs to know that attendee was never actually
+    checked."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["ghost@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["unchecked_attendees"] == ["ghost@example.com"]

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1600,12 +1600,15 @@ def test_update_events_treats_existing_attendee_case_insensitively(fake_service)
     with different casing must still be recognized as "already there" -
     otherwise it's treated as newly-added, gets checked against the
     unchanged window, and always self-conflicts on its own busy block for
-    this very event."""
+    this very event. Uses mismatched casing on BOTH sides (the event's own
+    stored casing, and the caller's resubmitted casing) - a fixture using
+    lowercase on the stored side alone can't tell a correct fold from a
+    mutation that drops .lower() on just that side."""
     fake_service._events._get_result = {
         "id": "self-1",
         "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
         "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
-        "attendees": [{"email": "old@example.com"}],
+        "attendees": [{"email": "Old@Example.com"}],
     }
     fake_service._freebusy = FakeFreebusy(
         {
@@ -1629,7 +1632,7 @@ def test_update_events_treats_existing_attendee_case_insensitively(fake_service)
     result = json.loads(
         calendar.google_calendar_update_events(
             event_id="self-1",
-            attendees=["Old@Example.com", "new@example.com"],
+            attendees=["old@example.com", "new@example.com"],
         )
     )
 

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -799,6 +799,37 @@ def test_event_response_caps_a_large_event_like_other_tools_in_this_package(
     assert len(result["event"]["attendees"]) < 200
 
 
+def test_event_response_caps_unchecked_attendees_on_the_success_path(
+    fake_service, monkeypatch
+):
+    """Regression test: unchecked_attendees is appended to the success
+    envelope AFTER success_with_capped_dict has already finalized the
+    event's own size budget, so a long enough list (e.g. from many
+    attendees absent from the freebusy response, or a whole-batch scope
+    error) could otherwise push the final response back over budget with
+    nothing left to shrink it - unlike conflict_response's payload, which
+    already caps both of its own list fields for the same reason."""
+    monkeypatch.setattr(calendar, "get_tool_max_output_length", lambda: 300)
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=[f"person{i}@example.com" for i in range(200)],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert len(result["unchecked_attendees"]) < 200
+
+
 def test_event_response_does_not_truncate_a_small_event(monkeypatch):
     service = _fake_service({"id": "evt1", "summary": "1:1"})
     monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1658,6 +1658,38 @@ def test_update_events_missing_scope_on_the_organizer_backfill_is_skipped_with_i
     assert len(fake_service._events.update_calls) == 1
 
 
+def test_update_events_non_scope_error_on_the_organizer_backfill_is_also_skipped_with_ignore_conflicts(
+    fake_service,
+):
+    """Companion to the test above: the backfill must forgive ANY failure
+    of calendars().get(), not just the specifically-recognized missing-
+    scope one - _primary_calendar_info re-raises any other HttpError
+    (rate limiting, a transient 5xx, an unrelated 403) unchanged rather
+    than converting it to InsufficientScopeError, and that's still "this
+    lookup couldn't run" every bit as much as a missing scope is."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        # No "organizer" field at all - triggers the backfill attempt.
+    }
+    fake_service._calendars = FakeCalendars(
+        raise_error=HttpError(_FakeHttpResp(500), b'{"error": {"message": "boom"}}')
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
 def test_update_events_organizer_self_true_needs_no_identity_api_call(
     fake_service,
 ):
@@ -2648,6 +2680,37 @@ def test_update_events_calendar_timezone_lookup_missing_scope_falls_back_with_ig
         "attendees": [],
     }
     fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_calendar_timezone_lookup_non_scope_error_also_falls_back_with_ignore_conflicts(
+    fake_service,
+):
+    """Companion to the test above: the timezone lookup must forgive ANY
+    failure of calendars().get(), not just the specifically-recognized
+    missing-scope one - a bare HttpError (rate limiting, a transient
+    5xx, an unrelated 403) is still "this lookup couldn't run" too, and
+    must not defeat ignore_conflicts either."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(
+        raise_error=HttpError(_FakeHttpResp(500), b'{"error": {"message": "boom"}}')
+    )
 
     result = json.loads(
         calendar.google_calendar_update_events(

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1426,6 +1426,54 @@ def test_update_events_adding_the_organizer_as_an_attendee_does_not_self_conflic
     assert len(fake_service._events.list_calls) == 1
 
 
+def test_update_events_adding_self_as_attendee_with_no_organizer_field_does_not_self_conflict(
+    fake_service,
+):
+    """Regression test: Google omits the top-level `organizer` field
+    whenever the organizer is just the calendar owner - the overwhelmingly
+    common case, and the ONE this exclusion must also cover, not just the
+    explicit-organizer-field case the sibling test above pins. Without
+    resolving the caller's own identity as a fallback organizer address
+    here, adding the caller's own email as a "new" attendee would never
+    be excluded from the freebusy batch and would always find this very
+    event's own busy block on their calendar."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+        # No "organizer" field at all - implicit organizer is the caller,
+        # whose own resolved address defaults to "me@example.com" (see
+        # FakeCalendars).
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "me@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._freebusy.query_calls == []
+    assert len(fake_service._events.list_calls) == 1
+
+
 def test_update_events_adding_the_organizer_as_an_attendee_still_catches_a_real_conflict(
     fake_service,
 ):

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1337,6 +1337,134 @@ def test_update_events_excludes_a_recurring_events_own_instances_from_its_confli
     assert [c["summary"] for c in result["conflicts"]] == ["Board sync"]
 
 
+def test_update_events_refuses_to_move_a_recurring_masters_time(fake_service):
+    """Regression test: the conflict check only ever evaluates the single
+    window this call computes - it has no way to expand a recurring
+    master's RRULE and check every occurrence it generates. Moving the
+    master's own time (recurrence present on the fetched event) must be
+    refused outright rather than silently succeed having only verified
+    one occurrence, since a later occurrence at the new time could have a
+    real conflict this call never looked at."""
+    fake_service._events._get_result = {
+        "id": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TH"],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "recurring" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_refuses_to_add_an_attendee_to_a_recurring_master(fake_service):
+    """Companion to the test above: adding a genuinely new attendee to a
+    recurring master is refused for the same reason - their availability
+    can only be checked against the one occurrence this call computes,
+    not the whole series."""
+    fake_service._events._get_result = {
+        "id": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TH"],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "recurring" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_allows_metadata_only_edits_on_a_recurring_master(fake_service):
+    """A pure metadata edit (no time/attendee change) on a recurring
+    master is unaffected by the new restriction - it never needed the
+    per-occurrence conflict check the restriction exists to guard."""
+    fake_service._events._get_result = {
+        "id": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TH"],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1",
+            summary="Renamed series",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_recurring_master_restriction_can_be_bypassed_with_ignore_conflicts(
+    fake_service,
+):
+    """ignore_conflicts=True is the caller's explicit escape hatch for a
+    check that can't run at all - including this one, once the user has
+    confirmed they've verified every occurrence themselves."""
+    fake_service._events._get_result = {
+        "id": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TH"],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_moving_a_single_occurrence_is_unaffected_by_the_recurring_master_restriction(
+    fake_service,
+):
+    """A single occurrence (addressed by its own event id, carrying
+    recurringEventId rather than its own recurrence) is a single event
+    like any other for conflict-checking purposes - the restriction only
+    targets the master itself."""
+    fake_service._events._get_result = {
+        "id": "series-1_20260827T010000Z",
+        "recurringEventId": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+    }
+    fake_service._events._list_result = {"items": []}
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1_20260827T010000Z",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
 def test_update_events_metadata_only_edit_never_checks_conflicts(fake_service):
     """A pure metadata edit (no time/attendee change) must never run the
     conflict check at all - not just tolerate it, since even running the

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1538,23 +1538,22 @@ def test_update_events_adding_the_organizer_as_an_attendee_still_catches_a_real_
     assert fake_service._freebusy.query_calls == []
 
 
-def test_update_events_on_someone_elses_event_reports_the_real_organizer_unchecked(
+def test_update_events_on_someone_elses_event_actually_checks_the_real_organizer(
     fake_service,
 ):
     """Regression test: check_organizer queries calendarId="primary",
     which is always the AUTHENTICATED CALLER's own calendar, not
     necessarily this event's organizer - a guest with edit permission
     (guestsCanModify) can update an event they didn't organize. Before
-    this fix, the organizer's email was unconditionally excluded from the
-    freebusy-checked set on the assumption check_organizer already
-    covered them, which is only true when the caller IS the organizer;
-    here they differ, so the real organizer (boss@example.com) must be
-    reported as unchecked rather than silently treated as clear - and
-    "primary" (the caller's own calendar) must not be queried and
-    mislabeled as the organizer's. With nothing else to check here, the
-    write still proceeds (same as any other "can't verify this one
-    attendee" gap elsewhere in this module, e.g. one absent from a
-    freebusy response) - it just surfaces the gap in the response."""
+    this fix, the organizer's email was unconditionally excluded from
+    freebusy and merely reported as unchecked in this scenario, even
+    though freebusy.query accepts any calendar/email id - not just
+    "primary" - so the real organizer (boss@example.com) CAN be checked
+    the same way a retained attendee is: over just the delta segment
+    beyond the event's old window, so their own pre-existing footprint
+    on this same event doesn't self-conflict. A genuine busy block of
+    theirs in the new-only territory must now be caught as a real
+    conflict, not silently missed."""
     fake_service._events._get_result = {
         "id": "self-1",
         "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
@@ -1564,6 +1563,57 @@ def test_update_events_on_someone_elses_event_reports_the_real_organizer_uncheck
     }
     # Default FakeCalendars() resolves the connected account's own
     # address as "me@example.com" - different from the organizer above.
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "boss@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T14:10:00+08:00",
+                            "end": "2026-08-27T14:20:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["calendar"] for c in result["conflicts"]] == ["boss@example.com"]
+    assert result["unchecked_attendees"] == []
+    # Never queried "primary" (the caller's own calendar) as if it were
+    # the organizer's - the real organizer was checked via freebusy
+    # instead, using their own real address.
+    assert fake_service._events.list_calls == []
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["items"] == [{"id": "boss@example.com"}]
+
+
+def test_update_events_on_someone_elses_event_reports_the_real_organizer_unchecked_when_freebusy_has_no_data_for_them(
+    fake_service,
+):
+    """Companion to the test above: the real organizer IS now queried via
+    freebusy over the delta segment, but if their calendar is absent from
+    the response (the same per-attendee gap _find_conflicts already
+    handles for any other attendee), they must still be reported as
+    unchecked rather than silently treated as clear."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "boss@example.com"}],
+        "organizer": {"email": "boss@example.com"},
+    }
+    # FakeFreebusy defaults to an empty "calendars" dict - boss@example.com
+    # is absent from it, same as a real per-attendee visibility gap.
 
     result = json.loads(
         calendar.google_calendar_update_events(
@@ -1575,11 +1625,40 @@ def test_update_events_on_someone_elses_event_reports_the_real_organizer_uncheck
 
     assert result["status"] == "success"
     assert result["unchecked_attendees"] == ["boss@example.com"]
-    # Never queried "primary" (the caller's own calendar) as if it were
-    # the organizer's, and never freebusy-checked the real organizer
-    # either (which would have self-conflicted on their own copy of this
-    # event, same as the caller-is-organizer case this exclusion was
-    # originally written for).
+    assert fake_service._events.list_calls == []
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["items"] == [{"id": "boss@example.com"}]
+
+
+def test_update_events_organizer_newly_added_with_unchanged_window_is_still_unverifiable(
+    fake_service,
+):
+    """Regression test for the one residual case the delta-segment fix
+    above can't cover: the real organizer is added as a "new" attendee
+    but the window itself never moves. window_delta_segments finds no
+    new territory at all in that case (correctly - a retained party's
+    existing footprint already covers an unchanged window), so unlike a
+    genuine window move, there is no safe way to freebusy-check them
+    without risking a self-conflict on their own pre-existing copy of
+    this same event. Must still be reported as unchecked, not silently
+    treated as clear, and not freebusy-queried at all."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "boss@example.com"},
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["boss@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["boss@example.com"]
     assert fake_service._events.list_calls == []
     assert fake_service._freebusy.query_calls == []
 
@@ -1592,7 +1671,10 @@ def test_update_events_organizer_self_false_needs_no_identity_api_call(
     event appears") directly answers caller_is_organizer - when present,
     no calendars().get(calendarId="primary") call is needed at all for
     identity purposes, unlike the email-comparison fallback this uses
-    when organizer.self is absent."""
+    when organizer.self is absent. The organizer IS still freebusy-
+    checked over the delta segment (a separate mechanism from identity
+    resolution) - absent from the default empty freebusy response here,
+    so still reported as unchecked."""
     fake_service._events._get_result = {
         "id": "self-1",
         "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
@@ -1612,7 +1694,6 @@ def test_update_events_organizer_self_false_needs_no_identity_api_call(
     assert result["status"] == "success"
     assert result["unchecked_attendees"] == ["boss@example.com"]
     assert fake_service._events.list_calls == []
-    assert fake_service._freebusy.query_calls == []
     # The whole point: organizer.self answered caller_is_organizer
     # directly, so the connected account's own identity never needed
     # looking up via calendars().get() at all.

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -2261,6 +2261,136 @@ def test_update_events_all_day_with_existing_attendees_resubmitted_unchanged_ski
     assert fake_service._freebusy.query_calls == []
 
 
+def test_update_events_metadata_only_edit_on_someone_elses_event_skips_the_identity_lookup(
+    fake_service,
+):
+    """Regression test: caller_is_organizer must only be resolved (via a
+    calendars().get(calendarId="primary") call) when the organizer
+    actually needs (re)verifying at all (window_changed or
+    organizer_newly_added) - a metadata-only edit (here, just a summary
+    change) on an event with a different organizer must not pay for that
+    API call when nothing downstream would use its result."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "boss@example.com"}],
+        "organizer": {"email": "boss@example.com"},
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="Renamed",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls == []
+
+
+def test_update_events_organizer_identity_comparison_is_case_insensitive(
+    fake_service,
+):
+    """Regression test: the caller-is-organizer comparison must fold case
+    on both sides - a mutation dropping either side's .lower() would pass
+    every other organizer-identity test in this file, since they all
+    happen to use already-lowercase addresses on both sides."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "Me@Example.com"},
+    }
+    fake_service._calendars = FakeCalendars(email="me@EXAMPLE.com")
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    # caller_is_organizer must resolve True despite the differing case,
+    # so the organizer conflict is found via "primary" (check_organizer)
+    # rather than the caller being wrongly treated as a different person
+    # (which would instead report "Me@Example.com" as unchecked).
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["1:1 with Hazel"]
+    assert result.get("unchecked_attendees", []) == []
+
+
+def test_update_events_all_day_with_a_different_organizer_shares_one_calendar_lookup(
+    fake_service,
+):
+    """Regression test: an all-day event whose organizer differs from the
+    caller needs BOTH the real calendar timezone (to widen the all-day
+    boundary) and the caller's own identity (to know they aren't the
+    organizer) - both come from the same calendars().get(calendarId=
+    "primary") call, so this must fire exactly once, not twice, and the
+    real organizer must still end up in unchecked_attendees using a
+    correctly-widened (non-UTC-defaulted) window."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+        "organizer": {"email": "boss@example.com"},
+    }
+    fake_service._calendars = FakeCalendars(
+        timezone="Asia/Singapore", email="me@example.com"
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-28T00:00:00+08:00",  # moves the all-day window
+            end_time="2026-08-29T00:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._calendars.get_calls) == 1
+    assert result["unchecked_attendees"] == ["boss@example.com"]
+    assert fake_service._events.list_calls == []
+
+
+def test_update_events_missing_scope_at_the_identity_check_rejects_the_write(
+    fake_service,
+):
+    """Regression test: the calendars.get call also drives caller-is-
+    organizer identity resolution (not just all-day timezone widening) -
+    a missing calendar.calendars.readonly scope must reject the write via
+    THIS call site too, on a plain timed event whose organizer differs
+    from the caller (needs_real_calendar_timezone stays False here, so
+    only the identity check would ever trigger this lookup)."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "boss@example.com"},
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
 def test_update_events_calendar_timezone_lookup_missing_scope_rejects_the_write(
     fake_service,
 ):

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -925,8 +925,22 @@ class FakeFreebusy:
 
 
 class FakeCalendars:
-    def __init__(self, timezone: str = "UTC", *, raise_error: Exception | None = None):
+    def __init__(
+        self,
+        timezone: str = "UTC",
+        *,
+        email: str = "me@example.com",
+        raise_error: Exception | None = None,
+    ):
         self._timezone = timezone
+        # The connected account's own address (the "id" field
+        # calendars().get returns on a real primary calendar) - defaults
+        # to the same
+        # "me@example.com" convention most fixtures already use for the
+        # caller/organizer, so a test that never customizes this and
+        # never means to simulate a different-organizer scenario keeps
+        # caller_is_organizer=True without having to set this explicitly.
+        self._email = email
         self._raise_error = raise_error
         self.get_calls: list[dict[str, Any]] = []
 
@@ -934,7 +948,7 @@ class FakeCalendars:
         self.get_calls.append(kwargs)
         if self._raise_error is not None:
             raise self._raise_error
-        return _Exec({"timeZone": self._timezone})
+        return _Exec({"id": self._email, "timeZone": self._timezone})
 
 
 class FakeService:
@@ -1443,6 +1457,94 @@ def test_update_events_adding_the_organizer_as_an_attendee_still_catches_a_real_
     assert result["status"] == "conflict"
     assert [c["summary"] for c in result["conflicts"]] == ["Board sync"]
     assert fake_service._freebusy.query_calls == []
+
+
+def test_update_events_on_someone_elses_event_reports_the_real_organizer_unchecked(
+    fake_service,
+):
+    """Regression test: check_organizer queries calendarId="primary",
+    which is always the AUTHENTICATED CALLER's own calendar, not
+    necessarily this event's organizer - a guest with edit permission
+    (guestsCanModify) can update an event they didn't organize. Before
+    this fix, the organizer's email was unconditionally excluded from the
+    freebusy-checked set on the assumption check_organizer already
+    covered them, which is only true when the caller IS the organizer;
+    here they differ, so the real organizer (boss@example.com) must be
+    reported as unchecked rather than silently treated as clear - and
+    "primary" (the caller's own calendar) must not be queried and
+    mislabeled as the organizer's. With nothing else to check here, the
+    write still proceeds (same as any other "can't verify this one
+    attendee" gap elsewhere in this module, e.g. one absent from a
+    freebusy response) - it just surfaces the gap in the response."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "boss@example.com"}],
+        "organizer": {"email": "boss@example.com"},
+    }
+    # Default FakeCalendars() resolves the connected account's own
+    # address as "me@example.com" - different from the organizer above.
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["boss@example.com"]
+    # Never queried "primary" (the caller's own calendar) as if it were
+    # the organizer's, and never freebusy-checked the real organizer
+    # either (which would have self-conflicted on their own copy of this
+    # event, same as the caller-is-organizer case this exclusion was
+    # originally written for).
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+
+
+def test_update_events_on_someone_elses_event_still_catches_another_attendees_conflict(
+    fake_service,
+):
+    """Companion to the test above: the real organizer being unverifiable
+    must not swallow a genuinely different, checkable attendee's real
+    conflict."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "boss@example.com"}],
+        "organizer": {"email": "boss@example.com"},
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "coworker@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T14:10:00+08:00",
+                            "end": "2026-08-27T14:20:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",
+            end_time="2026-08-27T14:30:00+08:00",
+            attendees=["coworker@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["calendar"] for c in result["conflicts"]] == ["coworker@example.com"]
+    assert set(result["unchecked_attendees"]) == {"boss@example.com"}
 
 
 def test_update_events_treats_existing_attendee_case_insensitively(fake_service):
@@ -2126,6 +2228,39 @@ def test_update_events_organizer_only_new_attendee_on_all_day_event_widens_corre
     assert list_call["timeMax"] == "2026-08-28T00:00:00+08:00"
 
 
+def test_update_events_all_day_with_existing_attendees_resubmitted_unchanged_skips_the_timezone_lookup(
+    fake_service,
+):
+    """Regression test: an all-day event that already has attendees,
+    resubmitted with neither a new window nor new attendees (e.g. a
+    summary-only edit), must not trigger the calendar's real timezone
+    lookup at all - a resubmission that never moves the window makes any
+    retained attendee's delta segment trivially empty regardless of
+    timezone precision, so needs_real_calendar_timezone correctly stays
+    False here. Pins that this genuinely common "just editing the title"
+    case doesn't regress into an unnecessary API call (or a scope-403 for
+    a token that predates calendar.calendars.readonly, on an edit that
+    never needed timezone precision at all)."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="Renamed",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls == []
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+
+
 def test_update_events_calendar_timezone_lookup_missing_scope_rejects_the_write(
     fake_service,
 ):
@@ -2691,4 +2826,33 @@ def test_update_events_conflict_response_still_reports_unchecked_attendees(
     )
 
     assert result["status"] == "conflict"
+    assert result["unchecked_attendees"] == ["ghost@example.com"]
+
+
+def test_update_events_widening_both_boundaries_does_not_duplicate_unchecked_attendees(
+    fake_service,
+):
+    """Regression test: widening a window on BOTH sides produces two
+    delta segments (window_delta_segments), and a retained attendee who's
+    unverifiable for a reason unrelated to which segment ran (here,
+    absent from every freebusy response) gets checked - and appended to
+    unchecked_attendees - once per segment, not once overall."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "ghost@example.com"}],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T09:45:00+08:00",  # widened earlier...
+            end_time="2026-08-27T10:45:00+08:00",  # ...and later
+        )
+    )
+
+    assert result["status"] == "success"
     assert result["unchecked_attendees"] == ["ghost@example.com"]

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1879,7 +1879,21 @@ def test_is_insufficient_scope_error_tolerates_non_list_error_fields():
 
 
 def test_freebusy_other_http_errors_still_propagate(fake_service):
-    other_error = HttpError(_FakeHttpResp(500), b'{"error": {"message": "boom"}}')
+    """A 500 whose body happens to carry a scope-shaped reason must NOT be
+    treated as the missing-scope case - the gate is `status == 403` AND a
+    matching reason, not the reason alone. A body with no "errors"/
+    "details" field at all (as an arbitrary 500 body typically has) would
+    fail the reason check regardless of status, so it can't tell an
+    intact `status == 403` gate from a broken one; this fixture's body
+    would match the reason check, so it actually exercises the status
+    gate."""
+    other_error = HttpError(
+        _FakeHttpResp(500),
+        (
+            b'{"error": {"message": "boom", '
+            b'"errors": [{"reason": "insufficientPermissions"}]}}'
+        ),
+    )
     fake_service._freebusy = FakeFreebusy(raise_error=other_error)
 
     result = json.loads(
@@ -1892,6 +1906,7 @@ def test_freebusy_other_http_errors_still_propagate(fake_service):
     )
 
     assert result["status"] == "error"
+    assert "reconnect" not in result["message"].lower()
 
 
 def test_freebusy_attendee_absent_from_response_is_marked_unchecked(fake_service):
@@ -1949,6 +1964,12 @@ def test_update_events_checks_conflicts_for_an_all_day_event(fake_service):
     )
 
     assert result["status"] == "conflict"
+    # The fake calendar's own timezone also happens to be UTC, so a
+    # skipped lookup (needs_real_calendar_timezone wrongly False, falling
+    # through to the hardcoded "UTC" literal) would produce this exact
+    # same timeMin/timeMax undetected - assert the lookup actually ran,
+    # not just that its result looks right.
+    assert fake_service._calendars.get_calls
     query_call = fake_service._freebusy.query_calls[0]
     assert query_call["body"]["timeMin"] == "2026-08-27T00:00:00+00:00"
     assert query_call["body"]["timeMax"] == "2026-08-28T00:00:00+00:00"
@@ -2035,6 +2056,40 @@ def test_update_events_widens_all_day_boundary_in_the_calendars_own_timezone(
     assert query_call["body"]["timeMin"] == "2026-08-27T00:00:00+08:00"
     assert query_call["body"]["timeMax"] == "2026-08-28T00:00:00+08:00"
     assert fake_service._calendars.get_calls  # actually looked it up
+
+
+def test_update_events_organizer_only_new_attendee_on_all_day_event_widens_correctly(
+    fake_service,
+):
+    """Regression test: adding ONLY the organizer as a new attendee on an
+    all-day event, with the window otherwise unchanged, must still look
+    up the calendar's real timezone before checking their calendar - the
+    organizer-check that `organizer_newly_added` triggers on its own
+    (attendees_to_check ends up empty, the organizer is filtered out of
+    it) needs a correctly-widened window just as much as an ordinary new
+    attendee would, not one silently defaulted to UTC."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+        "organizer": {"email": "me@example.com"},
+    }
+    fake_service._calendars = FakeCalendars(timezone="Asia/Singapore")
+    fake_service._events._list_result = {"items": []}
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls  # actually looked it up
+    list_call = fake_service._events.list_calls[0]
+    assert list_call["timeMin"] == "2026-08-27T00:00:00+08:00"
+    assert list_call["timeMax"] == "2026-08-28T00:00:00+08:00"
 
 
 def test_update_events_calendar_timezone_lookup_missing_scope_rejects_the_write(
@@ -2505,6 +2560,45 @@ def test_update_events_missing_scope_on_retained_attendees_still_reports_the_fir
     assert result["status"] == "conflict"
     assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
     assert result["unchecked_attendees"] == ["existing@example.com"]
+
+
+def test_update_events_missing_scope_in_first_call_still_checks_retained_attendees(
+    fake_service,
+):
+    """Regression test: when the FIRST _find_conflicts call (newly-added
+    attendees + organizer) raises InsufficientScopeError but already
+    carries an already-confirmed organizer conflict, the accumulation
+    layer must still attempt the SECOND call (retained attendees' delta
+    segments) rather than returning immediately - otherwise a retained
+    attendee is silently dropped from the response entirely: neither
+    reported as conflicting nor as unchecked, contradicting the whole
+    feature's guarantee that an unverified attendee is always surfaced."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert set(result["unchecked_attendees"]) == {
+        "new@example.com",
+        "existing@example.com",
+    }
 
 
 def test_update_events_missing_scope_can_be_bypassed_with_ignore_conflicts(

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -115,3 +115,253 @@ def test_url_path_id_output_survives_requests_url_normalization():
 
     with pytest.raises(ValueError):
         utils.url_path_id("..", "record_id")
+
+
+def test_datetime_key_for_comparison_truncates_seven_digit_fractional_seconds():
+    """Outlook commonly reports 100-nanosecond (7-digit) fractional
+    seconds, one more digit than a microsecond can hold - this must not
+    depend on whichever CPython version happens to run it."""
+    key = utils.datetime_key_for_comparison("2026-08-27T10:00:00.0000000")
+    assert key == utils.datetime_key_for_comparison("2026-08-27T10:00:00")
+
+
+def test_datetime_key_for_comparison_treats_equal_instants_as_equal_across_offsets():
+    z_form = utils.datetime_key_for_comparison("2026-08-27T02:00:00Z")
+    offset_form = utils.datetime_key_for_comparison("2026-08-27T10:00:00+08:00")
+    assert z_form == offset_form
+
+
+def test_datetime_key_for_comparison_falls_back_to_raw_string_on_malformed_input():
+    assert utils.datetime_key_for_comparison("not-a-date") == "not-a-date"
+
+
+def test_datetime_key_for_comparison_passes_none_through():
+    assert utils.datetime_key_for_comparison(None) is None
+
+
+def test_normalize_addresses_drops_case_insensitive_duplicates():
+    """Regression test: email addresses are case-insensitive, so the same
+    person listed twice with different casing must not become two separate
+    attendee entries downstream - keeps the first casing seen."""
+    assert utils.normalize_addresses(
+        ["Chelsea@Example.com", "chelsea@example.com", "new@example.com"]
+    ) == ["Chelsea@Example.com", "new@example.com"]
+
+
+def test_normalize_addresses_dedup_works_for_comma_separated_string_input():
+    assert utils.normalize_addresses("a@x.com, A@X.com, b@x.com") == [
+        "a@x.com",
+        "b@x.com",
+    ]
+
+
+def test_attendees_were_given_treats_empty_string_as_not_provided():
+    assert utils.attendees_were_given(None) is False
+    assert utils.attendees_were_given("") is False
+
+
+def test_attendees_were_given_treats_empty_list_as_provided():
+    """An explicit [] is a deliberate "clear everyone" - distinct from
+    not-provided, unlike an empty string."""
+    assert utils.attendees_were_given([]) is True
+    assert utils.attendees_were_given(["a@x.com"]) is True
+    assert utils.attendees_were_given("a@x.com") is True
+
+
+def test_attendees_to_add_filters_out_existing_and_normalizes():
+    assert utils.attendees_to_add(
+        ["Old@Example.com", "new@example.com"], {"old@example.com"}
+    ) == ["new@example.com"]
+
+
+def test_attendees_to_add_returns_empty_for_not_provided_or_empty():
+    assert utils.attendees_to_add(None, {"old@example.com"}) == []
+    assert utils.attendees_to_add("", {"old@example.com"}) == []
+    assert utils.attendees_to_add([], {"old@example.com"}) == []
+
+
+def test_unchecked_extra_empty_when_nothing_unchecked():
+    assert utils.unchecked_extra([]) == {}
+
+
+def test_unchecked_extra_includes_attendees_when_given():
+    assert utils.unchecked_extra(["a@x.com"]) == {"unchecked_attendees": ["a@x.com"]}
+
+
+def _key(value: str):
+    return utils.datetime_key_for_comparison(value)
+
+
+def test_window_delta_segments_empty_for_unchanged_or_shrunk_window():
+    """A retained attendee's own busy block already covers everything
+    inside the old window - a new window that's identical, or a strict
+    subset of it, adds no territory worth checking them against."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    assert utils.window_delta_segments(old_start, old_end, old_start, old_end) == []
+
+    shrunk_start = _key("2026-08-27T10:05:00+00:00")
+    shrunk_end = _key("2026-08-27T10:25:00+00:00")
+    assert (
+        utils.window_delta_segments(old_start, old_end, shrunk_start, shrunk_end) == []
+    )
+
+
+def test_window_delta_segments_returns_the_new_only_portion_of_a_partial_nudge():
+    """10:00-10:30 nudged to 10:15-10:45 - only 10:30-10:45 is new
+    territory a retained attendee could have a genuine conflict in;
+    10:15-10:30 is still covered by their busy block for this event."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    new_start, new_end = (
+        _key("2026-08-27T10:15:00+00:00"),
+        _key("2026-08-27T10:45:00+00:00"),
+    )
+
+    segments = utils.window_delta_segments(old_start, old_end, new_start, new_end)
+
+    assert segments == [(old_end, new_end)]
+
+
+def test_window_delta_segments_returns_two_segments_when_widened_on_both_sides():
+    """Extending a meeting earlier AND later in the same call creates new
+    territory on both sides of the old window."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    new_start, new_end = (
+        _key("2026-08-27T09:45:00+00:00"),
+        _key("2026-08-27T10:45:00+00:00"),
+    )
+
+    segments = utils.window_delta_segments(old_start, old_end, new_start, new_end)
+
+    assert len(segments) == 2
+    assert segments[0] == (new_start, old_start)
+    assert segments[1] == (old_end, new_end)
+
+
+def test_window_delta_segments_returns_the_whole_window_for_a_disjoint_move():
+    """A move to somewhere with zero overlap with the old window means the
+    entire new window is new territory - this test also confirms the
+    move-by-15-minutes example from the actual reported bug is caught:
+    the delta segment here is the same shape as the disjoint case."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    new_start, new_end = (
+        _key("2026-08-27T14:00:00+00:00"),
+        _key("2026-08-27T14:30:00+00:00"),
+    )
+
+    assert utils.window_delta_segments(old_start, old_end, new_start, new_end) == [
+        (new_start, new_end)
+    ]
+
+
+def test_window_delta_segments_is_conservative_on_unparseable_or_mismatched_keys():
+    """ "Can't confirm the delta is smaller than the whole window" must
+    never silently shrink what gets checked - falls back to the whole new
+    window, both for a key that never parsed to a real datetime, and for
+    two real datetimes that can't be compared (aware vs. naive raises
+    TypeError on `<`)."""
+    new_start, new_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    assert utils.window_delta_segments(
+        "not-a-date", "also-not", new_start, new_end
+    ) == [(new_start, new_end)]
+
+    naive_start = _key("2026-08-27T09:00:00")
+    naive_end = _key("2026-08-27T11:00:00")
+    assert utils.window_delta_segments(naive_start, naive_end, new_start, new_end) == [
+        (new_start, new_end)
+    ]
+
+
+def test_window_delta_segments_empty_when_new_window_itself_is_unparseable():
+    """No valid new window at all means nothing meaningful to check,
+    regardless of the old window."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    assert (
+        utils.window_delta_segments(old_start, old_end, "not-a-date", "also-not") == []
+    )
+
+
+def test_reject_reversed_window_raises_when_end_is_not_after_start():
+    with pytest.raises(ValueError, match="must be after"):
+        utils.reject_reversed_window(
+            "2026-08-27T10:30:00+00:00", "2026-08-27T10:00:00+00:00"
+        )
+    with pytest.raises(ValueError, match="must be after"):
+        utils.reject_reversed_window(
+            "2026-08-27T10:00:00+00:00", "2026-08-27T10:00:00+00:00"
+        )
+
+
+def test_reject_reversed_window_allows_a_forward_window():
+    utils.reject_reversed_window(
+        "2026-08-27T10:00:00+00:00", "2026-08-27T10:30:00+00:00"
+    )
+
+
+def test_reject_reversed_window_is_permissive_on_unparseable_input():
+    """Can't-tell must never read as "reject" - only a confirmed reversal
+    should raise."""
+    utils.reject_reversed_window("not-a-date", "also-not-a-date")
+
+
+def test_reject_reversed_window_is_permissive_when_aware_and_naive_are_mixed():
+    """Regression test: both sides parse to real `datetime` instances, but
+    comparing an offset-aware one against a naive one with `<=` raises
+    `TypeError` in Python - the `isinstance` check alone doesn't guard
+    against this, only checking that both are `datetime` instances of the
+    SAME awareness does. Must stay permissive here, not crash with a raw
+    TypeError, matching `window_delta_segments`'s handling of the
+    identical hazard."""
+    utils.reject_reversed_window("2026-08-27T10:30:00", "2026-08-27T10:30:00Z")
+    utils.reject_reversed_window("2026-08-27T10:30:00Z", "2026-08-27T10:00:00")
+
+
+def test_resolve_zone_name_covers_graphs_additional_time_zones():
+    """Regression test: `_WINDOWS_TO_IANA` was missing several of the
+    Windows names for zones Microsoft's own dateTimeTimeZone docs list
+    under "Additional time zones" (e.g. Kaliningrad, Ekaterinburg) - an
+    event whose originalStartTimeZone happened to be one of these
+    previously hard-failed every single-boundary update and conflict
+    check outright."""
+    assert utils.resolve_zone_name("Kaliningrad Standard Time") == "Europe/Kaliningrad"
+    assert utils.resolve_zone_name("Ekaterinburg Standard Time") == "Asia/Yekaterinburg"
+    assert utils.resolve_zone_name("Vladivostok Standard Time") == "Asia/Vladivostok"
+
+
+def test_offset_datetime_string_attaches_the_zone_offset_to_a_naive_value():
+    assert (
+        utils.offset_datetime_string("2026-08-27T10:00:00", "Asia/Singapore")
+        == "2026-08-27T10:00:00+08:00"
+    )
+
+
+def test_offset_datetime_string_rejects_input_that_already_carries_an_offset():
+    """Regression test: no public tool parameter is documented as requiring
+    a naive value, so a caller passing one with a trailing 'Z' or an
+    explicit offset is a real, reachable mistake - not a theoretical one.
+    `.replace(tzinfo=...)` doesn't convert an aware datetime, it just
+    relabels the same clock digits under a different zone, silently
+    shifting the real instant by however much the two offsets differ
+    (e.g. "10:00:00Z" relabeled as Asia/Shanghai reads as 10:00 Shanghai
+    time - actually 8 hours earlier). Must fail loudly instead."""
+    with pytest.raises(ValueError, match="already carries a UTC offset"):
+        utils.offset_datetime_string("2026-08-27T10:00:00Z", "Asia/Shanghai")
+    with pytest.raises(ValueError, match="already carries a UTC offset"):
+        utils.offset_datetime_string("2026-08-27T10:00:00+00:00", "Asia/Shanghai")

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -344,6 +344,20 @@ def test_require_offset_datetime_is_permissive_on_unparseable_input():
     utils.require_offset_datetime("not-a-date", "start_time")
 
 
+def test_calendar_day_bounds_spans_a_short_day_across_a_dst_spring_forward():
+    """2026-03-08 is when America/New_York springs forward (clocks skip
+    02:00-03:00), so the calendar day is only 23 hours long. `start +
+    timedelta(days=1)` on an aware datetime only advances the wall-clock
+    date/time components (per datetime's documented semantics) and
+    re-derives the UTC offset lazily via ZoneInfo - a naive
+    `timedelta(hours=24)` would instead land on 01:00 the following day,
+    silently mis-widening an all-day event's boundary by an hour on every
+    DST-transition day in a zone that observes it."""
+    start, end = utils.calendar_day_bounds("2026-03-08", "America/New_York")
+    assert start == "2026-03-08T00:00:00-05:00"
+    assert end == "2026-03-09T00:00:00-04:00"
+
+
 def test_offset_datetime_string_attaches_the_zone_offset_to_a_naive_value():
     assert (
         utils.offset_datetime_string("2026-08-27T10:00:00", "Asia/Singapore")

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -291,6 +291,25 @@ def test_window_delta_segments_empty_when_new_window_itself_is_unparseable():
     )
 
 
+def test_window_delta_segments_empty_when_only_one_of_the_new_window_parses():
+    """Regression test: the guard is `new_start AND new_end` both being
+    real datetimes - a MIXED pair (one parses, one doesn't) must still
+    return [], not fall through and try to build a segment out of a
+    half-valid window. A prior test only exercised BOTH sides failing
+    together, which can't tell `and` apart from a mistakenly-broadened
+    `or` in that guard - this fixture, with exactly one side invalid,
+    can."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    new_start = _key("2026-08-27T14:00:00+00:00")
+    assert utils.window_delta_segments(old_start, old_end, new_start, "also-not") == []
+    assert (
+        utils.window_delta_segments(old_start, old_end, "not-a-date", new_start) == []
+    )
+
+
 def test_reject_reversed_window_raises_when_end_is_not_after_start():
     with pytest.raises(ValueError, match="must be after"):
         utils.reject_reversed_window(

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 import pytest
@@ -180,14 +181,6 @@ def test_attendees_to_add_returns_empty_for_not_provided_or_empty():
     assert utils.attendees_to_add([], {"old@example.com"}) == []
 
 
-def test_unchecked_extra_empty_when_nothing_unchecked():
-    assert utils.unchecked_extra([]) == {}
-
-
-def test_unchecked_extra_includes_attendees_when_given():
-    assert utils.unchecked_extra(["a@x.com"]) == {"unchecked_attendees": ["a@x.com"]}
-
-
 def _key(value: str):
     return utils.datetime_key_for_comparison(value)
 
@@ -333,16 +326,22 @@ def test_reject_reversed_window_is_permissive_when_aware_and_naive_are_mixed():
     utils.reject_reversed_window("2026-08-27T10:30:00Z", "2026-08-27T10:00:00")
 
 
-def test_resolve_zone_name_covers_graphs_additional_time_zones():
-    """Regression test: `_WINDOWS_TO_IANA` was missing several of the
-    Windows names for zones Microsoft's own dateTimeTimeZone docs list
-    under "Additional time zones" (e.g. Kaliningrad, Ekaterinburg) - an
-    event whose originalStartTimeZone happened to be one of these
-    previously hard-failed every single-boundary update and conflict
-    check outright."""
-    assert utils.resolve_zone_name("Kaliningrad Standard Time") == "Europe/Kaliningrad"
-    assert utils.resolve_zone_name("Ekaterinburg Standard Time") == "Asia/Yekaterinburg"
-    assert utils.resolve_zone_name("Vladivostok Standard Time") == "Asia/Vladivostok"
+def test_require_offset_datetime_rejects_a_naive_value():
+    with pytest.raises(ValueError, match="start_time"):
+        utils.require_offset_datetime("2026-08-27T10:30:00", "start_time")
+
+
+def test_require_offset_datetime_accepts_an_offset_or_z_suffixed_value():
+    utils.require_offset_datetime("2026-08-27T10:30:00+08:00", "start_time")
+    utils.require_offset_datetime("2026-08-27T10:30:00Z", "start_time")
+
+
+def test_require_offset_datetime_is_permissive_on_unparseable_input():
+    """A value that doesn't even parse is a different failure a caller
+    will already hit downstream with its own clear error - not this
+    function's job to preempt with a possibly-confusing offset-specific
+    message."""
+    utils.require_offset_datetime("not-a-date", "start_time")
 
 
 def test_offset_datetime_string_attaches_the_zone_offset_to_a_naive_value():
@@ -365,3 +364,49 @@ def test_offset_datetime_string_rejects_input_that_already_carries_an_offset():
         utils.offset_datetime_string("2026-08-27T10:00:00Z", "Asia/Shanghai")
     with pytest.raises(ValueError, match="already carries a UTC offset"):
         utils.offset_datetime_string("2026-08-27T10:00:00+00:00", "Asia/Shanghai")
+
+
+def test_conflict_response_uncapped_when_it_fits(monkeypatch):
+    monkeypatch.setenv("XAGENT_TOOL_MAX_OUTPUT_LENGTH", "50000")
+    conflicts = [{"calendar": "organizer", "summary": "1:1", "start": "a", "end": "b"}]
+    response = json.loads(
+        utils.conflict_response(
+            conflicts, [], "2026-08-27T10:00:00", "2026-08-27T10:30:00"
+        )
+    )
+    assert response["conflicts"] == conflicts
+    assert "truncated" not in response
+
+
+def test_conflict_response_caps_an_oversized_conflicts_list(monkeypatch):
+    """Regression test: unlike every other response path in this module,
+    conflict_response used to return an uncapped payload - a busy shared
+    calendar or wide window can turn up far more overlapping events than
+    fit the platform's output budget. Only `conflicts` (the field that
+    can actually grow large) should be halved to fit; small fields like
+    `hint`/`unchecked_attendees` must survive untouched."""
+    monkeypatch.setenv("XAGENT_TOOL_MAX_OUTPUT_LENGTH", "2000")
+    conflicts = [
+        {
+            "calendar": f"person{i}@example.com",
+            "summary": "Busy block " + "x" * 50,
+            "start": "2026-08-27T10:00:00+00:00",
+            "end": "2026-08-27T10:30:00+00:00",
+        }
+        for i in range(100)
+    ]
+    response = json.loads(
+        utils.conflict_response(
+            conflicts,
+            ["unreachable@example.com"],
+            "2026-08-27T10:00:00",
+            "2026-08-27T10:30:00",
+        )
+    )
+
+    assert response["status"] == "conflict"
+    assert response["truncated"] is True
+    assert len(response["conflicts"]) < len(conflicts)
+    assert response["conflicts"] == conflicts[: len(response["conflicts"])]
+    assert response["unchecked_attendees"] == ["unreachable@example.com"]
+    assert len(json.dumps(response, ensure_ascii=False)) <= 2000

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -375,7 +375,7 @@ def test_conflict_response_uncapped_when_it_fits(monkeypatch):
         )
     )
     assert response["conflicts"] == conflicts
-    assert "truncated" not in response
+    assert response["truncated"] is False
 
 
 def test_conflict_response_caps_an_oversized_conflicts_list(monkeypatch):
@@ -409,4 +409,44 @@ def test_conflict_response_caps_an_oversized_conflicts_list(monkeypatch):
     assert len(response["conflicts"]) < len(conflicts)
     assert response["conflicts"] == conflicts[: len(response["conflicts"])]
     assert response["unchecked_attendees"] == ["unreachable@example.com"]
+    assert len(json.dumps(response, ensure_ascii=False)) <= 2000
+
+
+def test_conflict_response_caps_unchecked_attendees_when_conflicts_alone_is_not_enough(
+    monkeypatch,
+):
+    """Regression test: a single real conflict combined with a huge
+    unchecked_attendees list (e.g. every remaining attendee in a large
+    invite batch, marked unchecked after a mid-batch scope error) can
+    still exceed the output budget even after `conflicts` has been
+    shrunk to nothing - unchecked_attendees must also be capped, not
+    left untouched forever."""
+    monkeypatch.setenv("XAGENT_TOOL_MAX_OUTPUT_LENGTH", "2000")
+    conflicts = [
+        {
+            "calendar": "organizer",
+            "summary": "1:1 with Hazel",
+            "start": "2026-08-27T10:00:00+00:00",
+            "end": "2026-08-27T10:30:00+00:00",
+        }
+    ]
+    unchecked_attendees = [f"person{i}@example.com" for i in range(200)]
+
+    response = json.loads(
+        utils.conflict_response(
+            conflicts,
+            unchecked_attendees,
+            "2026-08-27T10:00:00",
+            "2026-08-27T10:30:00",
+        )
+    )
+
+    assert response["status"] == "conflict"
+    assert response["truncated"] is True
+    assert response["conflicts"] == conflicts
+    assert len(response["unchecked_attendees"]) < len(unchecked_attendees)
+    assert (
+        response["unchecked_attendees"]
+        == unchecked_attendees[: len(response["unchecked_attendees"])]
+    )
     assert len(json.dumps(response, ensure_ascii=False)) <= 2000

--- a/uv.lock
+++ b/uv.lock
@@ -4064,9 +4064,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "pyobjc-framework-vision" },
+    { name = "click", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -5404,7 +5404,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -5421,8 +5421,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -5439,8 +5439,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -5457,10 +5457,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreml" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [
@@ -6897,13 +6897,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", upload-time = "2026-05-12T16:20:07Z" },
@@ -6931,13 +6931,13 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:aaa9c1f5e8c518d7be1e3c3e1b090ca7d63b6e353a1abd6cfdaf902405093467", upload-time = "2026-05-12T23:16:01Z" },
@@ -6981,9 +6981,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:df0c166b6bdf7c47f88e81e8b43bc085451d5c50d0c5d1691bc474c1227d6fed", upload-time = "2026-05-12T16:20:37Z" },
@@ -7011,9 +7011,9 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "pillow", marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:99d05d071ff34305334ee1854f5edf7c2767b96ba59fe92e76d84a1fa72c8e06", upload-time = "2026-05-12T16:20:36Z" },
@@ -7828,6 +7828,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tiktoken" },
     { name = "tqdm" },
+    { name = "tzdata" },
     { name = "uvicorn" },
     { name = "volcengine-python-sdk", extra = ["ark"] },
     { name = "websockets" },
@@ -8094,6 +8095,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'router'", specifier = ">=4.51" },
     { name = "typer", marker = "extra == 'all'", specifier = ">=0.9.0" },
     { name = "typer", marker = "extra == 'document-processing'", specifier = ">=0.9.0" },
+    { name = "tzdata", specifier = ">=2024.1" },
     { name = "unstructured", marker = "extra == 'all'", specifier = ">=0.15.0" },
     { name = "unstructured", marker = "extra == 'document-processing'", specifier = ">=0.15.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },


### PR DESCRIPTION
## Summary
- `google_calendar_create_events`/`update_events` had no conflict/overlap detection at all — an agent could book or move a meeting straight over an existing one (same timezone included) with zero warning.
- Both tools now check the organizer's own calendar and, when attendees are given, each attendee's free/busy before writing the event. A conflict returns `status="conflict"` (with the overlapping events and any attendee whose calendar couldn't be checked) instead of silently booking over it. `ignore_conflicts=true` lets the caller proceed once the user has explicitly confirmed.
- Update calls only re-check what's actually new territory: a moved/widened window only checks retained attendees against the portion of the new window that's genuinely outside the old one (`window_delta_segments` in `utils.py`) — checking the whole new window would always flag the event's own prior busy block on their calendar as a false conflict. A newly-added attendee, or a fully disjoint move, gets the whole window checked. Same-instant timestamps written in different formats (`Z` vs `+00:00`, differing fractional-second precision, an offsetless `dateTime` paired with a sibling `timeZone` field) are compared correctly instead of as raw strings.
- A whole-batch missing-OAuth-scope error rejects the write outright rather than silently degrading to an unchecked write that could book straight over a real conflict — but a conflict already confirmed before the scope error hit (e.g. the organizer's own calendar, which needs no extra scope) is still reported rather than discarded, since blocking on a known problem is always safe. `ignore_conflicts=true` remains the explicit escape hatch.
- An organizer's own declined event is not treated as a non-conflict — Google documents `responseStatus` and `transparency` as independent fields with no guaranteed link, so a still-opaque declined event is correctly treated as busy. An attendee entirely missing from `freebusy.query`'s response is reported as `unchecked_attendees` rather than silently assumed free.
- An all-day event's boundary is widened using the *calendar's own* configured timezone (not a hardcoded UTC assumption), which needs a new OAuth scope (see below).

## OAuth scope changes — requires reconnecting Google Calendar
Two widening migrations add scopes the connector didn't need before:
- `calendar.freebusy` (`20260907_add_calendar_freebusy_scope`) — needed by the attendee availability check (`freebusy.query`); not covered by `calendar.events` alone.
- `calendar.calendars.readonly` (`20260909_add_calendar_calendars_readonly_scope`) — needed to look up the primary calendar's own timezone (`calendars.get`) when widening an all-day event's boundary; not covered by `calendar.events` or `calendar.freebusy`.

Neither is retroactive: an already-issued token only carries the old scope(s) and won't pick up the new one(s) automatically. Existing users hit the reject-and-reconnect path above (rather than a silent unchecked write) until they reconnect the connector; new connections after this ships get the correct scope immediately.

## Known follow-up (not in this PR)
- No optimistic-concurrency guard (etag/If-Match) on the read-check-then-write flow this PR introduces — two near-simultaneous updates could both pass the conflict check and both write. Flagging as a real but separate gap.
- The organizer's own conflict check (`events.list`) doesn't follow `nextPageToken` — a calendar with more events than one page in the checked window could miss a conflict further down the list.

## Test plan
- [x] `pytest tests/web/tools/test_google_calendar_mcp.py` and `tests/web/tools/test_mcp_utils.py` — organizer/attendee conflict detection (same-timezone overlap, transparent/cancelled/declined events, all-day events), partial-overlap window-delta checking, missing-scope rejection (and its `ignore_conflicts` bypass, and reporting an already-confirmed conflict instead of discarding it), attendee batch chunking over Google's 50-calendar cap, `unchecked_attendees` reporting, equivalent-timestamp handling, offsetless-`dateTime`-with-sibling-`timeZone` handling
- [x] `pytest tests/alembic/test_20260817_narrow_google_calendar_scope.py tests/alembic/test_20260907_add_calendar_freebusy_scope.py tests/alembic/test_20260909_add_calendar_calendars_readonly_scope.py` — scope migration upgrade/downgrade, idempotency, upgrade→downgrade→upgrade convergence, offline SQL generation, registry drift
- [x] `python tests/migrations/test_migration_integration.py --db sqlite all` — full migration chain applies cleanly
- [x] `alembic heads` — single head confirmed
- [x] `ruff format` / `ruff check` / `mypy` / `codespell` clean on all changed files
- [x] pre-commit hooks pass
