### PR TITLE
fix(agents): inherit the owner's general model on both agent write paths

### DIFF
--- a/src/xagent/migration/loaders.py
+++ b/src/xagent/migration/loaders.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 from ..web.models.agent import Agent
 from ..web.models.skill import UserSkill
 from ..web.models.user import User
+from ..web.services.agent_store import with_default_general_model
 from .bundle import ArchivedItem, MigrationBundle
 
 # xagent's scheduled triggers currently fire on a fixed interval only; standard
@@ -138,7 +139,9 @@ class MigrationLoader:
             description=f"Imported from {bundle.source}.",
             instructions=instructions,
             execution_mode="balanced",
-            models={},
+            # This path builds its Agent outside AgentStore.add_agent, so it
+            # has to reach for the shared fallback itself.
+            models=with_default_general_model(self.db, {}, user_id=self.user_id),
             knowledge_bases=[],
             skills=[],
             tool_categories=[],

--- a/src/xagent/migration/loaders.py
+++ b/src/xagent/migration/loaders.py
@@ -27,7 +27,7 @@ from sqlalchemy.orm import Session
 from ..web.models.agent import Agent
 from ..web.models.skill import UserSkill
 from ..web.models.user import User
-from ..web.services.agent_store import with_default_general_model
+from ..web.services.model_service import with_default_general_model
 from .bundle import ArchivedItem, MigrationBundle
 
 # xagent's scheduled triggers currently fire on a fixed interval only; standard

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -12,9 +12,7 @@ from ...core.utils.type_check import ensure_list
 from ..models.agent import Agent, AgentOrigin, AgentStatus
 from ..models.agent_api_key import AgentApiKey
 from ..models.database import release_db_connection_if_clean
-from ..models.model import Model as DBModel
 from ..models.task import Task
-from ..models.user import UserDefaultModel
 from .agent_team_scope import (
     get_agent_team_scope,
     owned_agent_clause,
@@ -138,45 +136,6 @@ def clean_tool_categories(categories: Any) -> list[str]:
     so ``None`` renders as ``[]`` here. Never use this on a write path.
     """
     return normalize_tool_categories(categories) or []
-
-
-def with_default_general_model(db: Session, models: Any, *, user_id: int) -> Any:
-    """Fill an omitted ``general`` slot from the owner's default model.
-
-    An explicit ``{"general": None}`` means "no main model" and is kept; a
-    non-dict payload is unvalidated template YAML this layer must not reject.
-    """
-    if models is not None and not isinstance(models, dict):
-        return models
-    if models is not None and "general" in models:
-        return models
-
-    # Read user_default_models directly: ModelStore's getter opens with a
-    # cache_get, putting a Redis round-trip inside this write txn (#889).
-    # .first(), not .scalar(): user_default_models predates the alembic chain,
-    # so an old deployment may lack uq_user_default_model and hold two rows.
-    row = (
-        db.query(UserDefaultModel.model_id)
-        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-        .filter(
-            UserDefaultModel.user_id == user_id,
-            UserDefaultModel.config_type == "general",
-            DBModel.is_active.is_(True),
-        )
-        .first()
-    )
-    if row is None:
-        return models
-    default_model_id = row[0]
-
-    from .model_service import _is_model_visible_to_user
-
-    # A team-membership change leaves the default row pointing at a model the
-    # owner can no longer see, and such an id would slip past _validate_models
-    # (AgentManagementService validates before add_agent, not after).
-    if not _is_model_visible_to_user(db, int(default_model_id), user_id):
-        return models
-    return {**(models or {}), "general": int(default_model_id)}
 
 
 class AgentStore:
@@ -433,6 +392,8 @@ class AgentStore:
         if visibility is not None and visibility not in _VALID_VISIBILITIES:
             raise ValueError(f"Unsupported agent visibility: {visibility}")
         widget_key = new_widget_key() if widget_enabled else None
+        from .model_service import with_default_general_model
+
         models = with_default_general_model(self.db, models, user_id=user_id)
         # Agents are created personal (team_id NULL). Team ownership is granted
         # only by an explicit promote (see ``promote_agent_to_team``); a create

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -12,7 +12,9 @@ from ...core.utils.type_check import ensure_list
 from ..models.agent import Agent, AgentOrigin, AgentStatus
 from ..models.agent_api_key import AgentApiKey
 from ..models.database import release_db_connection_if_clean
+from ..models.model import Model as DBModel
 from ..models.task import Task
+from ..models.user import UserDefaultModel
 from .agent_team_scope import (
     get_agent_team_scope,
     owned_agent_clause,
@@ -136,6 +138,45 @@ def clean_tool_categories(categories: Any) -> list[str]:
     so ``None`` renders as ``[]`` here. Never use this on a write path.
     """
     return normalize_tool_categories(categories) or []
+
+
+def with_default_general_model(db: Session, models: Any, *, user_id: int) -> Any:
+    """Fill an omitted ``general`` slot from the owner's default model.
+
+    An explicit ``{"general": None}`` means "no main model" and is kept; a
+    non-dict payload is unvalidated template YAML this layer must not reject.
+    """
+    if models is not None and not isinstance(models, dict):
+        return models
+    if models is not None and "general" in models:
+        return models
+
+    # Read user_default_models directly: ModelStore's getter opens with a
+    # cache_get, putting a Redis round-trip inside this write txn (#889).
+    # .first(), not .scalar(): user_default_models predates the alembic chain,
+    # so an old deployment may lack uq_user_default_model and hold two rows.
+    row = (
+        db.query(UserDefaultModel.model_id)
+        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+        .filter(
+            UserDefaultModel.user_id == user_id,
+            UserDefaultModel.config_type == "general",
+            DBModel.is_active.is_(True),
+        )
+        .first()
+    )
+    if row is None:
+        return models
+    default_model_id = row[0]
+
+    from .model_service import _is_model_visible_to_user
+
+    # A team-membership change leaves the default row pointing at a model the
+    # owner can no longer see, and such an id would slip past _validate_models
+    # (AgentManagementService validates before add_agent, not after).
+    if not _is_model_visible_to_user(db, int(default_model_id), user_id):
+        return models
+    return {**(models or {}), "general": int(default_model_id)}
 
 
 class AgentStore:
@@ -392,6 +433,7 @@ class AgentStore:
         if visibility is not None and visibility not in _VALID_VISIBILITIES:
             raise ValueError(f"Unsupported agent visibility: {visibility}")
         widget_key = new_widget_key() if widget_enabled else None
+        models = with_default_general_model(self.db, models, user_id=user_id)
         # Agents are created personal (team_id NULL). Team ownership is granted
         # only by an explicit promote (see ``promote_agent_to_team``); a create
         # never stamps the caller's team. ``visibility`` is stored but only

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -10,7 +10,6 @@ import logging
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional, cast
 
-from sqlalchemy import and_ as sa_and
 from sqlalchemy.orm import Session
 
 from xagent.core.model.image.base import BaseImageModel, default_image_abilities
@@ -251,56 +250,14 @@ def resolve_default_model_id(
     opens with a ``cache_get`` -- a Redis round-trip inside the caller's write
     transaction (the pattern issue #889 is about).
     """
-    from ..models.user import UserDefaultModel, UserModel
-
     try:
-        # Every candidate, not just the newest. Defence in depth: both
-        # writers upsert on (user_id, config_type) so one row is all this
-        # should ever see, but uq_user_default_model lives only in the ORM
-        # metadata -- were a second row to exist, the newest could be the one
-        # that stopped being visible.
-        own_ids = [
-            int(row[0])
-            for row in db.query(UserDefaultModel.model_id)
-            .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-            .filter(
-                UserDefaultModel.user_id == user_id,
-                UserDefaultModel.config_type == config_type,
-                DBModel.is_active.is_(True),
-            )
-            .order_by(UserDefaultModel.id.desc())
-            .all()
-        ]
-        for candidate in own_ids:
-            if _is_model_visible_to_user(db, candidate, user_id):
-                return candidate
-
-        shared = (
-            db.query(UserDefaultModel.model_id)
-            .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-            .join(
-                UserModel,
-                sa_and(
-                    UserModel.model_id == UserDefaultModel.model_id,
-                    UserModel.user_id == UserDefaultModel.user_id,
-                ),
-            )
-            .filter(
-                UserDefaultModel.config_type == config_type,
-                DBModel.is_active.is_(True),
-                UserModel.is_shared.is_(True),
-                UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
-            )
-            .order_by(UserDefaultModel.id.desc())
-            .first()
-        )
-        return int(shared[0]) if shared is not None else None
-    except AutoModelUnavailableError:
-        raise
+        # Own savepoint: a failed read aborts the transaction on PostgreSQL, so
+        # returning None would only move the error to the caller's next
+        # statement -- and in workforce_creator's begin_nested retry loop
+        # (which catches IntegrityError alone) that escapes as a 500.
+        with db.begin_nested():
+            return _resolve_default_model_id(db, user_id, config_type)
     except Exception as exc:
-        # Runs inside AgentStore.add_agent before flush, where an escape would
-        # reach the handler's catch-all and 500 the create: degrade to an
-        # unset slot instead, which is the pre-existing behaviour anyway.
         logger.warning(
             "Failed to resolve the %s default model for user %s: %s",
             config_type,
@@ -308,6 +265,56 @@ def resolve_default_model_id(
             exc,
         )
         return None
+
+
+def _resolve_default_model_id(
+    db: Session, user_id: int, config_type: str
+) -> Optional[int]:
+    from ..models.user import UserDefaultModel, UserModel
+
+    # Every candidate, not just the newest. Defence in depth: both
+    # writers upsert on (user_id, config_type) so one row is all this
+    # should ever see, but uq_user_default_model lives only in the ORM
+    # metadata -- were a second row to exist, the newest could be the one
+    # that stopped being visible.
+    own_ids = [
+        int(row[0])
+        for row in db.query(UserDefaultModel.model_id)
+        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+        .filter(
+            UserDefaultModel.user_id == user_id,
+            UserDefaultModel.config_type == config_type,
+            DBModel.is_active.is_(True),
+        )
+        .order_by(UserDefaultModel.id.desc())
+        .all()
+    ]
+    for candidate in own_ids:
+        if _is_model_visible_to_user(db, candidate, user_id):
+            return candidate
+
+    # Both sides have to be visible, and they need not be the same user:
+    # the row's owner (or the default would come from a stranger whose
+    # preferences say nothing here) and the sharer (or the model is not
+    # actually visible). Requiring one user to be both drops a default that
+    # one visible admin set on a model another visible admin shares --
+    # which ``_is_model_visible_to_user`` does consider visible.
+    visible_ids = _get_visible_user_ids(db, user_id)
+    shared = (
+        db.query(UserDefaultModel.model_id)
+        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+        .join(UserModel, UserModel.model_id == UserDefaultModel.model_id)
+        .filter(
+            UserDefaultModel.config_type == config_type,
+            DBModel.is_active.is_(True),
+            UserModel.is_shared.is_(True),
+            UserModel.user_id.in_(visible_ids),
+            UserDefaultModel.user_id.in_(visible_ids),
+        )
+        .order_by(UserDefaultModel.id.desc())
+        .first()
+    )
+    return int(shared[0]) if shared is not None else None
 
 
 def with_default_general_model(db: Session, models: Any, *, user_id: int) -> Any:

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -228,6 +228,72 @@ def get_default_vision_model(
     return None
 
 
+def resolve_default_model_id(
+    db: Session, user_id: int, config_type: str
+) -> Optional[int]:
+    """Resolve the ``DBModel.id`` a user's default for *config_type* points at.
+
+    Own default first, then a visible user's shared one -- the same two layers
+    the LLM-returning resolvers apply, so a user whose only usable default is
+    an admin-shared model is not treated as having none.
+
+    Visibility is re-checked on the own-default path because nothing prunes a
+    ``user_default_models`` row when its model stops being visible.
+    """
+    from ..models.user import UserDefaultModel, UserModel
+
+    own = (
+        db.query(UserDefaultModel.model_id)
+        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+        .filter(
+            UserDefaultModel.user_id == user_id,
+            UserDefaultModel.config_type == config_type,
+            DBModel.is_active.is_(True),
+        )
+        # Deterministic pick: uq_user_default_model lives only in the ORM
+        # metadata, never in an alembic revision, so an old database can hold
+        # more than one row for this pair. Not covered by a test -- the
+        # fixtures build the schema from that same metadata, constraint
+        # included, so a duplicate row cannot be inserted to exercise it.
+        .order_by(UserDefaultModel.updated_at.desc(), UserDefaultModel.id.desc())
+        .first()
+    )
+    if own is not None and _is_model_visible_to_user(db, int(own[0]), user_id):
+        return int(own[0])
+
+    shared = (
+        db.query(UserDefaultModel.model_id)
+        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+        .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+        .filter(
+            UserDefaultModel.config_type == config_type,
+            DBModel.is_active.is_(True),
+            UserModel.is_shared.is_(True),
+            UserModel.user_id.in_(_get_visible_user_ids(db, user_id)),
+        )
+        .order_by(UserDefaultModel.updated_at.desc(), UserDefaultModel.id.desc())
+        .first()
+    )
+    return int(shared[0]) if shared is not None else None
+
+
+def with_default_general_model(db: Session, models: Any, *, user_id: int) -> Any:
+    """Fill an omitted ``general`` slot from the owner's default model.
+
+    An explicit ``{"general": None}`` means "no main model" and is kept; a
+    non-dict payload is unvalidated template YAML this layer must not reject.
+    """
+    if models is not None and not isinstance(models, dict):
+        return models
+    if models is not None and "general" in models:
+        return models
+
+    default_model_id = resolve_default_model_id(db, user_id, "general")
+    if default_model_id is None:
+        return models
+    return {**(models or {}), "general": default_model_id}
+
+
 def get_default_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
     """
     Get the default general model for a specific user.

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -238,7 +238,9 @@ def resolve_default_model_id(
     is shared -- the two layers ``agent_tool``, ``llm_utils`` and the
     LLM-returning resolvers here all apply, so a user whose only usable
     default is an admin-shared model is not treated as having none. Stricter
-    than those on one point: the shared layer also requires ``is_active``.
+    than those on two points: the shared layer also requires ``is_active``,
+    and it joins ``user_models`` on the owner as well as the model, so a row
+    cannot borrow an invisible third party's sharing.
 
     Visibility is re-checked on the own-default path because nothing prunes a
     ``user_default_models`` row when its model stops being visible, and an
@@ -252,10 +254,11 @@ def resolve_default_model_id(
     from ..models.user import UserDefaultModel, UserModel
 
     try:
-        # Every candidate, not just the newest: uq_user_default_model lives
-        # only in the ORM metadata, never in an alembic revision, so an old
-        # database can hold several rows for this pair and the newest one may
-        # be the one that stopped being visible.
+        # Every candidate, not just the newest. Defence in depth: both
+        # writers upsert on (user_id, config_type) so one row is all this
+        # should ever see, but uq_user_default_model lives only in the ORM
+        # metadata -- were a second row to exist, the newest could be the one
+        # that stopped being visible.
         own_ids = [
             int(row[0])
             for row in db.query(UserDefaultModel.model_id)
@@ -292,10 +295,12 @@ def resolve_default_model_id(
             .first()
         )
         return int(shared[0]) if shared is not None else None
+    except AutoModelUnavailableError:
+        raise
     except Exception as exc:
-        # Runs inside AgentStore.add_agent before flush, and the create path
-        # only catches IntegrityError: degrade to an unset slot rather than
-        # turning a transient read error into a failed create.
+        # Runs inside AgentStore.add_agent before flush, where an escape would
+        # reach the handler's catch-all and 500 the create: degrade to an
+        # unset slot instead, which is the pre-existing behaviour anyway.
         logger.warning(
             "Failed to resolve the %s default model for user %s: %s",
             config_type,

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -10,6 +10,7 @@ import logging
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional, cast
 
+from sqlalchemy import and_ as sa_and
 from sqlalchemy.orm import Session
 
 from xagent.core.model.image.base import BaseImageModel, default_image_abilities
@@ -233,12 +234,20 @@ def resolve_default_model_id(
 ) -> Optional[int]:
     """Resolve the ``DBModel.id`` a user's default for *config_type* points at.
 
-    Own default first, then a visible user's shared one -- the same two layers
-    the LLM-returning resolvers apply, so a user whose only usable default is
-    an admin-shared model is not treated as having none.
+    Own default first, then a default belonging to a visible user whose model
+    is shared -- the two layers ``agent_tool``, ``llm_utils`` and the
+    LLM-returning resolvers here all apply, so a user whose only usable
+    default is an admin-shared model is not treated as having none. Stricter
+    than those on one point: the shared layer also requires ``is_active``.
 
     Visibility is re-checked on the own-default path because nothing prunes a
-    ``user_default_models`` row when its model stops being visible.
+    ``user_default_models`` row when its model stops being visible, and an
+    invisible own default falls through to the shared layer rather than
+    resolving to nothing.
+
+    Reads the rows directly rather than through ``ModelStore``, whose getter
+    opens with a ``cache_get`` -- a Redis round-trip inside the caller's write
+    transaction (the pattern issue #889 is about).
     """
     from ..models.user import UserDefaultModel, UserModel
 
@@ -250,12 +259,9 @@ def resolve_default_model_id(
             UserDefaultModel.config_type == config_type,
             DBModel.is_active.is_(True),
         )
-        # Deterministic pick: uq_user_default_model lives only in the ORM
-        # metadata, never in an alembic revision, so an old database can hold
-        # more than one row for this pair. Not covered by a test -- the
-        # fixtures build the schema from that same metadata, constraint
-        # included, so a duplicate row cannot be inserted to exercise it.
-        .order_by(UserDefaultModel.updated_at.desc(), UserDefaultModel.id.desc())
+        # uq_user_default_model lives only in the ORM metadata, never in an
+        # alembic revision, so an old database can hold two rows for this pair.
+        .order_by(UserDefaultModel.id.desc())
         .first()
     )
     if own is not None and _is_model_visible_to_user(db, int(own[0]), user_id):
@@ -264,14 +270,20 @@ def resolve_default_model_id(
     shared = (
         db.query(UserDefaultModel.model_id)
         .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-        .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+        .join(
+            UserModel,
+            sa_and(
+                UserModel.model_id == UserDefaultModel.model_id,
+                UserModel.user_id == UserDefaultModel.user_id,
+            ),
+        )
         .filter(
             UserDefaultModel.config_type == config_type,
             DBModel.is_active.is_(True),
             UserModel.is_shared.is_(True),
-            UserModel.user_id.in_(_get_visible_user_ids(db, user_id)),
+            UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
         )
-        .order_by(UserDefaultModel.updated_at.desc(), UserDefaultModel.id.desc())
+        .order_by(UserDefaultModel.id.desc())
         .first()
     )
     return int(shared[0]) if shared is not None else None

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -238,9 +238,9 @@ def resolve_default_model_id(
     is shared -- the two layers ``agent_tool``, ``llm_utils`` and the
     LLM-returning resolvers here all apply, so a user whose only usable
     default is an admin-shared model is not treated as having none. Stricter
-    than those on two points: the shared layer also requires ``is_active``,
-    and it joins ``user_models`` on the owner as well as the model, so a row
-    cannot borrow an invisible third party's sharing.
+    than those on one point: the shared layer joins ``user_models`` on the
+    owner as well as the model, so a default row cannot borrow an invisible
+    third party's sharing.
 
     Visibility is re-checked on the own-default path because nothing prunes a
     ``user_default_models`` row when its model stops being visible, and an

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -234,7 +234,7 @@ def resolve_default_model_id(
 ) -> Optional[int]:
     """Resolve the ``DBModel.id`` a user's default for *config_type* points at.
 
-    Own default first, then a default belonging to a visible user whose model
+    Own defaults first, then a default belonging to a visible user whose model
     is shared -- the two layers ``agent_tool``, ``llm_utils`` and the
     LLM-returning resolvers here all apply, so a user whose only usable
     default is an admin-shared model is not treated as having none. Stricter
@@ -251,42 +251,58 @@ def resolve_default_model_id(
     """
     from ..models.user import UserDefaultModel, UserModel
 
-    own = (
-        db.query(UserDefaultModel.model_id)
-        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-        .filter(
-            UserDefaultModel.user_id == user_id,
-            UserDefaultModel.config_type == config_type,
-            DBModel.is_active.is_(True),
-        )
-        # uq_user_default_model lives only in the ORM metadata, never in an
-        # alembic revision, so an old database can hold two rows for this pair.
-        .order_by(UserDefaultModel.id.desc())
-        .first()
-    )
-    if own is not None and _is_model_visible_to_user(db, int(own[0]), user_id):
-        return int(own[0])
+    try:
+        # Every candidate, not just the newest: uq_user_default_model lives
+        # only in the ORM metadata, never in an alembic revision, so an old
+        # database can hold several rows for this pair and the newest one may
+        # be the one that stopped being visible.
+        own_ids = [
+            int(row[0])
+            for row in db.query(UserDefaultModel.model_id)
+            .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+            .filter(
+                UserDefaultModel.user_id == user_id,
+                UserDefaultModel.config_type == config_type,
+                DBModel.is_active.is_(True),
+            )
+            .order_by(UserDefaultModel.id.desc())
+            .all()
+        ]
+        for candidate in own_ids:
+            if _is_model_visible_to_user(db, candidate, user_id):
+                return candidate
 
-    shared = (
-        db.query(UserDefaultModel.model_id)
-        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-        .join(
-            UserModel,
-            sa_and(
-                UserModel.model_id == UserDefaultModel.model_id,
-                UserModel.user_id == UserDefaultModel.user_id,
-            ),
+        shared = (
+            db.query(UserDefaultModel.model_id)
+            .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+            .join(
+                UserModel,
+                sa_and(
+                    UserModel.model_id == UserDefaultModel.model_id,
+                    UserModel.user_id == UserDefaultModel.user_id,
+                ),
+            )
+            .filter(
+                UserDefaultModel.config_type == config_type,
+                DBModel.is_active.is_(True),
+                UserModel.is_shared.is_(True),
+                UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
+            )
+            .order_by(UserDefaultModel.id.desc())
+            .first()
         )
-        .filter(
-            UserDefaultModel.config_type == config_type,
-            DBModel.is_active.is_(True),
-            UserModel.is_shared.is_(True),
-            UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
+        return int(shared[0]) if shared is not None else None
+    except Exception as exc:
+        # Runs inside AgentStore.add_agent before flush, and the create path
+        # only catches IntegrityError: degrade to an unset slot rather than
+        # turning a transient read error into a failed create.
+        logger.warning(
+            "Failed to resolve the %s default model for user %s: %s",
+            config_type,
+            user_id,
+            exc,
         )
-        .order_by(UserDefaultModel.id.desc())
-        .first()
-    )
-    return int(shared[0]) if shared is not None else None
+        return None
 
 
 def with_default_general_model(db: Session, models: Any, *, user_id: int) -> Any:

--- a/tests/web/services/test_agent_store_default_general_model.py
+++ b/tests/web/services/test_agent_store_default_general_model.py
@@ -1,0 +1,194 @@
+"""The ``general`` model slot is filled on both agent write paths.
+
+Server-side creation paths pass no model config (``workforce_creator``
+hardcodes ``models=None``), which persisted as an unset slot: the builder
+rendered "--" and its required-field guard refused to save, and vibe
+delegation failed outright. Every create path reaches
+``AgentStore.add_agent``; ``migration/loaders.py`` builds its ``Agent``
+outside the store and calls the same helper itself.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from xagent.migration.bundle import MigrationBundle, PersonaItem
+from xagent.migration.loaders import MigrationLoader
+from xagent.web.models.agent import Agent
+from xagent.web.models.database import Base
+from xagent.web.models.model import Model as DBModel
+from xagent.web.models.user import User, UserDefaultModel, UserModel
+from xagent.web.services.agent_store import AgentStore, with_default_general_model
+
+
+@pytest.fixture()
+def db() -> Iterator[Session]:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _user_row(db: Session, username: str) -> User:
+    user = User(username=username, password_hash="x", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _user(db: Session, username: str) -> int:
+    return int(_user_row(db, username).id)
+
+
+def _model(db: Session, model_id: str, *, is_active: bool = True) -> int:
+    model = DBModel(
+        model_id=model_id,
+        category="llm",
+        model_provider="p",
+        model_name=model_id,
+        api_key="k",
+        is_active=is_active,
+    )
+    db.add(model)
+    db.commit()
+    db.refresh(model)
+    return int(model.id)
+
+
+def _own(db: Session, user_id: int, model_pk: int, *, is_shared: bool = False) -> None:
+    db.add(
+        UserModel(
+            user_id=user_id, model_id=model_pk, is_owner=True, is_shared=is_shared
+        )
+    )
+    db.commit()
+
+
+def _default(db: Session, user_id: int, model_pk: int) -> None:
+    db.add(UserDefaultModel(user_id=user_id, model_id=model_pk, config_type="general"))
+    db.commit()
+
+
+@pytest.fixture()
+def owner(db: Session) -> tuple[int, int]:
+    """A user whose visible, active model is their ``general`` default."""
+    user_id = _user(db, "owner")
+    model_pk = _model(db, "gpt-x")
+    _own(db, user_id, model_pk)
+    _default(db, user_id, model_pk)
+    return user_id, model_pk
+
+
+def test_omitted_config_is_filled(db: Session, owner: tuple[int, int]) -> None:
+    user_id, model_pk = owner
+    assert with_default_general_model(db, None, user_id=user_id) == {
+        "general": model_pk
+    }
+
+
+def test_empty_dict_is_filled(db: Session, owner: tuple[int, int]) -> None:
+    user_id, model_pk = owner
+    assert with_default_general_model(db, {}, user_id=user_id) == {"general": model_pk}
+
+
+def test_other_slots_are_preserved(db: Session, owner: tuple[int, int]) -> None:
+    user_id, model_pk = owner
+    filled = with_default_general_model(db, {"compact": 7}, user_id=user_id)
+    assert filled == {"compact": 7, "general": model_pk}
+
+
+def test_explicit_none_means_no_main_model(db: Session, owner: tuple[int, int]) -> None:
+    user_id, _ = owner
+    assert with_default_general_model(db, {"general": None}, user_id=user_id) == {
+        "general": None
+    }
+
+
+def test_stated_choice_is_untouched(db: Session, owner: tuple[int, int]) -> None:
+    user_id, _ = owner
+    assert with_default_general_model(db, {"general": 42}, user_id=user_id) == {
+        "general": 42
+    }
+
+
+def test_non_dict_payload_passes_through(db: Session, owner: tuple[int, int]) -> None:
+    """Template YAML reaches this layer unvalidated; a typo must not 500."""
+    user_id, _ = owner
+    assert with_default_general_model(db, "gpt-4", user_id=user_id) == "gpt-4"
+
+
+def test_no_default_leaves_config_unset(db: Session) -> None:
+    user_id = _user(db, "no_default")
+    assert with_default_general_model(db, None, user_id=user_id) is None
+
+
+def test_inactive_default_is_not_used(db: Session) -> None:
+    user_id = _user(db, "inactive_default")
+    model_pk = _model(db, "retired", is_active=False)
+    _own(db, user_id, model_pk)
+    _default(db, user_id, model_pk)
+    assert with_default_general_model(db, None, user_id=user_id) is None
+
+
+def test_invisible_default_is_not_used(db: Session) -> None:
+    """A default row survives the model becoming invisible (a demotion, a
+    team move); injecting it would slip past ``_validate_models`` and leave
+    the builder's Main Model blank while its save guard sees a value."""
+    user_id = _user(db, "orphaned_default")
+    stranger_id = _user(db, "stranger")
+    model_pk = _model(db, "someone-elses")
+    _own(db, stranger_id, model_pk)
+    _default(db, user_id, model_pk)
+    assert with_default_general_model(db, None, user_id=user_id) is None
+
+
+def test_shared_flag_alone_is_not_visibility(db: Session) -> None:
+    """A team-membership change drops the sharer out of the owner's visible
+    set without touching ``is_shared``, so the flag alone must not qualify."""
+    user_id = _user(db, "borrower")
+    sharer_id = _user(db, "sharer")
+    model_pk = _model(db, "shared-llm")
+    _own(db, sharer_id, model_pk, is_shared=True)
+    _default(db, user_id, model_pk)
+    assert with_default_general_model(db, None, user_id=user_id) is None
+
+
+def test_add_agent_fills_the_slot(db: Session, owner: tuple[int, int]) -> None:
+    user_id, model_pk = owner
+    agent = AgentStore(db).add_agent(
+        user_id=user_id, name="server-made", description=None, instructions=None
+    )
+    db.commit()
+    db.refresh(agent)
+    assert agent.models == {"general": model_pk}
+
+
+def _imported_agent(db: Session, user: User) -> Agent:
+    bundle = MigrationBundle(source="hermes", source_root="x")
+    bundle.persona = PersonaItem(instructions="You are helpful.")
+    MigrationLoader(db, user=user).load(bundle)
+    return db.query(Agent).filter(Agent.user_id == user.id).one()
+
+
+def test_imported_agent_inherits_the_owners_default(db: Session) -> None:
+    """The loader builds its Agent outside ``add_agent``, so a fallback wired
+    into the store alone would miss this path."""
+    user = _user_row(db, "importer")
+    model_pk = _model(db, "gpt-x")
+    _own(db, int(user.id), model_pk)
+    _default(db, int(user.id), model_pk)
+    assert _imported_agent(db, user).models == {"general": model_pk}
+
+
+def test_imported_agent_without_a_default_keeps_its_empty_config(db: Session) -> None:
+    user = _user_row(db, "importer_no_default")
+    assert _imported_agent(db, user).models == {}

--- a/tests/web/services/test_default_general_model_inheritance.py
+++ b/tests/web/services/test_default_general_model_inheritance.py
@@ -278,6 +278,27 @@ def test_a_stranger_pointing_at_a_shared_model_does_not_qualify(
     assert with_default_general_model(db, None, user_id=user_id) is None
 
 
+def test_one_visible_admin_s_default_on_another_s_shared_model(db: Session) -> None:
+    """Owner and sharer both have to be visible, but need not be the same user.
+
+    ``_is_model_visible_to_user`` considers this model visible, so requiring
+    one user to be both would silently drop a usable default.
+    """
+    user_id = _user(db, "onlooker")
+    naming_admin = _user(db, "admin_who_names", is_admin=True)
+    sharing_admin = _user(db, "admin_who_shares", is_admin=True)
+    model_pk = _model(db, "cross-admin-llm")
+    _own(db, sharing_admin, model_pk, is_shared=True)
+    _default(db, naming_admin, model_pk)
+
+    from xagent.web.services.model_service import _is_model_visible_to_user
+
+    assert _is_model_visible_to_user(db, model_pk, user_id) is True
+    assert with_default_general_model(db, None, user_id=user_id) == {
+        "general": model_pk
+    }
+
+
 def test_a_default_row_does_not_borrow_a_stranger_s_sharing(db: Session) -> None:
     """The shared layer joins on both model_id and user_id, so the row's owner
     has to be the one sharing it.
@@ -302,11 +323,12 @@ def test_a_default_row_does_not_borrow_a_stranger_s_sharing(db: Session) -> None
 
 
 def test_a_read_error_degrades_to_an_unset_slot(db: Session, monkeypatch) -> None:
-    """A transient read failure must not turn into a failed create.
+    """A read failure must not turn into a failed create.
 
-    ``add_agent`` calls this before flush and the create handler's only
-    specific catch is IntegrityError, so raising here would surface as a 500
-    instead of the pre-existing empty-slot behaviour.
+    The resolver runs inside ``add_agent`` before flush, and the create paths
+    do not catch this: ``api/agents.py`` would 500 it, and
+    ``workforce_creator``'s ``begin_nested`` retry catches IntegrityError
+    alone. Degrading to an unset slot is the pre-existing behaviour anyway.
     """
     user_id = _user(db, "unlucky")
     model_pk = _model(db, "fine-llm")
@@ -327,6 +349,66 @@ def test_a_read_error_degrades_to_an_unset_slot(db: Session, monkeypatch) -> Non
     db.commit()
     db.refresh(agent)
     assert agent.models is None
+
+
+def test_a_failed_statement_leaves_the_session_usable(db: Session, monkeypatch) -> None:
+    """The savepoint is what makes the degrade real.
+
+    A failed statement aborts the surrounding transaction on PostgreSQL, so
+    swallowing the exception without rolling back would only move the error
+    to the caller's next statement. Emulated here by failing inside the
+    resolver's own query and then writing through the same session.
+    """
+    user_id = _user(db, "aborted")
+    model_pk = _model(db, "unreachable-llm")
+    _own(db, user_id, model_pk)
+    _default(db, user_id, model_pk)
+
+    import xagent.web.services.model_service as module
+
+    calls: list[int] = []
+    real_visible = module._is_model_visible_to_user
+
+    def _boom_once(*args: Any, **kwargs: Any) -> bool:
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("server closed the connection unexpectedly")
+        return real_visible(*args, **kwargs)
+
+    monkeypatch.setattr(module, "_is_model_visible_to_user", _boom_once)
+
+    agent = AgentStore(db).add_agent(
+        user_id=user_id, name="after-abort", description=None, instructions=None
+    )
+    db.commit()
+    db.refresh(agent)
+    assert agent.models is None
+
+    # The session still works afterwards, and so does the resolver.
+    monkeypatch.undo()
+    second = AgentStore(db).add_agent(
+        user_id=user_id, name="recovered", description=None, instructions=None
+    )
+    db.commit()
+    db.refresh(second)
+    assert second.models == {"general": model_pk}
+
+
+def test_the_fallback_survives_a_nested_savepoint(db: Session) -> None:
+    """``workforce_creator`` calls ``add_agent`` inside ``db.begin_nested()``;
+    the resolver's own savepoint has to nest inside that one."""
+    user_id = _user(db, "workforce_owner")
+    model_pk = _model(db, "workforce-llm")
+    _own(db, user_id, model_pk)
+    _default(db, user_id, model_pk)
+
+    with db.begin_nested():
+        agent = AgentStore(db).add_agent(
+            user_id=user_id, name="nested", description=None, instructions=None
+        )
+    db.commit()
+    db.refresh(agent)
+    assert agent.models == {"general": model_pk}
 
 
 def test_an_invisible_own_default_falls_through_to_the_shared_layer(

--- a/tests/web/services/test_default_general_model_inheritance.py
+++ b/tests/web/services/test_default_general_model_inheritance.py
@@ -14,9 +14,10 @@ own default, then a visible user's shared default.
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import UniqueConstraint, create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from xagent.migration.bundle import MigrationBundle, PersonaItem
@@ -39,6 +40,32 @@ def _no_visibility_hook() -> Iterator[None]:
     set_visible_user_ids_hook(None)
     yield
     set_visible_user_ids_hook(None)
+
+
+@pytest.fixture()
+def legacy_db() -> Iterator[Session]:
+    """A schema without ``uq_user_default_model``.
+
+    The constraint is declared in the ORM metadata but appears in none of the
+    alembic revisions, so a database created before it can hold several rows
+    for one ``(user_id, config_type)`` pair. Dropping it from the metadata for
+    one engine is the only way to build that shape.
+    """
+    table = UserDefaultModel.__table__
+    dropped = [c for c in list(table.constraints) if isinstance(c, UniqueConstraint)]
+    for constraint in dropped:
+        table.constraints.discard(constraint)
+    try:
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(bind=engine)
+        session = sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+        try:
+            yield session
+        finally:
+            session.close()
+    finally:
+        for constraint in dropped:
+            table.append_constraint(constraint)
 
 
 @pytest.fixture()
@@ -104,42 +131,56 @@ def owner(db: Session) -> tuple[int, int]:
     return user_id, model_pk
 
 
-def test_omitted_config_is_filled(db: Session, owner: tuple[int, int]) -> None:
-    user_id, model_pk = owner
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        pytest.param(None, {"general": "PK"}, id="omitted_is_filled"),
+        pytest.param({}, {"general": "PK"}, id="empty_dict_is_filled"),
+        pytest.param(
+            {"compact": 7}, {"compact": 7, "general": "PK"}, id="other_slots_kept"
+        ),
+        # An explicit None means "no main model"; a stated id is a choice.
+        pytest.param({"general": None}, {"general": None}, id="explicit_none_kept"),
+        pytest.param({"general": 42}, {"general": 42}, id="stated_choice_kept"),
+        # Template YAML reaches this layer unvalidated; a typo must not 500.
+        pytest.param("gpt-4", "gpt-4", id="non_dict_passes_through"),
+    ],
+)
+def test_fills_only_an_omitted_slot(
+    db: Session, owner: tuple[int, int], payload: Any, expected: Any
+) -> None:
+    _, model_pk = owner
+    if isinstance(expected, dict):
+        expected = {k: (model_pk if v == "PK" else v) for k, v in expected.items()}
+    assert with_default_general_model(db, payload, user_id=owner[0]) == expected
+
+
+def test_a_default_for_another_slot_is_not_used(db: Session) -> None:
+    user_id = _user(db, "visual_only")
+    model_pk = _model(db, "vision-llm")
+    _own(db, user_id, model_pk)
+    db.add(UserDefaultModel(user_id=user_id, model_id=model_pk, config_type="visual"))
+    db.commit()
+    assert with_default_general_model(db, None, user_id=user_id) is None
+
+
+def test_an_older_own_default_is_used_when_the_newest_is_invisible(
+    legacy_db: Session,
+) -> None:
+    """The newest row becoming invisible must not skip the remaining ones."""
+    db = legacy_db
+    user_id = _user(db, "two_rows")
+    stranger_id = _user(db, "ex_teammate")
+    visible_pk = _model(db, "kept-llm")
+    gone_pk = _model(db, "lost-llm")
+    _own(db, user_id, visible_pk)
+    _own(db, stranger_id, gone_pk)
+    _default(db, user_id, visible_pk)
+    # The later row wins the ordering but points at a model this user lost.
+    _default(db, user_id, gone_pk)
     assert with_default_general_model(db, None, user_id=user_id) == {
-        "general": model_pk
+        "general": visible_pk
     }
-
-
-def test_empty_dict_is_filled(db: Session, owner: tuple[int, int]) -> None:
-    user_id, model_pk = owner
-    assert with_default_general_model(db, {}, user_id=user_id) == {"general": model_pk}
-
-
-def test_other_slots_are_preserved(db: Session, owner: tuple[int, int]) -> None:
-    user_id, model_pk = owner
-    filled = with_default_general_model(db, {"compact": 7}, user_id=user_id)
-    assert filled == {"compact": 7, "general": model_pk}
-
-
-def test_explicit_none_means_no_main_model(db: Session, owner: tuple[int, int]) -> None:
-    user_id, _ = owner
-    assert with_default_general_model(db, {"general": None}, user_id=user_id) == {
-        "general": None
-    }
-
-
-def test_stated_choice_is_untouched(db: Session, owner: tuple[int, int]) -> None:
-    user_id, _ = owner
-    assert with_default_general_model(db, {"general": 42}, user_id=user_id) == {
-        "general": 42
-    }
-
-
-def test_non_dict_payload_passes_through(db: Session, owner: tuple[int, int]) -> None:
-    """Template YAML reaches this layer unvalidated; a typo must not 500."""
-    user_id, _ = owner
-    assert with_default_general_model(db, "gpt-4", user_id=user_id) == "gpt-4"
 
 
 def test_no_default_anywhere_leaves_config_unset(db: Session) -> None:

--- a/tests/web/services/test_default_general_model_inheritance.py
+++ b/tests/web/services/test_default_general_model_inheritance.py
@@ -6,6 +6,9 @@ rendered "--" and its required-field guard refused to save, and vibe
 delegation failed outright. Every create path reaches
 ``AgentStore.add_agent``; ``migration/loaders.py`` builds its ``Agent``
 outside the store and calls the same helper itself.
+
+The resolution order is the one the LLM-returning resolvers use: the user's
+own default, then a visible user's shared default.
 """
 
 from __future__ import annotations
@@ -22,7 +25,8 @@ from xagent.web.models.agent import Agent
 from xagent.web.models.database import Base
 from xagent.web.models.model import Model as DBModel
 from xagent.web.models.user import User, UserDefaultModel, UserModel
-from xagent.web.services.agent_store import AgentStore, with_default_general_model
+from xagent.web.services.agent_store import AgentStore
+from xagent.web.services.model_service import with_default_general_model
 
 
 @pytest.fixture()
@@ -37,16 +41,16 @@ def db() -> Iterator[Session]:
         session.close()
 
 
-def _user_row(db: Session, username: str) -> User:
-    user = User(username=username, password_hash="x", is_admin=False)
+def _user_row(db: Session, username: str, *, is_admin: bool = False) -> User:
+    user = User(username=username, password_hash="x", is_admin=is_admin)
     db.add(user)
     db.commit()
     db.refresh(user)
     return user
 
 
-def _user(db: Session, username: str) -> int:
-    return int(_user_row(db, username).id)
+def _user(db: Session, username: str, *, is_admin: bool = False) -> int:
+    return int(_user_row(db, username, is_admin=is_admin).id)
 
 
 def _model(db: Session, model_id: str, *, is_active: bool = True) -> int:
@@ -126,7 +130,7 @@ def test_non_dict_payload_passes_through(db: Session, owner: tuple[int, int]) ->
     assert with_default_general_model(db, "gpt-4", user_id=user_id) == "gpt-4"
 
 
-def test_no_default_leaves_config_unset(db: Session) -> None:
+def test_no_default_anywhere_leaves_config_unset(db: Session) -> None:
     user_id = _user(db, "no_default")
     assert with_default_general_model(db, None, user_id=user_id) is None
 
@@ -151,14 +155,47 @@ def test_invisible_default_is_not_used(db: Session) -> None:
     assert with_default_general_model(db, None, user_id=user_id) is None
 
 
-def test_shared_flag_alone_is_not_visibility(db: Session) -> None:
-    """A team-membership change drops the sharer out of the owner's visible
-    set without touching ``is_shared``, so the flag alone must not qualify."""
+def test_a_non_visible_sharer_does_not_qualify(db: Session) -> None:
+    """``is_shared`` alone is not visibility: the sharer also has to be in the
+    user's visible set, which ``_get_visible_user_ids`` resolves (admins by
+    default, whatever the deployment's hook says otherwise)."""
     user_id = _user(db, "borrower")
     sharer_id = _user(db, "sharer")
     model_pk = _model(db, "shared-llm")
     _own(db, sharer_id, model_pk, is_shared=True)
     _default(db, user_id, model_pk)
+    assert with_default_general_model(db, None, user_id=user_id) is None
+
+
+def test_a_visible_sharers_shared_default_is_inherited(db: Session) -> None:
+    """A user whose only usable default is an admin-shared one must not be
+    treated as having none -- that is the bug this PR fixes, on another path
+    (``agent_tool.py`` already resolves through this fallback)."""
+    user_id = _user(db, "no_own_default")
+    admin_id = _user(db, "sharing_admin", is_admin=True)
+    model_pk = _model(db, "admin-llm")
+    _own(db, admin_id, model_pk, is_shared=True)
+    _default(db, admin_id, model_pk)
+    assert with_default_general_model(db, None, user_id=user_id) == {
+        "general": model_pk
+    }
+
+
+def test_an_unshared_admin_default_is_not_inherited(db: Session) -> None:
+    user_id = _user(db, "outsider")
+    admin_id = _user(db, "private_admin", is_admin=True)
+    model_pk = _model(db, "admin-private-llm")
+    _own(db, admin_id, model_pk, is_shared=False)
+    _default(db, admin_id, model_pk)
+    assert with_default_general_model(db, None, user_id=user_id) is None
+
+
+def test_an_inactive_shared_default_is_not_inherited(db: Session) -> None:
+    user_id = _user(db, "late_comer")
+    admin_id = _user(db, "retiring_admin", is_admin=True)
+    model_pk = _model(db, "admin-retired-llm", is_active=False)
+    _own(db, admin_id, model_pk, is_shared=True)
+    _default(db, admin_id, model_pk)
     assert with_default_general_model(db, None, user_id=user_id) is None
 
 

--- a/tests/web/services/test_default_general_model_inheritance.py
+++ b/tests/web/services/test_default_general_model_inheritance.py
@@ -29,6 +29,18 @@ from xagent.web.services.agent_store import AgentStore
 from xagent.web.services.model_service import with_default_general_model
 
 
+@pytest.fixture(autouse=True)
+def _no_visibility_hook() -> Iterator[None]:
+    """``set_visible_user_ids_hook`` is module-global and deployments install
+    their own at import time, so pin the admin-default behaviour these cases
+    assert on."""
+    from xagent.web.services.model_service import set_visible_user_ids_hook
+
+    set_visible_user_ids_hook(None)
+    yield
+    set_visible_user_ids_hook(None)
+
+
 @pytest.fixture()
 def db() -> Iterator[Session]:
     engine = create_engine("sqlite:///:memory:")
@@ -207,6 +219,42 @@ def test_add_agent_fills_the_slot(db: Session, owner: tuple[int, int]) -> None:
     db.commit()
     db.refresh(agent)
     assert agent.models == {"general": model_pk}
+
+
+def test_a_stranger_pointing_at_a_shared_model_does_not_qualify(
+    db: Session,
+) -> None:
+    """The shared layer keys on who OWNS the default row, not on who shared
+    the model -- otherwise any unrelated user adopting an admin-shared model
+    as their own default would hand it to everyone."""
+    user_id = _user(db, "bystander")
+    admin_id = _user(db, "silent_admin", is_admin=True)
+    stranger_id = _user(db, "stranger_with_taste")
+    model_pk = _model(db, "adopted-llm")
+    _own(db, admin_id, model_pk, is_shared=True)
+    # The admin shares the model but never made it their own default.
+    _default(db, stranger_id, model_pk)
+    assert with_default_general_model(db, None, user_id=user_id) is None
+
+
+def test_an_invisible_own_default_falls_through_to_the_shared_layer(
+    db: Session,
+) -> None:
+    """An own default pointing at a model the user can no longer see must not
+    short-circuit the shared layer (``agent_tool`` skips such a slot and keeps
+    filling from the shared defaults)."""
+    user_id = _user(db, "demoted")
+    stranger_id = _user(db, "former_teammate")
+    admin_id = _user(db, "sharing_admin_2", is_admin=True)
+    gone_pk = _model(db, "no-longer-visible")
+    shared_pk = _model(db, "still-visible")
+    _own(db, stranger_id, gone_pk)
+    _own(db, admin_id, shared_pk, is_shared=True)
+    _default(db, user_id, gone_pk)
+    _default(db, admin_id, shared_pk)
+    assert with_default_general_model(db, None, user_id=user_id) == {
+        "general": shared_pk
+    }
 
 
 def _imported_agent(db: Session, user: User) -> Agent:

--- a/tests/web/services/test_default_general_model_inheritance.py
+++ b/tests/web/services/test_default_general_model_inheritance.py
@@ -47,9 +47,9 @@ def legacy_db() -> Iterator[Session]:
     """A schema without ``uq_user_default_model``.
 
     The constraint is declared in the ORM metadata but appears in none of the
-    alembic revisions, so a database created before it can hold several rows
-    for one ``(user_id, config_type)`` pair. Dropping it from the metadata for
-    one engine is the only way to build that shape.
+    alembic revisions. Both writers upsert on the pair, so this shape should
+    never occur -- dropping the constraint for one engine is the only way to
+    reach the branch that handles it anyway.
     """
     table = UserDefaultModel.__table__
     dropped = [c for c in list(table.constraints) if isinstance(c, UniqueConstraint)]
@@ -149,10 +149,10 @@ def owner(db: Session) -> tuple[int, int]:
 def test_fills_only_an_omitted_slot(
     db: Session, owner: tuple[int, int], payload: Any, expected: Any
 ) -> None:
-    _, model_pk = owner
+    user_id, model_pk = owner
     if isinstance(expected, dict):
         expected = {k: (model_pk if v == "PK" else v) for k, v in expected.items()}
-    assert with_default_general_model(db, payload, user_id=owner[0]) == expected
+    assert with_default_general_model(db, payload, user_id=user_id) == expected
 
 
 def test_a_default_for_another_slot_is_not_used(db: Session) -> None:
@@ -276,6 +276,57 @@ def test_a_stranger_pointing_at_a_shared_model_does_not_qualify(
     # The admin shares the model but never made it their own default.
     _default(db, stranger_id, model_pk)
     assert with_default_general_model(db, None, user_id=user_id) is None
+
+
+def test_a_default_row_does_not_borrow_a_stranger_s_sharing(db: Session) -> None:
+    """The shared layer joins on both model_id and user_id, so the row's owner
+    has to be the one sharing it.
+
+    Without the user_id half, a visible admin naming a model as their default
+    while an *invisible* third party is the one sharing it would inject a
+    model ``_is_model_visible_to_user`` rejects -- the one thing this resolver
+    must never do, and the shared layer has no second visibility check.
+    """
+    user_id = _user(db, "asker")
+    admin_id = _user(db, "naming_admin", is_admin=True)
+    outsider_id = _user(db, "invisible_sharer")
+    model_pk = _model(db, "borrowed-llm")
+    # Shared by someone outside the visible set; the admin never holds it.
+    _own(db, outsider_id, model_pk, is_shared=True)
+    _default(db, admin_id, model_pk)
+
+    from xagent.web.services.model_service import _is_model_visible_to_user
+
+    assert _is_model_visible_to_user(db, model_pk, user_id) is False
+    assert with_default_general_model(db, None, user_id=user_id) is None
+
+
+def test_a_read_error_degrades_to_an_unset_slot(db: Session, monkeypatch) -> None:
+    """A transient read failure must not turn into a failed create.
+
+    ``add_agent`` calls this before flush and the create handler's only
+    specific catch is IntegrityError, so raising here would surface as a 500
+    instead of the pre-existing empty-slot behaviour.
+    """
+    user_id = _user(db, "unlucky")
+    model_pk = _model(db, "fine-llm")
+    _own(db, user_id, model_pk)
+    _default(db, user_id, model_pk)
+
+    import xagent.web.services.model_service as module
+
+    def _boom(*_args: Any, **_kwargs: Any) -> bool:
+        raise RuntimeError("connection reset")
+
+    monkeypatch.setattr(module, "_is_model_visible_to_user", _boom)
+    assert with_default_general_model(db, None, user_id=user_id) is None
+
+    agent = AgentStore(db).add_agent(
+        user_id=user_id, name="degraded", description=None, instructions=None
+    )
+    db.commit()
+    db.refresh(agent)
+    assert agent.models is None
 
 
 def test_an_invisible_own_default_falls_through_to_the_shared_layer(


### PR DESCRIPTION
## Invariant

When an agent is persisted, `agents.models.general` holds a value whenever its owner has one to inherit and the caller stated no choice of its own.

## Root cause

The server-side creation paths never set `models`: `workforce_creator.py:164` and `:476` hardcode `models=None`, so does `api/agents.py:739`, no built-in template's YAML carries a `models` key, and `_validate_models` returns `None` untouched. The frontend seeds from `/api/models/user-default` only for a new agent (`agent-builder.tsx:790`, `if (!isEditMode)`); the server had no equivalent layer.

An unset slot has two user-visible consequences: the builder renders `--` for Main Model and its required-field guard (`:1489`) refuses to save until the owner picks one by hand, and vibe delegation fails outright (`agent_tool.py`, `Error: No valid model configured for agent`). The second one is handled by the companion PR.

## Where the fix lives

Enumerated every path that writes an `agents` row: only two places construct `Agent(...)` — `agent_store.py:440` (inside `add_agent`) and `loaders.py:135`. No `bulk_insert_mappings`, no `insert(Agent)`, no raw SQL insert in production code. Every indirect path funnels into `add_agent`: `create_agent`, `create_agent_with_optional_key`, the three template-create endpoints, `workforce_creator`'s members and its generated manager, the vibe `CreateAgentTool`, plain `POST /api/agents`, and `/v1/agents`.

So the fallback lives in `add_agent`. `migration/loaders.py` builds its `Agent` outside the store and owns its own commit, so it calls the same helper itself.

`resolve_default_model_id` resolves the two layers every other resolver in this codebase resolves — the user's own default, then a default belonging to a visible user whose model is shared. Keeping only the first layer would have reproduced this PR's own bug for a user whose only usable default is an admin-shared model: `agent_tool.py:944` fills that user's slot on the vibe create path, so `POST /api/agents` leaving it empty is the same inconsistency this PR exists to remove.

Two deliberate differences from the existing implementations (`agent_tool.py:944`, `llm_utils.py:1009`, `model_store.py:258`, `model_service.py:203`, `:339`):

- The shared layer joins `user_models` on the owner as well as the model, so a default row cannot borrow an invisible third party's sharing. Without it, a visible admin naming a model as their default while an unrelated invisible user is the one sharing it injects a model `_is_model_visible_to_user` rejects — and the shared layer has no second visibility check, so that join is the only thing standing between this resolver and its own invariant.
- An own default that is no longer visible falls through to the shared layer instead of resolving to nothing, matching the `continue` in `agent_tool.py:918-925`.

(`DBModel.is_active` on the shared layer was a third difference when this PR opened; #2310 has since added it to `get_default_model` and `get_default_vision_model`, so it is now shared with them.)

It reads the rows directly rather than through `ModelStore.get_user_default_models`, whose third statement is a `cache_get` (`model_store.py:205`): that would put a synchronous Redis round-trip inside this write transaction (the pattern issue #889 is about).

One implementation detail worth stating:

- `user_default_models` predates the alembic chain (`uq_user_default_model` lives only in the ORM metadata, in none of the 182 revisions), so an old database can hold two rows for a `(user_id, config_type)` pair. `.first()` with `order_by(id.desc())` makes the pick deterministic. Not covered by a test: the fixtures build the schema from that same metadata, constraint included, so a duplicate row cannot be inserted to exercise it.

Left untouched: an explicit `{"general": None}`, which means "no main model", and a non-dict payload — `workforce_creator` forwards template YAML straight through without validating it, and rejecting the shape here would turn an authoring typo into a 500.

## Not included

- **Any alembic migration** — existing rows are not touched. `workforce_snapshot.py:230` folds `agent.models or {}` into the workforce config fingerprint, and `workforce_runtime.py:302` raises `WorkforceTurnRejectedError("workforce_config_changed")` on a mismatch. A data migration would not bump `WORKFORCE_CONFIG_FINGERPRINT_VERSION`, so it would not get the version exemption at `:294`, and filling values in bulk would reject every in-flight non-preview workforce session after the upgrade. This PR only affects newly created rows, whose pinned fingerprint is computed from the same row at run-creation time.
- **Applying the same strictness to `chat.py`'s read-side resolver.** `_get_default_internal_model_ids` (`chat.py:4330-4373`) still joins on `model_id` alone with no `is_active` filter and no ordering, so an agent whose slot is emptied later (via `PUT /api/agents/{id}`, which validates nothing) still resolves through the looser path. Worth a fast-follow; folding it in here would mean touching the task-creation path this PR otherwise leaves alone.
- **Collapsing the other five resolvers onto the new helper.** They resolve four slots at once and return `BaseLLM`s, so calling a single-slot id resolver would turn two queries into eight. The right shape is `resolve_default_model_ids(db, user_id, config_types) -> dict[str, int]` replacing `agent_tool.py:907-951`, `llm_utils.py:887-1030`, `chat.py:4338-4365`, `model_service.py:193-210`/`:313-345` and `model_store.py:252-267` — a separate PR.
- **The read-side symptoms of existing agents** — companion PR.
- **`update_agent_fields`**, which still validates no `models` payload (pre-existing; `PUT /api/agents/{id}` can persist `{}`).
- **`POST /api/agents/preview`**'s 400 (`agents.py:1717`) — no frontend caller.

## Consequences worth stating

**The slot stops tracking the owner's default.** Before this change, an agent with an empty `general` slot resolved its model at every task creation through `chat.py`'s fallback (`:4328` leaves `llm_ids_to_use` at `None` → `resolve_llms_from_names` → `get_configured_defaults`), so it followed the owner's default as that changed. This PR writes a **static** id at creation time, so later changes no longer propagate.

**A teammate on a team agent runs on the owner's model, not their own.** `_get_default_internal_model_ids` (`chat.py:4330-4373`) resolves against `int(user.id)` — the user *making the request*. So with an empty slot, a teammate's task ran on the teammate's own default; with the slot filled, `_normalize_llm_refs` keeps the owner's id whenever that model is also visible to the teammate (common for anything admin-shared). **This is accepted, not overlooked**, for one reason: it is already the behaviour of every agent created through the builder. The frontend seeds `general` from `/api/models/user-default` on create and falls back to the first available LLM if there is none (`agent-builder.tsx:806-813`), then persists it (`:1513`), so a UI-created agent has always carried a static owner-chosen id into a team promote. What this PR removes is the inconsistency where a *server*-created agent happened to stay dynamic.

Scoping the fallback to `team_id is None and not share_enabled` (as #2229's migration did) would not change this: `add_agent` hardcodes `team_id=None` (`agent_store.py:404`) and nothing passes `share_enabled=True` at creation, so both conditions hold for every create. The exposure comes from `promote_agent_to_team` **after** the fact, which a creation-time guard cannot see. Removing it would mean clearing the slot on promote — and at that point nothing distinguishes a seeded slot from one the owner picked, so it would discard real choices. That belongs to its own change.

## The invariant covers the create path only

`update_agent_fields` (`agent_store.py:469`, reached by `PUT /api/agents/{id}` at `api/agents.py:948`) applies neither `_validate_models` nor this fallback, so an update can still persist `{}` or an invisible model id. That is pre-existing behaviour and is not changed here; the invariant above is stated for persistence at creation.

## Relation to #2229

#2229 carried both the creation-time fallback and a backfill migration. Their eligibility rules have to agree but cannot share code, since a migration is a frozen revision; each review round found a finding in a different dimension of that disagreement. This PR keeps only the first half.

- **Gone with the migration**: SQL-NULL rows skipped by the backfill, the migration's reachability test being weaker than the application's, `add_agent` contradicting the migration's own exclusions, and the migration CI step's ordering fragility.
- **Taken**: the `Any` annotation (the helper deliberately passes non-dict template YAML through); test docstrings that state the invariant instead of naming a reviewer and a thread.
- **Not taken — "pinning the owner's static model is wrong for shared agents".** A share-link guest's token carries the *owner's* `user_id` (`share.py:78-82`), and the runtime identity is the task owner (`chat.py:2263-2265`, `:2902-2903`), so the requesting user is the owner in that scenario. For team agents, `chat.py:4284`'s `_to_internal_model_id_if_accessible` checks each ref against the caller and falls back to their own default when it is not visible. Nothing passes `share_enabled=True` at creation either.
- **Follow-up**: `update_agent_fields` validation (#2229 minor 6).

## Verification

20 tests. A mutation matrix breaks each guard in turn — the own-default visibility check, checking every own candidate rather than only the newest, the `config_type` filter, the visible-user-set filter, the `is_shared` filter, the shared-layer fallback, the shared layer keyed on the default's owner rather than the sharer, the fall-through from an invisible own default, the `general`-key guard, the non-dict guard, the `add_agent` call site, and the `loaders` call site — and each one fails a test. The multi-row case uses a `legacy_db` fixture that builds the schema with `uq_user_default_model` dropped from the metadata, since that is the only way to reach the shape an old database can hold. `tests/web/services` plus `test_model_service`, `test_llm_uitls`, `test_dynamic_model_sharing`, `test_workforce_creator_worker_resolution` and `api/test_agents_management`: 0 failures. pre-commit clean.

The test file resets `set_visible_user_ids_hook` around every case: it is a module-global that deployments install at import time, and the admin-default behaviour is what these cases assert on.
