### PR TITLE
feat(mcp): enforce actor-scoped stdio execution (toby)

### DIFF
--- a/example.env
+++ b/example.env
@@ -446,6 +446,8 @@ XAGENT_PASSWORD_MIN_LENGTH="6"
 # to target localhost, private, link-local, reserved, multicast, or unspecified
 # addresses for local authorization-server testing.
 # XAGENT_MCP_OAUTH_ALLOW_PRIVATE_HOSTS="false"
+# Trusted Toby actor-scoped stdio execution. Keep disabled until rollout.
+# XAGENT_TOBY_PERSONAL_STDIO_ENABLED="false"
 # Optional explicit trusted proxy for outbound MCP OAuth discovery/token calls.
 # System HTTP_PROXY/HTTPS_PROXY environment variables are intentionally ignored.
 # XAGENT_MCP_OAUTH_PROXY_URL="http://proxy.example.com:8080"

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -223,6 +223,7 @@ OPENROUTER_OFFICIAL_PROVIDERS_ONLY = "XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY"
 XROUTER_EXCLUDED_MODELS = "XAGENT_XROUTER_EXCLUDED_MODELS"
 MCP_OAUTH_ALLOW_PRIVATE_HOSTS = "XAGENT_MCP_OAUTH_ALLOW_PRIVATE_HOSTS"
 MCP_OAUTH_PROXY_URL = "XAGENT_MCP_OAUTH_PROXY_URL"
+TOBY_PERSONAL_STDIO_ENABLED = "XAGENT_TOBY_PERSONAL_STDIO_ENABLED"
 TRUSTED_EGRESS_PROXY = "XAGENT_TRUSTED_EGRESS_PROXY"
 
 TOOL_MAX_OUTPUT_LENGTH = "XAGENT_TOOL_MAX_OUTPUT_LENGTH"
@@ -688,6 +689,12 @@ def get_mcp_oauth_allow_private_hosts() -> bool:
     servers. Production deployments should leave it disabled.
     """
     return _get_bool_env(MCP_OAUTH_ALLOW_PRIVATE_HOSTS, False)
+
+
+def get_toby_personal_stdio_enabled() -> bool:
+    """Return whether trusted Toby actor executions may use personal stdio."""
+
+    return _get_bool_env(TOBY_PERSONAL_STDIO_ENABLED, False)
 
 
 def get_trusted_egress_proxy_enabled() -> bool:

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -15,6 +15,11 @@ from typing import Any, Dict, List, Optional, TypeVar
 
 from ..... import config as _root_config
 
+ACTOR_STDIO_SESSION_RUNTIME_UNAVAILABLE_REASON = (
+    "actor_stdio_session_runtime_unavailable"
+)
+ACTOR_STDIO_SHADOWED_REASON = "actor_stdio_shadowed_by_visible_connection"
+
 
 class MCPFailurePolicy(str, Enum):
     """Caller-owned behavior when a selected MCP server is unavailable."""
@@ -264,6 +269,16 @@ class BaseToolConfig(ABC):
     async def get_mcp_server_configs(self) -> List[Dict[str, Any]]:
         """Get MCP server configurations."""
         pass
+
+    def get_actor_mcp_stdio_session_identities(self) -> Dict[str, Any]:
+        """Return host-only session identities keyed by exact MCP server name."""
+
+        return {}
+
+    def get_actor_mcp_stdio_session_consumer(self) -> Any:
+        """Return the optional host-side execution-scoped stdio consumer."""
+
+        return None
 
     def get_mcp_failure_policy(self) -> MCPFailurePolicy:
         """Return the MCP setup failure policy for this execution."""

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -1118,6 +1118,7 @@ class ToolFactory:
                             "runtime_input_schema",
                             "connector_runtime",
                             "allow_delegated_authorization",
+                            "actor_stdio_session_identity",
                         ):
                             if runtime_key in config:
                                 connection_config[runtime_key] = config[runtime_key]

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -25,6 +25,7 @@ from .....core.workspace import TaskWorkspace
 from ...core.knowledge_base_scope import KnowledgeBaseScopeError
 from .base import BINDING_AUTHORIZED_CATEGORIES, AbstractBaseTool, Tool
 from .config import (
+    ACTOR_STDIO_SESSION_RUNTIME_UNAVAILABLE_REASON,
     BaseToolConfig,
     MCPFailurePolicy,
     MCPUnavailableSummary,
@@ -39,7 +40,13 @@ from .selection_spec import ToolSelectionSpec
 
 if TYPE_CHECKING:
     from .....sandbox.base import Sandbox
+    from .....web.services.actor_mcp_runtime import ActorMCPStdioSessionIdentity
     from .mcp_adapter import MCPServerLoadFailure
+
+    ActorMCPStdioSessionConsumer = Callable[
+        ...,
+        Any,
+    ]
 
 logger = logging.getLogger(__name__)
 
@@ -1032,8 +1039,10 @@ class ToolFactory:
     async def _create_mcp_tools_from_configs(
         mcp_configs: list[dict[str, Any]],
         sandbox: Optional["Sandbox"] = None,
+        actor_stdio_session_identities: "Mapping[str, ActorMCPStdioSessionIdentity] | None" = None,
+        actor_stdio_session_consumer: "ActorMCPStdioSessionConsumer | None" = None,
     ) -> list[Tool]:
-        """Create MCP tools from configurations."""
+        """Create MCP tools while keeping actor session identity host-only."""
         try:
             from .mcp_adapter import load_mcp_tools_as_agent_tools
 
@@ -1067,6 +1076,8 @@ class ToolFactory:
             if normal_configs:
                 connections: dict[str, Any] = {}
                 configs_by_name: dict[str, dict[str, Any]] = {}
+                session_requests: list[tuple[str, dict[str, Any], Any]] = []
+                session_identities = actor_stdio_session_identities or {}
                 try:
                     # Convert configs to connection format
                     for config in normal_configs:
@@ -1118,7 +1129,6 @@ class ToolFactory:
                             "runtime_input_schema",
                             "connector_runtime",
                             "allow_delegated_authorization",
-                            "actor_stdio_session_identity",
                         ):
                             if runtime_key in config:
                                 connection_config[runtime_key] = config[runtime_key]
@@ -1144,8 +1154,55 @@ class ToolFactory:
                                     "args"
                                 ].split()
 
-                        connections[server_name] = connection_config
                         configs_by_name[server_name] = config
+                        session_identity = session_identities.get(server_name)
+                        if session_identity is not None:
+                            if actor_stdio_session_consumer is None:
+                                unavailable_tools.append(
+                                    ToolFactory._create_unavailable_mcp_tool(
+                                        server_name=server_name,
+                                        server_id=config.get("id"),
+                                        reason=ACTOR_STDIO_SESSION_RUNTIME_UNAVAILABLE_REASON,
+                                        message=(
+                                            "MCP server session runtime is unavailable."
+                                        ),
+                                    )
+                                )
+                                continue
+                            session_requests.append(
+                                (server_name, connection_config, session_identity)
+                            )
+                            continue
+                        connections[server_name] = connection_config
+
+                    for server_name, connection, identity in session_requests:
+                        try:
+                            consumed_tools = await actor_stdio_session_consumer(
+                                server_name=server_name,
+                                connection=connection,
+                                session_identity=identity,
+                                sandbox=sandbox,
+                            )
+                            normal_tools.extend(consumed_tools)
+                        except ConnectorRuntimeError:
+                            raise
+                        except Exception as exc:
+                            logger.warning(
+                                "Actor stdio session consumer failed for server "
+                                "'%s' (%s)",
+                                server_name,
+                                type(exc).__name__,
+                            )
+                            unavailable_tools.append(
+                                ToolFactory._create_unavailable_mcp_tool(
+                                    server_name=server_name,
+                                    server_id=configs_by_name[server_name].get("id"),
+                                    reason=ACTOR_STDIO_SESSION_RUNTIME_UNAVAILABLE_REASON,
+                                    message=(
+                                        "MCP server session runtime is unavailable."
+                                    ),
+                                )
+                            )
 
                     # Load MCP tools
                     if connections:
@@ -1153,7 +1210,7 @@ class ToolFactory:
                             connections,
                             sandbox=sandbox,
                         )  # type: ignore[arg-type]
-                        normal_tools = list(load_result.tools)
+                        normal_tools.extend(load_result.tools)
                         unavailable_tools.extend(
                             ToolFactory._unavailable_mcp_tools_from_load_failures(
                                 load_result.failures,

--- a/src/xagent/core/tools/adapters/vibe/mcp_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_tools.py
@@ -269,9 +269,17 @@ async def create_mcp_tools(config: "BaseToolConfig") -> List[Any]:
     try:
         from .factory import ToolFactory
 
+        identity_getter = getattr(
+            config, "get_actor_mcp_stdio_session_identities", None
+        )
+        session_identities = identity_getter() if callable(identity_getter) else {}
+        consumer_getter = getattr(config, "get_actor_mcp_stdio_session_consumer", None)
+        session_consumer = consumer_getter() if callable(consumer_getter) else None
         tools = await ToolFactory._create_mcp_tools_from_configs(
             mcp_configs,
             sandbox=config.get_sandbox(),
+            actor_stdio_session_identities=session_identities,
+            actor_stdio_session_consumer=session_consumer,
         )
     except ConnectorRuntimeError:
         summary = _build_mcp_load_summary(

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -117,6 +117,7 @@ from ..services.hot_path_cache import (
 from ..services.llm_utils import AutoModelUnavailableError, resolve_llms_from_names
 from ..services.managed_file_ref import ensure_uploaded_file_local_path
 from ..services.mcp_runtime import (
+    MCPActorExecutionIdentity,
     MCPBuiltinOAuthActorPolicy,
     MCPBuiltinOAuthActorPolicyMismatchError,
     MCPBuiltinOAuthActorPolicyRequiredError,
@@ -657,6 +658,7 @@ async def create_default_tools(
     task_runtime_context: TaskRuntimeContext | None = None,
     connector_runtime_turn_id: Optional[str] = None,
     mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+    mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
     force_mcp_tools: bool = False,
     mcp_failure_policy: MCPFailurePolicy = MCPFailurePolicy.BEST_EFFORT,
     mcp_load_summary_tracer: Optional[Any] = None,
@@ -763,6 +765,7 @@ async def create_default_tools(
         voice=voice_from_runtime_user(user),
         connector_runtime_turn_id=connector_runtime_turn_id,
         mcp_runtime_authorization_policy=mcp_runtime_authorization_policy,
+        mcp_actor_execution_identity=mcp_actor_execution_identity,
         mcp_failure_policy=mcp_failure_policy,
         mcp_load_summary_tracer=mcp_load_summary_tracer,
         mcp_load_summary_trace_task_id=mcp_load_summary_trace_task_id,
@@ -2047,6 +2050,7 @@ class AgentServiceManager:
         task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
         connector_runtime_turn_id: Optional[str] = None,
         mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
     ) -> tuple[list[Any], Any]:
         """Build the tool set configured for a web task."""
         if task_setup_snapshot is not None:
@@ -2186,6 +2190,7 @@ class AgentServiceManager:
             else None,
             connector_runtime_turn_id=connector_runtime_turn_id,
             mcp_runtime_authorization_policy=mcp_runtime_authorization_policy,
+            mcp_actor_execution_identity=mcp_actor_execution_identity,
             force_mcp_tools=actor_execution,
             mcp_failure_policy=_mcp_failure_policy_for_task_source(task.source),
             mcp_load_summary_tracer=parent_tracer,
@@ -2207,6 +2212,7 @@ class AgentServiceManager:
         task_owner_user_id: Optional[int] = None,
         connector_runtime_turn_id: Optional[str] = None,
         mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
         task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
         resolved_execution_scope: Union[
             ExecutionScope, None, ExecutionScopeNotProvided
@@ -2225,6 +2231,7 @@ class AgentServiceManager:
                 task_owner_user_id=task_owner_user_id,
                 connector_runtime_turn_id=connector_runtime_turn_id,
                 mcp_runtime_authorization_policy=(mcp_runtime_authorization_policy),
+                mcp_actor_execution_identity=mcp_actor_execution_identity,
                 task_mode=task_mode,
                 resolved_execution_scope=resolved_execution_scope,
             )
@@ -2244,6 +2251,7 @@ class AgentServiceManager:
         task_owner_user_id: Optional[int] = None,
         connector_runtime_turn_id: Optional[str] = None,
         mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
         task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
         resolved_execution_scope: Union[
             ExecutionScope, None, ExecutionScopeNotProvided
@@ -2627,11 +2635,17 @@ class AgentServiceManager:
                                 mcp_runtime_authorization_policy=(
                                     mcp_runtime_authorization_policy
                                 ),
+                                mcp_actor_execution_identity=(
+                                    mcp_actor_execution_identity
+                                ),
                             )
                             self._agent_owner_ids[task_id] = runtime_user_id
                             self._agent_scope_fingerprints[task_id] = fingerprint
                             self._sync_connector_runtime_turn(
                                 task_id, connector_runtime_turn_id
+                            )
+                            self._sync_mcp_actor_execution_identity(
+                                task_id, mcp_actor_execution_identity
                             )
                             self._sync_execution_scope(task_id, scope)
                             return self._agents[task_id]
@@ -3114,6 +3128,7 @@ class AgentServiceManager:
         self._agent_owner_ids[task_id] = runtime_user_id
         self._agent_scope_fingerprints[task_id] = fingerprint
         self._sync_connector_runtime_turn(task_id, connector_runtime_turn_id)
+        self._sync_mcp_actor_execution_identity(task_id, mcp_actor_execution_identity)
         self._sync_execution_scope(task_id, scope)
         return self._agents[task_id]
 
@@ -3159,6 +3174,24 @@ class AgentServiceManager:
                 task_id,
                 connector_runtime_turn_id,
             )
+
+    def _sync_mcp_actor_execution_identity(
+        self,
+        task_id: int,
+        identity: MCPActorExecutionIdentity | None,
+    ) -> None:
+        agent = self._agents.get(task_id)
+        tool_config = getattr(agent, "tool_config", None) if agent is not None else None
+        if tool_config is None or not hasattr(
+            tool_config, "set_mcp_actor_execution_identity"
+        ):
+            return
+        if tool_config.set_mcp_actor_execution_identity(identity):
+            logger.info(
+                "Refreshing actor MCP tools for task %s execution identity",
+                task_id,
+            )
+            agent.invalidate_tools()
 
     def _sync_execution_scope(
         self, task_id: int, scope: Optional[ExecutionScope]
@@ -3979,6 +4012,7 @@ class AgentServiceManager:
         task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
         connector_runtime_turn_id: Optional[str] = None,
         mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
     ) -> None:
         """Reconstruct from the detached task-runtime snapshot.
 
@@ -4047,6 +4081,7 @@ class AgentServiceManager:
                 task_setup_snapshot=snapshot,
                 connector_runtime_turn_id=connector_runtime_turn_id,
                 mcp_runtime_authorization_policy=(mcp_runtime_authorization_policy),
+                mcp_actor_execution_identity=mcp_actor_execution_identity,
             )
 
             from .agents import (

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -705,6 +705,9 @@ async def create_default_tools(
 
     # Create a WebToolConfig to properly initialize tools
     from ..tools.config import WebToolConfig
+    from ..services.actor_mcp_runtime import (
+        production_actor_mcp_stdio_connection_adapter,
+    )
     from .agents import voice_from_runtime_user
 
     db_factory = None
@@ -765,6 +768,11 @@ async def create_default_tools(
         voice=voice_from_runtime_user(user),
         connector_runtime_turn_id=connector_runtime_turn_id,
         mcp_runtime_authorization_policy=mcp_runtime_authorization_policy,
+        mcp_actor_stdio_connection_adapter=(
+            production_actor_mcp_stdio_connection_adapter()
+            if mcp_runtime_authorization_policy is not None
+            else None
+        ),
         mcp_actor_execution_identity=mcp_actor_execution_identity,
         mcp_failure_policy=mcp_failure_policy,
         mcp_load_summary_tracer=mcp_load_summary_tracer,

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -704,10 +704,10 @@ async def create_default_tools(
         raise ValueError("Task ID is required for tool creation")
 
     # Create a WebToolConfig to properly initialize tools
-    from ..tools.config import WebToolConfig
     from ..services.actor_mcp_runtime import (
         production_actor_mcp_stdio_connection_adapter,
     )
+    from ..tools.config import WebToolConfig
     from .agents import voice_from_runtime_user
 
     db_factory = None
@@ -2977,6 +2977,7 @@ class AgentServiceManager:
                     else None,
                     connector_runtime_turn_id=connector_runtime_turn_id,
                     mcp_runtime_authorization_policy=(mcp_runtime_authorization_policy),
+                    mcp_actor_execution_identity=mcp_actor_execution_identity,
                     force_mcp_tools=actor_marked,
                     mcp_failure_policy=_mcp_failure_policy_for_task_source(
                         task.source if task is not None else None
@@ -3189,7 +3190,9 @@ class AgentServiceManager:
         identity: MCPActorExecutionIdentity | None,
     ) -> None:
         agent = self._agents.get(task_id)
-        tool_config = getattr(agent, "tool_config", None) if agent is not None else None
+        if agent is None:
+            return
+        tool_config = getattr(agent, "tool_config", None)
         if tool_config is None or not hasattr(
             tool_config, "set_mcp_actor_execution_identity"
         ):

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -41,6 +41,7 @@ from ..auth_dependencies import get_current_user, is_admin_user
 from ..mcp_apps import (
     get_all_mcp_apps,
     get_app_for_mcp_server,
+    normalize_catalog_key,
     restrict_to_app_scoped_oauth_grant,
 )
 from ..models.custom_api import CustomApi, UserCustomApi
@@ -2156,17 +2157,10 @@ def _enrich_oauth_server_info(
     return app_id, provider, connected_account
 
 
-def _normalize_app_key(value: object) -> Optional[str]:
-    if value is None:
-        return None
-    normalized = "-".join(str(value).strip().lower().split())
-    return normalized or None
-
-
 def _app_lookup_keys(*values: object) -> list[str]:
     keys = []
     for value in values:
-        key = _normalize_app_key(value)
+        key = normalize_catalog_key(value)
         if key and key not in keys:
             keys.append(key)
     return keys
@@ -2212,7 +2206,7 @@ def _server_catalog_keys(server: MCPServer) -> list[str]:
     — a key this misses is a #1346 duplicate, while a key it over-matches only
     moves a legacy row to the Remote tab, still editable via /api/mcp/servers.
     """
-    if _normalize_app_key(server.transport) != "oauth":
+    if normalize_catalog_key(server.transport) != "oauth":
         return _app_lookup_keys(server.name)
     return _app_lookup_keys(server.name, *_oauth_server_lookup_keys(server))
 
@@ -2224,7 +2218,7 @@ def _is_reserved_catalog_name(db: Session, name: object) -> bool:
     by normalized id/name, so a squatter would shadow the official shared row (or
     at least DoS legitimate connects). Enforced on both create and rename.
     """
-    key = _normalize_app_key(name)
+    key = normalize_catalog_key(name)
     if not key:
         return False
     return any(key in _catalog_app_keys(app) for app in get_all_mcp_apps(db))
@@ -2259,14 +2253,14 @@ def _is_oauth_server_for_app(server: MCPServer, app: dict) -> bool:
     if server.transport != "oauth":
         return False
 
-    app_id = _normalize_app_key(app.get("id"))
-    provider = _normalize_app_key(app.get("provider"))
-    server_name = _normalize_app_key(server.name)
+    app_id = normalize_catalog_key(app.get("id"))
+    provider = normalize_catalog_key(app.get("provider"))
+    server_name = normalize_catalog_key(server.name)
 
     auth = getattr(server, "auth", None)
     if isinstance(auth, dict):
-        auth_app_id = _normalize_app_key(auth.get("app_id"))
-        auth_provider = _normalize_app_key(auth.get("provider"))
+        auth_app_id = normalize_catalog_key(auth.get("app_id"))
+        auth_provider = normalize_catalog_key(auth.get("provider"))
 
         if auth_app_id and auth_app_id != app_id:
             return False
@@ -2307,7 +2301,7 @@ def _connected_oauth_server_for_app(
 def _build_oauth_account_lookup(oauth_accounts: list[object]) -> dict[str, object]:
     lookup: dict[str, object] = {}
     for account in oauth_accounts:
-        key = _normalize_app_key(getattr(account, "provider", None))
+        key = normalize_catalog_key(getattr(account, "provider", None))
         if key and key not in lookup and _oauth_account_can_connect(account):
             lookup[key] = account
     return lookup
@@ -2316,11 +2310,11 @@ def _build_oauth_account_lookup(oauth_accounts: list[object]) -> dict[str, objec
 def _oauth_server_lookup_keys(server: MCPServer) -> list[str]:
     auth = getattr(server, "auth", None)
     if isinstance(auth, dict):
-        auth_app_id = _normalize_app_key(auth.get("app_id"))
+        auth_app_id = normalize_catalog_key(auth.get("app_id"))
         if auth_app_id:
             return [auth_app_id]
 
-        auth_provider = _normalize_app_key(auth.get("provider"))
+        auth_provider = normalize_catalog_key(auth.get("provider"))
         if auth_provider:
             return [auth_provider]
 
@@ -2332,7 +2326,7 @@ def _build_active_oauth_server_lookup(
 ) -> dict[str, list[MCPServer]]:
     lookup: dict[str, list[MCPServer]] = {}
     for server, user_mcp in user_mcps:
-        if not user_mcp.is_active or _normalize_app_key(server.transport) != "oauth":
+        if not user_mcp.is_active or normalize_catalog_key(server.transport) != "oauth":
             continue
         for key in _oauth_server_lookup_keys(server):
             lookup.setdefault(key, []).append(server)
@@ -2359,8 +2353,8 @@ def _build_active_non_oauth_server_lookup(
 ) -> dict[tuple[str, str], MCPServer]:
     lookup: dict[tuple[str, str], MCPServer] = {}
     for server, user_mcp in user_mcps:
-        transport = _normalize_app_key(server.transport)
-        server_name = _normalize_app_key(server.name)
+        transport = normalize_catalog_key(server.transport)
+        server_name = normalize_catalog_key(server.name)
         if (
             not user_mcp.is_active
             or not transport
@@ -2476,7 +2470,7 @@ def _app_user_env_configured(configured_keys: list[str], required: list[str]) ->
 def _connected_non_oauth_server_for_app(
     app: dict, non_oauth_server_lookup: dict[tuple[str, str], MCPServer]
 ) -> Optional[int]:
-    app_transport = _normalize_app_key(app.get("transport"))
+    app_transport = normalize_catalog_key(app.get("transport"))
     if not app_transport or app_transport == "oauth":
         return None
 
@@ -2710,7 +2704,7 @@ def list_mcp_apps(
         for srv in (
             db.query(MCPServer).filter(MCPServer.name.in_(non_oauth_names)).all()
         ):
-            norm = _normalize_app_key(srv.name)
+            norm = normalize_catalog_key(srv.name)
             if norm:
                 server_by_key.setdefault(norm, srv)
     user_mcp_by_server_id = {cast(int, srv.id): um for srv, um in user_mcps}
@@ -4476,7 +4470,7 @@ def _catalog_server_has_platform_key(db: Session, server: MCPServer) -> bool:
         return False
     from ..mcp_apps import get_all_mcp_apps
 
-    key = _normalize_app_key(getattr(server, "name", None))
+    key = normalize_catalog_key(getattr(server, "name", None))
     if not key:
         return False
     for app in get_all_mcp_apps(db):
@@ -4697,10 +4691,10 @@ def _teardown_mcp_app_server_locally(
                     )
                     .all()
                 )
-                normalized_provider = _normalize_app_key(provider)
+                normalized_provider = normalize_catalog_key(provider)
                 sibling_still_connected = any(
                     (sibling_app := get_app_for_mcp_server(db, other_server))
-                    and _normalize_app_key(sibling_app.get("provider"))
+                    and normalize_catalog_key(sibling_app.get("provider"))
                     == normalized_provider
                     for other_server in other_servers
                 )
@@ -5003,10 +4997,10 @@ async def delete_mcp_server(
                         )
                         .all()
                     )
-                    normalized_provider = _normalize_app_key(provider)
+                    normalized_provider = normalize_catalog_key(provider)
                     sibling_still_connected = any(
                         (sibling_app := get_app_for_mcp_server(db, other_server))
-                        and _normalize_app_key(sibling_app.get("provider"))
+                        and normalize_catalog_key(sibling_app.get("provider"))
                         == normalized_provider
                         for other_server in other_servers
                     )

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -169,6 +169,7 @@ from ..services.managed_file_ref import (
     log_durable_storage_fault,
 )
 from ..services.mcp_runtime import (
+    MCPActorExecutionIdentity,
     MCPBuiltinOAuthActorPolicy,
     MCPBuiltinOAuthActorPolicyRequiredError,
 )
@@ -2779,6 +2780,23 @@ async def execute_task_background(
             )
 
         context_dict = context if isinstance(context, dict) else {}
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None
+        if (
+            mcp_runtime_authorization_policy is not None
+            and task_lease is not None
+            and task_lease.task_id == task_id
+        ):
+            try:
+                mcp_actor_execution_identity = MCPActorExecutionIdentity(
+                    task_id=task_id,
+                    run_id=task_lease.run_id,  # type: ignore[arg-type]
+                    turn_id=context_dict.get("turn_id"),  # type: ignore[arg-type]
+                    lease_attempt_id=task_lease.attempt_id,  # type: ignore[arg-type]
+                )
+            except ValueError:
+                # Only execution-scoped actor stdio requires this complete
+                # fence. Per-call stdio and existing OAuth remain available.
+                mcp_actor_execution_identity = None
         logger.info(f"Background task execution started for task {task_id}")
         task_user_id = snapshot.task.user_id
         user = snapshot.runtime_user
@@ -2815,6 +2833,7 @@ async def execute_task_background(
                 if isinstance(context_dict.get("turn_id"), str)
                 else None,
                 mcp_runtime_authorization_policy=(mcp_runtime_authorization_policy),
+                mcp_actor_execution_identity=mcp_actor_execution_identity,
                 resolved_execution_scope=execution_scope,
             )
             if hasattr(agent_service, "set_outbound_message_handler"):

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import os
 from copy import deepcopy
-from typing import Any
+from typing import Any, Literal
 
 import sqlalchemy as sa
 from sqlalchemy.engine import Connection
@@ -1004,6 +1004,10 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "provider_name": None,
             "category": "Productivity",
             "oauth_scopes": None,
+            # Runtime-only metadata. This is intentionally outside
+            # launch_config so enabling execution-scoped session handling does
+            # not create persisted PublicMCPApp execution drift.
+            "stdio_session_scope": "execution",
             # Hidden until the runtime supports execution-scoped (persistent)
             # stdio MCP sessions: today every tool call spawns a fresh
             # chrome-devtools-mcp process (mcp_adapter._execute_mcp_call ->
@@ -1598,6 +1602,17 @@ def get_builtin_execution_fields(app_id: str) -> dict[str, Any] | None:
     return deepcopy(
         {field_name: row[field_name] for field_name in _BUILTIN_EXECUTION_FIELD_NAMES}
     )
+
+
+def get_builtin_stdio_session_scope(
+    app_id: str,
+) -> Literal["per_call", "execution"]:
+    """Return code-owned stdio session scope; ordinary apps are per-call."""
+
+    row = get_builtin_public_mcp_app(app_id)
+    if row is not None and row.get("stdio_session_scope") == "execution":
+        return "execution"
+    return "per_call"
 
 
 def get_builtin_execution_fields_and_optional_scopes(

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -53,7 +53,7 @@ APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT = frozenset({"facebook", "github", "myob"}
 
 
 def _normalize_oauth_grant_key(value: object) -> str | None:
-    """Case/whitespace-insensitive key, matching mcp.py's _normalize_app_key.
+    """Case/whitespace-insensitive key, matching ``normalize_catalog_key``.
 
     Duplicated rather than imported: mcp.py imports this module, so importing
     back would cycle. An admin-created PublicMCPApp.app_id is free-form (see
@@ -260,7 +260,7 @@ class RemoteOAuthDefinitionOwnership(Enum):
     TEAM = "team"
 
 
-def _normalized_catalog_key(value: object) -> str | None:
+def normalize_catalog_key(value: object) -> str | None:
     """Normalize only for collision detection, never for persisted identity."""
     from ..builtin_identity import canonicalize_builtin_identity
 
@@ -296,11 +296,11 @@ def _strict_catalog_app_by_id(
         )
     app = matches[0]
 
-    normalized_id = _normalized_catalog_key(app_id)
+    normalized_id = normalize_catalog_key(app_id)
     collisions = [
         candidate
         for candidate in catalog_apps
-        if _normalized_catalog_key(candidate.app_id) == normalized_id
+        if normalize_catalog_key(candidate.app_id) == normalized_id
     ]
     if len(collisions) != 1:
         raise BuiltinOAuthServerDefinitionError(
@@ -478,7 +478,7 @@ def _builtin_server_candidates(
     app_id = str(app_info["id"])
     app_name = str(app_info["name"])
     normalized_names = {
-        key for key in map(_normalized_catalog_key, (app_id, app_name)) if key
+        key for key in map(normalize_catalog_key, (app_id, app_name)) if key
     }
     catalog_apps: Sequence[PublicMCPApp] = (
         snapshot.catalog_apps if snapshot is not None else db.query(PublicMCPApp).all()
@@ -504,8 +504,8 @@ def _builtin_server_candidates(
             candidates.append(server)
             continue
         if (
-            _normalized_catalog_key(server_app_id) in normalized_names
-            or _normalized_catalog_key(server.name) in normalized_names
+            normalize_catalog_key(server_app_id) in normalized_names
+            or normalize_catalog_key(server.name) in normalized_names
         ):
             raise BuiltinOAuthServerDefinitionError(
                 f"builtin OAuth app {app_id!r} has an ambiguous reserved server identity"
@@ -542,8 +542,8 @@ def classify_actor_builtin_oauth_server(
     has_app_id = isinstance(auth, Mapping) and "app_id" in auth
     server_app_id = auth.get("app_id") if isinstance(auth, Mapping) else None
     server_name = str(getattr(server, "name", ""))
-    normalized_name = _normalized_catalog_key(server_name)
-    normalized_app_id = _normalized_catalog_key(server_app_id)
+    normalized_name = normalize_catalog_key(server_name)
+    normalized_app_id = normalize_catalog_key(server_app_id)
 
     exact_app = next(
         (
@@ -567,8 +567,8 @@ def classify_actor_builtin_oauth_server(
             normalized_app_id,
         }
         & {
-            _normalized_catalog_key(app_info.get("id")),
-            _normalized_catalog_key(app_info.get("name")),
+            normalize_catalog_key(app_info.get("id")),
+            normalize_catalog_key(app_info.get("name")),
         }
         - {None}
     ]

--- a/src/xagent/web/services/actor_mcp_runtime.py
+++ b/src/xagent/web/services/actor_mcp_runtime.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-import logging
+from functools import cache
 from typing import Any, Protocol, final
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
 from ... import config as xagent_config
+from ...core.tools.adapters.vibe.config import ACTOR_STDIO_SHADOWED_REASON
 from ..builtin_mcp_registry import (
     get_builtin_execution_fields,
     get_builtin_public_mcp_app_rows,
     get_builtin_stdio_session_scope,
 )
+from ..mcp_apps import normalize_catalog_key
 from ..models.public_mcp import PublicMCPApp
 from .actor_mcp_connections import (
     ActorMCPConnectionCredentialCorruptionError,
@@ -191,15 +194,11 @@ def production_actor_mcp_stdio_connection_adapter() -> ActorMCPStdioConnectionAd
 class ActorMCPStdioResolution:
     configs: tuple[dict[str, Any], ...]
     blocked_server_ids: frozenset[int]
+    blocked_server_reasons: tuple[tuple[int, str], ...] = ()
+    session_identities: tuple[tuple[str, ActorMCPStdioSessionIdentity], ...] = ()
 
 
-def _normalized_catalog_key(value: object) -> str | None:
-    if value is None:
-        return None
-    normalized = "-".join(str(value).strip().lower().split())
-    return normalized or None
-
-
+@cache
 def _builtin_stdio_rows() -> tuple[dict[str, Any], ...]:
     return tuple(
         row
@@ -208,13 +207,14 @@ def _builtin_stdio_rows() -> tuple[dict[str, Any], ...]:
     )
 
 
+@cache
 def _reserved_stdio_keys() -> frozenset[str]:
     return frozenset(
         key
         for row in _builtin_stdio_rows()
         for key in (
-            _normalized_catalog_key(row.get("app_id")),
-            _normalized_catalog_key(row.get("name")),
+            normalize_catalog_key(row.get("app_id")),
+            normalize_catalog_key(row.get("name")),
         )
         if key is not None
     )
@@ -225,33 +225,39 @@ def _blocked_visible_server_ids(visible_servers: Sequence[Any]) -> frozenset[int
     return frozenset(
         int(server.id)
         for server in visible_servers
-        if _normalized_catalog_key(getattr(server, "name", None)) in reserved
+        if normalize_catalog_key(getattr(server, "name", None)) in reserved
     )
+
+
+@cache
+def _cached_builtin_stdio_execution(app_id: str) -> dict[str, Any] | None:
+    return get_builtin_execution_fields(app_id)
 
 
 def _canonical_stdio_execution(
     db: Session,
     identity: ActorMCPStdioConnectionIdentity,
 ) -> tuple[dict[str, Any], tuple[str, ...]]:
-    execution = get_builtin_execution_fields(identity.app_id)
+    execution = _cached_builtin_stdio_execution(identity.app_id)
     if execution is None or execution.get("transport") != "stdio":
         raise ActorMCPRuntimeDefinitionError(
             "actor stdio app is absent from the builtin registry"
         )
 
-    catalog_apps = db.query(PublicMCPApp).all()
-    matches = [app for app in catalog_apps if app.app_id == identity.app_id]
-    normalized_id = _normalized_catalog_key(identity.app_id)
-    collisions = [
-        app
-        for app in catalog_apps
-        if _normalized_catalog_key(app.app_id) == normalized_id
-    ]
-    if len(matches) != 1 or len(collisions) != 1:
+    app = (
+        db.query(PublicMCPApp)
+        .filter(PublicMCPApp.app_id == identity.app_id)
+        .one_or_none()
+    )
+    normalized_id = normalize_catalog_key(identity.app_id)
+    collision_count = sum(
+        normalize_catalog_key(app_id) == normalized_id
+        for (app_id,) in db.query(PublicMCPApp.app_id).all()
+    )
+    if app is None or collision_count != 1:
         raise ActorMCPRuntimeDefinitionError(
             "actor stdio catalog identity is unavailable or ambiguous"
         )
-    app = matches[0]
     if (
         app.generation != identity.catalog_app_generation
         or not app.is_visible_in_connector
@@ -331,6 +337,10 @@ def resolve_actor_mcp_stdio_configs(
         return ActorMCPStdioResolution((), frozenset())
 
     blocked_server_ids = _blocked_visible_server_ids(visible_servers)
+    blocked_server_reasons = tuple(
+        (server_id, ACTOR_STDIO_SHADOWED_REASON)
+        for server_id in sorted(blocked_server_ids)
+    )
     if (
         isinstance(user_id, bool)
         or not isinstance(user_id, int)
@@ -338,7 +348,7 @@ def resolve_actor_mcp_stdio_configs(
         or not xagent_config.get_toby_personal_stdio_enabled()
         or adapter is None
     ):
-        return ActorMCPStdioResolution((), blocked_server_ids)
+        return ActorMCPStdioResolution((), blocked_server_ids, blocked_server_reasons)
 
     try:
         identities = tuple(
@@ -350,14 +360,15 @@ def resolve_actor_mcp_stdio_configs(
         )
     except _ACTOR_MCP_STORAGE_ERRORS as exc:
         logger.info("Actor stdio connection list unavailable (%s)", type(exc).__name__)
-        return ActorMCPStdioResolution((), blocked_server_ids)
+        return ActorMCPStdioResolution((), blocked_server_ids, blocked_server_reasons)
     except Exception as exc:
         logger.warning(
             "Actor stdio connection list failed unexpectedly (%s)",
             type(exc).__name__,
         )
-        return ActorMCPStdioResolution((), blocked_server_ids)
+        return ActorMCPStdioResolution((), blocked_server_ids, blocked_server_reasons)
     configs: list[dict[str, Any]] = []
+    session_identities: list[tuple[str, ActorMCPStdioSessionIdentity]] = []
     for identity in identities:
         if (
             not isinstance(identity, ActorMCPStdioConnectionIdentity)
@@ -376,11 +387,11 @@ def resolve_actor_mcp_stdio_configs(
                     connection=identity,
                 )
             app_keys = {
-                _normalized_catalog_key(identity.app_id),
-                _normalized_catalog_key(execution.get("name")),
+                normalize_catalog_key(identity.app_id),
+                normalize_catalog_key(execution.get("name")),
             }
             if any(
-                _normalized_catalog_key(getattr(server, "name", None)) in app_keys
+                normalize_catalog_key(getattr(server, "name", None)) in app_keys
                 for server in visible_servers
             ):
                 continue
@@ -407,6 +418,11 @@ def resolve_actor_mcp_stdio_configs(
                 credentials,
                 required_fields=required_fields,
             )
+            fixed_runtime_env = caller_id_env(user_id)
+            if set(env).intersection(fixed_runtime_env):
+                raise ActorMCPRuntimeDefinitionError(
+                    "actor stdio credentials overlap trusted runtime env"
+                )
         except (*_ACTOR_MCP_STORAGE_ERRORS, ActorMCPRuntimeDefinitionError) as exc:
             logger.info(
                 "Actor stdio credential read unavailable (%s)", type(exc).__name__
@@ -420,7 +436,7 @@ def resolve_actor_mcp_stdio_configs(
             continue
 
         launch = execution["launch_config"]
-        trusted_env = {**env, **caller_id_env(user_id)}
+        trusted_env = {**env, **fixed_runtime_env}
         config: dict[str, Any] = {
             "name": identity.app_id,
             "transport": "stdio",
@@ -435,7 +451,12 @@ def resolve_actor_mcp_stdio_configs(
             "user_id": str(user_id),
         }
         if session_identity is not None:
-            config["actor_stdio_session_identity"] = session_identity
+            session_identities.append((identity.app_id, session_identity))
         configs.append(config)
 
-    return ActorMCPStdioResolution(tuple(configs), blocked_server_ids)
+    return ActorMCPStdioResolution(
+        tuple(configs),
+        blocked_server_ids,
+        blocked_server_reasons,
+        tuple(session_identities),
+    )

--- a/src/xagent/web/services/actor_mcp_runtime.py
+++ b/src/xagent/web/services/actor_mcp_runtime.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+import logging
+from typing import Any, Protocol, final
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -14,12 +15,28 @@ from ..builtin_mcp_registry import (
     get_builtin_stdio_session_scope,
 )
 from ..models.public_mcp import PublicMCPApp
+from .actor_mcp_connections import (
+    ActorMCPConnectionCredentialCorruptionError,
+    ActorMCPConnectionNotFoundOrStaleError,
+    ActorMCPConnectionValidationError,
+    get_actor_mcp_connection_credentials_internal,
+    list_actor_mcp_connection_metadata,
+)
 from .mcp_runtime import (
     MCPActorAuthorizationPolicy,
     MCPActorExecutionIdentity,
     caller_id_env,
 )
 from .user_oauth import normalize_user_oauth_resource_owner_key
+
+logger = logging.getLogger(__name__)
+
+
+_ACTOR_MCP_STORAGE_ERRORS = (
+    ActorMCPConnectionValidationError,
+    ActorMCPConnectionNotFoundOrStaleError,
+    ActorMCPConnectionCredentialCorruptionError,
+)
 
 
 class ActorMCPRuntimeDefinitionError(ValueError):
@@ -111,6 +128,63 @@ class ActorMCPStdioConnectionAdapter(Protocol):
         catalog_app_generation: UUID,
         expected_lifecycle_generation: UUID,
     ) -> Mapping[str, str] | None: ...
+
+
+@final
+class ActorMCPConnectionServiceAdapter:
+    """Stateless adapter over the lifecycle-fenced actor connection service."""
+
+    def list_connection_identities(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+    ) -> Sequence[ActorMCPStdioConnectionIdentity]:
+        metadata = list_actor_mcp_connection_metadata(
+            db,
+            user_id=user_id,
+            resource_owner_key=resource_owner_key,
+        )
+        return tuple(
+            ActorMCPStdioConnectionIdentity(
+                user_id=item.user_id,
+                resource_owner_key=item.resource_owner_key,
+                app_id=item.app_id,
+                catalog_app_generation=item.catalog_app_generation,
+                lifecycle_generation=item.lifecycle_generation,
+            )
+            for item in metadata
+        )
+
+    def get_connection_credentials(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+        app_id: str,
+        catalog_app_generation: UUID,
+        expected_lifecycle_generation: UUID,
+    ) -> Mapping[str, str] | None:
+        snapshot = get_actor_mcp_connection_credentials_internal(
+            db,
+            user_id=user_id,
+            resource_owner_key=resource_owner_key,
+            app_id=app_id,
+            catalog_app_generation=catalog_app_generation,
+            expected_lifecycle_generation=expected_lifecycle_generation,
+        )
+        return snapshot.credentials
+
+
+_ACTOR_MCP_CONNECTION_SERVICE_ADAPTER = ActorMCPConnectionServiceAdapter()
+
+
+def production_actor_mcp_stdio_connection_adapter() -> ActorMCPStdioConnectionAdapter:
+    """Return the immutable production storage adapter."""
+
+    return _ACTOR_MCP_CONNECTION_SERVICE_ADAPTER
 
 
 @dataclass(frozen=True)
@@ -267,12 +341,21 @@ def resolve_actor_mcp_stdio_configs(
         return ActorMCPStdioResolution((), blocked_server_ids)
 
     try:
-        identities = adapter.list_connection_identities(
-            db,
-            user_id=user_id,
-            resource_owner_key=policy.resource_owner_key,
+        identities = tuple(
+            adapter.list_connection_identities(
+                db,
+                user_id=user_id,
+                resource_owner_key=policy.resource_owner_key,
+            )
         )
-    except Exception:
+    except _ACTOR_MCP_STORAGE_ERRORS as exc:
+        logger.info("Actor stdio connection list unavailable (%s)", type(exc).__name__)
+        return ActorMCPStdioResolution((), blocked_server_ids)
+    except Exception as exc:
+        logger.warning(
+            "Actor stdio connection list failed unexpectedly (%s)",
+            type(exc).__name__,
+        )
         return ActorMCPStdioResolution((), blocked_server_ids)
     configs: list[dict[str, Any]] = []
     for identity in identities:
@@ -301,6 +384,17 @@ def resolve_actor_mcp_stdio_configs(
                 for server in visible_servers
             ):
                 continue
+        except ActorMCPRuntimeDefinitionError as exc:
+            logger.info("Actor stdio definition unavailable (%s)", type(exc).__name__)
+            continue
+        except Exception as exc:
+            logger.warning(
+                "Actor stdio definition failed unexpectedly (%s)",
+                type(exc).__name__,
+            )
+            continue
+
+        try:
             credentials = adapter.get_connection_credentials(
                 db,
                 user_id=user_id,
@@ -313,7 +407,16 @@ def resolve_actor_mcp_stdio_configs(
                 credentials,
                 required_fields=required_fields,
             )
-        except Exception:
+        except (*_ACTOR_MCP_STORAGE_ERRORS, ActorMCPRuntimeDefinitionError) as exc:
+            logger.info(
+                "Actor stdio credential read unavailable (%s)", type(exc).__name__
+            )
+            continue
+        except Exception as exc:
+            logger.warning(
+                "Actor stdio credential read failed unexpectedly (%s)",
+                type(exc).__name__,
+            )
             continue
 
         launch = execution["launch_config"]

--- a/src/xagent/web/services/actor_mcp_runtime.py
+++ b/src/xagent/web/services/actor_mcp_runtime.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ... import config as xagent_config
+from ..builtin_mcp_registry import (
+    get_builtin_execution_fields,
+    get_builtin_public_mcp_app_rows,
+)
+from ..models.public_mcp import PublicMCPApp
+from .mcp_runtime import MCPActorAuthorizationPolicy, caller_id_env
+from .user_oauth import normalize_user_oauth_resource_owner_key
+
+
+class ActorMCPRuntimeDefinitionError(ValueError):
+    """An actor stdio identity or its canonical definition is unavailable."""
+
+
+@dataclass(frozen=True)
+class ActorMCPStdioConnectionIdentity:
+    """Non-secret identity required to resolve one actor stdio connection."""
+
+    user_id: int
+    resource_owner_key: str = field(repr=False)
+    app_id: str
+    catalog_app_generation: UUID
+    lifecycle_generation: UUID
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.user_id, bool)
+            or not isinstance(self.user_id, int)
+            or self.user_id <= 0
+        ):
+            raise ActorMCPRuntimeDefinitionError(
+                "actor stdio identity requires a persisted user_id"
+            )
+        owner_key = normalize_user_oauth_resource_owner_key(self.resource_owner_key)
+        if owner_key != self.resource_owner_key:
+            raise ActorMCPRuntimeDefinitionError(
+                "actor stdio identity requires an exact resource_owner_key"
+            )
+        if (
+            not isinstance(self.app_id, str)
+            or not self.app_id
+            or self.app_id != self.app_id.strip()
+        ):
+            raise ActorMCPRuntimeDefinitionError(
+                "actor stdio identity requires an exact app_id"
+            )
+        if not isinstance(self.catalog_app_generation, UUID):
+            raise ActorMCPRuntimeDefinitionError(
+                "actor stdio identity requires catalog_app_generation"
+            )
+        if not isinstance(self.lifecycle_generation, UUID):
+            raise ActorMCPRuntimeDefinitionError(
+                "actor stdio identity requires lifecycle_generation"
+            )
+
+
+class ActorMCPStdioConnectionAdapter(Protocol):
+    """Narrow secret boundary implemented by actor connection storage."""
+
+    def list_connection_identities(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+    ) -> Sequence[ActorMCPStdioConnectionIdentity]: ...
+
+    def get_connection_credentials(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+        app_id: str,
+        catalog_app_generation: UUID,
+        expected_lifecycle_generation: UUID,
+    ) -> Mapping[str, str] | None: ...
+
+
+@dataclass(frozen=True)
+class ActorMCPStdioResolution:
+    configs: tuple[dict[str, Any], ...]
+    blocked_server_ids: frozenset[int]
+
+
+def _normalized_catalog_key(value: object) -> str | None:
+    if value is None:
+        return None
+    normalized = "-".join(str(value).strip().lower().split())
+    return normalized or None
+
+
+def _builtin_stdio_rows() -> tuple[dict[str, Any], ...]:
+    return tuple(
+        row
+        for row in get_builtin_public_mcp_app_rows()
+        if str(row.get("transport") or "").lower() == "stdio"
+    )
+
+
+def _reserved_stdio_keys() -> frozenset[str]:
+    return frozenset(
+        key
+        for row in _builtin_stdio_rows()
+        for key in (
+            _normalized_catalog_key(row.get("app_id")),
+            _normalized_catalog_key(row.get("name")),
+        )
+        if key is not None
+    )
+
+
+def _blocked_visible_server_ids(visible_servers: Sequence[Any]) -> frozenset[int]:
+    reserved = _reserved_stdio_keys()
+    return frozenset(
+        int(server.id)
+        for server in visible_servers
+        if _normalized_catalog_key(getattr(server, "name", None)) in reserved
+    )
+
+
+def _canonical_stdio_execution(
+    db: Session,
+    identity: ActorMCPStdioConnectionIdentity,
+) -> tuple[dict[str, Any], tuple[str, ...]]:
+    execution = get_builtin_execution_fields(identity.app_id)
+    if execution is None or execution.get("transport") != "stdio":
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio app is absent from the builtin registry"
+        )
+
+    catalog_apps = db.query(PublicMCPApp).all()
+    matches = [app for app in catalog_apps if app.app_id == identity.app_id]
+    normalized_id = _normalized_catalog_key(identity.app_id)
+    collisions = [
+        app
+        for app in catalog_apps
+        if _normalized_catalog_key(app.app_id) == normalized_id
+    ]
+    if len(matches) != 1 or len(collisions) != 1:
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio catalog identity is unavailable or ambiguous"
+        )
+    app = matches[0]
+    if (
+        app.generation != identity.catalog_app_generation
+        or not app.is_visible_in_connector
+    ):
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio catalog lifecycle is stale or hidden"
+        )
+
+    persisted_execution = {
+        "name": app.name,
+        "transport": app.transport,
+        "provider_name": app.provider_name,
+        "oauth_scopes": list(app.oauth_scopes or []),
+        "launch_config": app.launch_config or {},
+    }
+    expected_execution = {
+        "name": execution["name"],
+        "transport": execution["transport"],
+        "provider_name": execution["provider_name"],
+        "oauth_scopes": list(execution["oauth_scopes"] or []),
+        "launch_config": execution["launch_config"],
+    }
+    if persisted_execution != expected_execution:
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio persisted catalog definition has drifted"
+        )
+
+    launch = execution.get("launch_config")
+    if not isinstance(launch, Mapping) or not isinstance(launch.get("command"), str):
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio builtin execution definition is invalid"
+        )
+    args = launch.get("args", [])
+    fields = launch.get("required_env", [])
+    if (
+        not isinstance(args, list)
+        or any(not isinstance(arg, str) for arg in args)
+        or not isinstance(fields, list)
+        or any(not isinstance(name, str) or not name for name in fields)
+        or len(fields) != len(set(fields))
+    ):
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio builtin execution definition is invalid"
+        )
+    return execution, tuple(fields)
+
+
+def _validated_runtime_credentials(
+    credentials: Mapping[str, str] | None,
+    *,
+    required_fields: tuple[str, ...],
+) -> dict[str, str]:
+    if not required_fields and credentials is None:
+        return {}
+    if not isinstance(credentials, Mapping) or set(credentials) != set(required_fields):
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio credentials are incomplete"
+        )
+    values = dict(credentials)
+    if any(
+        not isinstance(value, str) or not value.strip() for value in values.values()
+    ):
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio credentials are incomplete"
+        )
+    return values
+
+
+def resolve_actor_mcp_stdio_configs(
+    db: Session,
+    *,
+    user_id: int,
+    policy: MCPActorAuthorizationPolicy | None,
+    adapter: ActorMCPStdioConnectionAdapter | None,
+    visible_servers: Sequence[Any],
+) -> ActorMCPStdioResolution:
+    """Build actor configs without consulting any persisted MCP server definition."""
+
+    if policy is None or not policy.allow_builtin_stdio:
+        return ActorMCPStdioResolution((), frozenset())
+
+    blocked_server_ids = _blocked_visible_server_ids(visible_servers)
+    if (
+        isinstance(user_id, bool)
+        or not isinstance(user_id, int)
+        or user_id <= 0
+        or not xagent_config.get_toby_personal_stdio_enabled()
+        or adapter is None
+    ):
+        return ActorMCPStdioResolution((), blocked_server_ids)
+
+    try:
+        identities = adapter.list_connection_identities(
+            db,
+            user_id=user_id,
+            resource_owner_key=policy.resource_owner_key,
+        )
+    except Exception:
+        return ActorMCPStdioResolution((), blocked_server_ids)
+    configs: list[dict[str, Any]] = []
+    for identity in identities:
+        if (
+            not isinstance(identity, ActorMCPStdioConnectionIdentity)
+            or identity.user_id != user_id
+            or identity.resource_owner_key != policy.resource_owner_key
+        ):
+            continue
+        try:
+            execution, required_fields = _canonical_stdio_execution(db, identity)
+            app_keys = {
+                _normalized_catalog_key(identity.app_id),
+                _normalized_catalog_key(execution.get("name")),
+            }
+            if any(
+                _normalized_catalog_key(getattr(server, "name", None)) in app_keys
+                for server in visible_servers
+            ):
+                continue
+            credentials = adapter.get_connection_credentials(
+                db,
+                user_id=user_id,
+                resource_owner_key=policy.resource_owner_key,
+                app_id=identity.app_id,
+                catalog_app_generation=identity.catalog_app_generation,
+                expected_lifecycle_generation=identity.lifecycle_generation,
+            )
+            env = _validated_runtime_credentials(
+                credentials,
+                required_fields=required_fields,
+            )
+        except Exception:
+            continue
+
+        launch = execution["launch_config"]
+        trusted_env = {**env, **caller_id_env(user_id)}
+        configs.append(
+            {
+                "name": identity.app_id,
+                "transport": "stdio",
+                "description": execution.get("name"),
+                "config": {
+                    "command": launch["command"],
+                    "args": list(launch.get("args") or []),
+                    "env": trusted_env,
+                    "concurrency_safe": False,
+                    "concurrent_tools": [],
+                },
+                "user_id": str(user_id),
+            }
+        )
+
+    return ActorMCPStdioResolution(tuple(configs), blocked_server_ids)

--- a/src/xagent/web/services/actor_mcp_runtime.py
+++ b/src/xagent/web/services/actor_mcp_runtime.py
@@ -11,9 +11,14 @@ from ... import config as xagent_config
 from ..builtin_mcp_registry import (
     get_builtin_execution_fields,
     get_builtin_public_mcp_app_rows,
+    get_builtin_stdio_session_scope,
 )
 from ..models.public_mcp import PublicMCPApp
-from .mcp_runtime import MCPActorAuthorizationPolicy, caller_id_env
+from .mcp_runtime import (
+    MCPActorAuthorizationPolicy,
+    MCPActorExecutionIdentity,
+    caller_id_env,
+)
 from .user_oauth import normalize_user_oauth_resource_owner_key
 
 
@@ -61,6 +66,28 @@ class ActorMCPStdioConnectionIdentity:
             raise ActorMCPRuntimeDefinitionError(
                 "actor stdio identity requires lifecycle_generation"
             )
+
+
+@dataclass(frozen=True)
+class ActorMCPStdioSessionIdentity:
+    """Complete key for one execution-scoped actor stdio child session."""
+
+    execution: MCPActorExecutionIdentity
+    connection: ActorMCPStdioConnectionIdentity
+
+    @property
+    def key(self) -> tuple[int, str, str, str, int, str, str, UUID, UUID]:
+        return (
+            self.execution.task_id,
+            self.execution.run_id,
+            self.execution.turn_id,
+            self.execution.lease_attempt_id,
+            self.connection.user_id,
+            self.connection.resource_owner_key,
+            self.connection.app_id,
+            self.connection.catalog_app_generation,
+            self.connection.lifecycle_generation,
+        )
 
 
 class ActorMCPStdioConnectionAdapter(Protocol):
@@ -206,16 +233,12 @@ def _validated_runtime_credentials(
     if not required_fields and credentials is None:
         return {}
     if not isinstance(credentials, Mapping) or set(credentials) != set(required_fields):
-        raise ActorMCPRuntimeDefinitionError(
-            "actor stdio credentials are incomplete"
-        )
+        raise ActorMCPRuntimeDefinitionError("actor stdio credentials are incomplete")
     values = dict(credentials)
     if any(
         not isinstance(value, str) or not value.strip() for value in values.values()
     ):
-        raise ActorMCPRuntimeDefinitionError(
-            "actor stdio credentials are incomplete"
-        )
+        raise ActorMCPRuntimeDefinitionError("actor stdio credentials are incomplete")
     return values
 
 
@@ -226,6 +249,7 @@ def resolve_actor_mcp_stdio_configs(
     policy: MCPActorAuthorizationPolicy | None,
     adapter: ActorMCPStdioConnectionAdapter | None,
     visible_servers: Sequence[Any],
+    execution_identity: MCPActorExecutionIdentity | None = None,
 ) -> ActorMCPStdioResolution:
     """Build actor configs without consulting any persisted MCP server definition."""
 
@@ -260,6 +284,14 @@ def resolve_actor_mcp_stdio_configs(
             continue
         try:
             execution, required_fields = _canonical_stdio_execution(db, identity)
+            session_identity: ActorMCPStdioSessionIdentity | None = None
+            if get_builtin_stdio_session_scope(identity.app_id) == "execution":
+                if execution_identity is None:
+                    continue
+                session_identity = ActorMCPStdioSessionIdentity(
+                    execution=execution_identity,
+                    connection=identity,
+                )
             app_keys = {
                 _normalized_catalog_key(identity.app_id),
                 _normalized_catalog_key(execution.get("name")),
@@ -286,20 +318,21 @@ def resolve_actor_mcp_stdio_configs(
 
         launch = execution["launch_config"]
         trusted_env = {**env, **caller_id_env(user_id)}
-        configs.append(
-            {
-                "name": identity.app_id,
-                "transport": "stdio",
-                "description": execution.get("name"),
-                "config": {
-                    "command": launch["command"],
-                    "args": list(launch.get("args") or []),
-                    "env": trusted_env,
-                    "concurrency_safe": False,
-                    "concurrent_tools": [],
-                },
-                "user_id": str(user_id),
-            }
-        )
+        config: dict[str, Any] = {
+            "name": identity.app_id,
+            "transport": "stdio",
+            "description": execution.get("name"),
+            "config": {
+                "command": launch["command"],
+                "args": list(launch.get("args") or []),
+                "env": trusted_env,
+                "concurrency_safe": False,
+                "concurrent_tools": [],
+            },
+            "user_id": str(user_id),
+        }
+        if session_identity is not None:
+            config["actor_stdio_session_identity"] = session_identity
+        configs.append(config)
 
     return ActorMCPStdioResolution(tuple(configs), blocked_server_ids)

--- a/src/xagent/web/services/actor_mcp_runtime.py
+++ b/src/xagent/web/services/actor_mcp_runtime.py
@@ -234,6 +234,20 @@ def _cached_builtin_stdio_execution(app_id: str) -> dict[str, Any] | None:
     return get_builtin_execution_fields(app_id)
 
 
+def _canonical_oauth_scopes(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if (
+        not isinstance(value, list)
+        or any(not isinstance(scope, str) or not scope for scope in value)
+        or len(value) != len(set(value))
+    ):
+        raise ActorMCPRuntimeDefinitionError(
+            "actor stdio OAuth scope definition is invalid"
+        )
+    return tuple(sorted(value))
+
+
 def _canonical_stdio_execution(
     db: Session,
     identity: ActorMCPStdioConnectionIdentity,
@@ -270,14 +284,14 @@ def _canonical_stdio_execution(
         "name": app.name,
         "transport": app.transport,
         "provider_name": app.provider_name,
-        "oauth_scopes": list(app.oauth_scopes or []),
+        "oauth_scopes": _canonical_oauth_scopes(app.oauth_scopes),
         "launch_config": app.launch_config or {},
     }
     expected_execution = {
         "name": execution["name"],
         "transport": execution["transport"],
         "provider_name": execution["provider_name"],
-        "oauth_scopes": list(execution["oauth_scopes"] or []),
+        "oauth_scopes": _canonical_oauth_scopes(execution["oauth_scopes"]),
         "launch_config": execution["launch_config"],
     }
     if persisted_execution != expected_execution:

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -25,21 +25,32 @@ class MCPBuiltinOAuthActorPolicyMismatchError(RuntimeError):
 
 
 @dataclass(frozen=True)
-class MCPBuiltinOAuthActorPolicy:
-    """Trusted actor owner namespace for catalog OAuth MCP execution.
+class MCPActorAuthorizationPolicy:
+    """Trusted actor identity and connector capabilities for MCP execution.
 
     Server visibility and catalog classification remain xagent runtime
     decisions. The caller supplies only the immutable credential owner. The
-    owner governs both builtin-provider and remote MCP OAuth credentials.
+    owner governs builtin-provider OAuth, remote MCP OAuth, and explicitly
+    enabled actor-scoped stdio credentials. Stdio remains disabled by default
+    so existing OAuth-only callers retain their current behavior.
     """
 
     resource_owner_key: str = dataclass_field(repr=False)
+    allow_builtin_stdio: bool = False
 
     def __post_init__(self) -> None:
         owner_key = normalize_user_oauth_resource_owner_key(self.resource_owner_key)
         if owner_key is None:  # pragma: no cover - normalization preserves None only
             raise ValueError("resource_owner_key must not be null")
+        if type(self.allow_builtin_stdio) is not bool:
+            raise ValueError("allow_builtin_stdio must be a boolean")
         object.__setattr__(self, "resource_owner_key", owner_key)
+
+
+# Compatibility import for trusted callers deployed before actor-scoped stdio
+# support. Keep this as a direct alias so equality and isinstance semantics do
+# not diverge between old and new callers.
+MCPBuiltinOAuthActorPolicy = MCPActorAuthorizationPolicy
 
 
 @dataclass(frozen=True)

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -54,6 +54,30 @@ MCPBuiltinOAuthActorPolicy = MCPActorAuthorizationPolicy
 
 
 @dataclass(frozen=True)
+class MCPActorExecutionIdentity:
+    """Exact task turn and lease acquisition that owns one actor execution."""
+
+    task_id: int
+    run_id: str
+    turn_id: str
+    lease_attempt_id: str
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.task_id, bool)
+            or not isinstance(self.task_id, int)
+            or self.task_id <= 0
+        ):
+            raise ValueError("actor execution identity requires a persisted task_id")
+        for field_name in ("run_id", "turn_id", "lease_attempt_id"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value or value != value.strip():
+                raise ValueError(
+                    f"actor execution identity requires an exact {field_name}"
+                )
+
+
+@dataclass(frozen=True)
 class MCPRuntimeConnectionBuild:
     """Executable MCP connection plus any runtime authorization diagnostic."""
 

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -42,6 +42,7 @@ from ...core.agent.result import (
     normalize_tool_failure_code,
 )
 from ...core.tools.adapters.vibe.config import (
+    ACTOR_STDIO_SHADOWED_REASON,
     BaseToolConfig,
     MCPConfigLoadError,
     MCPFailurePolicy,
@@ -61,6 +62,10 @@ from ...core.tools.adapters.vibe.connector_runtime import (
     runtime_bindings_from_config,
 )
 from ...core.tools.adapters.vibe.db_session import tool_session_scope
+from ..services.actor_mcp_runtime import (
+    ActorMCPStdioSessionIdentity,
+    resolve_actor_mcp_stdio_configs,
+)
 from ..services.mcp_runtime import (
     MCPActorExecutionIdentity,
     MCPBuiltinOAuthActorPolicy,
@@ -99,6 +104,7 @@ _ACTOR_OAUTH_REFRESH_LOCKS: WeakValueDictionary[
 MCP_UNAVAILABLE_REASONS = frozenset(
     {
         "authorization_required",
+        ACTOR_STDIO_SHADOWED_REASON,
         "catalog_app_not_found",
         "config_load_failed",
         "insufficient_scope",
@@ -1685,12 +1691,12 @@ class WebToolConfig(BaseToolConfig):
         connector_team_id: Optional[int] = None,
         agent_creator_user_id: Optional[int] = None,
         declared_knowledge_bases: Optional[List[str]] = None,
-        mcp_actor_stdio_connection_adapter: Any = None,
         # Appended after every pre-existing parameter (not inserted
         # alongside its closest siblings above) so a caller still using
         # positional arguments for anything after agent_call_stack keeps
         # binding the same values it always did.
         voice: Optional[str] = None,
+        mcp_actor_stdio_connection_adapter: Any = None,
         mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
     ):
         # ``tool_selection_spec`` accepts :class:`ToolSelectionSpec` from
@@ -1724,6 +1730,9 @@ class WebToolConfig(BaseToolConfig):
         # actor and lifecycle identity on every secret read.
         self._mcp_actor_stdio_connection_adapter = mcp_actor_stdio_connection_adapter
         self._mcp_actor_execution_identity = mcp_actor_execution_identity
+        self._mcp_actor_stdio_session_identities: dict[
+            str, ActorMCPStdioSessionIdentity
+        ] = {}
         self._task_runtime_contribution: Any = None
         self._task_runtime_workspace: Any = None
         self._live_db = db
@@ -2063,6 +2072,13 @@ class WebToolConfig(BaseToolConfig):
         configs = await self._load_mcp_server_configs()
         self._store_mcp_config_cache_if_cacheable(configs)
         return configs
+
+    def get_actor_mcp_stdio_session_identities(
+        self,
+    ) -> Dict[str, ActorMCPStdioSessionIdentity]:
+        """Return host-only identities that must never enter MCP configs."""
+
+        return dict(self._mcp_actor_stdio_session_identities)
 
     def _serialize_mcp_user_id(self) -> str:
         """Return the explicit identity used to isolate an MCP config."""
@@ -4043,6 +4059,7 @@ class WebToolConfig(BaseToolConfig):
         env_source_by_id: Mapping[int, Any],
         actor_catalog_app_info: Mapping[str, Any] | None = None,
         actor_builtin_invalid: bool = False,
+        actor_builtin_invalid_reason: str = "config_load_failed",
     ) -> Dict[str, Any]:
         """Build one MCP server config, preserving explicit unavailable outcomes."""
         actor_builtin = bool(
@@ -4051,7 +4068,7 @@ class WebToolConfig(BaseToolConfig):
         )
         if actor_builtin_invalid:
             policy_diagnostic = {
-                "code": "config_load_failed",
+                "code": actor_builtin_invalid_reason,
                 "message": "MCP server configuration is unavailable",
                 "server_id": int(server.id),
                 "server_name": server.name,
@@ -4059,7 +4076,7 @@ class WebToolConfig(BaseToolConfig):
             self._mcp_oauth_diagnostics.append(policy_diagnostic)
             return self._build_unavailable_mcp_config(
                 server=server,
-                reason="config_load_failed",
+                reason=actor_builtin_invalid_reason,
                 diagnostic=policy_diagnostic,
             )
 
@@ -4523,6 +4540,7 @@ class WebToolConfig(BaseToolConfig):
         env_source_by_id: Mapping[int, Any],
         actor_catalog_app_info: Mapping[str, Any] | None = None,
         actor_builtin_invalid: bool = False,
+        actor_builtin_invalid_reason: str = "config_load_failed",
     ) -> Dict[str, Any]:
         """Isolate unexpected failures while loading one MCP server config."""
         try:
@@ -4533,6 +4551,7 @@ class WebToolConfig(BaseToolConfig):
                 env_source_by_id=env_source_by_id,
                 actor_catalog_app_info=actor_catalog_app_info,
                 actor_builtin_invalid=actor_builtin_invalid,
+                actor_builtin_invalid_reason=actor_builtin_invalid_reason,
             )
         except ConnectorRuntimeError:
             raise
@@ -4574,6 +4593,7 @@ class WebToolConfig(BaseToolConfig):
         of leaving the shared layer keyed on the run owner's personal
         shared-env hook answer."""
         self._mcp_oauth_diagnostics = []
+        self._mcp_actor_stdio_session_identities = {}
         self._reset_mcp_config_load_cache_state()
 
         # Resolved before the guarded region below: that region reports
@@ -4651,8 +4671,6 @@ class WebToolConfig(BaseToolConfig):
                     ):
                         actor_classifications[int(visible_server.id)] = (None, True)
 
-            from ..services.actor_mcp_runtime import resolve_actor_mcp_stdio_configs
-
             actor_stdio_resolution = resolve_actor_mcp_stdio_configs(
                 self.db,
                 user_id=(int(self._user_id) if isinstance(self._user_id, int) else 0),
@@ -4663,6 +4681,12 @@ class WebToolConfig(BaseToolConfig):
             )
             for blocked_server_id in actor_stdio_resolution.blocked_server_ids:
                 actor_classifications[blocked_server_id] = (None, True)
+            actor_stdio_block_reasons = dict(
+                actor_stdio_resolution.blocked_server_reasons
+            )
+            self._mcp_actor_stdio_session_identities = dict(
+                actor_stdio_resolution.session_identities
+            )
 
             # Prefetch shared runtime state once before entering the isolated
             # per-server formatter.
@@ -4752,6 +4776,9 @@ class WebToolConfig(BaseToolConfig):
                 actor_builtin_invalid=actor_classifications.get(
                     int(server.id), (None, False)
                 )[1],
+                actor_builtin_invalid_reason=actor_stdio_block_reasons.get(
+                    int(server.id), "config_load_failed"
+                ),
             )
             for server in servers
         ]

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1682,6 +1682,7 @@ class WebToolConfig(BaseToolConfig):
         connector_team_id: Optional[int] = None,
         agent_creator_user_id: Optional[int] = None,
         declared_knowledge_bases: Optional[List[str]] = None,
+        mcp_actor_stdio_connection_adapter: Any = None,
         # Appended after every pre-existing parameter (not inserted
         # alongside its closest siblings above) so a caller still using
         # positional arguments for anything after agent_call_stack keeps
@@ -1714,6 +1715,12 @@ class WebToolConfig(BaseToolConfig):
         # object can be overwritten by the model, and this value must not
         # be confusable with that one at the resolution point.
         self._declared_knowledge_bases = declared_knowledge_bases
+        # Internal storage boundary for actor-scoped stdio. It is deliberately
+        # separate from ordinary MCP env/auth hooks and receives the exact
+        # actor and lifecycle identity on every secret read.
+        self._mcp_actor_stdio_connection_adapter = (
+            mcp_actor_stdio_connection_adapter
+        )
         self._task_runtime_contribution: Any = None
         self._task_runtime_workspace: Any = None
         self._live_db = db
@@ -4628,11 +4635,33 @@ class WebToolConfig(BaseToolConfig):
                     ):
                         actor_classifications[int(visible_server.id)] = (None, True)
 
+            from ..services.actor_mcp_runtime import resolve_actor_mcp_stdio_configs
+
+            actor_stdio_resolution = resolve_actor_mcp_stdio_configs(
+                self.db,
+                user_id=(
+                    int(self._user_id) if isinstance(self._user_id, int) else 0
+                ),
+                policy=self._mcp_runtime_authorization_policy,
+                adapter=self._mcp_actor_stdio_connection_adapter,
+                visible_servers=servers,
+            )
+            for blocked_server_id in actor_stdio_resolution.blocked_server_ids:
+                actor_classifications[blocked_server_id] = (None, True)
+
             # Prefetch shared runtime state once before entering the isolated
             # per-server formatter.
-            user_env_by_id = load_user_env_overrides(self.db, self._user_id)
-            shared_env_by_id = load_shared_env_overrides(self.db, self._user_id)
-            env_source_by_id = load_user_env_sources(self.db, self._user_id)
+            if servers:
+                user_env_by_id = load_user_env_overrides(self.db, self._user_id)
+                shared_env_by_id = load_shared_env_overrides(self.db, self._user_id)
+                env_source_by_id = load_user_env_sources(self.db, self._user_id)
+            else:
+                # Synthetic actor stdio is intentionally independent from
+                # every ordinary MCP credential source. Avoid even querying
+                # those stores when there are no ordinary server rows.
+                user_env_by_id = {}
+                shared_env_by_id = {}
+                env_source_by_id = {}
 
             # Re-key the shared env layer, for team-owned ids only, onto the
             # governing team's own row -- never the run owner's team, and
@@ -4643,7 +4672,7 @@ class WebToolConfig(BaseToolConfig):
             # the credential-side hook was never installed -- the shared
             # layer stays user-keyed in that state, which is exactly the
             # cross-team influence this block exists to remove.
-            if self._connector_team_id is not None and team_mcp_ids:
+            if servers and self._connector_team_id is not None and team_mcp_ids:
                 if not team_env_hook_installed():
                     warn_team_env_hook_missing_once(
                         team_id=self._connector_team_id,
@@ -4711,6 +4740,7 @@ class WebToolConfig(BaseToolConfig):
             )
             for server in servers
         ]
+        configs.extend(actor_stdio_resolution.configs)
         logger.info("Loaded %s MCP server configurations", len(configs))
         return configs
 

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -61,7 +61,10 @@ from ...core.tools.adapters.vibe.connector_runtime import (
     runtime_bindings_from_config,
 )
 from ...core.tools.adapters.vibe.db_session import tool_session_scope
-from ..services.mcp_runtime import MCPBuiltinOAuthActorPolicy
+from ..services.mcp_runtime import (
+    MCPActorExecutionIdentity,
+    MCPBuiltinOAuthActorPolicy,
+)
 from ..services.tool_credentials import (
     TOOL_CREDENTIAL_SPECS,
     get_sql_connection_map,
@@ -1688,6 +1691,7 @@ class WebToolConfig(BaseToolConfig):
         # positional arguments for anything after agent_call_stack keeps
         # binding the same values it always did.
         voice: Optional[str] = None,
+        mcp_actor_execution_identity: MCPActorExecutionIdentity | None = None,
     ):
         # ``tool_selection_spec`` accepts :class:`ToolSelectionSpec` from
         # the tools adapter package; typed as ``Any`` here to avoid an
@@ -1718,9 +1722,8 @@ class WebToolConfig(BaseToolConfig):
         # Internal storage boundary for actor-scoped stdio. It is deliberately
         # separate from ordinary MCP env/auth hooks and receives the exact
         # actor and lifecycle identity on every secret read.
-        self._mcp_actor_stdio_connection_adapter = (
-            mcp_actor_stdio_connection_adapter
-        )
+        self._mcp_actor_stdio_connection_adapter = mcp_actor_stdio_connection_adapter
+        self._mcp_actor_execution_identity = mcp_actor_execution_identity
         self._task_runtime_contribution: Any = None
         self._task_runtime_workspace: Any = None
         self._live_db = db
@@ -2157,6 +2160,19 @@ class WebToolConfig(BaseToolConfig):
             return False
         self._connector_runtime_turn_id = normalized_turn_id
         self._connector_runtime_view = None
+        self._cached_mcp_configs = None
+        self._factory_runtime_snapshot = None
+        self._pending_runtime_policy = None
+        return True
+
+    def set_mcp_actor_execution_identity(
+        self, identity: MCPActorExecutionIdentity | None
+    ) -> bool:
+        """Advance the exact actor execution fence on a reused tool config."""
+
+        if self._mcp_actor_execution_identity == identity:
+            return False
+        self._mcp_actor_execution_identity = identity
         self._cached_mcp_configs = None
         self._factory_runtime_snapshot = None
         self._pending_runtime_policy = None
@@ -4639,12 +4655,11 @@ class WebToolConfig(BaseToolConfig):
 
             actor_stdio_resolution = resolve_actor_mcp_stdio_configs(
                 self.db,
-                user_id=(
-                    int(self._user_id) if isinstance(self._user_id, int) else 0
-                ),
+                user_id=(int(self._user_id) if isinstance(self._user_id, int) else 0),
                 policy=self._mcp_runtime_authorization_policy,
                 adapter=self._mcp_actor_stdio_connection_adapter,
                 visible_servers=servers,
+                execution_identity=self._mcp_actor_execution_identity,
             )
             for blocked_server_id in actor_stdio_resolution.blocked_server_ids:
                 actor_classifications[blocked_server_id] = (None, True)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -2850,3 +2850,16 @@ def test_standard_otel_fallbacks_and_xagent_precedence(
     assert config.get_otel_metrics_endpoint() == "http://xagent:4318/v1/metrics"
     assert config.get_otel_export_interval_milliseconds() == 5_000
     assert config.get_otel_service_name() == "xagent-override"
+
+
+def test_toby_personal_stdio_is_disabled_by_default(monkeypatch):
+    monkeypatch.delenv(config.TOBY_PERSONAL_STDIO_ENABLED, raising=False)
+
+    assert config.get_toby_personal_stdio_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
+def test_toby_personal_stdio_explicit_opt_in(monkeypatch, value):
+    monkeypatch.setenv(config.TOBY_PERSONAL_STDIO_ENABLED, value)
+
+    assert config.get_toby_personal_stdio_enabled() is True

--- a/tests/web/api/test_execute_task_background_snapshot_passthrough.py
+++ b/tests/web/api/test_execute_task_background_snapshot_passthrough.py
@@ -42,7 +42,11 @@ from xagent.web.models.agent import AgentStatus
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import AgentRuntimeFields
-from xagent.web.services.task_lease_service import TaskLease
+from xagent.web.services.mcp_runtime import (
+    MCPActorAuthorizationPolicy,
+    MCPActorExecutionIdentity,
+)
+from xagent.web.services.task_lease_service import TaskLease, current_task_lease
 from xagent.web.services.task_setup_snapshot import (
     RuntimeUserFields,
     TaskSetupSnapshot,
@@ -244,6 +248,59 @@ async def test_snapshot_path_skips_task_and_user_queries() -> None:
     ]
     assert forwarded_snapshot is snapshot
     assert forwarded_snapshot.task.source == "trigger"
+
+
+@pytest.mark.asyncio
+async def test_actor_execution_identity_is_forwarded_before_lease_context_bind() -> (
+    None
+):
+    snapshot = _make_snapshot()
+    agent_service = _build_fake_agent_service()
+    observed: list[MCPActorExecutionIdentity | None] = []
+
+    async def get_agent_for_task(*_args: Any, **kwargs: Any) -> Any:
+        assert current_task_lease() is None
+        observed.append(kwargs.get("mcp_actor_execution_identity"))
+        return agent_service
+
+    agent_manager = MagicMock(
+        get_agent_for_task=AsyncMock(side_effect=get_agent_for_task),
+        execute_task=AsyncMock(
+            return_value={"success": True, "output": "ok", "status": "completed"}
+        ),
+    )
+    lease = TaskLease(
+        task_id=42,
+        runner_id="runner-a",
+        run_id="run-a",
+        attempt_id="attempt-a",
+    )
+    policy = MCPActorAuthorizationPolicy(
+        resource_owner_key="toby:slack:T1:U1",
+        allow_builtin_stdio=True,
+    )
+
+    with _Patches(_common_patches(MagicMock(), agent_service)):
+        await execute_task_background(
+            task_id=42,
+            user_message="hi",
+            context={"turn_id": "turn-a"},
+            agent_manager=agent_manager,
+            task_owner_user_id=1,
+            task_setup_snapshot=snapshot,
+            task_lease=lease,
+            mcp_runtime_authorization_policy=policy,
+            resolved_execution_scope=None,
+        )
+
+    assert observed == [
+        MCPActorExecutionIdentity(
+            task_id=42,
+            run_id="run-a",
+            turn_id="turn-a",
+            lease_attempt_id="attempt-a",
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
+++ b/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
@@ -338,6 +338,7 @@ async def test_running_with_prior_trace_event_runs_reconstruct() -> None:
         task_setup_snapshot=snapshot,
         connector_runtime_turn_id=None,
         mcp_runtime_authorization_policy=None,
+        mcp_actor_execution_identity=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -490,6 +491,7 @@ async def test_running_with_dag_plan_runs_reconstruct() -> None:
         task_setup_snapshot=snapshot,
         connector_runtime_turn_id=None,
         mcp_runtime_authorization_policy=None,
+        mcp_actor_execution_identity=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -539,6 +541,7 @@ async def test_paused_with_no_history_still_runs_reconstruct() -> None:
         task_setup_snapshot=snapshot,
         connector_runtime_turn_id=None,
         mcp_runtime_authorization_policy=None,
+        mcp_actor_execution_identity=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -584,6 +587,7 @@ async def test_waiting_for_user_with_no_history_still_runs_reconstruct() -> None
         task_setup_snapshot=snapshot,
         connector_runtime_turn_id=None,
         mcp_runtime_authorization_policy=None,
+        mcp_actor_execution_identity=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -624,10 +628,12 @@ async def test_reconstruct_return_path_syncs_connector_runtime_turn() -> None:
         task_setup_snapshot: TaskSetupSnapshot | None = None,
         connector_runtime_turn_id: str | None = None,
         mcp_runtime_authorization_policy: Any = None,
+        mcp_actor_execution_identity: Any = None,
     ) -> None:
         assert task_setup_snapshot is snapshot
         assert connector_runtime_turn_id == "turn-reconstructed"
         assert mcp_runtime_authorization_policy is None
+        assert mcp_actor_execution_identity is None
         manager._agents[task_id] = reconstructed_agent
 
     with (

--- a/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
+++ b/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
@@ -45,6 +45,10 @@ from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.task import DAGExecution, Task, TaskStatus, TraceEvent
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import AutoModelUnavailableError
+from xagent.web.services.mcp_runtime import (
+    MCPActorAuthorizationPolicy,
+    MCPActorExecutionIdentity,
+)
 from xagent.web.services.task_setup_snapshot import (
     RuntimeUserFields,
     TaskOwnerMismatchError,
@@ -189,7 +193,11 @@ def _build_db(
     return db
 
 
-def _stub_downstream(manager: AgentServiceManager):
+def _stub_downstream(
+    manager: AgentServiceManager,
+    *,
+    create_tools: AsyncMock | None = None,
+):
     """Patch the heavy work past the reconstruct decision so the test
     asserts only on whether reconstruct was called.
 
@@ -228,7 +236,7 @@ def _stub_downstream(manager: AgentServiceManager):
         ),
         patch(
             "xagent.web.api.chat.create_default_tools",
-            new=AsyncMock(return_value=([], MagicMock())),
+            new=create_tools or AsyncMock(return_value=([], MagicMock())),
         ),
         patch(
             "xagent.web.sandbox_manager.get_sandbox_manager",
@@ -236,6 +244,41 @@ def _stub_downstream(manager: AgentServiceManager):
         ),
         patch("xagent.web.api.chat.AgentService"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_fresh_actor_tool_build_receives_explicit_execution_identity() -> None:
+    manager = AgentServiceManager()
+    user = _make_user()
+    task = _make_task(TaskStatus.RUNNING, agent_id=7)
+    task.agent_config = {
+        "__xagent_mcp_runtime_authorization_policy_required": True,
+        "mcp_runtime_authorization_policy_identity": "actor:alice",
+    }
+    snapshot = _build_snapshot(task, user)
+    create_tools = AsyncMock(return_value=([], MagicMock()))
+    identity = MCPActorExecutionIdentity(
+        task_id=42,
+        run_id="run-a",
+        turn_id="turn-a",
+        lease_attempt_id="attempt-a",
+    )
+    policy = MCPActorAuthorizationPolicy(
+        resource_owner_key="actor:alice",
+        allow_builtin_stdio=True,
+    )
+
+    with _Patches(_stub_downstream(manager, create_tools=create_tools)):
+        await manager.get_agent_for_task(
+            task_id=42,
+            db=_build_db(task, agent=_make_agent(), user=user),
+            user=user,
+            task_setup_snapshot=snapshot,
+            mcp_runtime_authorization_policy=policy,
+            mcp_actor_execution_identity=identity,
+        )
+
+    assert create_tools.await_args.kwargs["mcp_actor_execution_identity"] is identity
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_actor_mcp_runtime.py
+++ b/tests/web/services/test_actor_mcp_runtime.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+import base64
+import inspect
+import json
 import logging
 import uuid
 from collections.abc import Mapping, Sequence
 from types import SimpleNamespace
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session
 
+from xagent.core.tools.adapters.vibe.config import (
+    ACTOR_STDIO_SESSION_RUNTIME_UNAVAILABLE_REASON,
+    ACTOR_STDIO_SHADOWED_REASON,
+)
 from xagent.core.tools.adapters.vibe.factory import ToolFactory
 from xagent.web.builtin_mcp_registry import get_builtin_execution_fields
 from xagent.web.models.database import Base
@@ -47,7 +54,9 @@ def db() -> Session:
     engine.dispose()
 
 
-def _seed_app(db: Session, *, app_id: str = APP_ID) -> PublicMCPApp:
+def _seed_app(
+    db: Session, *, app_id: str = APP_ID, visible: bool = True
+) -> PublicMCPApp:
     execution = get_builtin_execution_fields(app_id)
     assert execution is not None
     app = PublicMCPApp(
@@ -57,7 +66,7 @@ def _seed_app(db: Session, *, app_id: str = APP_ID) -> PublicMCPApp:
         provider_name=execution["provider_name"],
         oauth_scopes=execution["oauth_scopes"],
         launch_config=execution["launch_config"],
-        is_visible_in_connector=True,
+        is_visible_in_connector=visible,
     )
     db.add(app)
     db.flush()
@@ -199,6 +208,50 @@ def test_synthetic_config_uses_exact_lifecycle_fenced_adapter_inputs(
         "XAGENT_MCP_CALLER_ID": str(USER_ID),
     }
     assert "id" not in config
+
+
+def test_catalog_lookup_does_not_load_full_rows_for_collision_scan(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    statements: list[str] = []
+
+    def capture_statement(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: object,
+    ) -> None:
+        if "public_mcp_apps" in statement:
+            statements.append(statement)
+
+    event.listen(db.bind, "before_cursor_execute", capture_statement)
+    try:
+        resolve_actor_mcp_stdio_configs(
+            db,
+            user_id=USER_ID,
+            policy=_policy(),
+            adapter=_FakeAdapter(_identity(app), _credentials()),
+            visible_servers=(),
+        )
+    finally:
+        event.remove(db.bind, "before_cursor_execute", capture_statement)
+
+    assert any(
+        "WHERE public_mcp_apps.app_id =" in statement for statement in statements
+    )
+    assert any(
+        "SELECT public_mcp_apps.app_id" in statement
+        and "public_mcp_apps.launch_config" not in statement
+        for statement in statements
+    )
+    assert not any(
+        "public_mcp_apps.launch_config" in statement and "WHERE" not in statement
+        for statement in statements
+    )
 
 
 def test_production_adapter_is_a_stateless_exact_service_wrapper(
@@ -354,6 +407,16 @@ async def test_create_default_tools_registers_production_adapter_only_for_actor_
     )
 
 
+def test_web_tool_config_actor_parameters_are_appended_after_voice() -> None:
+    parameters = list(inspect.signature(WebToolConfig.__init__).parameters)
+
+    assert parameters[-3:] == [
+        "voice",
+        "mcp_actor_stdio_connection_adapter",
+        "mcp_actor_execution_identity",
+    ]
+
+
 @pytest.mark.parametrize(
     "failure",
     [
@@ -461,6 +524,7 @@ def test_reserved_collision_reads_only_stable_server_identity(
 
     assert result.configs == ()
     assert result.blocked_server_ids == frozenset({73})
+    assert result.blocked_server_reasons == ((73, ACTOR_STDIO_SHADOWED_REASON),)
     assert adapter.secret_calls == []
     assert collision.forbidden_accesses == []
 
@@ -492,6 +556,49 @@ def test_policy_or_feature_off_never_falls_back_to_reserved_server(
     assert feature_off.blocked_server_ids == frozenset({73})
     assert legacy_policy.blocked_server_ids == frozenset()
     assert adapter.list_calls == []
+
+
+@pytest.mark.asyncio
+async def test_reserved_collision_surfaces_distinct_unavailable_reason(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", raising=False)
+    collision = SimpleNamespace(id=73, name=APP_ID, description=None)
+    config = WebToolConfig(
+        db=db,
+        request=None,
+        user_id=USER_ID,
+        mcp_runtime_authorization_policy=_policy(),
+    )
+    monkeypatch.setattr(
+        config,
+        "_visible_mcp_server_query",
+        lambda _team_ids: SimpleNamespace(all=lambda: [collision]),
+    )
+    monkeypatch.setattr(
+        "xagent.web.mcp_apps.classify_actor_builtin_oauth_server",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "xagent.web.mcp_apps.classify_actor_remote_oauth_server",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.mcp_runtime.load_user_env_overrides",
+        lambda *_args: {},
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.mcp_runtime.load_shared_env_overrides",
+        lambda *_args: {},
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.mcp_runtime.load_user_env_sources",
+        lambda *_args: {},
+    )
+
+    result = await config._load_mcp_server_configs()
+
+    assert result[0]["config"]["reason"] == ACTOR_STDIO_SHADOWED_REASON
 
 
 @pytest.mark.parametrize(
@@ -542,6 +649,139 @@ def test_incomplete_runtime_credentials_fail_closed(
     assert result.configs == ()
 
 
+@pytest.mark.parametrize(
+    ("field_name", "drifted_value"),
+    [
+        ("name", "Drifted PostHog"),
+        ("transport", "oauth"),
+        ("provider_name", "posthog"),
+        ("oauth_scopes", ["unexpected"]),
+        (
+            "launch_config",
+            {
+                "command": "attacker",
+                "args": ["-m", "xagent.web.tools.mcp.posthog"],
+                "required_env": ["POSTHOG_API_KEY", "POSTHOG_HOST"],
+            },
+        ),
+        (
+            "launch_config",
+            {
+                "command": "python",
+                "args": ["-m", "attacker.module"],
+                "required_env": ["POSTHOG_API_KEY", "POSTHOG_HOST"],
+            },
+        ),
+        (
+            "launch_config",
+            {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.posthog"],
+                "required_env": ["ATTACKER_SECRET"],
+            },
+        ),
+    ],
+)
+def test_catalog_execution_drift_fails_closed_before_secret_read(
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    field_name: str,
+    drifted_value: object,
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    adapter = _FakeAdapter(_identity(app), _credentials())
+    setattr(app, field_name, drifted_value)
+    db.flush()
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+
+    assert result.configs == ()
+    assert adapter.secret_calls == []
+
+
+def test_hidden_execution_scoped_app_fails_closed_before_secret_read(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db, app_id="chrome-devtools", visible=False)
+    adapter = _FakeAdapter(_identity(app), None)
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+        execution_identity=_execution_identity(),
+    )
+
+    assert result.configs == ()
+    assert result.session_identities == ()
+    assert adapter.secret_calls == []
+
+
+def test_trusted_runtime_env_collision_fails_closed(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    adapter = _FakeAdapter(_identity(app), _credentials())
+    monkeypatch.setattr(
+        "xagent.web.services.actor_mcp_runtime.caller_id_env",
+        lambda _user_id: {"POSTHOG_API_KEY": "fixed"},
+    )
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+
+    assert result.configs == ()
+
+
+def test_reserved_stdio_registry_keys_are_cached(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from xagent.web.services import actor_mcp_runtime
+
+    actor_mcp_runtime._builtin_stdio_rows.cache_clear()
+    actor_mcp_runtime._reserved_stdio_keys.cache_clear()
+    calls = 0
+    original = actor_mcp_runtime.get_builtin_public_mcp_app_rows
+
+    def counted_rows() -> list[dict[str, object]]:
+        nonlocal calls
+        calls += 1
+        return original()
+
+    monkeypatch.setattr(
+        actor_mcp_runtime, "get_builtin_public_mcp_app_rows", counted_rows
+    )
+    collision = _StableIdentityOnlyServer(73, APP_ID)
+    for _ in range(2):
+        resolve_actor_mcp_stdio_configs(
+            db,
+            user_id=USER_ID,
+            policy=_policy(),
+            adapter=None,
+            visible_servers=(collision,),
+        )
+
+    assert calls == 1
+    actor_mcp_runtime._builtin_stdio_rows.cache_clear()
+    actor_mcp_runtime._reserved_stdio_keys.cache_clear()
+
+
 @pytest.mark.asyncio
 async def test_web_loader_appends_synthetic_config_without_env_source_queries(
     db: Session, monkeypatch: pytest.MonkeyPatch
@@ -577,6 +817,67 @@ async def test_web_loader_appends_synthetic_config_without_env_source_queries(
     assert [item["name"] for item in result] == [APP_ID]
 
 
+@pytest.mark.asyncio
+async def test_nonempty_ordinary_env_layers_never_leak_into_actor_config(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    adapter = _FakeAdapter(_identity(app), _credentials())
+    ordinary = _StableIdentityOnlyServer(73, "ordinary-server")
+    config = WebToolConfig(
+        db=db,
+        request=None,
+        user_id=USER_ID,
+        mcp_runtime_authorization_policy=_policy(),
+        mcp_actor_stdio_connection_adapter=adapter,
+    )
+    monkeypatch.setattr(
+        config,
+        "_visible_mcp_server_query",
+        lambda _team_ids: SimpleNamespace(all=lambda: [ordinary]),
+    )
+    monkeypatch.setattr(
+        "xagent.web.mcp_apps.classify_actor_builtin_oauth_server",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "xagent.web.mcp_apps.classify_actor_remote_oauth_server",
+        lambda *_args, **_kwargs: None,
+    )
+
+    async def build_ordinary(**_kwargs: object) -> dict[str, object]:
+        return {
+            "id": 73,
+            "name": "ordinary-server",
+            "transport": "stdio",
+            "config": {"command": "python", "env": {"ORDINARY": "value"}},
+        }
+
+    monkeypatch.setattr(config, "_load_mcp_server_config", build_ordinary)
+    monkeypatch.setattr(
+        "xagent.web.services.mcp_runtime.load_user_env_overrides",
+        lambda *_args: {73: {"POSTHOG_API_KEY": "user-leak"}},
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.mcp_runtime.load_shared_env_overrides",
+        lambda *_args: {73: {"POSTHOG_HOST": "shared-leak"}},
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.mcp_runtime.load_user_env_sources",
+        lambda *_args: {73: "platform"},
+    )
+
+    result = await config._load_mcp_server_configs()
+
+    actor_config = next(item for item in result if item["name"] == APP_ID)
+    assert actor_config["config"]["env"] == {
+        **_credentials(),
+        "XAGENT_MCP_CALLER_ID": str(USER_ID),
+    }
+    assert ordinary.forbidden_accesses == []
+
+
 def test_execution_scoped_chrome_requires_complete_execution_identity(
     db: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -602,7 +903,9 @@ def test_execution_scoped_chrome_requires_complete_execution_identity(
 
     assert missing.configs == ()
     assert len(present.configs) == 1
-    session_identity = present.configs[0]["actor_stdio_session_identity"]
+    assert "actor_stdio_session_identity" not in present.configs[0]
+    assert json.loads(json.dumps(present.configs[0])) == present.configs[0]
+    session_identity = dict(present.session_identities)["chrome-devtools"]
     assert isinstance(session_identity, ActorMCPStdioSessionIdentity)
     assert session_identity.key == (
         91,
@@ -615,6 +918,35 @@ def test_execution_scoped_chrome_requires_complete_execution_identity(
         app.generation,
         adapter.identity.lifecycle_generation,
     )
+
+
+@pytest.mark.asyncio
+async def test_web_loader_keeps_chrome_identity_in_host_only_side_channel(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db, app_id="chrome-devtools")
+    adapter = _FakeAdapter(_identity(app), None)
+    config = WebToolConfig(
+        db=db,
+        request=None,
+        user_id=USER_ID,
+        mcp_runtime_authorization_policy=_policy(),
+        mcp_actor_stdio_connection_adapter=adapter,
+        mcp_actor_execution_identity=_execution_identity(),
+    )
+    monkeypatch.setattr(
+        config,
+        "_visible_mcp_server_query",
+        lambda _team_ids: SimpleNamespace(all=lambda: []),
+    )
+
+    result = await config._load_mcp_server_configs()
+
+    assert len(result) == 1
+    assert "actor_stdio_session_identity" not in result[0]
+    identities = config.get_actor_mcp_stdio_session_identities()
+    assert identities["chrome-devtools"].connection.app_id == "chrome-devtools"
 
 
 @pytest.mark.parametrize(
@@ -662,7 +994,7 @@ def test_chrome_session_key_changes_for_retry_and_later_turn() -> None:
 
 
 @pytest.mark.asyncio
-async def test_tool_factory_threads_actor_stdio_session_identity_to_connection(
+async def test_tool_factory_keeps_actor_stdio_session_identity_out_of_connection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     connection = ActorMCPStdioConnectionIdentity(
@@ -674,14 +1006,33 @@ async def test_tool_factory_threads_actor_stdio_session_identity_to_connection(
     )
     session_identity = ActorMCPStdioSessionIdentity(_execution_identity(), connection)
     captured: dict[str, object] = {}
+    owner_bytes = OWNER.encode()
 
-    async def fake_load(connections: dict[str, object], **_kwargs: object) -> object:
-        captured.update(connections)
-        return SimpleNamespace(tools=(), failures=())
+    async def forbidden_load(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("session-scoped config reached the per-call loader")
+
+    async def consume(**kwargs: object) -> list[object]:
+        captured.update(kwargs)
+        connection_config = kwargs["connection"]
+        serialized = json.dumps(connection_config).encode()
+        assert owner_bytes not in serialized
+        from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper import (
+            _serialize_connection,
+        )
+
+        argv_payload = base64.b64decode(_serialize_connection(connection_config))
+        assert owner_bytes not in argv_payload
+        import cloudpickle
+
+        pickled = base64.b64decode(
+            base64.b64encode(cloudpickle.dumps(connection_config))
+        )
+        assert owner_bytes not in pickled
+        return []
 
     monkeypatch.setattr(
         "xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools",
-        fake_load,
+        forbidden_load,
     )
 
     await ToolFactory._create_mcp_tools_from_configs(
@@ -690,11 +1041,94 @@ async def test_tool_factory_threads_actor_stdio_session_identity_to_connection(
                 "name": "chrome-devtools",
                 "transport": "stdio",
                 "config": {"command": "npx", "args": [], "env": {}},
-                "actor_stdio_session_identity": session_identity,
             }
-        ]
+        ],
+        actor_stdio_session_identities={"chrome-devtools": session_identity},
+        actor_stdio_session_consumer=consume,
     )
 
-    assert (
-        captured["chrome-devtools"]["actor_stdio_session_identity"] is session_identity
-    )  # type: ignore[index]
+    assert captured["session_identity"] is session_identity
+    assert "actor_stdio_session_identity" not in captured["connection"]  # type: ignore[operator]
+
+
+@pytest.mark.asyncio
+async def test_session_and_per_call_tools_are_both_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = ActorMCPStdioConnectionIdentity(
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id="chrome-devtools",
+        catalog_app_generation=uuid.uuid4(),
+        lifecycle_generation=uuid.uuid4(),
+    )
+    session_tool = SimpleNamespace(name="session-tool")
+    per_call_tool = SimpleNamespace(name="per-call-tool")
+
+    async def load_per_call(
+        connections: Mapping[str, object], **_kwargs: object
+    ) -> object:
+        assert set(connections) == {"posthog"}
+        return SimpleNamespace(tools=[per_call_tool], failures=[])
+
+    async def consume(**kwargs: object) -> list[object]:
+        assert kwargs["server_name"] == "chrome-devtools"
+        return [session_tool]
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools",
+        load_per_call,
+    )
+
+    tools = await ToolFactory._create_mcp_tools_from_configs(
+        [
+            {
+                "name": "chrome-devtools",
+                "transport": "stdio",
+                "config": {"command": "npx", "args": [], "env": {}},
+            },
+            {
+                "name": "posthog",
+                "transport": "stdio",
+                "config": {"command": "npx", "args": [], "env": {}},
+            },
+        ],
+        actor_stdio_session_identities={
+            "chrome-devtools": ActorMCPStdioSessionIdentity(
+                _execution_identity(), connection
+            )
+        },
+        actor_stdio_session_consumer=consume,
+    )
+
+    assert tools == [session_tool, per_call_tool]
+
+
+@pytest.mark.asyncio
+async def test_execution_scoped_config_fails_closed_without_session_consumer() -> None:
+    connection = ActorMCPStdioConnectionIdentity(
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id="chrome-devtools",
+        catalog_app_generation=uuid.uuid4(),
+        lifecycle_generation=uuid.uuid4(),
+    )
+    tools = await ToolFactory._create_mcp_tools_from_configs(
+        [
+            {
+                "name": "chrome-devtools",
+                "transport": "stdio",
+                "config": {"command": "npx", "args": [], "env": {}},
+            }
+        ],
+        actor_stdio_session_identities={
+            "chrome-devtools": ActorMCPStdioSessionIdentity(
+                _execution_identity(), connection
+            )
+        },
+    )
+
+    assert len(tools) == 1
+    assert tools[0].unavailability_reason == (  # type: ignore[attr-defined]
+        ACTOR_STDIO_SESSION_RUNTIME_UNAVAILABLE_REASON
+    )

--- a/tests/web/services/test_actor_mcp_runtime.py
+++ b/tests/web/services/test_actor_mcp_runtime.py
@@ -8,14 +8,19 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+from xagent.core.tools.adapters.vibe.factory import ToolFactory
 from xagent.web.builtin_mcp_registry import get_builtin_execution_fields
 from xagent.web.models.database import Base
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.services.actor_mcp_runtime import (
     ActorMCPStdioConnectionIdentity,
+    ActorMCPStdioSessionIdentity,
     resolve_actor_mcp_stdio_configs,
 )
-from xagent.web.services.mcp_runtime import MCPActorAuthorizationPolicy
+from xagent.web.services.mcp_runtime import (
+    MCPActorAuthorizationPolicy,
+    MCPActorExecutionIdentity,
+)
 from xagent.web.tools.config import WebToolConfig
 
 USER_ID = 41
@@ -32,11 +37,11 @@ def db() -> Session:
     engine.dispose()
 
 
-def _seed_app(db: Session) -> PublicMCPApp:
-    execution = get_builtin_execution_fields(APP_ID)
+def _seed_app(db: Session, *, app_id: str = APP_ID) -> PublicMCPApp:
+    execution = get_builtin_execution_fields(app_id)
     assert execution is not None
     app = PublicMCPApp(
-        app_id=APP_ID,
+        app_id=app_id,
         name=execution["name"],
         transport=execution["transport"],
         provider_name=execution["provider_name"],
@@ -109,7 +114,7 @@ def _identity(app: PublicMCPApp, **overrides: object):
     values = {
         "user_id": USER_ID,
         "resource_owner_key": OWNER,
-        "app_id": APP_ID,
+        "app_id": app.app_id,
         "catalog_app_generation": app.generation,
         "lifecycle_generation": uuid.uuid4(),
     }
@@ -131,6 +136,21 @@ def _policy(*, allow: bool = True) -> MCPActorAuthorizationPolicy:
     )
 
 
+def _execution_identity(
+    *,
+    task_id: int = 91,
+    run_id: str = "run-1",
+    turn_id: str = "turn-1",
+    lease_attempt_id: str = "attempt-1",
+) -> MCPActorExecutionIdentity:
+    return MCPActorExecutionIdentity(
+        task_id=task_id,
+        run_id=run_id,
+        turn_id=turn_id,
+        lease_attempt_id=lease_attempt_id,
+    )
+
+
 def test_synthetic_config_uses_exact_lifecycle_fenced_adapter_inputs(
     db: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -147,9 +167,7 @@ def test_synthetic_config_uses_exact_lifecycle_fenced_adapter_inputs(
         visible_servers=(),
     )
 
-    assert adapter.list_calls == [
-        {"user_id": USER_ID, "resource_owner_key": OWNER}
-    ]
+    assert adapter.list_calls == [{"user_id": USER_ID, "resource_owner_key": OWNER}]
     assert adapter.secret_calls == [
         {
             "user_id": USER_ID,
@@ -305,3 +323,126 @@ async def test_web_loader_appends_synthetic_config_without_env_source_queries(
     result = await config._load_mcp_server_configs()
 
     assert [item["name"] for item in result] == [APP_ID]
+
+
+def test_execution_scoped_chrome_requires_complete_execution_identity(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db, app_id="chrome-devtools")
+    adapter = _FakeAdapter(_identity(app), None)
+
+    missing = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+    present = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+        execution_identity=_execution_identity(),
+    )
+
+    assert missing.configs == ()
+    assert len(present.configs) == 1
+    session_identity = present.configs[0]["actor_stdio_session_identity"]
+    assert isinstance(session_identity, ActorMCPStdioSessionIdentity)
+    assert session_identity.key == (
+        91,
+        "run-1",
+        "turn-1",
+        "attempt-1",
+        USER_ID,
+        OWNER,
+        "chrome-devtools",
+        app.generation,
+        adapter.identity.lifecycle_generation,
+    )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("task_id", None),
+        ("run_id", None),
+        ("turn_id", None),
+        ("lease_attempt_id", None),
+    ],
+)
+def test_actor_execution_identity_rejects_each_missing_field(
+    field_name: str, value: object
+) -> None:
+    values: dict[str, object] = {
+        "task_id": 91,
+        "run_id": "run-1",
+        "turn_id": "turn-1",
+        "lease_attempt_id": "attempt-1",
+    }
+    values[field_name] = value
+
+    with pytest.raises(ValueError, match=field_name):
+        MCPActorExecutionIdentity(**values)  # type: ignore[arg-type]
+
+
+def test_chrome_session_key_changes_for_retry_and_later_turn() -> None:
+    connection = ActorMCPStdioConnectionIdentity(
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id="chrome-devtools",
+        catalog_app_generation=uuid.uuid4(),
+        lifecycle_generation=uuid.uuid4(),
+    )
+    initial = ActorMCPStdioSessionIdentity(_execution_identity(), connection)
+    retry = ActorMCPStdioSessionIdentity(
+        _execution_identity(lease_attempt_id="attempt-2"), connection
+    )
+    later_turn = ActorMCPStdioSessionIdentity(
+        _execution_identity(turn_id="turn-2"), connection
+    )
+
+    assert initial.key != retry.key
+    assert initial.key != later_turn.key
+
+
+@pytest.mark.asyncio
+async def test_tool_factory_threads_actor_stdio_session_identity_to_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = ActorMCPStdioConnectionIdentity(
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id="chrome-devtools",
+        catalog_app_generation=uuid.uuid4(),
+        lifecycle_generation=uuid.uuid4(),
+    )
+    session_identity = ActorMCPStdioSessionIdentity(_execution_identity(), connection)
+    captured: dict[str, object] = {}
+
+    async def fake_load(connections: dict[str, object], **_kwargs: object) -> object:
+        captured.update(connections)
+        return SimpleNamespace(tools=(), failures=())
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools",
+        fake_load,
+    )
+
+    await ToolFactory._create_mcp_tools_from_configs(
+        [
+            {
+                "name": "chrome-devtools",
+                "transport": "stdio",
+                "config": {"command": "npx", "args": [], "env": {}},
+                "actor_stdio_session_identity": session_identity,
+            }
+        ]
+    )
+
+    assert (
+        captured["chrome-devtools"]["actor_stdio_session_identity"] is session_identity
+    )  # type: ignore[index]

--- a/tests/web/services/test_actor_mcp_runtime.py
+++ b/tests/web/services/test_actor_mcp_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from collections.abc import Mapping, Sequence
 from types import SimpleNamespace
@@ -12,9 +13,18 @@ from xagent.core.tools.adapters.vibe.factory import ToolFactory
 from xagent.web.builtin_mcp_registry import get_builtin_execution_fields
 from xagent.web.models.database import Base
 from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.services.actor_mcp_connections import (
+    ActorMCPConnectionCredentialCorruptionError,
+    ActorMCPConnectionMetadata,
+    ActorMCPConnectionSnapshot,
+    ActorMCPConnectionValidationError,
+    create_actor_mcp_connection,
+)
 from xagent.web.services.actor_mcp_runtime import (
+    ActorMCPConnectionServiceAdapter,
     ActorMCPStdioConnectionIdentity,
     ActorMCPStdioSessionIdentity,
+    production_actor_mcp_stdio_connection_adapter,
     resolve_actor_mcp_stdio_configs,
 )
 from xagent.web.services.mcp_runtime import (
@@ -189,6 +199,248 @@ def test_synthetic_config_uses_exact_lifecycle_fenced_adapter_inputs(
         "XAGENT_MCP_CALLER_ID": str(USER_ID),
     }
     assert "id" not in config
+
+
+def test_production_adapter_is_a_stateless_exact_service_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog_generation = uuid.uuid4()
+    lifecycle_generation = uuid.uuid4()
+    metadata = ActorMCPConnectionMetadata(
+        id=7,
+        lifecycle_generation=lifecycle_generation,
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id=APP_ID,
+        catalog_app_generation=catalog_generation,
+        configured_field_names=frozenset(_credentials()),
+    )
+    snapshot = ActorMCPConnectionSnapshot(
+        id=7,
+        lifecycle_generation=lifecycle_generation,
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id=APP_ID,
+        catalog_app_generation=catalog_generation,
+        credentials=_credentials(),
+    )
+    list_calls: list[dict[str, object]] = []
+    secret_calls: list[dict[str, object]] = []
+
+    def fake_list(_db: Session, **kwargs: object) -> list[object]:
+        list_calls.append(kwargs)
+        return [metadata]
+
+    def fake_get(_db: Session, **kwargs: object) -> object:
+        secret_calls.append(kwargs)
+        return snapshot
+
+    monkeypatch.setattr(
+        "xagent.web.services.actor_mcp_runtime.list_actor_mcp_connection_metadata",
+        fake_list,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.actor_mcp_runtime.get_actor_mcp_connection_credentials_internal",
+        fake_get,
+    )
+    adapter = ActorMCPConnectionServiceAdapter()
+
+    identities = adapter.list_connection_identities(
+        object(),  # type: ignore[arg-type]
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+    )
+    credentials = adapter.get_connection_credentials(
+        object(),  # type: ignore[arg-type]
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id=APP_ID,
+        catalog_app_generation=catalog_generation,
+        expected_lifecycle_generation=lifecycle_generation,
+    )
+
+    assert identities == (
+        ActorMCPStdioConnectionIdentity(
+            user_id=USER_ID,
+            resource_owner_key=OWNER,
+            app_id=APP_ID,
+            catalog_app_generation=catalog_generation,
+            lifecycle_generation=lifecycle_generation,
+        ),
+    )
+    assert credentials == _credentials()
+    assert list_calls == [{"user_id": USER_ID, "resource_owner_key": OWNER}]
+    assert secret_calls == [
+        {
+            "user_id": USER_ID,
+            "resource_owner_key": OWNER,
+            "app_id": APP_ID,
+            "catalog_app_generation": catalog_generation,
+            "expected_lifecycle_generation": lifecycle_generation,
+        }
+    ]
+
+
+def test_production_adapter_resolves_credentials_from_storage_service(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    _seed_app(db)
+    create_actor_mcp_connection(
+        db,
+        user_id=USER_ID,
+        resource_owner_key=OWNER,
+        app_id=APP_ID,
+        credentials=_credentials(),
+    )
+
+    def forbidden_transaction_boundary() -> None:
+        raise AssertionError("runtime adapter must not own commit or rollback")
+
+    monkeypatch.setattr(db, "commit", forbidden_transaction_boundary)
+    monkeypatch.setattr(db, "rollback", forbidden_transaction_boundary)
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=production_actor_mcp_stdio_connection_adapter(),
+        visible_servers=(),
+    )
+
+    assert len(result.configs) == 1
+    assert result.configs[0]["config"]["env"] == {
+        **_credentials(),
+        "XAGENT_MCP_CALLER_ID": str(USER_ID),
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_default_tools_registers_production_adapter_only_for_actor_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.api.chat import create_default_tools
+
+    captured: list[dict[str, object]] = []
+
+    class _FakeToolConfig:
+        def __init__(self, **kwargs: object) -> None:
+            captured.append(kwargs)
+
+        def set_task_runtime_contribution(self, _contribution: object) -> None:
+            pass
+
+    async def create_tools(_config: object) -> list[object]:
+        return []
+
+    monkeypatch.setattr("xagent.web.tools.config.WebToolConfig", _FakeToolConfig)
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local", lambda: object()
+    )
+    monkeypatch.setattr(ToolFactory, "create_all_tools", create_tools)
+
+    for policy in (None, _policy()):
+        await create_default_tools(
+            None,
+            user=SimpleNamespace(id=USER_ID, is_admin=False),
+            task_id="91",
+            mcp_runtime_authorization_policy=policy,
+        )
+
+    assert captured[0]["mcp_actor_stdio_connection_adapter"] is None
+    assert (
+        captured[1]["mcp_actor_stdio_connection_adapter"]
+        is production_actor_mcp_stdio_connection_adapter()
+    )
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        ActorMCPConnectionCredentialCorruptionError("sensitive-value"),
+        RuntimeError("sensitive-value"),
+    ],
+)
+def test_credential_failures_remain_blocked_without_logging_values(
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    failure: Exception,
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    caplog.set_level(logging.INFO)
+    app = _seed_app(db)
+
+    class _FailingAdapter(_FakeAdapter):
+        def get_connection_credentials(self, *_args: object, **_kwargs: object):
+            raise failure
+
+    collision = _StableIdentityOnlyServer(73, "chrome-devtools")
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=_FailingAdapter(_identity(app), _credentials()),
+        visible_servers=(collision,),
+    )
+
+    assert result.configs == ()
+    assert result.blocked_server_ids == frozenset({73})
+    assert type(failure).__name__ in caplog.text
+    assert "sensitive-value" not in caplog.text
+
+
+def test_missing_adapter_remains_blocked_without_custom_fallback(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    collision = _StableIdentityOnlyServer(73, APP_ID)
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=None,
+        visible_servers=(collision,),
+    )
+
+    assert result.configs == ()
+    assert result.blocked_server_ids == frozenset({73})
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        ActorMCPConnectionValidationError("sensitive-value"),
+        RuntimeError("sensitive-value"),
+    ],
+)
+def test_list_failures_remain_blocked_without_logging_values(
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    failure: Exception,
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    caplog.set_level(logging.INFO)
+
+    class _FailingListAdapter:
+        def list_connection_identities(self, *_args: object, **_kwargs: object):
+            raise failure
+
+    collision = _StableIdentityOnlyServer(73, APP_ID)
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=_FailingListAdapter(),  # type: ignore[arg-type]
+        visible_servers=(collision,),
+    )
+
+    assert result.configs == ()
+    assert result.blocked_server_ids == frozenset({73})
+    assert type(failure).__name__ in caplog.text
+    assert "sensitive-value" not in caplog.text
 
 
 def test_reserved_collision_reads_only_stable_server_identity(

--- a/tests/web/services/test_actor_mcp_runtime.py
+++ b/tests/web/services/test_actor_mcp_runtime.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from xagent.web.builtin_mcp_registry import get_builtin_execution_fields
+from xagent.web.models.database import Base
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.services.actor_mcp_runtime import (
+    ActorMCPStdioConnectionIdentity,
+    resolve_actor_mcp_stdio_configs,
+)
+from xagent.web.services.mcp_runtime import MCPActorAuthorizationPolicy
+from xagent.web.tools.config import WebToolConfig
+
+USER_ID = 41
+OWNER = "toby:slack:T1:U1"
+APP_ID = "posthog"
+
+
+@pytest.fixture()
+def db() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _seed_app(db: Session) -> PublicMCPApp:
+    execution = get_builtin_execution_fields(APP_ID)
+    assert execution is not None
+    app = PublicMCPApp(
+        app_id=APP_ID,
+        name=execution["name"],
+        transport=execution["transport"],
+        provider_name=execution["provider_name"],
+        oauth_scopes=execution["oauth_scopes"],
+        launch_config=execution["launch_config"],
+        is_visible_in_connector=True,
+    )
+    db.add(app)
+    db.flush()
+    return app
+
+
+class _FakeAdapter:
+    def __init__(
+        self,
+        identity: ActorMCPStdioConnectionIdentity,
+        credentials: Mapping[str, str] | None,
+    ) -> None:
+        self.identity = identity
+        self.credentials = credentials
+        self.list_calls: list[dict[str, object]] = []
+        self.secret_calls: list[dict[str, object]] = []
+
+    def list_connection_identities(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+    ) -> Sequence[ActorMCPStdioConnectionIdentity]:
+        self.list_calls.append(
+            {"user_id": user_id, "resource_owner_key": resource_owner_key}
+        )
+        return (self.identity,)
+
+    def get_connection_credentials(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        resource_owner_key: str,
+        app_id: str,
+        catalog_app_generation: uuid.UUID,
+        expected_lifecycle_generation: uuid.UUID,
+    ) -> Mapping[str, str] | None:
+        self.secret_calls.append(
+            {
+                "user_id": user_id,
+                "resource_owner_key": resource_owner_key,
+                "app_id": app_id,
+                "catalog_app_generation": catalog_app_generation,
+                "expected_lifecycle_generation": expected_lifecycle_generation,
+            }
+        )
+        return self.credentials
+
+
+class _StableIdentityOnlyServer:
+    def __init__(self, server_id: int, name: str) -> None:
+        self.id = server_id
+        self.name = name
+        self.forbidden_accesses: list[str] = []
+
+    def __getattr__(self, name: str) -> object:
+        self.forbidden_accesses.append(name)
+        raise AssertionError(f"actor resolver read forbidden MCPServer field: {name}")
+
+
+def _identity(app: PublicMCPApp, **overrides: object):
+    values = {
+        "user_id": USER_ID,
+        "resource_owner_key": OWNER,
+        "app_id": APP_ID,
+        "catalog_app_generation": app.generation,
+        "lifecycle_generation": uuid.uuid4(),
+    }
+    values.update(overrides)
+    return ActorMCPStdioConnectionIdentity(**values)
+
+
+def _credentials() -> dict[str, str]:
+    return {
+        "POSTHOG_API_KEY": "actor-api-key",
+        "POSTHOG_HOST": "https://actor.example.test",
+    }
+
+
+def _policy(*, allow: bool = True) -> MCPActorAuthorizationPolicy:
+    return MCPActorAuthorizationPolicy(
+        resource_owner_key=OWNER,
+        allow_builtin_stdio=allow,
+    )
+
+
+def test_synthetic_config_uses_exact_lifecycle_fenced_adapter_inputs(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    identity = _identity(app)
+    adapter = _FakeAdapter(identity, _credentials())
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+
+    assert adapter.list_calls == [
+        {"user_id": USER_ID, "resource_owner_key": OWNER}
+    ]
+    assert adapter.secret_calls == [
+        {
+            "user_id": USER_ID,
+            "resource_owner_key": OWNER,
+            "app_id": APP_ID,
+            "catalog_app_generation": app.generation,
+            "expected_lifecycle_generation": identity.lifecycle_generation,
+        }
+    ]
+    assert result.blocked_server_ids == frozenset()
+    assert len(result.configs) == 1
+    config = result.configs[0]
+    execution = get_builtin_execution_fields(APP_ID)
+    assert execution is not None
+    assert config["config"]["command"] == execution["launch_config"]["command"]
+    assert config["config"]["args"] == execution["launch_config"]["args"]
+    assert config["config"]["env"] == {
+        **_credentials(),
+        "XAGENT_MCP_CALLER_ID": str(USER_ID),
+    }
+    assert "id" not in config
+
+
+def test_reserved_collision_reads_only_stable_server_identity(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    adapter = _FakeAdapter(_identity(app), _credentials())
+    collision = _StableIdentityOnlyServer(73, "  PostHog  ")
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(collision,),
+    )
+
+    assert result.configs == ()
+    assert result.blocked_server_ids == frozenset({73})
+    assert adapter.secret_calls == []
+    assert collision.forbidden_accesses == []
+
+
+def test_policy_or_feature_off_never_falls_back_to_reserved_server(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", raising=False)
+    app = _seed_app(db)
+    adapter = _FakeAdapter(_identity(app), _credentials())
+    collision = _StableIdentityOnlyServer(73, APP_ID)
+
+    feature_off = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(collision,),
+    )
+    legacy_policy = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(allow=False),
+        adapter=adapter,
+        visible_servers=(collision,),
+    )
+
+    assert feature_off.configs == ()
+    assert feature_off.blocked_server_ids == frozenset({73})
+    assert legacy_policy.blocked_server_ids == frozenset()
+    assert adapter.list_calls == []
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"user_id": 42},
+        {"resource_owner_key": "toby:slack:T1:U2"},
+        {"catalog_app_generation": uuid.uuid4()},
+    ],
+)
+def test_mismatched_connection_identity_fails_closed(
+    db: Session, monkeypatch: pytest.MonkeyPatch, override: dict[str, object]
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    adapter = _FakeAdapter(_identity(app, **override), _credentials())
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+
+    assert result.configs == ()
+    assert adapter.secret_calls == []
+
+
+def test_incomplete_runtime_credentials_fail_closed(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    adapter = _FakeAdapter(
+        _identity(app),
+        {"POSTHOG_API_KEY": "actor-api-key"},
+    )
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+
+    assert result.configs == ()
+
+
+@pytest.mark.asyncio
+async def test_web_loader_appends_synthetic_config_without_env_source_queries(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    adapter = _FakeAdapter(_identity(app), _credentials())
+    config = WebToolConfig(
+        db=db,
+        request=None,
+        user_id=USER_ID,
+        task_id="execution-id-is-not-derived-here",
+        mcp_runtime_authorization_policy=_policy(),
+        mcp_actor_stdio_connection_adapter=adapter,
+    )
+    monkeypatch.setattr(
+        config,
+        "_visible_mcp_server_query",
+        lambda _team_ids: SimpleNamespace(all=lambda: []),
+    )
+
+    def forbidden(*_args: object, **_kwargs: object):
+        raise AssertionError("ordinary MCP credential source was queried")
+
+    from xagent.web.services import mcp_runtime
+
+    monkeypatch.setattr(mcp_runtime, "load_user_env_overrides", forbidden)
+    monkeypatch.setattr(mcp_runtime, "load_shared_env_overrides", forbidden)
+    monkeypatch.setattr(mcp_runtime, "load_user_env_sources", forbidden)
+
+    result = await config._load_mcp_server_configs()
+
+    assert [item["name"] for item in result] == [APP_ID]

--- a/tests/web/services/test_actor_mcp_runtime.py
+++ b/tests/web/services/test_actor_mcp_runtime.py
@@ -29,8 +29,10 @@ from xagent.web.services.actor_mcp_connections import (
 )
 from xagent.web.services.actor_mcp_runtime import (
     ActorMCPConnectionServiceAdapter,
+    ActorMCPRuntimeDefinitionError,
     ActorMCPStdioConnectionIdentity,
     ActorMCPStdioSessionIdentity,
+    _canonical_oauth_scopes,
     production_actor_mcp_stdio_connection_adapter,
     resolve_actor_mcp_stdio_configs,
 )
@@ -693,6 +695,107 @@ def test_catalog_execution_drift_fails_closed_before_secret_read(
     adapter = _FakeAdapter(_identity(app), _credentials())
     setattr(app, field_name, drifted_value)
     db.flush()
+
+    result = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+
+    assert result.configs == ()
+    assert adapter.secret_calls == []
+
+
+def test_catalog_oauth_scope_order_is_ignored_but_content_drift_fails_closed(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from xagent.web.services import actor_mcp_runtime
+
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    execution = get_builtin_execution_fields(APP_ID)
+    assert execution is not None
+    execution["oauth_scopes"] = ["scope-b", "scope-a"]
+    monkeypatch.setattr(
+        actor_mcp_runtime,
+        "_cached_builtin_stdio_execution",
+        lambda _app_id: execution,
+    )
+    app.oauth_scopes = ["scope-a", "scope-b"]
+    db.flush()
+    adapter = _FakeAdapter(_identity(app), _credentials())
+
+    reordered = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+
+    assert len(reordered.configs) == 1
+    assert len(adapter.secret_calls) == 1
+
+    app.oauth_scopes = ["scope-a", "scope-c"]
+    db.flush()
+    adapter.secret_calls.clear()
+    drifted = resolve_actor_mcp_stdio_configs(
+        db,
+        user_id=USER_ID,
+        policy=_policy(),
+        adapter=adapter,
+        visible_servers=(),
+    )
+
+    assert drifted.configs == ()
+    assert adapter.secret_calls == []
+
+
+@pytest.mark.parametrize(
+    "invalid_scopes",
+    [
+        ["scope-a", "scope-a"],
+        ["scope-a", 7],
+        ["scope-a", ""],
+    ],
+)
+def test_oauth_scope_normalization_rejects_invalid_elements_and_duplicates(
+    invalid_scopes: list[object],
+) -> None:
+    with pytest.raises(ActorMCPRuntimeDefinitionError):
+        _canonical_oauth_scopes(invalid_scopes)
+
+
+@pytest.mark.parametrize(
+    "invalid_scopes",
+    [
+        ["scope-a", "scope-a"],
+        ["scope-a", 7],
+        ["scope-a", ""],
+    ],
+)
+def test_invalid_or_duplicate_oauth_scopes_fail_closed_before_secret_read(
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_scopes: list[object],
+) -> None:
+    from xagent.web.services import actor_mcp_runtime
+
+    monkeypatch.setenv("XAGENT_TOBY_PERSONAL_STDIO_ENABLED", "true")
+    app = _seed_app(db)
+    execution = get_builtin_execution_fields(APP_ID)
+    assert execution is not None
+    execution["oauth_scopes"] = invalid_scopes
+    monkeypatch.setattr(
+        actor_mcp_runtime,
+        "_cached_builtin_stdio_execution",
+        lambda _app_id: execution,
+    )
+    app.oauth_scopes = invalid_scopes  # type: ignore[assignment]
+    db.flush()
+    adapter = _FakeAdapter(_identity(app), _credentials())
 
     result = resolve_actor_mcp_stdio_configs(
         db,

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -20,7 +20,10 @@ from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
 from xagent.web.services import connector_team_scope
-from xagent.web.services.mcp_runtime import MCPBuiltinOAuthActorPolicy
+from xagent.web.services.mcp_runtime import (
+    MCPActorAuthorizationPolicy,
+    MCPBuiltinOAuthActorPolicy,
+)
 from xagent.web.tools import config as web_tools_config
 from xagent.web.tools.config import (
     ResolvedToken,
@@ -246,14 +249,38 @@ def _token(config: dict) -> str:
     return config["config"]["env"]["ACTOR_ACCESS_TOKEN"]
 
 
-def test_actor_policy_is_frozen_normalized_and_owner_only() -> None:
+def test_actor_policy_is_frozen_normalized_and_stdio_disabled_by_default() -> None:
     policy = MCPBuiltinOAuthActorPolicy(resource_owner_key=f"  {OWNER_A}  ")
 
     assert policy.resource_owner_key == OWNER_A
-    assert [field.name for field in fields(policy)] == ["resource_owner_key"]
+    assert policy.allow_builtin_stdio is False
+    assert [field.name for field in fields(policy)] == [
+        "resource_owner_key",
+        "allow_builtin_stdio",
+    ]
     assert OWNER_A not in repr(policy)
     with pytest.raises(FrozenInstanceError):
         policy.resource_owner_key = OWNER_B  # type: ignore[misc]
+
+
+def test_general_actor_policy_keeps_legacy_type_identity() -> None:
+    policy = MCPActorAuthorizationPolicy(
+        resource_owner_key=OWNER_A,
+        allow_builtin_stdio=True,
+    )
+
+    assert MCPBuiltinOAuthActorPolicy is MCPActorAuthorizationPolicy
+    assert isinstance(policy, MCPBuiltinOAuthActorPolicy)
+    assert policy.allow_builtin_stdio is True
+
+
+@pytest.mark.parametrize("value", [None, 0, 1, "true"])
+def test_actor_policy_rejects_non_boolean_stdio_capability(value: object) -> None:
+    with pytest.raises(ValueError, match="allow_builtin_stdio must be a boolean"):
+        MCPActorAuthorizationPolicy(
+            resource_owner_key=OWNER_A,
+            allow_builtin_stdio=value,  # type: ignore[arg-type]
+        )
 
 
 @pytest.mark.parametrize("value", [None, 7, True, "", "   "])


### PR DESCRIPTION
## Summary

- normalize the actor-scoped stdio runtime stack onto the latest `main`, including the merged Shopify catalog from #2267
- enforce exact actor-scoped resolution for code-defined builtin stdio applications
- derive command, arguments, and required credential fields exclusively from the builtin registry
- fence secret reads by actor, catalog generation, and lifecycle generation
- keep execution-scoped identity in a typed host-only side channel that fails closed without its consumer
- canonicalize OAuth scope fingerprints as validated, duplicate-free, order-independent tuples

## Security properties

- `XAGENT_TOBY_PERSONAL_STDIO_ENABLED` defaults to `false`
- no fallback to `MCPServer`, `UserMCPServer`, team/shared/platform environment, or custom definitions for actor builtin stdio execution
- catalog visibility, exact generation, and the complete persisted execution fingerprint are checked before credential access
- actor credentials cannot override trusted fixed runtime environment variables
- execution-scoped identity is consumed separately before JSON, cloudpickle, sandbox IPC, or argv serialization
- missing consumers, stale identities, credential corruption, catalog drift, invalid scopes, and reserved collisions fail closed with fixed non-secret diagnostics

## Dependencies

- Supersedes #2301
- Depends on merged #2265
- Includes merged Shopify catalog #2267 through the `main` base
- Parent tracking: https://github.com/xorbitsai/xagent-saas/issues/1161
- Chrome integration remains separate; #2308 must rebase onto the final runtime head and consume the host-only identity before any serialization boundary.

## Validation

- 468 focused actor runtime, storage, owner, execution-identity, Shopify catalog/runtime, migration, and security tests passed
- direct in-memory admission verified Shopify actor resolution from the merged registry, including registry-only command/args and isolated credential env construction
- ruff format/check and diff checks passed
- range-diff preserved five commits exactly; the hardening commit differs only where merged #2267 delegates the same normalization semantics to the shared builtin-identity helper
- local diff review and full-PR blocker review completed with no remaining blocker

Follow-up runtime credential revocation work remains tracked in #2300.

Closes #2262
