### PR TITLE
Support DeepSeek Flash and inactive model guards (toby)

### DIFF
--- a/src/xagent/core/model/chat/basic/deepseek.py
+++ b/src/xagent/core/model/chat/basic/deepseek.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 DEEPSEEK_DEFAULT_BASE_URL = "https://api.deepseek.com"
 DEEPSEEK_SUPPORTED_MODELS = (
+    "deepseek-flash",
     "deepseek-v4-flash",
     "deepseek-v4-pro",
 )
@@ -272,6 +273,12 @@ class DeepSeekLLM(OpenAICompatibleLLM):
     ) -> List[Dict[str, Any]]:
         _ = api_key, base_url
         return [
+            {
+                "id": "deepseek-flash",
+                "created": 0,
+                "owned_by": "deepseek",
+                "abilities": ["chat", "tool_calling", "thinking_mode"],
+            },
             {
                 "id": "deepseek-v4-flash",
                 "created": 0,

--- a/src/xagent/core/model/providers.py
+++ b/src/xagent/core/model/providers.py
@@ -61,6 +61,7 @@ _CURATED_MODELS_BY_PROVIDER: dict[str, tuple[str, ...]] = {
     # OpenRouter directly. Users may also type any OpenRouter slug.
     "openrouter": (AUTO_MODEL_NAME,),
     "deepseek": (
+        "deepseek-flash",
         "deepseek-v4-flash",
         "deepseek-v4-pro",
     ),

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -4292,7 +4292,7 @@ async def create_task(
                     return None
 
             db_model = core_storage.get_db_model(model_ref)
-            if not db_model:
+            if not db_model or not bool(db_model.is_active):
                 return None
 
             # Two-step access check: own → shared from visible users
@@ -4358,8 +4358,10 @@ async def create_task(
                 shared_defaults = (
                     db.query(UserDefaultModel)
                     .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.config_type.in_(config_types),
+                        DBModel.is_active,
                         UserModel.is_shared.is_(True),
                         UserDefaultModel.user_id.in_(visible_ids),
                     )

--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -1105,18 +1105,22 @@ class UserAwareModelStorage:
         vision_name = llm_names[2]
         compact_name = llm_names[3]
 
-        # Get default LLM (required)
-        if not default_name:
-            logger.error(
-                "Default model name is required but not provided. Using configured defaults."
-            )
-            return self.get_configured_defaults(user_id)
-
-        default_llm = self.get_llm_by_name_with_access(default_name, user_id)
+        # Resolve the required general slot independently. A missing or unavailable
+        # general model must not discard valid explicit models in the other slots.
+        default_llm = (
+            self.get_llm_by_name_with_access(default_name, user_id)
+            if default_name
+            else None
+        )
         if not default_llm:
-            logger.warning(
-                f"Default LLM '{default_name}' not found or no access, falling back to configured default"
-            )
+            if default_name:
+                logger.warning(
+                    f"Default LLM '{default_name}' not found or no access, falling back to configured default"
+                )
+            else:
+                logger.warning(
+                    "Default model name is not available; using configured default"
+                )
             default_llm, _, _, _ = self.get_configured_defaults(
                 user_id, config_types=("general",)
             )
@@ -1143,8 +1147,8 @@ class UserAwareModelStorage:
         missing_defaults = tuple(
             kind
             for kind, needed in (
-                ("small_fast", bool(fast_name) and fast_llm is None),
-                ("visual", bool(vision_name) and vision_llm is None),
+                ("small_fast", fast_llm is None),
+                ("visual", vision_llm is None),
                 ("compact", compact_llm is None),
             )
             if needed
@@ -1156,16 +1160,18 @@ class UserAwareModelStorage:
                 )
             )
 
-        if fast_name and not fast_llm:
-            logger.warning(
-                f"Fast LLM '{fast_name}' not found or no access, using configured fast default"
-            )
+        if not fast_llm:
+            if fast_name:
+                logger.warning(
+                    f"Fast LLM '{fast_name}' not found or no access, using configured fast default"
+                )
             fast_llm = default_fast_llm
 
-        if vision_name and not vision_llm:
-            logger.warning(
-                f"Vision LLM '{vision_name}' not found or no access, using configured vision default"
-            )
+        if not vision_llm:
+            if vision_name:
+                logger.warning(
+                    f"Vision LLM '{vision_name}' not found or no access, using configured vision default"
+                )
             vision_llm = default_vision_llm
 
         if compact_name:

--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -647,11 +647,14 @@ class UserAwareModelStorage:
         try:
             # Try to get by model_id first, then by model_name
             logger.info(f"Looking for model: {model_name} for user {user_id}")
-            model_config = self.core_storage.load(model_name)
             db_model = self.core_storage.get_db_model(model_name)
             if not db_model:
                 logger.warning(f"Cannot find model for id: {model_name}")
                 return None
+            if not bool(getattr(db_model, "is_active", True)):
+                logger.warning(f"Model '{model_name}' is inactive")
+                return None
+            model_config = self.core_storage.load(model_name)
             logger.info(
                 f"Found model: id={db_model.id}, model_id={db_model.model_id}, model_name={db_model.model_name}"
             )
@@ -844,6 +847,9 @@ class UserAwareModelStorage:
     ) -> Optional[BaseLLM]:
         """Create a default model, hydrating configured Auto when necessary."""
 
+        if not bool(getattr(db_model, "is_active", True)):
+            return None
+
         model_id = str(db_model.model_id)
         model_config = self.core_storage.load(model_id)
         if (
@@ -1005,6 +1011,7 @@ class UserAwareModelStorage:
                     )
                     .filter(
                         UserDefaultModel.config_type.in_(config_types),
+                        UserDefaultModel.model.has(Model.is_active),
                         UserModel.is_shared.is_(True),
                         UserDefaultModel.user_id.in_(visible_ids),
                     )
@@ -1325,13 +1332,17 @@ def make_normalize_model_id(core_storage: CoreStorage) -> Callable:
         if model_id:
             db_model = core_storage.get_db_model(model_id)
             if db_model:
-                return str(db_model.model_id)
+                return str(db_model.model_id) if bool(db_model.is_active) else None
             # Preserve stored identifier even if the backing model row no longer exists.
             # This avoids API inconsistencies when models are deleted/migrated.
             return str(model_id).strip() if isinstance(model_id, str) else str(model_id)
         if model_name:
             db_model = core_storage.get_db_model(str(model_name))
-            return str(db_model.model_id) if db_model else None
+            return (
+                str(db_model.model_id)
+                if db_model and bool(db_model.is_active)
+                else None
+            )
         return None
 
     return normalize_model_id

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -197,8 +197,10 @@ def get_default_vision_model(
                 admin_vision_defaults = (
                     model_db.query(UserDefaultModel)
                     .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.config_type == "visual",
+                        DBModel.is_active,
                         UserModel.is_shared.is_(True),
                         UserDefaultModel.user_id.in_(
                             _get_visible_user_ids(model_db, user_id)
@@ -267,8 +269,10 @@ def get_default_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
             admin_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                 .filter(
                     UserDefaultModel.config_type == "general",
+                    DBModel.is_active,
                     UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
@@ -335,8 +339,10 @@ def get_fast_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
             admin_fast_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                 .filter(
                     UserDefaultModel.config_type == "small_fast",
+                    DBModel.is_active,
                     UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
@@ -403,8 +409,10 @@ def get_compact_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
             admin_compact_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                 .filter(
                     UserDefaultModel.config_type == "compact",
+                    DBModel.is_active,
                     UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
@@ -472,8 +480,10 @@ def get_embedding_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
             admin_embedding_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                 .filter(
                     UserDefaultModel.config_type == "embedding",
+                    DBModel.is_active,
                     UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
@@ -774,6 +784,7 @@ def get_default_image_generate_model(
                     .join(DBModel, UserModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.config_type == "image",
+                        DBModel.is_active,
                         UserModel.is_shared.is_(True),
                         UserDefaultModel.user_id.in_(
                             _get_visible_user_ids(model_db, user_id)
@@ -865,8 +876,10 @@ def get_default_image_edit_model(
                 admin_image_defaults = (
                     model_db.query(UserDefaultModel)
                     .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.config_type == "image_edit",
+                        DBModel.is_active,
                         UserModel.is_shared.is_(True),
                         UserDefaultModel.user_id.in_(
                             _get_visible_user_ids(model_db, user_id)
@@ -1040,8 +1053,10 @@ def get_default_embedding_model(
         admin_embedding_defaults = (
             model_db.query(UserDefaultModel)
             .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+            .join(DBModel, UserDefaultModel.model_id == DBModel.id)
             .filter(
                 UserDefaultModel.config_type == "embedding",
+                DBModel.is_active,
                 UserModel.is_shared.is_(True),
                 UserDefaultModel.user_id.in_(_get_visible_user_ids(model_db, user_id)),
             )
@@ -1091,8 +1106,10 @@ def get_default_rerank_model(
             admin_rerank_defaults = (
                 model_db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                 .filter(
                     UserDefaultModel.config_type == "rerank",
+                    DBModel.is_active,
                     UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(
                         _get_visible_user_ids(model_db, user_id)
@@ -1366,6 +1383,7 @@ def get_default_asr_model(
                     .join(DBModel, UserModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.config_type == "asr",
+                        DBModel.is_active,
                         UserModel.is_shared.is_(True),
                         UserDefaultModel.user_id.in_(
                             _get_visible_user_ids(model_db, user_id)
@@ -1442,6 +1460,7 @@ def get_default_tts_model(
                     .join(DBModel, UserModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.config_type == "tts",
+                        DBModel.is_active,
                         UserModel.is_shared.is_(True),
                         UserDefaultModel.user_id.in_(
                             _get_visible_user_ids(model_db, user_id)

--- a/tests/core/model/chat/basic/test_deepseek.py
+++ b/tests/core/model/chat/basic/test_deepseek.py
@@ -64,6 +64,29 @@ class TestDeepSeekLLM:
         with pytest.raises(ValueError, match="Unsupported DeepSeek model"):
             DeepSeekLLM(model_name="not-a-deepseek-model", api_key="test-api-key")
 
+    @pytest.mark.asyncio
+    async def test_stable_flash_name_is_forwarded_to_direct_api(self, mocker):
+        message = SimpleNamespace(content="ok", tool_calls=None, reasoning_content=None)
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=message)],
+            usage=None,
+            model_dump=lambda: {"id": "deepseek-stable-flash"},
+        )
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = response
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = DeepSeekLLM(model_name="deepseek-flash", api_key="test-api-key")
+        result = await llm.chat([{"role": "user", "content": "Hello"}])
+
+        assert result["content"] == "ok"
+        assert mock_client.chat.completions.create.call_args.kwargs["model"] == (
+            "deepseek-flash"
+        )
+
     def test_structured_output_capabilities(self, llm):
         assert llm.supports_json_schema_response_format is False
         assert llm.supports_json_object_response_format is True
@@ -928,10 +951,11 @@ class TestDeepSeekLLM:
         }
 
     @pytest.mark.asyncio
-    async def test_list_available_models_returns_curated_v4_models(self):
+    async def test_list_available_models_returns_curated_models(self):
         models = await DeepSeekLLM.list_available_models("test-api-key")
 
         assert [model["id"] for model in models] == [
+            "deepseek-flash",
             "deepseek-v4-flash",
             "deepseek-v4-pro",
         ]

--- a/tests/core/model/test_deepseek_provider_config.py
+++ b/tests/core/model/test_deepseek_provider_config.py
@@ -12,7 +12,7 @@ def test_create_base_llm_returns_deepseek_llm():
     config = ChatModelConfig(
         id="deepseek-model",
         model_provider="deepseek",
-        model_name="deepseek-v4-flash",
+        model_name="deepseek-flash",
         api_key="test-api-key",
     )
 
@@ -20,6 +20,7 @@ def test_create_base_llm_returns_deepseek_llm():
 
     assert hasattr(llm, "_inner")
     assert isinstance(llm._inner, DeepSeekLLM)
+    assert llm.model_name == "deepseek-flash"
 
 
 def test_create_base_llm_accepts_canonicalized_deepseek_provider():
@@ -60,8 +61,9 @@ def test_deepseek_default_base_url():
     assert default_base_url_for_provider("deepseek") == "https://api.deepseek.com"
 
 
-def test_deepseek_curated_models_are_limited_to_v4():
+def test_deepseek_curated_models_include_stable_flash_name_and_v4_aliases():
     assert curated_models_for_provider("deepseek") == (
+        "deepseek-flash",
         "deepseek-v4-flash",
         "deepseek-v4-pro",
     )

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -506,6 +506,55 @@ def test_task_create_allows_shared_model_ids(
     assert data["model_id"] == shared_model_id
 
 
+def test_task_create_does_not_persist_inactive_owned_or_shared_model_ids(
+    test_db, user1_headers, sample_model_data
+):
+    from xagent.web.models.database import get_db
+    from xagent.web.models.model import Model
+
+    # An owner link must not make a deactivated model runtime-available.
+    owned_data = dict(sample_model_data)
+    owned_data["model_id"] = "inactive-owned-model"
+    created_owned = client.post("/api/models/", json=owned_data, headers=user1_headers)
+    assert created_owned.status_code == 200
+
+    # A shared link must not bypass the same active gate for another user.
+    admin_login = client.post(
+        "/api/auth/login", json={"username": "admin", "password": "admin123"}
+    )
+    assert admin_login.status_code == 200
+    admin_headers = {"Authorization": f"Bearer {admin_login.json()['access_token']}"}
+    shared_data = dict(sample_model_data)
+    shared_data.update({"model_id": "inactive-shared-model", "share_with_users": True})
+    created_shared = client.post(
+        "/api/models/", json=shared_data, headers=admin_headers
+    )
+    assert created_shared.status_code == 200
+
+    db = next(get_db())
+    try:
+        inactive_ids = ("inactive-owned-model", "inactive-shared-model")
+        db.query(Model).filter(Model.model_id.in_(inactive_ids)).update(
+            {Model.is_active: False}, synchronize_session=False
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    for model_id in inactive_ids:
+        response = client.post(
+            "/api/chat/task/create",
+            json={
+                "title": f"task-{model_id}",
+                "description": "desc",
+                "llm_ids": [model_id, None, None, None],
+            },
+            headers=user1_headers,
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["model_id"] != model_id
+
+
 def test_standalone_task_create_defaults_to_auto(test_db, user1_headers):
     resp = client.post(
         "/api/chat/task/create",
@@ -833,6 +882,45 @@ def test_get_task_llm_ids_preserves_stored_id_when_model_missing(test_db):
         assert ids[1] == "deleted-fast-id"
         assert ids[2] == "deleted-visual-id"
         assert ids[3] == "deleted-compact-id"
+    finally:
+        db.close()
+
+
+def test_get_task_llm_ids_drops_stored_id_when_model_is_inactive(test_db):
+    ensure_system_initialized()
+    from xagent.web.models.database import get_db
+    from xagent.web.models.model import Model
+    from xagent.web.models.task import Task, TaskStatus
+    from xagent.web.models.user import User
+
+    db = next(get_db())
+    try:
+        admin = db.query(User).filter(User.username == "admin").one()
+        inactive = Model(
+            model_id="inactive-persisted-model",
+            category="llm",
+            model_provider="openai",
+            model_name="gpt-4.1",
+            api_key="test-key",
+            abilities=["chat"],
+            is_active=False,
+        )
+        db.add(inactive)
+        db.flush()
+        task = Task(
+            user_id=admin.id,
+            title="inactive persisted model",
+            description="d",
+            status=TaskStatus.PENDING,
+            model_id=inactive.model_id,
+            model_name=inactive.model_name,
+        )
+        db.add(task)
+        db.commit()
+
+        ids = AgentServiceManager()._get_task_llm_ids(task, db)
+
+        assert ids[0] is None
     finally:
         db.close()
 

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -148,6 +148,22 @@ def sample_model_data():
     }
 
 
+def create_test_models(headers, template, specs, *, shared=False):
+    for model_id, model_name in specs:
+        payload = dict(template)
+        payload.update(
+            {
+                "model_id": model_id,
+                "model_name": model_name,
+                "share_with_users": shared,
+            }
+        )
+        assert (
+            client.post("/api/models/", json=payload, headers=headers).status_code
+            == 200
+        )
+
+
 class DummyLLM(BaseLLM):
     def __init__(self, name: str):
         self._name = name
@@ -553,6 +569,198 @@ def test_task_create_does_not_persist_inactive_owned_or_shared_model_ids(
         )
         assert response.status_code == 200, response.text
         assert response.json()["model_id"] != model_id
+
+
+def test_task_create_falls_back_general_without_replacing_active_explicit_slots(
+    test_db, user1_headers, sample_model_data
+):
+    from xagent.web.models.database import get_db
+    from xagent.web.models.model import Model
+    from xagent.web.models.user import User, UserDefaultModel
+
+    model_specs = [
+        ("fallback-general-id", "fallback-general"),
+        ("inactive-general-id", "inactive-general"),
+        ("active-fast-id", "active-fast"),
+        ("active-vision-id", "active-vision"),
+        ("active-compact-id", "active-compact"),
+    ]
+    create_test_models(user1_headers, sample_model_data, model_specs)
+
+    db = next(get_db())
+    try:
+        user = db.query(User).filter(User.username == "user1").one()
+        fallback = db.query(Model).filter(Model.model_id == "fallback-general-id").one()
+        inactive = db.query(Model).filter(Model.model_id == "inactive-general-id").one()
+        inactive.is_active = False
+        db.add(
+            UserDefaultModel(
+                user_id=user.id,
+                model_id=fallback.id,
+                config_type="general",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        "/api/chat/task/create",
+        json={
+            "title": "slot-wise-create",
+            "description": "desc",
+            "llm_ids": [
+                "inactive-general-id",
+                "active-fast-id",
+                "active-vision-id",
+                "active-compact-id",
+            ],
+        },
+        headers=user1_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert [
+        data["model_id"],
+        data["small_fast_model_id"],
+        data["visual_model_id"],
+        data["compact_model_id"],
+    ] == [
+        "fallback-general-id",
+        "active-fast-id",
+        "active-vision-id",
+        "active-compact-id",
+    ]
+    assert [
+        data["model_name"],
+        data["small_fast_model_name"],
+        data["visual_model_name"],
+        data["compact_model_name"],
+    ] == ["fallback-general", "active-fast", "active-vision", "active-compact"]
+
+
+def test_persisted_task_falls_back_general_without_replacing_active_slots(
+    test_db, user1_headers, sample_model_data
+):
+    from xagent.web.models.database import get_db
+    from xagent.web.models.model import Model
+    from xagent.web.models.task import Task
+    from xagent.web.models.user import User, UserDefaultModel
+    from xagent.web.services.llm_utils import resolve_task_runtime_config_core
+
+    model_specs = [
+        ("resume-fallback-id", "resume-fallback"),
+        ("resume-general-id", "resume-general"),
+        ("resume-fast-id", "resume-fast"),
+        ("resume-vision-id", "resume-vision"),
+        ("resume-compact-id", "resume-compact"),
+    ]
+    create_test_models(user1_headers, sample_model_data, model_specs)
+
+    created = client.post(
+        "/api/chat/task/create",
+        json={
+            "title": "slot-wise-resume",
+            "description": "desc",
+            "llm_ids": [
+                "resume-general-id",
+                "resume-fast-id",
+                "resume-vision-id",
+                "resume-compact-id",
+            ],
+        },
+        headers=user1_headers,
+    )
+    assert created.status_code == 200, created.text
+
+    db = next(get_db())
+    try:
+        user = db.query(User).filter(User.username == "user1").one()
+        fallback = db.query(Model).filter(Model.model_id == "resume-fallback-id").one()
+        general = db.query(Model).filter(Model.model_id == "resume-general-id").one()
+        general.is_active = False
+        db.add(
+            UserDefaultModel(
+                user_id=user.id,
+                model_id=fallback.id,
+                config_type="general",
+            )
+        )
+        db.commit()
+
+        task = db.get(Task, created.json()["task_id"])
+        runtime = resolve_task_runtime_config_core(task, db, user_id=user.id)
+
+        assert [llm.model_name if llm else None for llm in runtime.llms] == [
+            "resume-fallback",
+            "resume-fast",
+            "resume-vision",
+            "resume-compact",
+        ]
+    finally:
+        db.close()
+
+
+def test_task_create_shared_default_skips_inactive_and_accepts_active(
+    test_db, user1_headers, sample_model_data
+):
+    from xagent.web.models.database import get_db
+    from xagent.web.models.model import Model
+    from xagent.web.models.user import User, UserDefaultModel
+
+    admin_login = client.post(
+        "/api/auth/login", json={"username": "admin", "password": "admin123"}
+    )
+    assert admin_login.status_code == 200
+    admin_headers = {"Authorization": f"Bearer {admin_login.json()['access_token']}"}
+    create_test_models(
+        admin_headers,
+        sample_model_data,
+        [("shared-default-id", "shared-default")],
+        shared=True,
+    )
+
+    db = next(get_db())
+    try:
+        admin = db.query(User).filter(User.username == "admin").one()
+        model = db.query(Model).filter(Model.model_id == "shared-default-id").one()
+        model.is_active = False
+        db.add(
+            UserDefaultModel(
+                user_id=admin.id,
+                model_id=model.id,
+                config_type="general",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    inactive_response = client.post(
+        "/api/chat/task/create",
+        json={"title": "inactive-shared-default", "description": "desc"},
+        headers=user1_headers,
+    )
+    assert inactive_response.status_code == 200, inactive_response.text
+    assert inactive_response.json()["model_id"] != "shared-default-id"
+
+    db = next(get_db())
+    try:
+        model = db.query(Model).filter(Model.model_id == "shared-default-id").one()
+        model.is_active = True
+        db.commit()
+    finally:
+        db.close()
+
+    active_response = client.post(
+        "/api/chat/task/create",
+        json={"title": "active-shared-default", "description": "desc"},
+        headers=user1_headers,
+    )
+    assert active_response.status_code == 200, active_response.text
+    assert active_response.json()["model_id"] == "shared-default-id"
+    assert active_response.json()["model_name"] == "shared-default"
 
 
 def test_standalone_task_create_defaults_to_auto(test_db, user1_headers):

--- a/tests/web/test_llm_uitls.py
+++ b/tests/web/test_llm_uitls.py
@@ -26,6 +26,22 @@ def storage(mock_db, mock_core_storage):
 
 
 class TestGetLLMByNameWithAccess:
+    def test_returns_none_for_inactive_model_before_loading_config(
+        self, storage, mock_core_storage
+    ):
+        mock_core_storage.get_db_model.return_value = Mock(
+            id=1,
+            model_id="inactive-model",
+            model_name="inactive-model",
+            is_active=False,
+        )
+
+        result = storage.get_llm_by_name_with_access("inactive-model", user_id=1)
+
+        assert result is None
+        mock_core_storage.load.assert_not_called()
+        mock_core_storage.create_llm_instance.assert_not_called()
+
     def test_returns_llm_when_model_exists_no_user(self, storage, mock_core_storage):
         mock_llm = Mock()
         mock_model = Mock(

--- a/tests/web/test_llm_uitls.py
+++ b/tests/web/test_llm_uitls.py
@@ -203,6 +203,66 @@ class TestGetLLMByNameWithAccess:
 
 
 class TestGetConfiguredDefaults:
+    def test_inactive_model_is_rejected_by_default_creation_boundary(
+        self, storage, mock_core_storage
+    ):
+        inactive = Mock(model_id="inactive-default", is_active=False)
+
+        assert storage._create_default_model(inactive, user_id=1) is None
+        mock_core_storage.load.assert_not_called()
+        mock_core_storage.create_llm_instance.assert_not_called()
+
+    def test_missing_general_falls_back_without_discarding_explicit_slots(
+        self, storage
+    ):
+        explicit = {
+            name: Mock(model_name=name)
+            for name in ("active-fast", "active-vision", "active-compact")
+        }
+        fallback_general = Mock(model_name="fallback-general")
+
+        with (
+            patch.object(
+                storage,
+                "get_llm_by_name_with_access",
+                side_effect=lambda name, user_id: explicit[name],
+            ),
+            patch.object(
+                storage,
+                "get_configured_defaults",
+                return_value=(fallback_general, None, None, None),
+            ) as get_defaults,
+        ):
+            result = storage.resolve_llms_from_names(
+                [None, "active-fast", "active-vision", "active-compact"],
+                user_id=7,
+            )
+
+        assert result == (
+            fallback_general,
+            explicit["active-fast"],
+            explicit["active-vision"],
+            explicit["active-compact"],
+        )
+        get_defaults.assert_called_once_with(7, config_types=("general",))
+
+    def test_missing_optional_slots_use_their_configured_defaults(self, storage):
+        general = Mock(model_name="explicit-general")
+        defaults = tuple(
+            Mock(model_name=name)
+            for name in ("unused", "default-fast", "default-vision", "default-compact")
+        )
+
+        with (
+            patch.object(storage, "get_llm_by_name_with_access", return_value=general),
+            patch.object(storage, "get_configured_defaults", return_value=defaults),
+        ):
+            result = storage.resolve_llms_from_names(
+                ["explicit-general", None, None, None], user_id=7
+            )
+
+        assert result == (general, *defaults[1:])
+
     def test_returns_user_specific_defaults(self, storage, mock_db, mock_core_storage):
         """Test that user-specific defaults are returned when available"""
         mock_llm = Mock()

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -2010,7 +2010,7 @@ class TestModelAPI:
             == "https://ark.ap-southeast.bytepluses.com/api/v3"
         )
 
-    def test_fetch_deepseek_provider_models_returns_curated_v4_models(
+    def test_fetch_deepseek_provider_models_returns_curated_models(
         self, test_db, regular_user, regular_headers
     ):
         response = client.post(
@@ -2021,8 +2021,9 @@ class TestModelAPI:
 
         assert response.status_code == 200
         data = response.json()
-        assert data["count"] == 2
+        assert data["count"] == 3
         assert [model["id"] for model in data["models"]] == [
+            "deepseek-flash",
             "deepseek-v4-flash",
             "deepseek-v4-pro",
         ]

--- a/tests/web/test_model_service.py
+++ b/tests/web/test_model_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import sessionmaker
 from xagent.web.models.database import Base
 from xagent.web.models.model import Model
 from xagent.web.models.user import User, UserDefaultModel, UserModel
+from xagent.web.services.llm_utils import UserAwareModelStorage
 from xagent.web.services.model_service import (
     _create_default_llm_instance,
     _is_model_visible_to_user,
@@ -33,7 +34,6 @@ from xagent.web.services.model_service import (
     get_tts_models,
     get_vision_model,
 )
-from xagent.web.services.llm_utils import UserAwareModelStorage
 
 # Test database setup - use in-memory database
 SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"

--- a/tests/web/test_model_service.py
+++ b/tests/web/test_model_service.py
@@ -1,5 +1,6 @@
 """Test model service functionality"""
 
+from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,17 +14,26 @@ from xagent.web.services.model_service import (
     _create_default_llm_instance,
     _is_model_visible_to_user,
     get_asr_models,
+    get_compact_model,
+    get_default_asr_model,
     get_default_embedding_model,
+    get_default_image_edit_model,
+    get_default_image_generate_model,
     get_default_model,
     get_default_music_model,
     get_default_rerank_model,
     get_default_sound_effect_model,
+    get_default_tts_model,
+    get_default_vision_model,
+    get_embedding_model,
+    get_fast_model,
     get_image_models,
     get_music_models,
     get_sound_effect_models,
     get_tts_models,
     get_vision_model,
 )
+from xagent.web.services.llm_utils import UserAwareModelStorage
 
 # Test database setup - use in-memory database
 SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
@@ -122,6 +132,169 @@ class TestModelService:
             "router-auto", 7
         )
         legacy_create.assert_not_called()
+
+    def test_user_aware_shared_default_query_skips_inactive_model(
+        self, db_session, admin_user, regular_user, monkeypatch
+    ):
+        model = Model(
+            model_id="shared-general",
+            category="llm",
+            model_provider="openai",
+            model_name="shared-general",
+            api_key="test-api-key",
+            abilities=["chat"],
+            is_active=False,
+        )
+        db_session.add(model)
+        db_session.flush()
+        db_session.add_all(
+            [
+                UserModel(
+                    user_id=admin_user.id,
+                    model_id=model.id,
+                    is_owner=True,
+                    is_shared=True,
+                ),
+                UserDefaultModel(
+                    user_id=admin_user.id,
+                    model_id=model.id,
+                    config_type="general",
+                ),
+            ]
+        )
+        db_session.commit()
+
+        storage = UserAwareModelStorage(db_session)
+        monkeypatch.setattr(
+            storage,
+            "_create_default_model",
+            lambda db_model, user_id: str(db_model.model_id),
+        )
+        monkeypatch.setattr(
+            "xagent.web.services.llm_utils.create_llm_from_env", lambda: None
+        )
+
+        assert (
+            storage.get_configured_defaults(regular_user.id, config_types=("general",))[
+                0
+            ]
+            is None
+        )
+
+        model.is_active = True
+        db_session.commit()
+
+        assert (
+            storage.get_configured_defaults(regular_user.id, config_types=("general",))[
+                0
+            ]
+            == "shared-general"
+        )
+
+    @pytest.mark.parametrize(
+        ("resolver_name", "config_type", "category", "factory_kind"),
+        [
+            ("vision", "visual", "llm", "chat"),
+            ("general", "general", "llm", "chat"),
+            ("fast", "small_fast", "llm", "chat"),
+            ("compact", "compact", "llm", "chat"),
+            ("embedding_instance", "embedding", "embedding", "embedding"),
+            ("image_generate", "image", "image", "image"),
+            ("image_edit", "image_edit", "image", "image"),
+            ("embedding_id", "embedding", "embedding", None),
+            ("rerank_id", "rerank", "rerank", None),
+            ("asr", "asr", "asr", "asr"),
+            ("tts", "tts", "tts", "tts"),
+        ],
+    )
+    def test_shared_default_resolvers_skip_inactive_models(
+        self,
+        db_session,
+        admin_user,
+        resolver_name,
+        config_type,
+        category,
+        factory_kind,
+    ):
+        model = Model(
+            model_id=f"shared-{resolver_name}",
+            category=category,
+            model_provider="openai",
+            model_name=f"shared-{resolver_name}",
+            api_key="test-api-key",
+            abilities=["chat", "generate"],
+            is_active=False,
+        )
+        db_session.add(model)
+        db_session.flush()
+        db_session.add_all(
+            [
+                UserModel(
+                    user_id=admin_user.id,
+                    model_id=model.id,
+                    is_owner=True,
+                    is_shared=True,
+                ),
+                UserDefaultModel(
+                    user_id=admin_user.id,
+                    model_id=model.id,
+                    config_type=config_type,
+                ),
+            ]
+        )
+        db_session.commit()
+
+        resolvers = {
+            "vision": lambda: get_default_vision_model(None, db=db_session),
+            "general": lambda: get_default_model(None),
+            "fast": lambda: get_fast_model(None),
+            "compact": lambda: get_compact_model(None),
+            "embedding_instance": lambda: get_embedding_model(None),
+            "image_generate": lambda: get_default_image_generate_model(
+                None, db=db_session
+            ),
+            "image_edit": lambda: get_default_image_edit_model(None, db=db_session),
+            "embedding_id": lambda: get_default_embedding_model(None, db=db_session),
+            "rerank_id": lambda: get_default_rerank_model(None, db=db_session),
+            "asr": lambda: get_default_asr_model(None, db=db_session),
+            "tts": lambda: get_default_tts_model(None, db=db_session),
+        }
+        factory_targets = {
+            "chat": "xagent.web.services.model_service._create_default_llm_instance",
+            "embedding": "xagent.web.services.llm_utils._create_llm_instance",
+            "image": "xagent.core.model.image.adapter.get_image_model_instance",
+            "asr": "xagent.core.model.asr.adapter.get_asr_model_instance",
+            "tts": "xagent.core.model.tts.adapter.get_tts_model_instance",
+        }
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "xagent.web.models.database.get_db",
+                    side_effect=lambda: iter([db_session]),
+                )
+            )
+            factory = (
+                stack.enter_context(patch(factory_targets[factory_kind]))
+                if factory_kind
+                else None
+            )
+            if factory is not None:
+                factory.return_value = MagicMock(name=f"{resolver_name}-instance")
+
+            assert resolvers[resolver_name]() is None
+            if factory is not None:
+                factory.assert_not_called()
+
+            model.is_active = True
+            db_session.commit()
+            result = resolvers[resolver_name]()
+
+            if factory is None:
+                assert result == model.model_id
+            else:
+                factory.assert_called_once()
+                assert result is factory.return_value
 
     def test_get_default_model_user_specific(self):
         """Test getting user-specific default model"""
@@ -844,7 +1017,7 @@ class TestModelService:
         mock_db, session_factory = owned_model_session
         shared_default = MagicMock()
         shared_default.model.model_id = "shared-text-model"
-        shared_query = mock_db.query.return_value.join.return_value.filter.return_value
+        shared_query = mock_db.query.return_value.join.return_value.join.return_value.filter.return_value
         shared_query.limit.return_value.all.return_value = [shared_default]
         monkeypatch.setattr(
             "xagent.web.services.model_service._get_visible_user_ids",
@@ -911,9 +1084,7 @@ class TestModelService:
         self, get_default, monkeypatch
     ):
         caller_db = MagicMock()
-        shared_query = (
-            caller_db.query.return_value.join.return_value.filter.return_value
-        )
+        shared_query = caller_db.query.return_value.join.return_value.join.return_value.filter.return_value
         shared_query.limit.return_value.all.return_value = []
         monkeypatch.setattr(
             "xagent.web.services.model_service._get_visible_user_ids",


### PR DESCRIPTION
## Summary

- accept the stable `deepseek-flash` model name across the DeepSeek provider catalog, adapter, direct runtime client, and model listing while preserving existing v4 aliases
- reject inactive database models before runtime configuration loading and access resolution
- prevent inactive owner/shared selections and persisted task model references from bypassing active-model fallback
- filter inactive shared defaults while preserving configured-default and environment/BYO fallback behavior

## Validation

- 111 targeted tests passed across DeepSeek provider/runtime and task model resolution suites
- Ruff formatting and lint checks passed for all changed files
- `py_compile` passed for changed production modules
- mutation checks confirmed failures when removing `deepseek-flash` support, explicit task active gating, persisted-task active gating, or the runtime resolver guard

## Scope

- no database migration
- no catalog/pricing changes outside XAgent runtime support
- no user data deletion
