### PR TITLE
fix(agents): resolve an empty model config instead of failing the delegation

### DIFF
--- a/frontend/src/components/build/agent-builder-model-seed.test.tsx
+++ b/frontend/src/components/build/agent-builder-model-seed.test.tsx
@@ -1,0 +1,373 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Server-side creation paths persisted no model config, so opening such an
+// agent in the builder rendered "--" and the required-model guard refused to
+// save. The edit-mode seed fills the slot from the owner's own default, and
+// must not count as a user edit (that would disable Publish on open).
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper"
+  )
+  return { ...actual, apiRequest: apiRequestMock }
+})
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return {
+    ...actual,
+    getApiUrl: () => "http://api.local",
+    getUploadApiUrl: () => "http://api.local",
+    getWsUrl: () => "ws://api.local",
+  }
+})
+
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({
+    state: {
+      messages: [],
+      traceEvents: [],
+      currentTask: null,
+      isProcessing: false,
+      isHistoryLoading: false,
+      taskId: null,
+      filePreview: { isOpen: false },
+      dagExecution: null,
+      steps: [],
+    },
+    setTaskId: vi.fn(),
+    sendMessage: vi.fn(),
+    dispatch: vi.fn(),
+    closeFilePreview: vi.fn(),
+    pauseTask: vi.fn(),
+    resumeTask: vi.fn(),
+    openFilePreview: vi.fn(),
+    requestStatus: vi.fn(),
+  }),
+}))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ token: "token", user: { id: "1", is_admin: false } }),
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    locale: "en",
+    t: (key: string, vars?: Record<string, string>) =>
+      vars?.appName ? `${key}:${vars.appName}` : key,
+  }),
+}))
+
+vi.mock("@/contexts/mcp-apps-context", () => ({
+  useMcpApps: () => ({ apps: [], getAppIcon: () => null }),
+}))
+
+vi.mock("@/lib/branding", () => ({
+  getBrandingFromEnv: () => ({ appName: "Xagent" }),
+}))
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}))
+
+vi.mock("@/components/layout/resizable-three-column-layout", () => ({
+  ResizableThreeColumnLayout: ({ middlePanel }: { middlePanel: React.ReactNode }) => (
+    <div>{middlePanel}</div>
+  ),
+}))
+
+vi.mock("@/components/task/task-conversation-panel", () => ({
+  TaskConversationPanel: () => null,
+}))
+
+vi.mock("@/components/build/agent-builder-chat", () => ({ AgentBuilderChat: () => null }))
+vi.mock("@/components/kb/knowledge-base-creation-dialog", () => ({
+  KnowledgeBaseCreationDialog: () => null,
+}))
+vi.mock("@/components/mcp/connect-mcp-dialog", () => ({
+  ConnectMcpDialog: () => null,
+}))
+vi.mock("@/components/chat/FileMentionDropdown", () => ({ FileMentionDropdown: () => null }))
+vi.mock("@/hooks/use-file-mention", () => ({
+  useFileMention: () => ({
+    checkTrigger: vi.fn(),
+    isOpen: false,
+    items: [],
+    selectedIndex: 0,
+    selectItem: vi.fn(),
+    close: vi.fn(),
+  }),
+}))
+vi.mock("@/components/ui/multi-select", () => ({
+  MultiSelect: (props: any) => (
+    <div data-testid="multi-select" data-placeholder={props.placeholder}>
+      {(props.options || []).map((o: any) => o.value).join("|")}
+    </div>
+  ),
+}))
+vi.mock("@/components/ui/select", () => ({ Select: () => null }))
+vi.mock("@/components/build/build-file-preview-sheet", () => ({
+  BuildFilePreviewSheet: () => null,
+}))
+
+import { toast } from "sonner"
+
+import { AgentBuilder } from "./agent-builder"
+
+const AGENT_ID = "5"
+const DEFAULT_MODEL_ID = 42
+
+function agentResponse(models: unknown, canEdit = true) {
+  return {
+    id: Number(AGENT_ID),
+    user_id: 1,
+    team_id: null,
+    name: "Seed Test Agent",
+    description: "",
+    instructions: "You are a test agent.",
+    execution_mode: "balanced",
+    models,
+    knowledge_bases: [],
+    skills: [],
+    tool_categories: [],
+    suggested_prompts: [],
+    logo_url: null,
+    status: "draft",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    widget_enabled: false,
+    allowed_domains: [],
+    share_enabled: false,
+    share_updated_at: null,
+    can_edit: canEdit,
+  }
+}
+
+const userDefault = (modelId: number) => [
+  { config_type: "general", model: { id: modelId, model_name: "seeded-llm" } },
+]
+
+type Gate = { release: () => void }
+
+function installApi(opts: {
+  models: unknown
+  userDefaults?: unknown[]
+  llms?: unknown[]
+  canEdit?: boolean
+  gateAgent?: Gate
+  gateDefaults?: Gate
+}) {
+  const defer = (gate: Gate | undefined, value: Response) => {
+    if (!gate) return Promise.resolve(value)
+    return new Promise<Response>(resolve => {
+      gate.release = () => resolve(value)
+    })
+  }
+  apiRequestMock.mockImplementation(
+    (url: string, o?: { method?: string; body?: string }) => {
+      if (o?.method === "PUT")
+        return Promise.resolve(
+          new Response(JSON.stringify(agentResponse(opts.models)), { status: 200 })
+        )
+      if (url.endsWith("/api/kb/collections"))
+        return Promise.resolve(
+          new Response(JSON.stringify({ collections: [] }), { status: 200 })
+        )
+      if (url.endsWith("/api/skills/"))
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      if (url.endsWith("/api/tools/available"))
+        return Promise.resolve(new Response(JSON.stringify({ tools: [] }), { status: 200 }))
+      if (url.endsWith("/api/models/?category=llm"))
+        return Promise.resolve(
+          new Response(JSON.stringify(opts.llms ?? []), { status: 200 })
+        )
+      if (url.endsWith("/api/models/user-default"))
+        return defer(
+          opts.gateDefaults,
+          new Response(
+            JSON.stringify(opts.userDefaults ?? userDefault(DEFAULT_MODEL_ID)),
+            { status: 200 }
+          )
+        )
+      if (url.includes(`/api/agents/${AGENT_ID}/triggers`))
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      if (url.endsWith(`/api/agents/${AGENT_ID}`))
+        return defer(
+          opts.gateAgent,
+          new Response(
+            JSON.stringify(agentResponse(opts.models, opts.canEdit ?? true)),
+            { status: 200 }
+          )
+        )
+      if (url.includes("/api/mcp/servers"))
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+    }
+  )
+}
+
+const updateButton = () => screen.getByText("builds.editor.header.update")
+const publishButton = () => screen.getByText("builds.editor.header.publish")
+const nameBox = () => screen.getByDisplayValue("Seed Test Agent")
+const loaded = () =>
+  waitFor(() => expect(screen.getByDisplayValue("Seed Test Agent")).toBeInTheDocument())
+
+const savedModels = async () => {
+  await waitFor(() => {
+    const put = apiRequestMock.mock.calls.find(([, o]) => (o as any)?.method === "PUT")
+    expect(put).toBeTruthy()
+  })
+  const put = apiRequestMock.mock.calls.find(([, o]) => (o as any)?.method === "PUT")
+  return JSON.parse((put![1] as any).body).models
+}
+
+beforeEach(() => {
+  apiRequestMock.mockReset()
+  ;(globalThis as any).WebSocket = vi.fn()
+})
+
+afterEach(() => cleanup())
+
+describe("AgentBuilder edit-mode general-model seed", () => {
+  it("saves an agent whose stored config is null", async () => {
+    installApi({ models: null })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    fireEvent.change(nameBox(), { target: { value: "Renamed" } })
+    fireEvent.click(updateButton())
+
+    expect((await savedModels()).general).toBe(DEFAULT_MODEL_ID)
+  })
+
+  it("treats a truthy-empty stored config as unset too", async () => {
+    installApi({ models: {} })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    fireEvent.change(nameBox(), { target: { value: "Renamed" } })
+    fireEvent.click(updateButton())
+
+    expect((await savedModels()).general).toBe(DEFAULT_MODEL_ID)
+  })
+
+  it("keeps Publish enabled on open: a seeded slot is not a user edit", async () => {
+    installApi({ models: null })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    await waitFor(() => expect(publishButton()).not.toBeDisabled())
+    expect(updateButton()).toBeDisabled()
+  })
+
+  it("does not overwrite a slot the owner already chose", async () => {
+    installApi({ models: { general: 7 } })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    fireEvent.change(nameBox(), { target: { value: "Renamed" } })
+    fireEvent.click(updateButton())
+
+    expect((await savedModels()).general).toBe(7)
+  })
+
+  it("preserves the other slots it does not fill", async () => {
+    installApi({ models: { compact: 3 } })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    fireEvent.change(nameBox(), { target: { value: "Renamed" } })
+    fireEvent.click(updateButton())
+
+    const models = await savedModels()
+    expect(models.general).toBe(DEFAULT_MODEL_ID)
+    expect(models.compact).toBe(3)
+  })
+
+  it("does not fall back to the first available LLM in edit mode", async () => {
+    // Silently pinning "whatever is first in the model list" onto an agent
+    // that already exists is a choice the owner never made; the required-model
+    // guard keeps holding instead.
+    installApi({
+      models: null,
+      userDefaults: [],
+      llms: [{ id: 99, model_name: "some-llm" }],
+    })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    fireEvent.change(nameBox(), { target: { value: "Renamed" } })
+    fireEvent.click(updateButton())
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(
+      apiRequestMock.mock.calls.find(([, o]) => (o as any)?.method === "PUT")
+    ).toBeUndefined()
+  })
+
+  it("shows the seeded model in the flow view when the viewer owns the agent", async () => {
+    installApi({
+      models: null,
+      llms: [{ id: DEFAULT_MODEL_ID, model_name: "seeded-llm" }],
+    })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+    fireEvent.click(screen.getByText("builds.editor.viewTabs.flow"))
+
+    await waitFor(() => expect(screen.getByText("seeded-llm")).toBeInTheDocument())
+  })
+
+  it("does not seed a read-only cross-user view", async () => {
+    // userDefaultGeneralRef holds the VIEWER's default; seeding here would
+    // render someone else's model as this agent's configuration.
+    installApi({
+      models: null,
+      canEdit: false,
+      llms: [{ id: DEFAULT_MODEL_ID, model_name: "seeded-llm" }],
+    })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+    fireEvent.click(screen.getByText("builds.editor.viewTabs.flow"))
+
+    await waitFor(() => expect(screen.getByText("—")).toBeInTheDocument())
+    expect(screen.queryByText("seeded-llm")).toBeNull()
+  })
+
+  it("seeds when the agent load resolves last", async () => {
+    const gateAgent: Gate = { release: () => {} }
+    installApi({ models: null, gateAgent })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalled())
+    gateAgent.release()
+    await loaded()
+
+    fireEvent.change(nameBox(), { target: { value: "Renamed" } })
+    fireEvent.click(updateButton())
+
+    expect((await savedModels()).general).toBe(DEFAULT_MODEL_ID)
+  })
+
+  it("seeds when the user-default fetch resolves last", async () => {
+    // The seed effect must wait for BOTH mount fetches: keyed on the agent
+    // load alone it would run while the default is still in flight and never
+    // re-run once it landed.
+    const gateDefaults: Gate = { release: () => {} }
+    installApi({ models: null, gateDefaults })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+    gateDefaults.release()
+
+    await waitFor(() => expect(publishButton()).not.toBeDisabled())
+    fireEvent.change(nameBox(), { target: { value: "Renamed" } })
+    fireEvent.click(updateButton())
+
+    expect((await savedModels()).general).toBe(DEFAULT_MODEL_ID)
+  })
+})

--- a/frontend/src/components/build/agent-builder-model-seed.test.tsx
+++ b/frontend/src/components/build/agent-builder-model-seed.test.tsx
@@ -258,13 +258,37 @@ describe("AgentBuilder edit-mode general-model seed", () => {
     expect((await savedModels()).general).toBe(DEFAULT_MODEL_ID)
   })
 
-  it("keeps Publish enabled on open: a seeded slot is not a user edit", async () => {
+  it("leaves Publish enabled and Update reachable on open", async () => {
+    // Publish posts no body, so Update is the only flow that persists the
+    // seeded slot -- it has to stay reachable, and Publish must not be
+    // blocked for the very agents the seed exists to unblock.
     installApi({ models: null })
     render(<AgentBuilder agentId={AGENT_ID} />)
     await loaded()
 
-    await waitFor(() => expect(publishButton()).not.toBeDisabled())
-    expect(updateButton()).toBeDisabled()
+    await waitFor(() => expect(updateButton()).not.toBeDisabled())
+    expect(publishButton()).not.toBeDisabled()
+  })
+
+  it("persists the seeded slot when Update is clicked with nothing else changed", async () => {
+    installApi({ models: null })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    await waitFor(() => expect(updateButton()).not.toBeDisabled())
+    fireEvent.click(updateButton())
+
+    expect((await savedModels()).general).toBe(DEFAULT_MODEL_ID)
+  })
+
+  it("still blocks Publish once the user edits something else", async () => {
+    installApi({ models: null })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    fireEvent.change(nameBox(), { target: { value: "Renamed" } })
+
+    await waitFor(() => expect(publishButton()).toBeDisabled())
   })
 
   it("does not overwrite a slot the owner already chose", async () => {
@@ -289,6 +313,23 @@ describe("AgentBuilder edit-mode general-model seed", () => {
     const models = await savedModels()
     expect(models.general).toBe(DEFAULT_MODEL_ID)
     expect(models.compact).toBe(3)
+  })
+
+  it("ignores a malformed entry without losing a valid one", async () => {
+    installApi({
+      models: null,
+      userDefaults: [
+        { config_type: "general", model: { id: DEFAULT_MODEL_ID } },
+        { config_type: "general", model: null },
+      ],
+    })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    await waitFor(() => expect(updateButton()).not.toBeDisabled())
+    fireEvent.click(updateButton())
+
+    expect((await savedModels()).general).toBe(DEFAULT_MODEL_ID)
   })
 
   it("does not fall back to the first available LLM in edit mode", async () => {

--- a/frontend/src/components/build/agent-builder-model-seed.test.tsx
+++ b/frontend/src/components/build/agent-builder-model-seed.test.tsx
@@ -112,7 +112,21 @@ vi.mock("@/components/ui/multi-select", () => ({
     </div>
   ),
 }))
-vi.mock("@/components/ui/select", () => ({ Select: () => null }))
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ value, onValueChange, options }: any) => (
+    <select
+      data-testid="model-select"
+      value={value ?? ""}
+      onChange={(e) => onValueChange(e.target.value)}
+    >
+      {(options || []).map((o: any) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  ),
+}))
 vi.mock("@/components/build/build-file-preview-sheet", () => ({
   BuildFilePreviewSheet: () => null,
 }))
@@ -172,10 +186,15 @@ function installApi(opts: {
   }
   apiRequestMock.mockImplementation(
     (url: string, o?: { method?: string; body?: string }) => {
-      if (o?.method === "PUT")
+      if (o?.method === "PUT") {
+        const sent = JSON.parse(o.body || "{}")
         return Promise.resolve(
-          new Response(JSON.stringify(agentResponse(opts.models)), { status: 200 })
+          new Response(
+            JSON.stringify(agentResponse(sent.models ?? opts.models)),
+            { status: 200 }
+          )
         )
+      }
       if (url.endsWith("/api/kb/collections"))
         return Promise.resolve(
           new Response(JSON.stringify({ collections: [] }), { status: 200 })
@@ -213,6 +232,8 @@ function installApi(opts: {
   )
 }
 
+const generalSelect = () =>
+  screen.getAllByTestId("model-select")[0] as HTMLSelectElement
 const updateButton = () => screen.getByText("builds.editor.header.update")
 const publishButton = () => screen.getByText("builds.editor.header.publish")
 const nameBox = () => screen.getByDisplayValue("Seed Test Agent")
@@ -353,16 +374,17 @@ describe("AgentBuilder edit-mode general-model seed", () => {
     ).toBeUndefined()
   })
 
-  it("shows the seeded model in the flow view when the viewer owns the agent", async () => {
+  it("shows the seeded model when the viewer owns the agent", async () => {
     installApi({
       models: null,
       llms: [{ id: DEFAULT_MODEL_ID, model_name: "seeded-llm" }],
     })
     render(<AgentBuilder agentId={AGENT_ID} />)
     await loaded()
-    fireEvent.click(screen.getByText("builds.editor.viewTabs.flow"))
 
-    await waitFor(() => expect(screen.getByText("seeded-llm")).toBeInTheDocument())
+    await waitFor(() =>
+      expect(generalSelect().value).toBe(String(DEFAULT_MODEL_ID))
+    )
   })
 
   it("does not seed a read-only cross-user view", async () => {
@@ -375,10 +397,9 @@ describe("AgentBuilder edit-mode general-model seed", () => {
     })
     render(<AgentBuilder agentId={AGENT_ID} />)
     await loaded()
-    fireEvent.click(screen.getByText("builds.editor.viewTabs.flow"))
 
-    await waitFor(() => expect(screen.getByText("—")).toBeInTheDocument())
-    expect(screen.queryByText("seeded-llm")).toBeNull()
+    await waitFor(() => expect(generalSelect()).toBeDisabled())
+    expect(generalSelect().value).toBe("")
   })
 
   it("seeds when the agent load resolves last", async () => {
@@ -410,5 +431,57 @@ describe("AgentBuilder edit-mode general-model seed", () => {
     fireEvent.click(updateButton())
 
     expect((await savedModels()).general).toBe(DEFAULT_MODEL_ID)
+  })
+})
+
+describe("AgentBuilder seed provenance after a save", () => {
+  const OTHER_MODEL_ID = 7
+
+  it("stops exempting the seeded model once an Update has persisted another", async () => {
+    // seed A -> pick B -> Update (B is now stored) -> pick A again. A is no
+    // longer "the slot this page seeded", it is an unsaved edit, and Publish
+    // cannot persist it (the request carries no body).
+    installApi({
+      models: null,
+      llms: [
+        { id: DEFAULT_MODEL_ID, model_name: "seeded-llm" },
+        { id: OTHER_MODEL_ID, model_name: "other-llm" },
+      ],
+    })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+    await waitFor(() => expect(publishButton()).not.toBeDisabled())
+
+    fireEvent.change(generalSelect(), { target: { value: String(OTHER_MODEL_ID) } })
+    fireEvent.click(updateButton())
+    expect((await savedModels()).general).toBe(OTHER_MODEL_ID)
+
+    await waitFor(() => expect(updateButton()).toBeDisabled())
+    fireEvent.change(generalSelect(), {
+      target: { value: String(DEFAULT_MODEL_ID) },
+    })
+
+    await waitFor(() => expect(publishButton()).toBeDisabled())
+  })
+
+  it("still exempts the seeded model before any save", async () => {
+    installApi({
+      models: null,
+      llms: [
+        { id: DEFAULT_MODEL_ID, model_name: "seeded-llm" },
+        { id: OTHER_MODEL_ID, model_name: "other-llm" },
+      ],
+    })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    await waitFor(() => expect(publishButton()).not.toBeDisabled())
+    fireEvent.change(generalSelect(), { target: { value: String(OTHER_MODEL_ID) } })
+    await waitFor(() => expect(publishButton()).toBeDisabled())
+
+    fireEvent.change(generalSelect(), {
+      target: { value: String(DEFAULT_MODEL_ID) },
+    })
+    await waitFor(() => expect(publishButton()).not.toBeDisabled())
   })
 })

--- a/frontend/src/components/build/agent-builder-model-seed.test.tsx
+++ b/frontend/src/components/build/agent-builder-model-seed.test.tsx
@@ -50,8 +50,12 @@ vi.mock("@/contexts/app-context-chat", () => ({
   }),
 }))
 
+const authUser = vi.hoisted(() => ({
+  current: { id: "1", is_admin: false } as { id: string; is_admin: boolean },
+}))
+
 vi.mock("@/contexts/auth-context", () => ({
-  useAuth: () => ({ token: "token", user: { id: "1", is_admin: false } }),
+  useAuth: () => ({ token: "token", user: authUser.current }),
 }))
 
 vi.mock("@/contexts/i18n-context", () => ({
@@ -177,6 +181,7 @@ function installApi(opts: {
   canEdit?: boolean
   gateAgent?: Gate
   gateDefaults?: Gate
+  gateOwnerMcp?: Gate
 }) {
   const defer = (gate: Gate | undefined, value: Response) => {
     if (!gate) return Promise.resolve(value)
@@ -204,8 +209,15 @@ function installApi(opts: {
       if (url.endsWith("/api/tools/available"))
         return Promise.resolve(new Response(JSON.stringify({ tools: [] }), { status: 200 }))
       if (url.endsWith("/api/models/?category=llm"))
+        // The default general model is always in this list for real: both go
+        // through the same visibility filter.
         return Promise.resolve(
-          new Response(JSON.stringify(opts.llms ?? []), { status: 200 })
+          new Response(
+            JSON.stringify(
+              opts.llms ?? [{ id: DEFAULT_MODEL_ID, model_name: "seeded-llm" }]
+            ),
+            { status: 200 }
+          )
         )
       if (url.endsWith("/api/models/user-default"))
         return defer(
@@ -224,6 +236,11 @@ function installApi(opts: {
             JSON.stringify(agentResponse(opts.models, opts.canEdit ?? true)),
             { status: 200 }
           )
+        )
+      if (url.includes("/api/mcp/servers?user_id="))
+        return defer(
+          opts.gateOwnerMcp,
+          new Response(JSON.stringify([]), { status: 200 })
         )
       if (url.includes("/api/mcp/servers"))
         return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
@@ -251,6 +268,7 @@ const savedModels = async () => {
 
 beforeEach(() => {
   apiRequestMock.mockReset()
+  authUser.current = { id: "1", is_admin: false }
   ;(globalThis as any).WebSocket = vi.fn()
 })
 
@@ -353,6 +371,20 @@ describe("AgentBuilder edit-mode general-model seed", () => {
     expect((await savedModels()).general).toBe(DEFAULT_MODEL_ID)
   })
 
+  it("does not seed an id the model list does not contain", async () => {
+    // A default pointing at a model absent from /api/models would render an
+    // empty Select while counting as an edit.
+    installApi({
+      models: null,
+      llms: [{ id: 123, model_name: "other-llm" }],
+    })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    await waitFor(() => expect(generalSelect().value).toBe(""))
+    expect(updateButton()).toBeDisabled()
+  })
+
   it("does not fall back to the first available LLM in edit mode", async () => {
     // Silently pinning "whatever is first in the model list" onto an agent
     // that already exists is a choice the owner never made; the required-model
@@ -416,10 +448,11 @@ describe("AgentBuilder edit-mode general-model seed", () => {
     expect((await savedModels()).general).toBe(DEFAULT_MODEL_ID)
   })
 
-  it("seeds when the user-default fetch resolves last", async () => {
-    // The seed effect must wait for BOTH mount fetches: keyed on the agent
-    // load alone it would run while the default is still in flight and never
-    // re-run once it landed.
+  it("seeds when isInitialDataLoaded is the last dependency to land", async () => {
+    // Gating the user-default response also gates isInitialDataLoaded (both
+    // come from the same Promise.all), so this is not a race between the two
+    // fetches -- it is the case where the agent load commits first and the
+    // effect must still fire once the mount fetch finally reports in.
     const gateDefaults: Gate = { release: () => {} }
     installApi({ models: null, gateDefaults })
     render(<AgentBuilder agentId={AGENT_ID} />)
@@ -483,5 +516,35 @@ describe("AgentBuilder seed provenance after a save", () => {
       target: { value: String(DEFAULT_MODEL_ID) },
     })
     await waitFor(() => expect(publishButton()).not.toBeDisabled())
+  })
+})
+
+describe("AgentBuilder seed across loadAgent's awaits", () => {
+  it("keeps the seed when an admin cross-user load awaits mid-way", async () => {
+    // The admin branch of loadAgent awaits an owner-scoped MCP fetch. React 18
+    // does not batch across it, so a setModelConfig placed after the await
+    // clobbers a seed that already ran -- and the stamped ref would stop it
+    // from ever running again. Only a truthy-empty `models` reaches that
+    // assignment (null skips the `if`), which is what loaders.py used to write.
+    const gateOwnerMcp: Gate = { release: () => {} }
+    authUser.current = { id: "9", is_admin: true }
+    installApi({
+      models: {},
+      gateOwnerMcp,
+      llms: [{ id: DEFAULT_MODEL_ID, model_name: "seeded-llm" }],
+    })
+    render(<AgentBuilder agentId={AGENT_ID} />)
+    await loaded()
+
+    // Parked inside the await, with originalData already committed: the seed
+    // effect gets its chance here.
+    await waitFor(() =>
+      expect(generalSelect().value).toBe(String(DEFAULT_MODEL_ID))
+    )
+    gateOwnerMcp.release()
+
+    // ...and whatever runs after the await must not undo it.
+    await waitFor(() => expect(screen.getByText("seeded-llm")).toBeInTheDocument())
+    expect(generalSelect().value).toBe(String(DEFAULT_MODEL_ID))
   })
 })

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -794,6 +794,8 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
 
           // One pass: the general-default ref is needed in edit mode too (the
           // seed effect above reads it), the rest only seeds a new agent.
+          // The shape guards are defensive -- fetchData's catch already
+          // swallows a malformed response, so no test can tell them apart.
           const config: AgentModelConfig = {
             general: null,
             small_fast: null,
@@ -1348,11 +1350,13 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   // Enables Update, so the seeded value has a way into the database: Publish
   // posts no body and never persists models.
   const isDirty = isDirtyBeyondGeneralModel || generalModelDiffers
-  // ...but a slot this page seeded is not an edit the user made, so it must
-  // not block Publish for the very agents the seed exists to unblock. The
-  // stored-slot test retires the exemption: once an Update has persisted a
-  // model, re-picking the seeded one is an ordinary unsaved edit again.
-  const seedStillUnsaved = ((originalData?.models || {}).general || null) === null
+  // ...but a slot holding the seeded value is not an edit worth blocking
+  // Publish over, for the very agents the seed exists to unblock. Picking the
+  // seeded model by hand is indistinguishable from the seed itself, which is
+  // harmless: either way the delegation resolves the same default. The
+  // stored-slot test retires the exemption once an Update has persisted a
+  // model, so re-picking the seeded one is then an ordinary unsaved edit.
+  const seedStillUnsaved = !(originalData?.models || {}).general
   const publishBlockedByEdits =
     isDirtyBeyondGeneralModel ||
     (generalModelDiffers &&

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -792,26 +792,27 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         if (userDefaultsRes.ok) {
           const userDefaults = await userDefaultsRes.json()
 
-          for (const m of userDefaults) {
-            if (m.config_type === 'general') userDefaultGeneralRef.current = m.model.id
+          // One pass: the general-default ref is needed in edit mode too (the
+          // seed effect above reads it), the rest only seeds a new agent.
+          const config: AgentModelConfig = {
+            general: null,
+            small_fast: null,
+            visual: null,
+            compact: null,
+          }
+          for (const m of Array.isArray(userDefaults) ? userDefaults : []) {
+            const id = m?.model?.id
+            if (!id) continue
+            if (m.config_type === 'general') {
+              config.general = id
+              userDefaultGeneralRef.current = id
+            }
+            else if (m.config_type === 'small_fast') config.small_fast = id
+            else if (m.config_type === 'visual') config.visual = id
+            else if (m.config_type === 'compact') config.compact = id
           }
 
-          // Set model config based on user defaults (only for new agent)
           if (!isEditMode) {
-            const config: AgentModelConfig = {
-              general: null,
-              small_fast: null,
-              visual: null,
-              compact: null,
-            }
-
-            for (const m of userDefaults) {
-              if (m.config_type === 'general') config.general = m.model.id
-              else if (m.config_type === 'small_fast') config.small_fast = m.model.id
-              else if (m.config_type === 'visual') config.visual = m.model.id
-              else if (m.config_type === 'compact') config.compact = m.model.id
-            }
-
             // Fallback: If no general model set, pick first available LLM
             if (!config.general && availableModels.length > 0) {
               // models endpoint was called with ?category=llm so these should be LLMs
@@ -853,12 +854,12 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     // Not in a read-only cross-user view: the default below is the viewer's,
     // so seeding there would render someone else's model as this agent's.
     if (!isEditMode || readOnly || !isInitialDataLoaded || !originalData) return
-    if (seededGeneralRef.current !== null) return
+    if (seededGeneralRef.current !== null || modelConfig.general) return
     const seeded = userDefaultGeneralRef.current
     if (!seeded) return
     seededGeneralRef.current = seeded
-    setModelConfig(prev => (prev.general ? prev : { ...prev, general: seeded }))
-  }, [isEditMode, isInitialDataLoaded, originalData])
+    setModelConfig(prev => ({ ...prev, general: seeded }))
+  }, [isEditMode, readOnly, isInitialDataLoaded, originalData, modelConfig.general])
 
   // Load agent data in edit mode
   useEffect(() => {
@@ -1291,7 +1292,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     })
   }
 
-  const isDirty = useMemo(() => {
+  const isDirtyBeyondGeneralModel = useMemo(() => {
     if (!originalData) return false
 
     // Helper to normalize arrays for comparison
@@ -1331,21 +1332,27 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     const originalNonMcpCategories = (originalData.tool_categories || []).filter((c: string) => !c.startsWith('mcp:'))
     if (normalize(nonMcpCategories) !== normalize(originalNonMcpCategories)) return true
 
-    // Compare models
+    // Compare models. The general slot is compared outside this memo: the
+    // seed has to leave Update enabled (that is the only flow that persists
+    // it) while not blocking Publish.
     const origModels = originalData.models || {}
-    // A seeded slot is not a user edit: counting it would disable Publish on
-    // open for exactly the agents this seed exists to unblock. The stored-slot
-    // test is what keeps a real edit that lands on the seeded model dirty.
-    const seededOnly =
-      (origModels.general || null) === null &&
-      modelConfig.general === seededGeneralRef.current
-    if (!seededOnly && (modelConfig.general || null) !== (origModels.general || null)) return true
     if ((modelConfig.small_fast || null) !== (origModels.small_fast || null)) return true
     if ((modelConfig.visual || null) !== (origModels.visual || null)) return true
     if ((modelConfig.compact || null) !== (origModels.compact || null)) return true
 
     return false
   }, [name, description, instructions, executionMode, ownership, visibility, logoFile, logoRemoved, suggestedPrompts, selectedKbs, selectedSkills, selectedToolCategories, selectedMcpServers, modelConfig, originalData])
+
+  const generalModelDiffers =
+    (modelConfig.general || null) !== ((originalData?.models || {}).general || null)
+  // Enables Update, so the seeded value has a way into the database: Publish
+  // posts no body and never persists models.
+  const isDirty = isDirtyBeyondGeneralModel || generalModelDiffers
+  // ...but a slot this page seeded is not an edit the user made, so it must
+  // not block Publish for the very agents the seed exists to unblock.
+  const publishBlockedByEdits =
+    isDirtyBeyondGeneralModel ||
+    (generalModelDiffers && modelConfig.general !== seededGeneralRef.current)
 
   // After a successful save, align server-side ownership with the chosen control:
   // promote a personal agent to team (with visibility) or demote a team agent back
@@ -2033,7 +2040,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
                   <Button
                     variant="secondary"
                     onClick={handlePublish}
-                    disabled={isCreating || loadingAgent || isDirty}
+                    disabled={isCreating || loadingAgent || publishBlockedByEdits}
                   >
                     {t("builds.editor.header.publish")}
                   </Button>

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -858,10 +858,12 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     if (!isEditMode || readOnly || !isInitialDataLoaded || !originalData) return
     if (seededGeneralRef.current !== null || modelConfig.general) return
     const seeded = userDefaultGeneralRef.current
-    if (!seeded) return
+    // Only an id the dropdown can actually show: seeding one that is missing
+    // from the fetched list renders an empty Select while counting as dirty.
+    if (!seeded || !models.some(m => m.id === seeded)) return
     seededGeneralRef.current = seeded
     setModelConfig(prev => ({ ...prev, general: seeded }))
-  }, [isEditMode, readOnly, isInitialDataLoaded, originalData, modelConfig.general])
+  }, [isEditMode, readOnly, isInitialDataLoaded, originalData, modelConfig.general, models])
 
   // Load agent data in edit mode
   useEffect(() => {
@@ -882,6 +884,18 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           if (!active) return
           setOriginalData(agent)
           setReadOnly(agent.can_edit === false)
+          // Same synchronous block as originalData: React 18 does not batch
+          // across the await below, so leaving this after it lets the seed
+          // effect run against a committed originalData and then be clobbered
+          // -- with the ref already stamped, it would never seed again.
+          if (agent.models) {
+            setModelConfig({
+              general: agent.models.general || null,
+              small_fast: agent.models.small_fast || null,
+              visual: agent.models.visual || null,
+              compact: agent.models.compact || null,
+            })
+          }
           setName(agent.name || "")
           setDescription(agent.description || "")
           setInstructions(agent.instructions || "")
@@ -926,16 +940,6 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
 
           setLogoUrl(agent.logo_url || null)
           setLogoRemoved(false)
-
-          // Load models
-          if (agent.models) {
-            setModelConfig({
-              general: agent.models.general || null,
-              small_fast: agent.models.small_fast || null,
-              visual: agent.models.visual || null,
-              compact: agent.models.compact || null,
-            })
-          }
         } else if (response.status === 404) {
           setNotFound(true)
         }

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -1349,10 +1349,14 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   // posts no body and never persists models.
   const isDirty = isDirtyBeyondGeneralModel || generalModelDiffers
   // ...but a slot this page seeded is not an edit the user made, so it must
-  // not block Publish for the very agents the seed exists to unblock.
+  // not block Publish for the very agents the seed exists to unblock. The
+  // stored-slot test retires the exemption: once an Update has persisted a
+  // model, re-picking the seeded one is an ordinary unsaved edit again.
+  const seedStillUnsaved = ((originalData?.models || {}).general || null) === null
   const publishBlockedByEdits =
     isDirtyBeyondGeneralModel ||
-    (generalModelDiffers && modelConfig.general !== seededGeneralRef.current)
+    (generalModelDiffers &&
+      !(seedStillUnsaved && modelConfig.general === seededGeneralRef.current))
 
   // After a successful save, align server-side ownership with the chosen control:
   // promote a personal agent to team (with visibility) or demote a team agent back

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -268,6 +268,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   // Set once loadAgent decides to load an owner-scoped MCP list for an admin
   // cross-user view, so the mount-time self-scoped fetch won't clobber it.
   const ownerScopedMcpRef = useRef(false)
+  // The CURRENT user's general default (not necessarily the agent owner's),
+  // kept so the edit-mode seed below can run whichever mount fetch lands last.
+  const userDefaultGeneralRef = useRef<number | null>(null)
+  const seededGeneralRef = useRef<number | null>(null)
   const router = useRouter()
   const searchParams = useSearchParams()
   const templateId = searchParams.get("template")
@@ -788,6 +792,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         if (userDefaultsRes.ok) {
           const userDefaults = await userDefaultsRes.json()
 
+          for (const m of userDefaults) {
+            if (m.config_type === 'general') userDefaultGeneralRef.current = m.model.id
+          }
+
           // Set model config based on user defaults (only for new agent)
           if (!isEditMode) {
             const config: AgentModelConfig = {
@@ -837,6 +845,20 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       console.error("Failed to refresh KBs:", error)
     }
   }
+
+  // Server-side creation paths persisted no model config, which rendered "--"
+  // and tripped the required-model guard on save. Both mount fetches must have
+  // landed before we can tell an unset slot from one still loading.
+  useEffect(() => {
+    // Not in a read-only cross-user view: the default below is the viewer's,
+    // so seeding there would render someone else's model as this agent's.
+    if (!isEditMode || readOnly || !isInitialDataLoaded || !originalData) return
+    if (seededGeneralRef.current !== null) return
+    const seeded = userDefaultGeneralRef.current
+    if (!seeded) return
+    seededGeneralRef.current = seeded
+    setModelConfig(prev => (prev.general ? prev : { ...prev, general: seeded }))
+  }, [isEditMode, isInitialDataLoaded, originalData])
 
   // Load agent data in edit mode
   useEffect(() => {
@@ -1311,7 +1333,13 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
 
     // Compare models
     const origModels = originalData.models || {}
-    if ((modelConfig.general || null) !== (origModels.general || null)) return true
+    // A seeded slot is not a user edit: counting it would disable Publish on
+    // open for exactly the agents this seed exists to unblock. The stored-slot
+    // test is what keeps a real edit that lands on the seeded model dirty.
+    const seededOnly =
+      (origModels.general || null) === null &&
+      modelConfig.general === seededGeneralRef.current
+    if (!seededOnly && (modelConfig.general || null) !== (origModels.general || null)) return true
     if ((modelConfig.small_fast || null) !== (origModels.small_fast || null)) return true
     if ((modelConfig.visual || null) !== (origModels.visual || null)) return true
     if ((modelConfig.compact || null) !== (origModels.compact || null)) return true

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -2175,13 +2175,18 @@ class AgentTool(AbstractBaseTool):
                 # Resolve models
                 storage = UserAwareModelStorage(db)
 
-                if agent_models:
-                    from .agent_model_resolution import resolve_agent_model_llms
+                from .agent_model_resolution import resolve_agent_model_llms
 
-                    default_llm, fast_llm, vision_llm, compact_llm = (
-                        resolve_agent_model_llms(
-                            db, storage, agent_models, self._user_id
-                        )
+                default_llm, fast_llm, vision_llm, compact_llm = (
+                    resolve_agent_model_llms(db, storage, agent_models, self._user_id)
+                )
+                # Server-side creation paths persisted no model config, and an
+                # unset slot must not fail the delegation outright. This is the
+                # same chain the plain chat path already resolves through, env
+                # tail included -- see resolve_llms_from_names.
+                if not default_llm:
+                    default_llm, _, _, _ = storage.get_configured_defaults(
+                        self._user_id, config_types=("general",)
                     )
             # ---- Phase 1 session closed here. ----
 

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -2182,11 +2182,12 @@ class AgentTool(AbstractBaseTool):
                 )
                 # Keyed on the general slot, not on the whole mapping: an
                 # agent carrying only e.g. {"compact": id} has an unset general
-                # slot too. A stated id that no longer resolves keeps failing
-                # closed rather than silently running on a different model.
+                # slot too. Anything stated there keeps failing closed when it
+                # will not resolve -- including a model *name* forwarded from
+                # template YAML, which resolves by id only.
                 stated_general = (
                     agent_models.get("general")
-                    if isinstance(agent_models, dict)
+                    if isinstance(agent_models, Mapping)
                     else None
                 )
                 if not stated_general and not default_llm:
@@ -2201,7 +2202,7 @@ class AgentTool(AbstractBaseTool):
                     if default_llm is not None:
                         logger.info(
                             "Agent %s has no general model set; delegating on "
-                            "the configured default %s",
+                            "the resolved default %s",
                             self._agent_id,
                             getattr(
                                 default_llm, "model_name", type(default_llm).__name__

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -2182,15 +2182,15 @@ class AgentTool(AbstractBaseTool):
                 )
                 # Keyed on the general slot, not on the whole mapping: an
                 # agent carrying only e.g. {"compact": id} has an unset general
-                # slot too. Anything stated there keeps failing closed when it
-                # will not resolve -- including a model *name* forwarded from
-                # template YAML, which resolves by id only.
-                stated_general = (
-                    agent_models.get("general")
-                    if isinstance(agent_models, Mapping)
-                    else None
+                # slot too. Anything else keeps failing closed when it will not
+                # resolve -- a model *name* forwarded from template YAML (which
+                # resolves by id only), or a payload that is not even a mapping,
+                # which is a stated-but-corrupt config rather than an unset one.
+                general_unset = agent_models is None or (
+                    isinstance(agent_models, Mapping)
+                    and not agent_models.get("general")
                 )
-                if not stated_general and not default_llm:
+                if general_unset and not default_llm:
                     from .....web.services.llm_utils import AutoModelUnavailableError
 
                     try:
@@ -2198,6 +2198,12 @@ class AgentTool(AbstractBaseTool):
                             self._user_id, config_types=("general",)
                         )
                     except AutoModelUnavailableError:
+                        logger.warning(
+                            "Agent %s has no general model and no default is "
+                            "configured for user %s; failing the delegation",
+                            self._agent_id,
+                            self._user_id,
+                        )
                         default_llm = None
                     if default_llm is not None:
                         logger.info(

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -2180,14 +2180,27 @@ class AgentTool(AbstractBaseTool):
                 default_llm, fast_llm, vision_llm, compact_llm = (
                     resolve_agent_model_llms(db, storage, agent_models, self._user_id)
                 )
-                # Server-side creation paths persisted no model config, and an
-                # unset slot must not fail the delegation outright. This is the
-                # same chain the plain chat path already resolves through, env
-                # tail included -- see resolve_llms_from_names.
-                if not default_llm:
-                    default_llm, _, _, _ = storage.get_configured_defaults(
-                        self._user_id, config_types=("general",)
-                    )
+                # Only an unset config, never a resolution failure: a stored id
+                # that is gone or no longer visible has to keep failing closed
+                # rather than silently run on a different model.
+                if not agent_models and not default_llm:
+                    from .....web.services.llm_utils import AutoModelUnavailableError
+
+                    try:
+                        default_llm, _, _, _ = storage.get_configured_defaults(
+                            self._user_id, config_types=("general",)
+                        )
+                    except AutoModelUnavailableError:
+                        default_llm = None
+                    if default_llm is not None:
+                        logger.info(
+                            "Agent %s has no model config; delegating on the "
+                            "configured default %s",
+                            self._agent_id,
+                            getattr(
+                                default_llm, "model_name", type(default_llm).__name__
+                            ),
+                        )
             # ---- Phase 1 session closed here. ----
 
             if not default_llm:

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -2180,10 +2180,16 @@ class AgentTool(AbstractBaseTool):
                 default_llm, fast_llm, vision_llm, compact_llm = (
                     resolve_agent_model_llms(db, storage, agent_models, self._user_id)
                 )
-                # Only an unset config, never a resolution failure: a stored id
-                # that is gone or no longer visible has to keep failing closed
-                # rather than silently run on a different model.
-                if not agent_models and not default_llm:
+                # Keyed on the general slot, not on the whole mapping: an
+                # agent carrying only e.g. {"compact": id} has an unset general
+                # slot too. A stated id that no longer resolves keeps failing
+                # closed rather than silently running on a different model.
+                stated_general = (
+                    agent_models.get("general")
+                    if isinstance(agent_models, dict)
+                    else None
+                )
+                if not stated_general and not default_llm:
                     from .....web.services.llm_utils import AutoModelUnavailableError
 
                     try:
@@ -2194,8 +2200,8 @@ class AgentTool(AbstractBaseTool):
                         default_llm = None
                     if default_llm is not None:
                         logger.info(
-                            "Agent %s has no model config; delegating on the "
-                            "configured default %s",
+                            "Agent %s has no general model set; delegating on "
+                            "the configured default %s",
                             self._agent_id,
                             getattr(
                                 default_llm, "model_name", type(default_llm).__name__

--- a/tests/core/tools/conftest.py
+++ b/tests/core/tools/conftest.py
@@ -5,16 +5,17 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def no_resolvable_default_llm(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make the delegation model fallback yield nothing by default.
+    """Make the delegation model fallback yield nothing.
 
     ``get_configured_defaults`` ends in ``create_llm_from_env()``, so a test
     asserting the no-valid-model exit would otherwise pass only on a machine
     with no provider key exported -- and would issue a real request on one
-    that has it. Autouse so a new test cannot reintroduce that hazard by
-    forgetting to ask; a test that wants a resolvable default overrides this
-    with its own monkeypatch.
+    that has it. The two modules that assert that exit apply this module-wide
+    via ``pytestmark``, so a new test there cannot reintroduce the hazard by
+    forgetting to ask; a test wanting a resolvable default overrides it with
+    its own monkeypatch.
     """
     from xagent.web.services.llm_utils import UserAwareModelStorage
 

--- a/tests/core/tools/conftest.py
+++ b/tests/core/tools/conftest.py
@@ -1,0 +1,26 @@
+"""Shared fixtures for the vibe agent-tool tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+
+@pytest.fixture()
+def no_resolvable_default_llm(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Make the delegation model fallback yield nothing.
+
+    ``get_configured_defaults`` ends in ``create_llm_from_env()``, so a test
+    asserting the no-valid-model exit would otherwise pass only on a machine
+    with no provider key exported -- and would issue a real request on one
+    that has it.
+    """
+    from xagent.web.services.llm_utils import UserAwareModelStorage
+
+    monkeypatch.setattr(
+        UserAwareModelStorage,
+        "get_configured_defaults",
+        lambda self, *args, **kwargs: (None, None, None, None),
+    )
+    yield

--- a/tests/core/tools/conftest.py
+++ b/tests/core/tools/conftest.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-
 import pytest
 
 
-@pytest.fixture()
-def no_resolvable_default_llm(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Make the delegation model fallback yield nothing.
+@pytest.fixture(autouse=True)
+def no_resolvable_default_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the delegation model fallback yield nothing by default.
 
     ``get_configured_defaults`` ends in ``create_llm_from_env()``, so a test
     asserting the no-valid-model exit would otherwise pass only on a machine
     with no provider key exported -- and would issue a real request on one
-    that has it.
+    that has it. Autouse so a new test cannot reintroduce that hazard by
+    forgetting to ask; a test that wants a resolvable default overrides this
+    with its own monkeypatch.
     """
     from xagent.web.services.llm_utils import UserAwareModelStorage
 
@@ -23,4 +23,3 @@ def no_resolvable_default_llm(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]
         "get_configured_defaults",
         lambda self, *args, **kwargs: (None, None, None, None),
     )
-    yield

--- a/tests/core/tools/test_agent_tool_publish_status.py
+++ b/tests/core/tools/test_agent_tool_publish_status.py
@@ -469,9 +469,9 @@ async def test_agent_tool_execution_enforces_target_allowed_agent_ids() -> None:
 
 
 @pytest.mark.asyncio
-async def test_agent_tool_execution_allows_cross_user_only_with_target_allowlist(
-    no_resolvable_default_llm: None,
-) -> None:
+async def test_agent_tool_execution_allows_cross_user_only_with_target_allowlist() -> (
+    None
+):
     db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="cross_owner", password_hash="x", is_admin=False)
@@ -533,9 +533,9 @@ async def test_agent_tool_execution_allows_cross_user_only_with_target_allowlist
 
 
 @pytest.mark.asyncio
-async def test_delegation_allowed_agent_ids_do_not_block_current_worker_execution(
-    no_resolvable_default_llm: None,
-) -> None:
+async def test_delegation_allowed_agent_ids_do_not_block_current_worker_execution() -> (
+    None
+):
     db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="nested_owner", password_hash="x", is_admin=False)

--- a/tests/core/tools/test_agent_tool_publish_status.py
+++ b/tests/core/tools/test_agent_tool_publish_status.py
@@ -29,6 +29,11 @@ from xagent.web.models.database import Base
 from xagent.web.models.user import User
 from xagent.web.tools.config import WebToolConfig
 
+# Every no-valid-model assertion in this module depends on the fallback
+# resolving to nothing; see the fixture for why that cannot be left to the
+# machine's environment.
+pytestmark = pytest.mark.usefixtures("no_resolvable_default_llm")
+
 
 def _create_session() -> tuple[Session, str, sessionmaker]:
     temp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)

--- a/tests/core/tools/test_agent_tool_publish_status.py
+++ b/tests/core/tools/test_agent_tool_publish_status.py
@@ -469,9 +469,9 @@ async def test_agent_tool_execution_enforces_target_allowed_agent_ids() -> None:
 
 
 @pytest.mark.asyncio
-async def test_agent_tool_execution_allows_cross_user_only_with_target_allowlist() -> (
-    None
-):
+async def test_agent_tool_execution_allows_cross_user_only_with_target_allowlist(
+    no_resolvable_default_llm: None,
+) -> None:
     db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="cross_owner", password_hash="x", is_admin=False)
@@ -533,9 +533,9 @@ async def test_agent_tool_execution_allows_cross_user_only_with_target_allowlist
 
 
 @pytest.mark.asyncio
-async def test_delegation_allowed_agent_ids_do_not_block_current_worker_execution() -> (
-    None
-):
+async def test_delegation_allowed_agent_ids_do_not_block_current_worker_execution(
+    no_resolvable_default_llm: None,
+) -> None:
     db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="nested_owner", password_hash="x", is_admin=False)

--- a/tests/core/tools/test_agent_tool_session_isolation.py
+++ b/tests/core/tools/test_agent_tool_session_isolation.py
@@ -938,6 +938,87 @@ async def test_empty_model_config_falls_back_to_the_configured_default(
     assert fallback_calls == [(7, ("general",))]
 
 
+@pytest.mark.parametrize(
+    "models",
+    [
+        pytest.param({"compact": 3}, id="compact_only"),
+        pytest.param({"general": None, "compact": 3}, id="explicit_null_general"),
+        pytest.param({}, id="empty_dict"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_partial_config_without_a_general_slot_falls_back(monkeypatch, models):
+    """An unset general slot is unset whether or not other slots carry ids."""
+
+    fallback_calls: list[int] = []
+    llm = _StubSingleCallLLM(
+        {
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "final_answer",
+                        "arguments": json.dumps({"answer": "delegated output"}),
+                    },
+                }
+            ],
+            "done": False,
+        }
+    )
+
+    def _get_configured_defaults(self, user_id=None, **_kwargs):
+        fallback_calls.append(user_id)
+        return llm, None, None, None
+
+    from xagent.web.services.llm_utils import UserAwareModelStorage
+
+    monkeypatch.setattr(
+        UserAwareModelStorage, "get_configured_defaults", _get_configured_defaults
+    )
+    monkeypatch.setattr(
+        mod, "WebToolConfig", lambda **_kwargs: _SucceedingCloseConfig()
+    )
+
+    async def _no_tools(*_args, **_kwargs):
+        return []
+
+    import xagent.core.tools.adapters.vibe.agent_model_resolution as resolution
+    import xagent.core.tools.adapters.vibe.factory as factory_module
+
+    monkeypatch.setattr(factory_module.ToolFactory, "create_all_tools", _no_tools)
+    # Whatever the other slots resolve to, the general one stays empty.
+    monkeypatch.setattr(
+        resolution, "resolve_agent_model_llms", lambda *_args: (None, None, None, None)
+    )
+
+    tool = AgentTool(
+        agent_id=1,
+        agent_name="Delegated",
+        agent_description="d",
+        session_factory=lambda: _DelegatedSession(
+            SimpleNamespace(
+                id=1,
+                name="Delegated",
+                instructions=None,
+                knowledge_bases=None,
+                skills=None,
+                tool_categories=[],
+                models=models,
+                execution_mode=None,
+            )
+        ),
+        user_id=7,
+        tool_name="delegated",
+        tool_description="d",
+    )
+
+    result = await tool.run_json_async({"task": "run"})
+
+    assert tool_result_succeeded(result) is True
+    assert fallback_calls == [7]
+
+
 @pytest.mark.asyncio
 async def test_a_stored_model_that_no_longer_resolves_still_fails_closed(monkeypatch):
     """A stated choice that is gone or no longer visible must keep failing

--- a/tests/core/tools/test_agent_tool_session_isolation.py
+++ b/tests/core/tools/test_agent_tool_session_isolation.py
@@ -803,12 +803,14 @@ async def test_agent_tool_missing_agent_fails_closed(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_agent_tool_without_resolved_model_fails_closed(monkeypatch):
+async def test_agent_tool_without_resolved_model_fails_closed(
+    monkeypatch, no_resolvable_default_llm: None
+):
     """The no-valid-model preflight exit must be a classified failure.
 
-    ``agent_models`` is falsy so model resolution is skipped entirely and
-    ``default_llm`` stays ``None``, driving the same preflight exit a
-    resolution failure would.
+    ``agent_models`` is falsy and the fixture leaves the configured-defaults
+    fallback empty, driving the same preflight exit a resolution failure
+    would.
     """
 
     traced_statuses: list[str] = []
@@ -854,6 +856,61 @@ async def test_agent_tool_without_resolved_model_fails_closed(monkeypatch):
         "response",
     ]
     assert traced_statuses == ["start", "error"]
+
+
+@pytest.mark.asyncio
+async def test_empty_model_config_falls_back_to_the_configured_default(monkeypatch):
+    """Server-side creation paths persisted no model config; an unset slot
+    must not fail the delegation when the user has a default to resolve."""
+
+    fallback_calls: list[tuple[int, tuple[str, ...]]] = []
+
+    def _get_configured_defaults(self, user_id=None, *, config_types, **_kwargs):
+        fallback_calls.append((user_id, config_types))
+        return _StubSingleCallLLM(), None, None, None
+
+    from xagent.web.services.llm_utils import UserAwareModelStorage
+
+    monkeypatch.setattr(
+        UserAwareModelStorage,
+        "get_configured_defaults",
+        _get_configured_defaults,
+    )
+
+    async def _trace_delegation(self, status, **_kwargs):
+        return None
+
+    monkeypatch.setattr(AgentTool, "_trace_delegation", _trace_delegation)
+
+    tool = AgentTool(
+        agent_id=1,
+        agent_name="Delegated",
+        agent_description="d",
+        session_factory=lambda: _DelegatedSession(
+            SimpleNamespace(
+                id=1,
+                name="Delegated",
+                instructions=None,
+                knowledge_bases=None,
+                skills=None,
+                tool_categories=[],
+                models=None,
+                execution_mode=None,
+            )
+        ),
+        user_id=7,
+        tool_name="delegated",
+        tool_description="d",
+    )
+
+    result = await tool.run_json_async({"task": "run"})
+
+    # Only the general slot: the other three are left as resolved (here None),
+    # so the fallback does not instantiate three default LLMs to discard.
+    assert fallback_calls == [(7, ("general",))]
+    assert result.get("response") != (
+        "Error: No valid model configured for agent Delegated"
+    )
 
 
 class _StubSingleCallLLM:

--- a/tests/core/tools/test_agent_tool_session_isolation.py
+++ b/tests/core/tools/test_agent_tool_session_isolation.py
@@ -803,12 +803,10 @@ async def test_agent_tool_missing_agent_fails_closed(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_agent_tool_without_resolved_model_fails_closed(
-    monkeypatch, no_resolvable_default_llm: None
-):
+async def test_agent_tool_without_resolved_model_fails_closed(monkeypatch):
     """The no-valid-model preflight exit must be a classified failure.
 
-    ``agent_models`` is falsy and the fixture leaves the configured-defaults
+    ``agent_models`` is falsy and the autouse fixture leaves the configured
     fallback empty, driving the same preflight exit a resolution failure
     would.
     """
@@ -859,15 +857,37 @@ async def test_agent_tool_without_resolved_model_fails_closed(
 
 
 @pytest.mark.asyncio
-async def test_empty_model_config_falls_back_to_the_configured_default(monkeypatch):
+async def test_empty_model_config_falls_back_to_the_configured_default(
+    monkeypatch, tmp_path
+):
     """Server-side creation paths persisted no model config; an unset slot
-    must not fail the delegation when the user has a default to resolve."""
+    must not fail the delegation when the user has a default to resolve.
+
+    Drives the real execution stack (unlike ``_real_delegated_agent_tool``,
+    which fakes ``resolve_agent_model_llms`` -- the very seam under test), so
+    the child has to actually run on the fallback LLM.
+    """
 
     fallback_calls: list[tuple[int, tuple[str, ...]]] = []
+    llm = _StubSingleCallLLM(
+        {
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "final_answer",
+                        "arguments": json.dumps({"answer": "delegated output"}),
+                    },
+                }
+            ],
+            "done": False,
+        }
+    )
 
     def _get_configured_defaults(self, user_id=None, *, config_types, **_kwargs):
         fallback_calls.append((user_id, config_types))
-        return _StubSingleCallLLM(), None, None, None
+        return llm, None, None, None
 
     from xagent.web.services.llm_utils import UserAwareModelStorage
 
@@ -876,11 +896,16 @@ async def test_empty_model_config_falls_back_to_the_configured_default(monkeypat
         "get_configured_defaults",
         _get_configured_defaults,
     )
+    monkeypatch.setattr(
+        mod, "WebToolConfig", lambda **_kwargs: _SucceedingCloseConfig()
+    )
 
-    async def _trace_delegation(self, status, **_kwargs):
-        return None
+    async def _no_tools(*_args, **_kwargs):
+        return []
 
-    monkeypatch.setattr(AgentTool, "_trace_delegation", _trace_delegation)
+    import xagent.core.tools.adapters.vibe.factory as factory_module
+
+    monkeypatch.setattr(factory_module.ToolFactory, "create_all_tools", _no_tools)
 
     tool = AgentTool(
         agent_id=1,
@@ -905,12 +930,68 @@ async def test_empty_model_config_falls_back_to_the_configured_default(monkeypat
 
     result = await tool.run_json_async({"task": "run"})
 
-    # Only the general slot: the other three are left as resolved (here None),
-    # so the fallback does not instantiate three default LLMs to discard.
+    assert tool_result_succeeded(result) is True
+    assert "delegated output" in str(result.get("response"))
+    # Only the general slot: the other three stay as resolved, so the fallback
+    # does not instantiate three default LLMs to discard. Narrower than the
+    # plain chat path, which backfills all four.
     assert fallback_calls == [(7, ("general",))]
-    assert result.get("response") != (
-        "Error: No valid model configured for agent Delegated"
+
+
+@pytest.mark.asyncio
+async def test_a_stored_model_that_no_longer_resolves_still_fails_closed(monkeypatch):
+    """A stated choice that is gone or no longer visible must keep failing
+    closed -- the fallback covers an unset config, not a resolution failure."""
+
+    called: list[int] = []
+
+    def _get_configured_defaults(self, user_id=None, **_kwargs):
+        called.append(user_id)
+        return None, None, None, None
+
+    from xagent.web.services.llm_utils import UserAwareModelStorage
+
+    monkeypatch.setattr(
+        UserAwareModelStorage, "get_configured_defaults", _get_configured_defaults
     )
+
+    async def _trace_delegation(self, status, **_kwargs):
+        return None
+
+    monkeypatch.setattr(AgentTool, "_trace_delegation", _trace_delegation)
+
+    import xagent.core.tools.adapters.vibe.agent_model_resolution as resolution
+
+    # What a stale or newly invisible id resolves to.
+    monkeypatch.setattr(
+        resolution, "resolve_agent_model_llms", lambda *_args: (None, None, None, None)
+    )
+
+    tool = AgentTool(
+        agent_id=1,
+        agent_name="Delegated",
+        agent_description="d",
+        session_factory=lambda: _DelegatedSession(
+            SimpleNamespace(
+                id=1,
+                name="Delegated",
+                instructions=None,
+                knowledge_bases=None,
+                skills=None,
+                tool_categories=[],
+                models={"general": 999999},
+                execution_mode=None,
+            )
+        ),
+        user_id=7,
+        tool_name="delegated",
+        tool_description="d",
+    )
+
+    result = await tool.run_json_async({"task": "run"})
+
+    assert result["response"] == "Error: No valid model configured for agent Delegated"
+    assert called == []
 
 
 class _StubSingleCallLLM:

--- a/tests/core/tools/test_agent_tool_session_isolation.py
+++ b/tests/core/tools/test_agent_tool_session_isolation.py
@@ -22,6 +22,11 @@ from xagent.web.models.model import Model
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import UserAwareModelStorage
 
+# Every no-valid-model assertion in this module depends on the fallback
+# resolving to nothing; see the fixture for why that cannot be left to the
+# machine's environment.
+pytestmark = pytest.mark.usefixtures("no_resolvable_default_llm")
+
 
 class _Stop(Exception):
     """Halt the run before the sub-agent executes."""
@@ -1022,77 +1027,57 @@ async def test_a_partial_config_without_a_general_slot_falls_back(monkeypatch, m
     assert fallback_calls == [7]
 
 
-@pytest.mark.asyncio
-async def test_a_model_name_in_the_general_slot_fails_closed(monkeypatch):
-    """``workforce_creator`` forwards template YAML unvalidated, so the slot
-    can hold a model *name* (see test_workforce_creator_worker_resolution).
+def _real_session_factory(models: object) -> tuple[sessionmaker, str]:
+    """A sqlite-backed factory holding one agent with *models*.
 
-    Names resolve by id only, so this states a choice that cannot be honoured
-    -- it keeps failing closed rather than quietly running on something else.
+    Stubbing ``resolve_agent_model_llms`` would skip the very pipeline these
+    cases are about -- id coercion and the model lookup -- so the resolver
+    runs for real against a database that simply has no matching row.
     """
-
-    called: list[int] = []
-
-    def _get_configured_defaults(self, user_id=None, **_kwargs):
-        called.append(user_id)
-        return None, None, None, None
-
-    from xagent.web.services.llm_utils import UserAwareModelStorage
-
-    monkeypatch.setattr(
-        UserAwareModelStorage, "get_configured_defaults", _get_configured_defaults
-    )
-
-    async def _trace_delegation(self, status, **_kwargs):
-        return None
-
-    monkeypatch.setattr(AgentTool, "_trace_delegation", _trace_delegation)
-
-    import xagent.core.tools.adapters.vibe.agent_model_resolution as resolution
-
-    monkeypatch.setattr(
-        resolution, "resolve_agent_model_llms", lambda *_args: (None, None, None, None)
-    )
-
-    tool = AgentTool(
-        agent_id=1,
-        agent_name="Delegated",
-        agent_description="d",
-        session_factory=lambda: _DelegatedSession(
-            SimpleNamespace(
-                id=1,
-                name="Delegated",
-                instructions=None,
-                knowledge_bases=None,
-                skills=None,
-                tool_categories=[],
-                models={"general": "gpt-4o"},
-                execution_mode=None,
-            )
-        ),
-        user_id=7,
-        tool_name="delegated",
-        tool_description="d",
-    )
-
-    result = await tool.run_json_async({"task": "run"})
-
-    assert result["response"] == "Error: No valid model configured for agent Delegated"
-    assert called == []
+    temp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    temp_db.close()
+    engine = create_engine(f"sqlite:///{temp_db.name}")
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+    try:
+        user = User(username="delegator", password_hash="x", is_admin=False)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        agent = Agent(
+            user_id=user.id,
+            name="Delegated",
+            models=models,
+            status=AgentStatus.DRAFT,
+        )
+        db.add(agent)
+        db.commit()
+        return SessionLocal, temp_db.name
+    finally:
+        db.close()
 
 
+@pytest.mark.parametrize(
+    "models",
+    [
+        # Resolves by id only, so a name states a choice that cannot be met.
+        pytest.param({"general": "gpt-4o"}, id="model_name"),
+        pytest.param({"general": 999999}, id="missing_id"),
+        # Not even a mapping: stated-but-corrupt, not unset.
+        pytest.param("gpt-4o", id="non_mapping"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_a_stored_model_that_no_longer_resolves_still_fails_closed(monkeypatch):
-    """A stated choice that is gone or no longer visible must keep failing
-    closed -- the fallback covers an unset config, not a resolution failure."""
+async def test_a_general_slot_that_cannot_resolve_fails_closed(monkeypatch, models):
+    """The fallback covers an unset general slot, never a stated one that will
+    not resolve -- substituting a model there would hide the owner's intent."""
 
     called: list[int] = []
 
     def _get_configured_defaults(self, user_id=None, **_kwargs):
         called.append(user_id)
         return None, None, None, None
-
-    from xagent.web.services.llm_utils import UserAwareModelStorage
 
     monkeypatch.setattr(
         UserAwareModelStorage, "get_configured_defaults", _get_configured_defaults
@@ -1103,38 +1088,31 @@ async def test_a_stored_model_that_no_longer_resolves_still_fails_closed(monkeyp
 
     monkeypatch.setattr(AgentTool, "_trace_delegation", _trace_delegation)
 
-    import xagent.core.tools.adapters.vibe.agent_model_resolution as resolution
+    SessionLocal, db_path = _real_session_factory(models)
+    try:
+        db = SessionLocal()
+        agent_id = int(db.query(Agent).one().id)
+        user_id = int(db.query(User).one().id)
+        db.close()
 
-    # What a stale or newly invisible id resolves to.
-    monkeypatch.setattr(
-        resolution, "resolve_agent_model_llms", lambda *_args: (None, None, None, None)
-    )
+        tool = AgentTool(
+            agent_id=agent_id,
+            agent_name="Delegated",
+            agent_description="d",
+            session_factory=SessionLocal,
+            user_id=user_id,
+            tool_name="delegated",
+            tool_description="d",
+        )
 
-    tool = AgentTool(
-        agent_id=1,
-        agent_name="Delegated",
-        agent_description="d",
-        session_factory=lambda: _DelegatedSession(
-            SimpleNamespace(
-                id=1,
-                name="Delegated",
-                instructions=None,
-                knowledge_bases=None,
-                skills=None,
-                tool_categories=[],
-                models={"general": 999999},
-                execution_mode=None,
-            )
-        ),
-        user_id=7,
-        tool_name="delegated",
-        tool_description="d",
-    )
+        result = await tool.run_json_async({"task": "run"})
 
-    result = await tool.run_json_async({"task": "run"})
-
-    assert result["response"] == "Error: No valid model configured for agent Delegated"
-    assert called == []
+        assert (
+            result["response"] == "Error: No valid model configured for agent Delegated"
+        )
+        assert called == []
+    finally:
+        os.remove(db_path)
 
 
 class _StubSingleCallLLM:

--- a/tests/core/tools/test_agent_tool_session_isolation.py
+++ b/tests/core/tools/test_agent_tool_session_isolation.py
@@ -944,6 +944,9 @@ async def test_empty_model_config_falls_back_to_the_configured_default(
         pytest.param({"compact": 3}, id="compact_only"),
         pytest.param({"general": None, "compact": 3}, id="explicit_null_general"),
         pytest.param({}, id="empty_dict"),
+        # No autoincrement PK is 0, so these state nothing either.
+        pytest.param({"general": 0}, id="zero_id"),
+        pytest.param({"general": False}, id="false_id"),
     ],
 )
 @pytest.mark.asyncio
@@ -1017,6 +1020,65 @@ async def test_a_partial_config_without_a_general_slot_falls_back(monkeypatch, m
 
     assert tool_result_succeeded(result) is True
     assert fallback_calls == [7]
+
+
+@pytest.mark.asyncio
+async def test_a_model_name_in_the_general_slot_fails_closed(monkeypatch):
+    """``workforce_creator`` forwards template YAML unvalidated, so the slot
+    can hold a model *name* (see test_workforce_creator_worker_resolution).
+
+    Names resolve by id only, so this states a choice that cannot be honoured
+    -- it keeps failing closed rather than quietly running on something else.
+    """
+
+    called: list[int] = []
+
+    def _get_configured_defaults(self, user_id=None, **_kwargs):
+        called.append(user_id)
+        return None, None, None, None
+
+    from xagent.web.services.llm_utils import UserAwareModelStorage
+
+    monkeypatch.setattr(
+        UserAwareModelStorage, "get_configured_defaults", _get_configured_defaults
+    )
+
+    async def _trace_delegation(self, status, **_kwargs):
+        return None
+
+    monkeypatch.setattr(AgentTool, "_trace_delegation", _trace_delegation)
+
+    import xagent.core.tools.adapters.vibe.agent_model_resolution as resolution
+
+    monkeypatch.setattr(
+        resolution, "resolve_agent_model_llms", lambda *_args: (None, None, None, None)
+    )
+
+    tool = AgentTool(
+        agent_id=1,
+        agent_name="Delegated",
+        agent_description="d",
+        session_factory=lambda: _DelegatedSession(
+            SimpleNamespace(
+                id=1,
+                name="Delegated",
+                instructions=None,
+                knowledge_bases=None,
+                skills=None,
+                tool_categories=[],
+                models={"general": "gpt-4o"},
+                execution_mode=None,
+            )
+        ),
+        user_id=7,
+        tool_name="delegated",
+        tool_description="d",
+    )
+
+    result = await tool.run_json_async({"task": "run"})
+
+    assert result["response"] == "Error: No valid model configured for agent Delegated"
+    assert called == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Invariant

An existing agent whose `models.general` is unset no longer fails a delegation outright, no longer renders `--` in the builder, and no longer trips the required-model guard on save.

## Two symptoms

**Vibe delegation failed outright.** In `agent_tool.py`, `if agent_models:` skipped model resolution entirely when the config was empty, `default_llm` stayed `None`, and the call returned `Error: No valid model configured for agent {name}`. That guard is redundant: `agent_model_resolution.py:26-27` already returns four `None`s for an empty or non-Mapping payload and issues no query, so calling it unconditionally is equivalent.

The fallback is gated on `not agent_models`, i.e. an unset config only — **not** on the resolution having failed. A stored id that is gone, renamed, or no longer visible keeps failing closed, because silently running such an agent on a different model would hide a configuration the owner did state. When the fallback does fire it logs the substituted model. It fills only the general slot via `config_types=("general",)`, leaving the other three as resolved (`AgentService.fast_llm` is `BaseLLM | None` already) — narrower than the plain chat path, which backfills all four.

**The builder could not save.** `agent-builder.tsx:790`'s `if (!isEditMode)` gates the whole user-default seeding block; edit mode reads only `agent.models.general`, so an unset slot goes straight to the required-model guard. A third effect now seeds from the current user's default once both mount fetches have landed — `isInitialDataLoaded` and `originalData`, both required because the two resolve in no fixed order.

The seeded slot counts as dirty for **Update** and is exempt only for **Publish**. That split matters: `handlePublish` posts no body and `publish_agent` never touches `models`, so Update is the only flow that persists the seeded value — leaving it disabled would mean the value never reaches the database. Publish, meanwhile, must not be blocked (`:2036`) for the very agents the seed exists to unblock. Once the user edits anything else, Publish is blocked again as before.

## Scope of the fallback (please confirm)

`get_configured_defaults` is three layers: the user's own default (checked with `_is_model_visible_to_user`), then a visible user's shared default (`is_shared` plus `_get_visible_user_ids`), then `create_llm_from_env()`. The first two filter on visibility; the third is a deployment-level model that is not in the model registry at all. So for a delegated agent with an empty config:

| Situation | Before | After |
|---|---|---|
| A DB default exists (own or a visible shared one) | error | that default is used |
| No DB default, deployment exports a provider key | error | the env model is used |
| No DB default, no provider key | error | error |

The second row is the trade-off: the user gets a model they never picked in the UI. The reason to accept it is that this row already matches what happens when the same agent is used in plain chat — `chat.py:4328` (`if selected_agent.models:` is false) leaves `llm_ids_to_use` at `None`, `resolve_llms_from_names` resolves through the same chain, and lands on the same env tail. What this PR removes is the inconsistency of "the same agent works in chat but errors when delegated", not a new path. The affected population also shrinks: after the companion PR new agents are never empty, and after this one an existing agent gets a real value the first time it is saved.

## Not included

- **The write-side fallback** — companion PR.
- **Any migration.**
- **The "no model" chip on `/agent/[id]` and `/task`** (`page-client.tsx:63`, `task/page.tsx:255`) — display only, and it clears once the owner saves in the builder.
- **`POST /api/agents/preview`**'s 400 (`agents.py:1717`) — no frontend caller.
- **Read-only cross-user views are not seeded.** `userDefaultGeneralRef` holds the *viewer's* default, not the agent owner's, so seeding there would render the viewer's model as this agent's configuration.

## Verification

13 frontend tests, two backend tests, and an autouse `no_resolvable_default_llm` fixture in a new `tests/core/tools/conftest.py`.

That fixture is a requirement, not a convenience. Since `get_configured_defaults` ends in `create_llm_from_env()`, three existing tests that assert `No valid model configured` fail on a machine with `OPENAI_API_KEY` exported — and two of them (`test_agent_tool_execution_allows_cross_user_only_with_target_allowlist`, `test_delegation_allowed_agent_ids_do_not_block_current_worker_execution`) did not touch this path before this change and would issue a real network request. It is autouse so a new test in this directory cannot reintroduce the hazard by forgetting to ask for it; a test that wants a resolvable default overrides it. With and without a provider key, the `tests/core/tools` failure set is identical line for line (89 pre-existing environment failures).

The fallback test drives the real execution stack rather than `_real_delegated_agent_tool`, which fakes `resolve_agent_model_llms` — the very seam under test — and asserts the child actually ran on the fallback LLM, not merely that some specific error string was absent.

Mutation matrix, backend: dropping the fallback, widening its trigger back to any resolution failure, and widening `config_types` each fail a test. Frontend: the seed write, the Update-stays-dirty half, the Publish exemption, the read-only gate, the already-set check, whole-object overwrite clobbering the other slots, the ref record, and the malformed-entry guard each fail a test. One is not pinned — widening the Publish exemption to *any* model change — because reaching it needs the model dropdown, and `@/components/ui/select` is mocked to `() => null` in the builder tests.

292 tests pass across `src/components/build/` and every file that imports `AgentBuilder`. pre-commit clean, including npm lint and type-check.
