### PR TITLE
fix: clean up completed background task owners

### DIFF
--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -4408,6 +4408,13 @@ class BackgroundTaskManager:
             task.cancel()
             raise RuntimeError("Background task manager is shutting down")
         self.running_tasks[task_id] = task
+        # Execution may run in a lease-guard child task, whose finally block
+        # cannot remove this still-running outer owner. Release the registration
+        # when its actual owner finishes, including failure or early cancellation.
+        # Fence by identity so an old completion cannot remove a newer run.
+        task.add_done_callback(
+            lambda finished: self.cleanup_task(task_id, expected_task=finished)
+        )
         logger.info(f"Registered background task for task {task_id}")
 
     def resume_admission_state(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -4514,6 +4514,12 @@ class BackgroundTaskManager:
         self._resume_owner_started_at.setdefault(task_id, time.monotonic())
         self.resume_tasks[task_id] = task
         self._resume_run_ids[task_id] = run_id
+        # Cancellation before the coroutine starts skips its finally block.
+        # Use the same owner fence as execution completion, including after
+        # this coordinator has been promoted into running_tasks.
+        task.add_done_callback(
+            lambda finished: self.cleanup_task(task_id, expected_task=finished)
+        )
         logger.info("Registered resume coordinator for task %s", task_id)
 
     def release_resume_reservation(self, task_id: int) -> None:

--- a/tests/web/api/test_websocket_turn_routing.py
+++ b/tests/web/api/test_websocket_turn_routing.py
@@ -64,6 +64,8 @@ def test_pause_accepted_marker_can_be_cleared() -> None:
 async def test_resume_coordinator_does_not_replace_task_that_it_waits_for() -> None:
     manager = BackgroundTaskManager()
     allow_original_to_check = asyncio.Event()
+    promoted = asyncio.Event()
+    allow_resume_to_finish = asyncio.Event()
 
     async def original_runner() -> None:
         await allow_original_to_check.wait()
@@ -78,6 +80,8 @@ async def test_resume_coordinator_does_not_replace_task_that_it_waits_for() -> N
         current = asyncio.current_task()
         assert current is not None
         manager.promote_resume_task(7, current)
+        promoted.set()
+        await allow_resume_to_finish.wait()
 
     resume = asyncio.create_task(resume_runner())
     manager.register_reserved_resume(7, resume, run_id=None)
@@ -88,9 +92,22 @@ async def test_resume_coordinator_does_not_replace_task_that_it_waits_for() -> N
     assert manager.resume_tasks[7] is resume
     assert not manager.reserve_resume(7)
 
-    allow_original_to_check.set()
-    await asyncio.wait_for(asyncio.gather(original, resume), timeout=1)
-    assert manager.running_tasks[7] is resume
+    try:
+        allow_original_to_check.set()
+        await asyncio.wait_for(promoted.wait(), timeout=1)
+        # Check ownership while the promoted coordinator is still running;
+        # completed owners are intentionally removed by their done callback.
+        assert original.done()
+        assert not resume.done()
+        assert manager.running_tasks[7] is resume
+        assert manager.resume_tasks[7] is resume
+    finally:
+        allow_original_to_check.set()
+        allow_resume_to_finish.set()
+        await asyncio.wait_for(asyncio.gather(original, resume), timeout=1)
+
+    assert 7 not in manager.running_tasks
+    assert 7 not in manager.resume_tasks
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -1064,7 +1064,13 @@ async def test_recovery_dispatches_committed_message_across_run_rotation(
     runtime_manager = MagicMock(
         get_agent_for_task=AsyncMock(return_value=runtime_agent)
     )
-    resume = AsyncMock()
+    allow_resume_to_finish = asyncio.Event()
+
+    async def hold_resume(*args, **kwargs) -> None:
+        await allow_resume_to_finish.wait()
+
+    resume = AsyncMock(side_effect=hold_resume)
+    resume_task = None
 
     with (
         patch(
@@ -1073,19 +1079,25 @@ async def test_recovery_dispatches_committed_message_across_run_rotation(
         ),
         patch.object(websocket_api, "execute_resume_background", new=resume),
     ):
-        assert await dispatch_one_task_command(
-            execute_durable_task_command,
-            command_db_id=enqueued.command_id,
-        )
-        resume_task = websocket_api.background_task_manager.resume_tasks.get(
-            int(task.id)
-        )
-        assert resume_task is not None
-        await resume_task
-        websocket_api.background_task_manager.cleanup_task(
-            int(task.id),
-            expected_task=resume_task,
-        )
+        try:
+            assert await dispatch_one_task_command(
+                execute_durable_task_command,
+                command_db_id=enqueued.command_id,
+            )
+            # A completed mock can already have been unregistered by the time
+            # command dispatch returns. Hold execution to inspect live ownership.
+            resume_task = websocket_api.background_task_manager.resume_tasks.get(
+                int(task.id)
+            )
+            assert resume_task is not None
+            assert not resume_task.done()
+        finally:
+            allow_resume_to_finish.set()
+            if resume_task is not None:
+                await asyncio.wait_for(resume_task, timeout=1)
+
+    assert int(task.id) not in websocket_api.background_task_manager.resume_tasks
+    assert int(task.id) not in websocket_api.background_task_manager.running_tasks
 
     db_session.expire_all()
     messages = (

--- a/tests/web/test_background_task_registration.py
+++ b/tests/web/test_background_task_registration.py
@@ -56,18 +56,23 @@ async def test_old_completion_does_not_remove_replacement():
     replacement = asyncio.create_task(asyncio.Event().wait())
     manager.register_task(42, old)
     manager.register_task(42, replacement)
-    manager.resume_tasks[42] = replacement
+    assert manager.reserve_resume(42)
+    manager.register_reserved_resume(42, replacement, run_id="replacement-run")
     try:
         await old
         await asyncio.sleep(0)
         assert manager.running_tasks[42] is replacement
         assert manager.resume_tasks[42] is replacement
+        assert manager._resume_run_ids[42] == "replacement-run"
+        assert 42 in manager._resume_owner_started_at
     finally:
         replacement.cancel()
         await asyncio.gather(replacement, return_exceptions=True)
         await asyncio.sleep(0)
     assert manager.running_tasks == {}
     assert manager.resume_tasks == {}
+    assert manager._resume_run_ids == {}
+    assert manager._resume_owner_started_at == {}
 
 
 @pytest.mark.asyncio
@@ -79,3 +84,87 @@ async def test_cancellation_before_owner_starts_removes_registration():
     await asyncio.gather(task, return_exceptions=True)
     await asyncio.sleep(0)
     assert manager.running_tasks == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("promote", [False, True])
+async def test_resume_cancelled_before_start_cleans_all_registrations(promote):
+    manager = BackgroundTaskManager()
+    entered = []
+
+    async def resume():
+        entered.append(True)
+        await asyncio.Event().wait()
+
+    assert manager.reserve_resume(42)
+    task = asyncio.create_task(resume())
+    manager.register_reserved_resume(42, task, run_id="run-a")
+    if promote:
+        manager.promote_resume_task(42, task)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)
+    assert not entered
+    assert manager.running_tasks == {}
+    assert manager.resume_tasks == {}
+    assert manager._resume_run_ids == {}
+    assert manager._resume_owner_started_at == {}
+    assert manager._resume_reservations == set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail", [False, True])
+async def test_resume_completion_cleans_metadata(fail):
+    manager = BackgroundTaskManager()
+
+    async def resume():
+        await asyncio.sleep(0)
+        if fail:
+            raise ValueError("resume failed")
+
+    assert manager.reserve_resume(42)
+    task = asyncio.create_task(resume())
+    manager.register_reserved_resume(42, task, run_id="run-a")
+    result = (await asyncio.gather(task, return_exceptions=True))[0]
+    await asyncio.sleep(0)
+    assert isinstance(result, ValueError) if fail else result is None
+    assert manager.resume_tasks == {}
+    assert manager._resume_run_ids == {}
+    assert manager._resume_owner_started_at == {}
+
+
+@pytest.mark.asyncio
+async def test_delayed_shutdown_callbacks_cannot_remove_new_lifespan_owner(monkeypatch):
+    manager = BackgroundTaskManager()
+    deferred = []
+    cleanup = manager.cleanup_task
+
+    def defer_cleanup(task_id, *, expected_task=None):
+        deferred.append((task_id, expected_task, manager._shutting_down))
+
+    monkeypatch.setattr(manager, "cleanup_task", defer_cleanup)
+    old = asyncio.create_task(asyncio.Event().wait())
+    manager.register_task(42, old)
+    assert manager.reserve_resume(42)
+    manager.register_reserved_resume(42, old, run_id="old-run")
+    await manager.shutdown()
+    assert len(deferred) == 2
+    assert all(during_shutdown for _, _, during_shutdown in deferred)
+    manager.start_accepting()
+    monkeypatch.setattr(manager, "cleanup_task", cleanup)
+    replacement = asyncio.create_task(asyncio.Event().wait())
+    manager.register_task(42, replacement)
+    assert manager.reserve_resume(42)
+    manager.register_reserved_resume(42, replacement, run_id="new-run")
+    try:
+        # Replay both actual completion callbacks after admission has reopened.
+        for task_id, expected_task, _ in deferred:
+            cleanup(task_id, expected_task=expected_task)
+        assert manager.running_tasks[42] is replacement
+        assert manager.resume_tasks[42] is replacement
+        assert manager._resume_run_ids[42] == "new-run"
+        assert 42 in manager._resume_owner_started_at
+    finally:
+        await manager.shutdown()
+    assert manager.running_tasks == {}
+    assert manager.resume_tasks == {}

--- a/tests/web/test_background_task_registration.py
+++ b/tests/web/test_background_task_registration.py
@@ -1,0 +1,81 @@
+import asyncio
+
+import pytest
+
+from xagent.web.api.websocket import BackgroundTaskManager
+from xagent.web.services.task_lease_service import run_while_task_lease_owned
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["success", "failure", "cancel"])
+async def test_registered_owner_is_removed_after_lease_child_finishes(outcome):
+    manager = BackgroundTaskManager()
+    started = asyncio.Event()
+    child_cleanup_kept_owner = []
+
+    async def operation():
+        started.set()
+        try:
+            if outcome == "failure":
+                raise ValueError("execution failed")
+            if outcome == "cancel":
+                await asyncio.Event().wait()
+        finally:
+            manager.cleanup_task(42)
+            child_cleanup_kept_owner.append(42 in manager.running_tasks)
+
+    async def owner():
+        heartbeat = asyncio.create_task(asyncio.Event().wait())
+        try:
+            await run_while_task_lease_owned(operation(), heartbeat)
+        finally:
+            heartbeat.cancel()
+            await asyncio.gather(heartbeat, return_exceptions=True)
+
+    task = asyncio.create_task(owner())
+    manager.register_task(42, task)
+    await started.wait()
+    if outcome == "cancel":
+        task.cancel()
+    result = (await asyncio.gather(task, return_exceptions=True))[0]
+    await asyncio.sleep(0)
+    assert child_cleanup_kept_owner == [True]
+    assert manager.running_tasks == {}
+    if outcome == "failure":
+        assert isinstance(result, ValueError)
+    elif outcome == "cancel":
+        assert isinstance(result, asyncio.CancelledError)
+    else:
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_old_completion_does_not_remove_replacement():
+    manager = BackgroundTaskManager()
+    old = asyncio.create_task(asyncio.sleep(0))
+    replacement = asyncio.create_task(asyncio.Event().wait())
+    manager.register_task(42, old)
+    manager.register_task(42, replacement)
+    manager.resume_tasks[42] = replacement
+    try:
+        await old
+        await asyncio.sleep(0)
+        assert manager.running_tasks[42] is replacement
+        assert manager.resume_tasks[42] is replacement
+    finally:
+        replacement.cancel()
+        await asyncio.gather(replacement, return_exceptions=True)
+        await asyncio.sleep(0)
+    assert manager.running_tasks == {}
+    assert manager.resume_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_cancellation_before_owner_starts_removes_registration():
+    manager = BackgroundTaskManager()
+    task = asyncio.create_task(asyncio.Event().wait())
+    manager.register_task(42, task)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)
+    assert manager.running_tasks == {}


### PR DESCRIPTION
## Problem
The background manager registers the outer orchestrator task, while execution and its finally cleanup run inside the child task created by run_while_task_lease_owned. Identity-aware cleanup correctly refuses to remove the still-running outer owner. However, no later cleanup runs when that owner finishes, leaving completed task objects in running_tasks and inflating the runtime gauge.

## Fix
Attach an identity-fenced completion callback to the registered owner. It cleans up successful, failed and cancelled owners without deleting a newer registration under the same task ID. Existing shutdown ownership remains unchanged.

## Validation
- 54 focused regression/lifecycle/contention tests passed against the current main base.
- All applicable pre-commit checks passed.
- Real local PostgreSQL/DeepSeek validation of this patch: 4 submitted tasks completed and the running-task gauge returned to zero; one additional scheduled request was shed by the concurrency cap.

This PR contains only the cleanup fix and regression tests. It excludes the baseline runner and local DeepSeek adapter changes.