### PR TITLE
enh: reduce trace dispatch logging overhead

### DIFF
--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -1163,34 +1163,32 @@ class ConsoleTraceHandler(BaseTraceHandler):
     persistence handlers keep the untrimmed payload.
     """
 
-    async def _handle_task_event(self, event: TraceEvent) -> None:
-        """Handle task-level events."""
+    async def handle_event(self, event: TraceEvent) -> None:
+        """Skip console dispatch and payload rendering when INFO is disabled."""
         if not logger.isEnabledFor(logging.INFO):
             return
+        await super().handle_event(event)
+
+    async def _handle_task_event(self, event: TraceEvent) -> None:
+        """Handle task-level events."""
         logger.info(
             f"[TASK] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Task {event.task_id} - {_render_event_data_for_log(event.data)}"
         )
 
     async def _handle_step_event(self, event: TraceEvent) -> None:
         """Handle step-level events."""
-        if not logger.isEnabledFor(logging.INFO):
-            return
         logger.info(
             f"[STEP] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Step {event.step_id} - {_render_event_data_for_log(event.data)}"
         )
 
     async def _handle_action_event(self, event: TraceEvent) -> None:
         """Handle action-level events."""
-        if not logger.isEnabledFor(logging.INFO):
-            return
         logger.info(
             f"[ACTION] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Step {event.step_id} - {_render_event_data_for_log(event.data)}"
         )
 
     async def _handle_system_event(self, event: TraceEvent) -> None:
         """Handle system-level events."""
-        if not logger.isEnabledFor(logging.INFO):
-            return
         logger.info(
             f"[SYSTEM] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - {_render_event_data_for_log(event.data)}"
         )

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -1165,24 +1165,32 @@ class ConsoleTraceHandler(BaseTraceHandler):
 
     async def _handle_task_event(self, event: TraceEvent) -> None:
         """Handle task-level events."""
+        if not logger.isEnabledFor(logging.INFO):
+            return
         logger.info(
             f"[TASK] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Task {event.task_id} - {_render_event_data_for_log(event.data)}"
         )
 
     async def _handle_step_event(self, event: TraceEvent) -> None:
         """Handle step-level events."""
+        if not logger.isEnabledFor(logging.INFO):
+            return
         logger.info(
             f"[STEP] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Step {event.step_id} - {_render_event_data_for_log(event.data)}"
         )
 
     async def _handle_action_event(self, event: TraceEvent) -> None:
         """Handle action-level events."""
+        if not logger.isEnabledFor(logging.INFO):
+            return
         logger.info(
             f"[ACTION] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Step {event.step_id} - {_render_event_data_for_log(event.data)}"
         )
 
     async def _handle_system_event(self, event: TraceEvent) -> None:
         """Handle system-level events."""
+        if not logger.isEnabledFor(logging.INFO):
+            return
         logger.info(
             f"[SYSTEM] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - {_render_event_data_for_log(event.data)}"
         )
@@ -1260,9 +1268,16 @@ class Tracer:
             "xagent.trace.events",
             attributes={"event.type": event_type.value},
         )
-        logger.info(
-            f"trace_event called: {event_type.value} for task {task_id}, step {step_id} with data keys: {list(data.keys()) if data else []}"
-        )
+        # Dispatch diagnostics are verbose on the event-loop hot path. Keep
+        # them opt-in; durable events and ConsoleTraceHandler are independent.
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "trace_event called: %s for task %s, step %s with data keys: %s",
+                event_type.value,
+                task_id,
+                step_id,
+                list(data.keys()) if data else [],
+            )
 
         event = TraceEvent(
             event_type=event_type,
@@ -1274,8 +1289,8 @@ class Tracer:
         )
 
         # Notify all handlers
-        logger.info(
-            f"Notifying {len(self.handlers)} handlers for event {event_type.value}"
+        logger.debug(
+            "Notifying %s handlers for event %s", len(self.handlers), event_type.value
         )
         handler_errors: List[Exception] = []
         # Snapshot: a handler removed mid-dispatch must not shift its
@@ -1284,13 +1299,13 @@ class Tracer:
             for i, handler in enumerate(list(self.handlers)):
                 handler_name = type(handler).__name__
                 try:
-                    logger.info(f"Calling handler {i}: {handler_name}")
+                    logger.debug("Calling handler %s: %s", i, handler_name)
                     with observe_duration(
                         "xagent.trace.handler.duration",
                         attributes={"handler": handler_name},
                     ):
                         await handler.handle_event(event)
-                    logger.info(f"Handler {i} completed successfully")
+                    logger.debug("Handler %s completed successfully", i)
                 except Exception as e:
                     increment_counter(
                         "xagent.trace.handler.errors",
@@ -1314,8 +1329,8 @@ class Tracer:
                     "No trace handlers are configured for required trace persistence."
                 )
 
-        logger.info(
-            f"trace_event completed for {event_type.value}, event_id: {event.id}"
+        logger.debug(
+            "trace_event completed for %s, event_id: %s", event_type.value, event.id
         )
         return event.id
 

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -1351,10 +1351,8 @@ async def test_console_cap_does_not_shrink_the_persisted_payload(
     assert persistence_handler.received[0] is original_payload
     assert persistence_handler.received[0] == expected_content
 
-    # Console side: the log line is still capped. ``Tracer.trace_event``
-    # itself logs several diagnostic lines through the same module logger
-    # (dispatch bookkeeping), so filter down to the one line
-    # ``ConsoleTraceHandler._handle_system_event`` actually renders.
+    # Dispatch bookkeeping is DEBUG-only; INFO keeps the console event.
+    assert len(caplog.records) == 1
     console_records = [
         r for r in caplog.records if r.getMessage().startswith("[SYSTEM]")
     ]
@@ -1409,3 +1407,49 @@ async def test_console_handler_caps_every_scope(
     message_bytes = len(message.encode("utf-8"))
     assert message_bytes <= 50_000 + 200, f"log line not bounded: {message_bytes}"
     assert "[truncated" in message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", ["TASK", "STEP", "ACTION", "SYSTEM"])
+async def test_console_handler_skips_disabled_payload_rendering(
+    scope: str, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+    from unittest.mock import Mock
+
+    from xagent.core.agent import trace
+
+    renderer = Mock(side_effect=AssertionError("disabled log rendered payload"))
+    monkeypatch.setattr(trace, "_render_event_data_for_log", renderer)
+    event = trace.TraceEvent(
+        trace.TraceEventType(
+            getattr(trace.TraceScope, scope),
+            trace.TraceAction.INFO,
+            trace.TraceCategory.GENERAL,
+        ),
+        data={"snapshot": "must remain untouched"},
+        task_id="task",
+        step_id="step",
+    )
+    with caplog.at_level(logging.WARNING, logger=trace.__name__):
+        await trace.ConsoleTraceHandler().handle_event(event)
+    renderer.assert_not_called()
+    assert not caplog.records
+
+
+@pytest.mark.asyncio
+async def test_dispatch_diagnostics_available_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+
+    from xagent.core.agent.trace import SYSTEM_INFO, ConsoleTraceHandler, Tracer
+
+    tracer = Tracer()
+    tracer.add_handler(ConsoleTraceHandler())
+    with caplog.at_level(logging.DEBUG, logger="xagent.core.agent.trace"):
+        await tracer.trace_event(SYSTEM_INFO, data={"key": "value"})
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("with data keys: ['key']" in message for message in messages)
+    assert "Calling handler 0: ConsoleTraceHandler" in messages
+    assert "Handler 0 completed successfully" in messages

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -1351,8 +1351,7 @@ async def test_console_cap_does_not_shrink_the_persisted_payload(
     assert persistence_handler.received[0] is original_payload
     assert persistence_handler.received[0] == expected_content
 
-    # Dispatch bookkeeping is DEBUG-only; INFO keeps the console event.
-    assert len(caplog.records) == 1
+    # The console payload is bounded independently of persistence.
     console_records = [
         r for r in caplog.records if r.getMessage().startswith("[SYSTEM]")
     ]
@@ -1438,18 +1437,26 @@ async def test_console_handler_skips_disabled_payload_rendering(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_diagnostics_available_at_debug(
+@pytest.mark.parametrize("level", ["INFO", "DEBUG"])
+async def test_dispatch_diagnostics_are_debug_only(
+    level: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     import logging
 
-    from xagent.core.agent.trace import SYSTEM_INFO, ConsoleTraceHandler, Tracer
+    from xagent.core.agent import trace
 
-    tracer = Tracer()
-    tracer.add_handler(ConsoleTraceHandler())
-    with caplog.at_level(logging.DEBUG, logger="xagent.core.agent.trace"):
-        await tracer.trace_event(SYSTEM_INFO, data={"key": "value"})
+    tracer = trace.Tracer()
+    # A silent handler isolates dispatch bookkeeping from console event logs.
+    tracer.add_handler(trace.BaseTraceHandler())
+    with caplog.at_level(getattr(logging, level), logger=trace.__name__):
+        await tracer.trace_event(trace.SYSTEM_INFO, data={"key": "value"})
+    if level == "INFO":
+        assert not caplog.records
+        return
+    assert caplog.records
+    assert all(record.levelno == logging.DEBUG for record in caplog.records)
     messages = [record.getMessage() for record in caplog.records]
     assert any("with data keys: ['key']" in message for message in messages)
-    assert "Calling handler 0: ConsoleTraceHandler" in messages
+    assert "Calling handler 0: BaseTraceHandler" in messages
     assert "Handler 0 completed successfully" in messages


### PR DESCRIPTION
## Summary

- Move per-event/per-handler trace dispatch bookkeeping from INFO to DEBUG, with lazy formatting and guarded payload-key collection.
- Skip console payload rendering when INFO is disabled across all four event scopes; retain INFO console events when enabled.
- Leave event delivery, persistence/checkpoint payloads, error handling, and OpenTelemetry metrics unchanged.

## Validation

- 90 focused tests passed on this PR branch: `PYTHONPATH=src python -m pytest tests/core/agent/pattern/test_llm_trace_audit.py tests/core/agent/test_checkpoint.py tests/web/test_tracing_factory.py -q --disable-warnings`.
- Ruff lint/format and `git diff --check` passed.
- Local real-service A/B testing with PostgreSQL, the same DeepSeek model/payload, INFO logging, and actual peak concurrency 50 (profilers disabled):

| Metric | Before | After | After repeat |
| --- | ---: | ---: | ---: |
| Login p95 | 953 ms | 523 ms | 716 ms |
| Health p95 | 430 ms | 77 ms | 201 ms |
| Median task duration | 35.4 s | 30.7 s | 31.9 s |

Each measured run completed 50 tasks, with exactly 10 successful tool calls and the expected final answer per task. Each run retained 400 checkpoint snapshot events. Running-task and WebSocket gauges returned to zero.

These are directional results from a local development checkout containing unrelated existing adapter/runtime changes held constant across A/B, not benchmarks of the rebased PR head. A preliminary run overlapping unit tests was excluded. Real-provider variation remains; the repeat still had a 1.19 s maximum login latency, so this does not resolve all high-concurrency tail latency.
