### PR TITLE
fix(web): replay one event per assistant question

### DIFF
--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -757,6 +757,207 @@ describe("AppProvider websocket message routing", () => {
     })
   })
 
+  it("collapses one assistant question replayed after a reconnect", async () => {
+    render(
+      <AppProvider token="token">
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+    const interactions = [{ type: "confirm", label: "Proceed?" }]
+
+    // Live delivery: the raw prompt, carrying the form.
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:00Z",
+        data: {
+          event_id: "question-1",
+          event_type: "agent_message",
+          data: {
+            message: "Round 1: please confirm",
+            expect_response: true,
+            request_id: "req-1",
+            metadata: { interactions },
+          },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "Round 1: please confirm"
+      )
+    })
+
+    // Reconnect replay: same question, same event identity, but the
+    // transcript copy has the rendered interaction list appended, so no
+    // content comparison could pair the two.
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:05Z",
+        data: {
+          event_id: "question-1",
+          event_type: "agent_message",
+          data: {
+            message:
+              "Round 1: please confirm\n\nPlease answer the following questions:\n- Proceed?",
+            role: "assistant",
+            source: "chat_history",
+            display: "chat",
+            expect_response: false,
+            visible: true,
+            metadata: { interactions },
+          },
+        },
+      })
+    })
+
+    // A second reconnect replays it again. The issue reported three copies on
+    // screen at this point; the widget session page never clears messages on
+    // reconnect, so nothing but identity stops them accumulating.
+    act(() => {
+      ;(window as typeof window & { clearDuplicateMessageCache?: () => void })
+        .clearDuplicateMessageCache?.()
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:09Z",
+        data: {
+          event_id: "question-1",
+          event_type: "agent_message",
+          data: {
+            message:
+              "Round 1: please confirm\n\nPlease answer the following questions:\n- Proceed?",
+            role: "assistant",
+            source: "chat_history",
+            display: "chat",
+            expect_response: false,
+            visible: true,
+            metadata: { interactions },
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ id: string; role: string; content: string }>
+      const assistant = messages.filter(message => message.role === "assistant")
+      expect(assistant).toHaveLength(1)
+      expect(assistant[0].id).toBe("msg-agent-event-question-1")
+      expect(assistant[0].content).toBe("Round 1: please confirm")
+    })
+  })
+
+  it("does not re-print the question when replay is followed by the waiting re-assert", async () => {
+    // After the snapshot, the server re-asserts WAITING_FOR_USER with the
+    // question text read straight off the transcript row
+    // (get_latest_waiting_question returns TaskChatMessage.content), so it is
+    // byte-identical to the replayed row event. Suppressing the trace twin
+    // must not leave that frame as a fresh third bubble.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+    const interactions = [{ type: "confirm", label: "Proceed?" }]
+    const transcriptText =
+      "Round 1: please confirm\n\nPlease answer the following questions:\n- Proceed?"
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:00Z",
+        data: {
+          event_id: "question-1",
+          event_type: "agent_message",
+          data: {
+            message: transcriptText,
+            role: "assistant",
+            source: "chat_history",
+            display: "chat",
+            expect_response: false,
+            visible: true,
+            metadata: { interactions },
+          },
+        },
+      })
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        question: transcriptText,
+        message: transcriptText,
+        interactions,
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    })
+    const messages = JSON.parse(
+      screen.getByTestId("messages").textContent || "[]"
+    ) as Array<{ role: string; content: string }>
+    expect(messages.filter(message => message.role === "assistant")).toHaveLength(1)
+  })
+
+  it("keeps two rounds that ask the same question verbatim", async () => {
+    render(
+      <AppProvider token="token">
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:00Z",
+        data: {
+          event_id: "question-1",
+          event_type: "agent_message",
+          data: {
+            message: "Please confirm",
+            expect_response: true,
+            request_id: "req-1",
+          },
+        },
+      })
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:01Z",
+        data: {
+          event_id: "question-2",
+          event_type: "agent_message",
+          data: {
+            message: "Please confirm",
+            expect_response: true,
+            request_id: "req-2",
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ id: string; role: string; content: string }>
+      expect(messages.filter(message => message.content === "Please confirm"))
+        .toHaveLength(2)
+    })
+  })
+
   it("keeps identical text from distinct user turns", async () => {
     render(
       <AppProvider token="token">

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -374,6 +374,10 @@ import {
   shouldBufferMessageForHistoricalReplay,
 } from "@/lib/streaming-final-answer"
 import { extractSharedChatResponse } from "@/lib/chat-response"
+import {
+  isStableAssistantMessageId,
+  stableAssistantMessageId,
+} from "@/lib/assistant-message-identity"
 
 // Unique ID generator for messages
 let messageIdCounter = 0
@@ -1413,6 +1417,39 @@ function projectAppState(state: AppState, action: AppAction): AppState {
           if (streamingIndex >= 0) {
             return replaceMessageAt(streamingIndex)
           }
+        }
+      }
+
+      // One assistant question can be delivered twice -- live, then replayed
+      // from the transcript after a reconnect -- under one event identity but
+      // with different text, because the replayed copy carries the rendered
+      // interaction list. Identity decides, never text: #2250 is the record
+      // of what text matching costs. The mounted bubble is kept rather than
+      // replaced so an open clarification form is not remounted under the
+      // visitor; the re-delivery only fills in what the bubble lacks. Content
+      // is deliberately not among those fields: one event id is one question,
+      // and the replayed copy differs only by the rendered interaction list
+      // the form already draws.
+      if (messageToAdd.role === "assistant" && isStableAssistantMessageId(messageToAdd.id)) {
+        const deliveredIndex = state.messages.findIndex(
+          message => message.role === "assistant" && message.id === messageToAdd.id,
+        )
+        if (deliveredIndex >= 0) {
+          const updatedMessages = state.messages.map((message, index) =>
+            index === deliveredIndex
+              ? {
+                ...message,
+                interactions: message.interactions ?? messageToAdd.interactions,
+                interactionRequestId:
+                  message.interactionRequestId ?? messageToAdd.interactionRequestId,
+                traceEvents: mergeTraceEventsById(
+                  message.traceEvents,
+                  messageToAdd.traceEvents,
+                ),
+              }
+              : message
+          )
+          return { ...state, messages: updatedMessages, traceEvents: newTraceEvents }
         }
       }
 
@@ -3249,7 +3286,12 @@ export function AppProvider({
             )) {
               return
             }
-            const msgId = generateMessageId("msg-agent")
+            const msgId =
+              (isAgentMessage
+                ? stableAssistantMessageId(
+                  message.event_id || traceEventData.event_id || eventData.event_id,
+                )
+                : null) ?? generateMessageId("msg-agent")
             dispatch({
               type: "ADD_MESSAGE",
               payload: {

--- a/frontend/src/lib/assistant-message-identity.ts
+++ b/frontend/src/lib/assistant-message-identity.ts
@@ -1,0 +1,22 @@
+/**
+ * Stable identity for assistant messages, mirroring what #2254 gave user turns.
+ *
+ * A question reaches the client twice across a reconnect: live as its own
+ * trace event, then replayed from the transcript. The two carry different
+ * text -- the replayed copy has the rendered interaction list appended -- so
+ * only identity can pair them. The server sends both under the originating
+ * trace event's id (#2292), which is what this keys on.
+ */
+
+const ASSISTANT_EVENT_MESSAGE_PREFIX = "msg-agent-event"
+
+/** `null` for identity-less legacy events, which keep a minted id. */
+export const stableAssistantMessageId = (eventId: unknown): string | null => {
+  if (typeof eventId === "string" && eventId.trim()) {
+    return `${ASSISTANT_EVENT_MESSAGE_PREFIX}-${eventId.trim()}`
+  }
+  return null
+}
+
+export const isStableAssistantMessageId = (id: string): boolean =>
+  id.startsWith(`${ASSISTANT_EVENT_MESSAGE_PREFIX}-`)

--- a/src/xagent/migrations/versions/20260911_add_assistant_source_event_id.py
+++ b/src/xagent/migrations/versions/20260911_add_assistant_source_event_id.py
@@ -1,0 +1,65 @@
+"""add source_event_id column to task_chat_messages
+
+Records which assistant trace event a transcript row was written from, so
+historical replay can drop the trace twin of a question instead of printing
+the same clarification form again on every reconnect (#2292).
+
+Revision ID: 20260911_assistant_source_event
+Revises: 20260909_seed_shopify_mcp_app
+Create Date: 2026-09-11 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision: str = "20260911_assistant_source_event"
+down_revision: Union[str, None] = "20260909_seed_shopify_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Deliberately not backfilled. A row's originating event cannot be
+    # recovered from its text alone: consecutive rounds routinely ask the same
+    # question verbatim, so a text backfill would hand some rows another
+    # round's identity. Replay pairs those NULL rows by re-deriving the
+    # transcript text from each trace event instead, which is exact.
+    from alembic import context
+
+    bind = context.get_bind()
+    inspector = Inspector.from_engine(bind)
+
+    if "task_chat_messages" not in inspector.get_table_names():
+        # Base table doesn't exist yet; nothing to do for this migration.
+        return
+
+    existing_columns = {
+        col["name"] for col in inspector.get_columns("task_chat_messages")
+    }
+    if "source_event_id" not in existing_columns:
+        op.add_column(
+            "task_chat_messages",
+            sa.Column("source_event_id", sa.String(255), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    from alembic import context
+
+    bind = context.get_bind()
+    inspector = Inspector.from_engine(bind)
+
+    if "task_chat_messages" not in inspector.get_table_names():
+        return
+
+    existing_columns = {
+        col["name"] for col in inspector.get_columns("task_chat_messages")
+    }
+    if "source_event_id" in existing_columns:
+        with op.batch_alter_table("task_chat_messages") as batch:
+            batch.drop_column("source_event_id")

--- a/src/xagent/migrations/versions/20260911_add_assistant_source_event_id.py
+++ b/src/xagent/migrations/versions/20260911_add_assistant_source_event_id.py
@@ -61,5 +61,7 @@ def downgrade() -> None:
         col["name"] for col in inspector.get_columns("task_chat_messages")
     }
     if "source_event_id" in existing_columns:
-        with op.batch_alter_table("task_chat_messages") as batch:
-            batch.drop_column("source_event_id")
+        # Plain drop_column, matching 20260522_add_turn_id_to_task_chat_messages.
+        # batch_alter_table would rebuild the table on SQLite, putting the named
+        # unique index uq_task_chat_messages_task_role_turn_id at risk.
+        op.drop_column("task_chat_messages", "source_event_id")

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -119,6 +119,7 @@ from ..services.assistant_history_safety import (
     assistant_history_has_safe_ancillary_payload,
     client_safe_assistant_history_content,
 )
+from ..services.assistant_question_replay import load_transcript_replay
 from ..services.chat_history_service import (
     DELIVERY_COMPLETED,
     DELIVERY_DISPATCHED,
@@ -151,7 +152,6 @@ from ..services.external_task_input import (
     external_input_terminal_message,
 )
 from ..services.file_reference_output_service import (
-    load_assistant_file_reference_records,
     reconcile_assistant_file_references,
 )
 from ..services.file_turn import (
@@ -4362,7 +4362,7 @@ def _load_historical_stream_snapshot_sync(
                 if is_workforce_run
                 else public_task_trace_filter(TraceEvent)
             )
-            trace_scope = "workforce-top-level-v1" if is_workforce_run else "public-v1"
+            trace_scope = "workforce-top-level-v2" if is_workforce_run else "public-v2"
 
             max_trace_event_id = (
                 db.query(func.max(TraceEvent.id))
@@ -4556,11 +4556,25 @@ def _load_historical_stream_snapshot_sync(
                             ("assistant", content.strip(), attachment_key)
                         )
 
+            # A waiting question is persisted as both a trace event and a
+            # transcript row, and replay used to ship both (#2292). Keep the
+            # row and drop the trace twin it claims; see
+            # ``services.assistant_question_replay`` for why the row wins.
+            transcript = load_transcript_replay(
+                db,
+                task_id=int(task_id),
+                task_user_id=int(task.user_id),
+                trace_events=trace_events,
+                trace_data_by_event_id=normalized_trace_data_by_event_id,
+            )
+
             for trace_event in trace_events:
                 normalized_event_data = normalized_trace_data_by_event_id.get(
                     str(trace_event.event_id), trace_event.data
                 )
                 if _is_audit_only_trace_data(normalized_event_data):
+                    continue
+                if transcript.superseded(trace_event.event_id):
                     continue
                 if _is_duplicate_user_message_turn(
                     str(trace_event.event_type),
@@ -4597,18 +4611,7 @@ def _load_historical_stream_snapshot_sync(
                     }
                 )
 
-            chat_messages = (
-                db.query(TaskChatMessage)
-                .filter(TaskChatMessage.task_id == task_id)
-                .order_by(TaskChatMessage.created_at, TaskChatMessage.id)
-                .all()
-            )
-            file_reference_records = load_assistant_file_reference_records(
-                db,
-                task_id=int(task_id),
-                user_id=int(task.user_id),
-            )
-            for chat_message in chat_messages:
+            for chat_message in transcript.rows:
                 role = str(chat_message.role)
                 content = str(chat_message.content or "").strip()
                 if role == "assistant":
@@ -4621,7 +4624,7 @@ def _load_historical_stream_snapshot_sync(
                         task_id=int(task_id),
                         user_id=int(task.user_id),
                         content=content,
-                        records=file_reference_records,
+                        records=transcript.file_reference_records,
                     )
                 # Read attachments off the row so file-only turns (empty
                 # content + non-empty attachments) survive replay and so the
@@ -4674,7 +4677,7 @@ def _load_historical_stream_snapshot_sync(
                         data["files"] = row_attachments
                         data["attachments"] = row_attachments
                 elif role == "assistant":
-                    if (
+                    if not transcript.paired(chat_message.id) and (
                         content
                         and (role, content, _attachment_fingerprint(row_attachments))
                         in trace_message_keys
@@ -4707,7 +4710,9 @@ def _load_historical_stream_snapshot_sync(
                     {
                         "type": "trace_event",
                         "data": {
-                            "event_id": f"chat_message_{chat_message.id}",
+                            "event_id": transcript.event_id_for(
+                                chat_message.id, f"chat_message_{chat_message.id}"
+                            ),
                             "event_type": event_type,
                             "step_id": None,
                             "parent_event_id": None,

--- a/src/xagent/web/models/chat_message.py
+++ b/src/xagent/web/models/chat_message.py
@@ -30,6 +30,11 @@ class TaskChatMessage(Base):  # type: ignore
     content = Column(Text, nullable=False)
     message_type = Column(String(64), nullable=False)
     interactions = Column(JSON, nullable=True)
+    # Identity of the assistant TraceEvent this row was written from, so
+    # historical replay can drop the trace twin of a question instead of
+    # printing the same clarification form twice (#2292). NULL on rows
+    # written before the column existed; replay derives those instead.
+    source_event_id = Column(String(255), nullable=True)
     # Stable per-user-turn identity shared with user_message trace events. Used
     # by historical replay to reconcile trace rows with transcript rows without
     # collapsing distinct turns that happen to share text/attachments.

--- a/src/xagent/web/services/assistant_question_replay.py
+++ b/src/xagent/web/services/assistant_question_replay.py
@@ -1,0 +1,326 @@
+"""Pair replayed assistant question rows with the trace events behind them.
+
+One waiting question is persisted twice by a single producer
+(``_persist_agent_outbound_event``): as a ``TraceEvent`` holding the raw
+prompt, and as a transcript row whose content additionally carries the
+rendered interaction list appended by
+:func:`build_assistant_transcript_content`. The two therefore never compare
+equal, and historical replay used to ship both -- printing the clarification
+form twice, then a third time after another reconnect (#2292).
+
+Replay keeps the transcript row and drops its trace twin. The row is the
+sanitized producer: its synthesized payload sets ``expect_response: False``
+so a historical question cannot flip the client back into
+``waiting_for_user``, whereas the trace payload is passed through untouched.
+The surviving event inherits the trace event's id, which gives the client a
+stable identity to reconcile against across reconnects.
+
+The pairing is deliberately narrow. Only question rows and only
+``agent_message`` traces take part; assistant *answers* are still deduped the
+other way round (row dropped, trace kept) by the caller's content check,
+because their trace events carry streaming identity this must not disturb.
+
+Not every question row can carry ``source_event_id``: the channel bots
+persist their own question rows through ``persist_assistant_message`` with no
+originating trace event to name (``channels/telegram/utils.py``), so those
+stay on the derivation path permanently. That is a coverage limit, not a
+correctness one -- the symmetry gate below refuses an ambiguous pairing
+rather than guessing one.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, Optional, Sequence
+
+from ...core.agent.transcript import build_assistant_transcript_content
+from ..models.chat_message import TaskChatMessage
+from ..models.uploaded_file import UploadedFile
+from .file_reference_output_service import (
+    load_assistant_file_reference_records,
+    reconcile_assistant_file_references,
+)
+from .public_trace_events import is_audit_only_trace_data
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# ``question_superseded`` is the same row relabelled once a structured
+# publication has taken over its answer slot; it replays identically.
+QUESTION_MESSAGE_TYPES = frozenset({"question", "question_superseded"})
+
+# Questions are emitted as ``agent_message``. ``ai_message`` is the final
+# answer channel and is out of scope by construction.
+QUESTION_TRACE_EVENT_TYPE = "agent_message"
+
+
+@dataclass(frozen=True)
+class ReplayQuestionRow:
+    """One persisted assistant transcript row, as stored."""
+
+    row_id: int
+    content: str
+    message_type: str
+    source_event_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ReplayTraceQuestion:
+    """One assistant trace event competing to represent the same question."""
+
+    event_id: str
+    event_type: str
+    message: str
+    interactions: Optional[Sequence[Any]] = None
+
+
+@dataclass(frozen=True)
+class AssistantQuestionReplayPlan:
+    """Which trace events a snapshot's question rows have taken over."""
+
+    superseded_trace_event_ids: frozenset[str]
+    trace_event_id_by_row_id: Mapping[int, str]
+
+
+def _stripped_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def plan_assistant_question_replay(
+    *,
+    rows: Iterable[ReplayQuestionRow],
+    traces: Iterable[ReplayTraceQuestion],
+    normalize_message: Optional[Callable[[str], str]] = None,
+) -> AssistantQuestionReplayPlan:
+    """Decide, for one snapshot, which trace event each question row replaces.
+
+    ``normalize_message`` receives a trace event's raw message and must apply
+    whatever rewriting persistence applied before the transcript row was
+    built -- file-reference reconciliation, today. Without it a question whose
+    text contains a repaired ``file:`` link would not pair.
+    """
+
+    candidates = [
+        trace
+        for trace in traces
+        if trace.event_type == QUESTION_TRACE_EVENT_TYPE
+        and _stripped_text(trace.message)
+    ]
+    question_rows = [
+        row
+        for row in rows
+        if row.message_type in QUESTION_MESSAGE_TYPES and _stripped_text(row.content)
+    ]
+    if not candidates or not question_rows:
+        return AssistantQuestionReplayPlan(frozenset(), {})
+
+    by_event_id = {trace.event_id: trace for trace in candidates}
+    claimed_by_row: dict[int, str] = {}
+    claimed_event_ids: set[str] = set()
+
+    # An explicit ``source_event_id`` is the row's own statement of where it
+    # came from, so it is honoured before any derivation can claim the same
+    # event. A row naming an event this snapshot does not carry claims
+    # nothing: falling back to text here would hand it a different round's
+    # identity, and consecutive rounds routinely repeat a question verbatim.
+    deriving_rows: list[ReplayQuestionRow] = []
+    for row in question_rows:
+        source_event_id = _stripped_text(row.source_event_id)
+        if not source_event_id:
+            deriving_rows.append(row)
+            continue
+        if source_event_id in by_event_id and source_event_id not in claimed_event_ids:
+            claimed_by_row[row.row_id] = source_event_id
+            claimed_event_ids.add(source_event_id)
+
+    if deriving_rows:
+        derived = _derived_transcript_index(
+            candidates, claimed_event_ids, normalize_message
+        )
+        rows_by_content: dict[str, list[ReplayQuestionRow]] = defaultdict(list)
+        for row in deriving_rows:
+            rows_by_content[_stripped_text(row.content)].append(row)
+
+        for content, rows_for_content in rows_by_content.items():
+            queue = derived.get(content)
+            # Symmetry gate. Pair only when this text has exactly one
+            # unclaimed trace per row asking it, because without an explicit
+            # source_event_id nothing else says which trace belongs to which
+            # round. A snapshot missing one round's trace -- filtered out of
+            # the public scope, audit-only, pruned, or with a derivation that
+            # drifted because file-reference reconciliation now resolves
+            # differently -- would otherwise let the earlier row claim a later
+            # round's identity, and the client would merge two distinct
+            # questions into one bubble. That is #2250's failure reintroduced.
+            # Refusing costs only the legacy dedupe for this text: both copies
+            # replay, exactly as they did before this fix.
+            if queue is None or len(queue) != len(rows_for_content):
+                continue
+            for row, event_id in zip(rows_for_content, queue):
+                claimed_by_row[row.row_id] = event_id
+                claimed_event_ids.add(event_id)
+
+    return AssistantQuestionReplayPlan(
+        superseded_trace_event_ids=frozenset(claimed_event_ids),
+        trace_event_id_by_row_id=claimed_by_row,
+    )
+
+
+@dataclass(frozen=True)
+class TranscriptReplay:
+    """One snapshot's transcript rows plus the pairing they imply."""
+
+    rows: Sequence["TaskChatMessage"]
+    file_reference_records: Sequence["UploadedFile"]
+    plan: AssistantQuestionReplayPlan
+
+    def superseded(self, trace_event_id: Any) -> bool:
+        return str(trace_event_id) in self.plan.superseded_trace_event_ids
+
+    def event_id_for(self, row_id: Any, fallback: str) -> str:
+        return self.plan.trace_event_id_by_row_id.get(int(row_id), fallback)
+
+    def paired(self, row_id: Any) -> bool:
+        return int(row_id) in self.plan.trace_event_id_by_row_id
+
+
+def load_transcript_replay(
+    db: "Session",
+    *,
+    task_id: int,
+    task_user_id: int,
+    trace_events: Iterable[Any],
+    trace_data_by_event_id: Mapping[str, Any],
+) -> TranscriptReplay:
+    """Read a task's transcript rows and pair its questions with their traces.
+
+    Persistence reconciles file references into a question's text *before*
+    building the transcript row, so the trace payload is put through the same
+    reconciliation here; otherwise a question carrying a repaired ``file:``
+    link would not pair on a row predating ``source_event_id``.
+    """
+
+    rows = (
+        db.query(TaskChatMessage)
+        .filter(TaskChatMessage.task_id == task_id)
+        .order_by(TaskChatMessage.created_at, TaskChatMessage.id)
+        .all()
+    )
+    file_reference_records = load_assistant_file_reference_records(
+        db,
+        task_id=task_id,
+        user_id=task_user_id,
+    )
+    plan = plan_snapshot_question_replay(
+        chat_messages=rows,
+        trace_events=trace_events,
+        trace_data_by_event_id=trace_data_by_event_id,
+        normalize_message=lambda text: reconcile_assistant_file_references(
+            db,
+            task_id=task_id,
+            user_id=task_user_id,
+            content=text,
+            records=file_reference_records,
+        ),
+    )
+    return TranscriptReplay(
+        rows=rows,
+        file_reference_records=file_reference_records,
+        plan=plan,
+    )
+
+
+def plan_snapshot_question_replay(
+    *,
+    chat_messages: Iterable[Any],
+    trace_events: Iterable[Any],
+    trace_data_by_event_id: Mapping[str, Any],
+    normalize_message: Optional[Callable[[str], str]] = None,
+) -> AssistantQuestionReplayPlan:
+    """Adapt one historical snapshot's ORM rows onto :func:`plan_assistant_question_replay`.
+
+    ``trace_data_by_event_id`` holds the snapshot's already-normalized trace
+    payloads, so this never re-reads ``event.data``.
+    """
+
+    rows = [
+        ReplayQuestionRow(
+            row_id=int(row.id),
+            content=str(row.content or ""),
+            message_type=str(row.message_type or ""),
+            source_event_id=getattr(row, "source_event_id", None),
+        )
+        for row in chat_messages
+        if str(row.role) == "assistant"
+    ]
+
+    traces: list[ReplayTraceQuestion] = []
+    for event in trace_events:
+        data = trace_data_by_event_id.get(str(event.event_id))
+        # Audit-only payloads never reach the client, so letting one claim a
+        # row would strand that row's real twin.
+        if not isinstance(data, dict) or is_audit_only_trace_data(data):
+            continue
+        metadata = data.get("metadata")
+        interactions = (
+            metadata.get("interactions")
+            if isinstance(metadata, dict)
+            and isinstance(metadata.get("interactions"), list)
+            else None
+        )
+        traces.append(
+            ReplayTraceQuestion(
+                event_id=str(event.event_id),
+                event_type=str(event.event_type),
+                message=str(data.get("message") or data.get("content") or ""),
+                interactions=interactions,
+            )
+        )
+
+    return plan_assistant_question_replay(
+        rows=rows,
+        traces=traces,
+        normalize_message=normalize_message,
+    )
+
+
+def _derived_transcript_index(
+    candidates: Sequence[ReplayTraceQuestion],
+    claimed_event_ids: set[str],
+    normalize_message: Optional[Callable[[str], str]],
+) -> Mapping[str, deque[str]]:
+    """Index unclaimed trace events by the transcript text they would produce.
+
+    This reproduces the exact transformation that wrote the row rather than
+    comparing rendered text loosely -- the pairing is only as wide as
+    ``build_assistant_transcript_content`` is deterministic.
+    """
+
+    index: dict[str, deque[str]] = defaultdict(deque)
+    for trace in candidates:
+        if trace.event_id in claimed_event_ids:
+            continue
+        message = trace.message
+        if normalize_message is not None:
+            try:
+                message = normalize_message(message)
+            except Exception:
+                # Pairing degrades to "no match", which replays this question
+                # the way it did before the fix rather than mispairing it.
+                logger.warning(
+                    "Could not normalize trace %s for question pairing; "
+                    "its transcript row may replay twice",
+                    trace.event_id,
+                    exc_info=True,
+                )
+                message = trace.message
+        derived = build_assistant_transcript_content(
+            message,
+            list(trace.interactions) if trace.interactions else None,
+        )
+        index[derived.strip()].append(trace.event_id)
+    return index

--- a/src/xagent/web/services/assistant_question_replay.py
+++ b/src/xagent/web/services/assistant_question_replay.py
@@ -20,24 +20,30 @@ The pairing is deliberately narrow. Only question rows and only
 other way round (row dropped, trace kept) by the caller's content check,
 because their trace events carry streaming identity this must not disturb.
 
-Not every question row can carry ``source_event_id``: the channel bots
-persist their own question rows through ``persist_assistant_message`` with no
-originating trace event to name (``channels/telegram/utils.py``), so those
-stay on the derivation path permanently. That is a coverage limit, not a
-correctness one -- the symmetry gate below refuses an ambiguous pairing
-rather than guessing one.
+Not every question row can carry ``source_event_id``. The channel finalizers
+write theirs through ``persist_assistant_message_no_commit``, which has no
+such parameter, reached from ``execution_result_projection.py`` via
+``managed_task_lease.py``; only the Slack, Telegram and Feishu bots consume
+that projection, so no ordinary web-chat turn takes this path. Those rows
+stay on the derivation path permanently, and because the same waiting
+question also goes through the shared outbound handler, a channel task ends
+up with two question rows for one trace -- the projection row can never pair,
+since the trace is already claimed. That is a pre-existing channel-only
+limit tracked separately, not something this pairing introduces; the
+symmetry gate below refuses an ambiguous pairing rather than guessing one.
 """
 
 from __future__ import annotations
 
 import logging
-from collections import defaultdict, deque
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Sequence
 
 from ...core.agent.transcript import build_assistant_transcript_content
 from ..models.chat_message import TaskChatMessage
 from ..models.uploaded_file import UploadedFile
+from .chat_history_service import QUESTION_MESSAGE_TYPE, SUPERSEDED_MESSAGE_TYPE
 from .file_reference_output_service import (
     load_assistant_file_reference_records,
     reconcile_assistant_file_references,
@@ -49,9 +55,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# ``question_superseded`` is the same row relabelled once a structured
+# ``SUPERSEDED_MESSAGE_TYPE`` is the same row relabelled once a structured
 # publication has taken over its answer slot; it replays identically.
-QUESTION_MESSAGE_TYPES = frozenset({"question", "question_superseded"})
+QUESTION_MESSAGE_TYPES = frozenset({QUESTION_MESSAGE_TYPE, SUPERSEDED_MESSAGE_TYPE})
 
 # Questions are emitted as ``agent_message``. ``ai_message`` is the final
 # answer channel and is out of scope by construction.
@@ -92,8 +98,8 @@ def _stripped_text(value: Any) -> str:
 
 def plan_assistant_question_replay(
     *,
-    rows: Iterable[ReplayQuestionRow],
-    traces: Iterable[ReplayTraceQuestion],
+    rows: Sequence[ReplayQuestionRow],
+    traces: Sequence[ReplayTraceQuestion],
     normalize_message: Optional[Callable[[str], str]] = None,
 ) -> AssistantQuestionReplayPlan:
     """Decide, for one snapshot, which trace event each question row replaces.
@@ -193,7 +199,7 @@ def load_transcript_replay(
     *,
     task_id: int,
     task_user_id: int,
-    trace_events: Iterable[Any],
+    trace_events: Sequence[Any],
     trace_data_by_event_id: Mapping[str, Any],
 ) -> TranscriptReplay:
     """Read a task's transcript rows and pair its questions with their traces.
@@ -236,8 +242,8 @@ def load_transcript_replay(
 
 def plan_snapshot_question_replay(
     *,
-    chat_messages: Iterable[Any],
-    trace_events: Iterable[Any],
+    chat_messages: Sequence[Any],
+    trace_events: Sequence[Any],
     trace_data_by_event_id: Mapping[str, Any],
     normalize_message: Optional[Callable[[str], str]] = None,
 ) -> AssistantQuestionReplayPlan:
@@ -292,7 +298,7 @@ def _derived_transcript_index(
     candidates: Sequence[ReplayTraceQuestion],
     claimed_event_ids: set[str],
     normalize_message: Optional[Callable[[str], str]],
-) -> Mapping[str, deque[str]]:
+) -> Mapping[str, list[str]]:
     """Index unclaimed trace events by the transcript text they would produce.
 
     This reproduces the exact transformation that wrote the row rather than
@@ -300,7 +306,7 @@ def _derived_transcript_index(
     ``build_assistant_transcript_content`` is deterministic.
     """
 
-    index: dict[str, deque[str]] = defaultdict(deque)
+    index: dict[str, list[str]] = defaultdict(list)
     for trace in candidates:
         if trace.event_id in claimed_event_ids:
             continue
@@ -313,7 +319,8 @@ def _derived_transcript_index(
                 # the way it did before the fix rather than mispairing it.
                 logger.warning(
                     "Could not normalize trace %s for question pairing; "
-                    "its transcript row may replay twice",
+                    "falling back to its raw text, which pairs only if the "
+                    "row was written before any reconciliation applied",
                     trace.event_id,
                     exc_info=True,
                 )

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -660,6 +660,7 @@ def persist_assistant_message(
     interactions: Optional[List[Dict[str, Any]]] = None,
     turn_id: Optional[str] = None,
     content_is_reconciled: bool = False,
+    source_event_id: Optional[str] = None,
 ) -> Optional[TaskChatMessage]:
     reconciled_content = (
         content
@@ -683,6 +684,7 @@ def persist_assistant_message(
         message_type=message_type,
         interactions=interactions,
         turn_id=turn_id,
+        source_event_id=source_event_id,
     )
 
 
@@ -1043,6 +1045,7 @@ def _persist_message(
     attachments: Optional[List[Dict[str, Any]]] = None,
     turn_id: Optional[str] = None,
     delivery_status: Optional[str] = None,
+    source_event_id: Optional[str] = None,
 ) -> Optional[TaskChatMessage]:
     normalized_content = content.strip()
     if not normalized_content and not attachments:
@@ -1057,6 +1060,7 @@ def _persist_message(
         interactions=interactions,
         turn_id=turn_id,
         delivery_status=delivery_status,
+        source_event_id=source_event_id,
         # Pass through ``attachments`` directly so an explicit empty list
         # round-trips as ``[]`` rather than being coerced to ``NULL``.
         attachments=attachments,

--- a/src/xagent/web/services/task_execution.py
+++ b/src/xagent/web/services/task_execution.py
@@ -563,6 +563,7 @@ def _persist_agent_outbound_event(task_id: int, event: Dict[str, Any]) -> None:
                     content=message,
                     message_type="question",
                     interactions=interactions,
+                    source_event_id=str(trace_event.event_id),
                 )
 
         db.commit()

--- a/tests/web/api/test_assistant_question_replay_snapshot.py
+++ b/tests/web/api/test_assistant_question_replay_snapshot.py
@@ -1,0 +1,283 @@
+"""Historical replay must emit one event per assistant question (#2292).
+
+A waiting question is written both as a trace event and as a transcript row
+whose text has the rendered interaction list appended, so the two can never
+compare equal. Replay used to ship both, and the widget session page -- which
+never clears messages on reconnect -- printed the clarification form again on
+every reconnect.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from xagent.core.agent.transcript import build_assistant_transcript_content
+from xagent.web.api.websocket import send_historical_data_as_stream
+from xagent.web.models.chat_message import TaskChatMessage
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task import TraceEvent as DatabaseTraceEvent
+from xagent.web.models.user import User
+from xagent.web.services.task_execution import _persist_agent_outbound_event
+
+INTERACTIONS = [{"type": "confirm", "label": "Proceed?", "default": True}]
+QUESTION = "Round 1: please confirm"
+
+
+def _make_task(username: str):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    user = User(username=username, password_hash="hashed_password", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    task = Task(
+        user_id=int(user.id),
+        title="Chat task",
+        description="Task chat",
+        status=TaskStatus.PENDING,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return SessionLocal, db, task
+
+
+def _question_trace_row(task_id: int, event_id: str, when: datetime):
+    return DatabaseTraceEvent(
+        task_id=task_id,
+        event_id=event_id,
+        event_type="agent_message",
+        timestamp=when,
+        data={
+            "event_id": event_id,
+            "message": QUESTION,
+            "expect_response": True,
+            "metadata": {"interactions": INTERACTIONS},
+        },
+    )
+
+
+def _question_row(task_id: int, user_id: int, when: datetime, **kwargs):
+    return TaskChatMessage(
+        task_id=task_id,
+        user_id=user_id,
+        role="assistant",
+        content=build_assistant_transcript_content(QUESTION, INTERACTIONS),
+        message_type="question",
+        interactions=INTERACTIONS,
+        created_at=when,
+        **kwargs,
+    )
+
+
+async def _replay(monkeypatch, SessionLocal, task_id: int, user_id: int) -> list[dict]:
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    sent: list[dict] = []
+
+    async def send_personal_message(event: dict, websocket: object) -> None:
+        sent.append(event)
+
+    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
+    monkeypatch.setattr("xagent.web.api.websocket.get_db", get_test_db)
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.get_session_local", lambda: SessionLocal
+    )
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local", lambda: SessionLocal
+    )
+    monkeypatch.setattr("xagent.web.api.websocket.cache_get", lambda *args: None)
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.cache_set", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.manager.send_personal_message",
+        send_personal_message,
+    )
+
+    await send_historical_data_as_stream(
+        websocket=object(),
+        task_id=task_id,
+        user=SimpleNamespace(id=user_id, is_admin=False),
+    )
+    return sent
+
+
+def _question_events(sent: list[dict]) -> list[dict]:
+    return [
+        event
+        for event in sent
+        if event.get("type") == "trace_event"
+        and event.get("event_type") == "agent_message"
+        and QUESTION in str(event.get("data", {}).get("message", ""))
+    ]
+
+
+@pytest.mark.asyncio
+async def test_one_question_replays_once_and_keeps_the_trace_event_identity(
+    monkeypatch,
+) -> None:
+    SessionLocal, db, task = _make_task("replay-one")
+    task_id, user_id = int(task.id), int(task.user_id)
+    db.close()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    # Go through the real producer so the trace row and the transcript row are
+    # written exactly the way production writes them. ``task_execution`` binds
+    # ``get_db`` at import time, so the module attribute is the one to patch.
+    monkeypatch.setattr("xagent.web.services.task_execution.get_db", get_test_db)
+    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
+    _persist_agent_outbound_event(
+        task_id,
+        {
+            "event_type": "agent_message",
+            "timestamp": datetime(2026, 9, 10, tzinfo=timezone.utc).timestamp(),
+            "data": {
+                "event_id": "ea62bd91",
+                "message": QUESTION,
+                "expect_response": True,
+                "metadata": {"interactions": INTERACTIONS},
+            },
+        },
+    )
+
+    probe = SessionLocal()
+    try:
+        row = probe.query(TaskChatMessage).one()
+        # Precondition for the whole defect: the two texts differ, so no
+        # content comparison could ever have paired them.
+        assert row.content != QUESTION
+        assert row.source_event_id == "ea62bd91"
+    finally:
+        probe.close()
+
+    sent = await _replay(monkeypatch, SessionLocal, task_id, user_id)
+    questions = _question_events(sent)
+
+    assert len(questions) == 1
+    event = questions[0]
+    assert event["event_id"] == "ea62bd91"
+    # The surviving copy is the sanitized one: a historical question must not
+    # flip the client back into waiting_for_user.
+    assert event["data"]["expect_response"] is False
+    assert event["data"]["source"] == "chat_history"
+    assert event["data"]["metadata"]["interactions"] == INTERACTIONS
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_row_without_source_event_id_still_replays_once(
+    monkeypatch,
+) -> None:
+    SessionLocal, db, task = _make_task("replay-legacy")
+    task_id, user_id = int(task.id), int(task.user_id)
+    when = datetime(2026, 9, 10, tzinfo=timezone.utc)
+    try:
+        db.add(_question_trace_row(task_id, "ea62bd91", when))
+        db.add(_question_row(task_id, user_id, when))
+        db.commit()
+    finally:
+        db.close()
+
+    sent = await _replay(monkeypatch, SessionLocal, task_id, user_id)
+    questions = _question_events(sent)
+
+    assert len(questions) == 1
+    assert questions[0]["event_id"] == "ea62bd91"
+    assert questions[0]["data"]["expect_response"] is False
+
+
+@pytest.mark.asyncio
+async def test_two_rounds_asking_the_same_question_both_survive(
+    monkeypatch,
+) -> None:
+    # The guard against over-collapsing: identical text across rounds is
+    # routine, and #2250 is the record of what collapsing it costs.
+    SessionLocal, db, task = _make_task("replay-two-rounds")
+    task_id, user_id = int(task.id), int(task.user_id)
+    first = datetime(2026, 9, 10, 1, tzinfo=timezone.utc)
+    second = datetime(2026, 9, 10, 2, tzinfo=timezone.utc)
+    try:
+        db.add(_question_trace_row(task_id, "ea62bd91", first))
+        db.add(_question_row(task_id, user_id, first, source_event_id="ea62bd91"))
+        db.add(_question_trace_row(task_id, "79652fd2", second))
+        db.add(_question_row(task_id, user_id, second, source_event_id="79652fd2"))
+        db.commit()
+    finally:
+        db.close()
+
+    sent = await _replay(monkeypatch, SessionLocal, task_id, user_id)
+    questions = _question_events(sent)
+
+    assert len(questions) == 2
+    assert [event["event_id"] for event in questions] == ["ea62bd91", "79652fd2"]
+
+
+@pytest.mark.asyncio
+async def test_an_assistant_answer_is_not_touched_by_question_pairing(
+    monkeypatch,
+) -> None:
+    # Answers are deduped the other way round (row dropped, trace kept) and
+    # their trace events carry streaming identity. Pairing must not reach them.
+    SessionLocal, db, task = _make_task("replay-answer")
+    task_id, user_id = int(task.id), int(task.user_id)
+    when = datetime(2026, 9, 10, tzinfo=timezone.utc)
+    try:
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="final-1",
+                event_type="ai_message",
+                timestamp=when,
+                data={"event_id": "final-1", "message": "Final answer"},
+            )
+        )
+        db.add(
+            TaskChatMessage(
+                task_id=task_id,
+                user_id=user_id,
+                role="assistant",
+                content="Final answer",
+                message_type="assistant",
+                created_at=when,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    sent = await _replay(monkeypatch, SessionLocal, task_id, user_id)
+    answers = [
+        event
+        for event in sent
+        if event.get("type") == "trace_event"
+        and event.get("data", {}).get("message") == "Final answer"
+    ]
+
+    assert len(answers) == 1
+    assert answers[0]["event_id"] == "final-1"
+    assert answers[0]["event_type"] == "ai_message"

--- a/tests/web/api/test_legacy_failure_history_replay.py
+++ b/tests/web/api/test_legacy_failure_history_replay.py
@@ -163,7 +163,7 @@ def _history_cache_entry(task_id: int, events: list[dict]) -> dict[str, object]:
             or 0
         )
         return {
-            "trace_scope": "public-v1",
+            "trace_scope": "public-v2",
             "updated_at": cache_version_token(task.updated_at),
             "max_trace_event_id": 0,
             "max_chat_message_id": int(max_chat_message_id),

--- a/tests/web/services/test_assistant_question_replay.py
+++ b/tests/web/services/test_assistant_question_replay.py
@@ -1,0 +1,307 @@
+"""Pairing rules that keep one replayed event per assistant question.
+
+A waiting question is written twice by one producer: once as a TraceEvent
+carrying the raw prompt, and once as a transcript row whose content has the
+rendered interaction list appended. Replay must emit one of them, not both.
+"""
+
+from xagent.core.agent.transcript import build_assistant_transcript_content
+from xagent.web.services.assistant_question_replay import (
+    ReplayQuestionRow,
+    ReplayTraceQuestion,
+    plan_assistant_question_replay,
+    plan_snapshot_question_replay,
+)
+
+INTERACTIONS = [
+    {"type": "confirm", "label": "Proceed?", "default": True},
+]
+
+
+def _trace(event_id: str, message: str = "Round 1: please confirm", **kwargs):
+    return ReplayTraceQuestion(
+        event_id=event_id,
+        event_type=kwargs.pop("event_type", "agent_message"),
+        message=message,
+        interactions=kwargs.pop("interactions", INTERACTIONS),
+    )
+
+
+def _row(row_id: int, message: str = "Round 1: please confirm", **kwargs):
+    return ReplayQuestionRow(
+        row_id=row_id,
+        content=kwargs.pop(
+            "content",
+            build_assistant_transcript_content(message, INTERACTIONS),
+        ),
+        message_type=kwargs.pop("message_type", "question"),
+        source_event_id=kwargs.pop("source_event_id", None),
+    )
+
+
+def test_row_supersedes_its_own_trace_event_by_source_event_id():
+    plan = plan_assistant_question_replay(
+        rows=[_row(10, source_event_id="ea62bd91")],
+        traces=[_trace("ea62bd91")],
+    )
+
+    assert plan.superseded_trace_event_ids == frozenset({"ea62bd91"})
+    assert plan.trace_event_id_by_row_id == {10: "ea62bd91"}
+
+
+def test_legacy_row_without_source_event_id_pairs_by_derived_transcript_text():
+    # The row predates ``source_event_id``. Its content is still exactly what
+    # ``build_assistant_transcript_content`` produced from the trace payload,
+    # so the pair is recoverable without matching rendered text loosely.
+    plan = plan_assistant_question_replay(
+        rows=[_row(10)],
+        traces=[_trace("ea62bd91")],
+    )
+
+    assert plan.superseded_trace_event_ids == frozenset({"ea62bd91"})
+    assert plan.trace_event_id_by_row_id == {10: "ea62bd91"}
+
+
+def test_two_rounds_asking_the_same_question_pair_one_to_one():
+    # Separate rounds routinely repeat a question verbatim. Each row must claim
+    # its own trace event rather than both collapsing onto the first.
+    plan = plan_assistant_question_replay(
+        rows=[_row(10), _row(12)],
+        traces=[_trace("ea62bd91"), _trace("79652fd2")],
+    )
+
+    assert plan.trace_event_id_by_row_id == {10: "ea62bd91", 12: "79652fd2"}
+    assert plan.superseded_trace_event_ids == frozenset({"ea62bd91", "79652fd2"})
+
+
+def test_source_event_id_wins_over_an_earlier_text_identical_trace_event():
+    plan = plan_assistant_question_replay(
+        rows=[_row(12, source_event_id="79652fd2")],
+        traces=[_trace("ea62bd91"), _trace("79652fd2")],
+    )
+
+    assert plan.trace_event_id_by_row_id == {12: "79652fd2"}
+    assert plan.superseded_trace_event_ids == frozenset({"79652fd2"})
+
+
+def test_a_row_whose_trace_event_is_absent_supersedes_nothing():
+    # The trace row can be missing (pruned, or filtered out of the public
+    # scope). The transcript row still replays; it just keeps its own id.
+    plan = plan_assistant_question_replay(rows=[_row(10)], traces=[])
+
+    assert plan.superseded_trace_event_ids == frozenset()
+    assert plan.trace_event_id_by_row_id == {}
+
+
+def test_non_question_rows_are_left_to_the_existing_content_dedupe():
+    # Final answers are already deduped the other way round (row dropped,
+    # trace kept) and carry streaming identity this pairing must not disturb.
+    plan = plan_assistant_question_replay(
+        rows=[_row(10, message_type="assistant_response")],
+        traces=[_trace("ea62bd91")],
+    )
+
+    assert plan.superseded_trace_event_ids == frozenset()
+    assert plan.trace_event_id_by_row_id == {}
+
+
+def test_relabelled_superseded_question_rows_still_pair():
+    plan = plan_assistant_question_replay(
+        rows=[_row(10, message_type="question_superseded", source_event_id="ea62bd91")],
+        traces=[_trace("ea62bd91")],
+    )
+
+    assert plan.trace_event_id_by_row_id == {10: "ea62bd91"}
+
+
+def test_non_agent_message_trace_events_are_never_claimed():
+    plan = plan_assistant_question_replay(
+        rows=[_row(10, source_event_id="final-1")],
+        traces=[_trace("final-1", event_type="ai_message")],
+    )
+
+    assert plan.superseded_trace_event_ids == frozenset()
+    assert plan.trace_event_id_by_row_id == {}
+
+
+def test_question_without_interactions_pairs_on_the_unchanged_message():
+    plan = plan_assistant_question_replay(
+        rows=[_row(10, content="Which region?", message_type="question")],
+        traces=[_trace("ea62bd91", message="Which region?", interactions=None)],
+    )
+
+    assert plan.trace_event_id_by_row_id == {10: "ea62bd91"}
+
+
+def test_normalize_message_is_applied_before_deriving_transcript_text():
+    # Persistence reconciles file references into the message *before* building
+    # the transcript row, so the raw trace text can differ by exactly that
+    # rewrite. Callers pass the same reconciliation in.
+    stored = build_assistant_transcript_content(
+        "See [report](file:abc123)", INTERACTIONS
+    )
+    plan = plan_assistant_question_replay(
+        rows=[_row(10, content=stored)],
+        traces=[_trace("ea62bd91", message="See [report](file:stale)")],
+        normalize_message=lambda text: text.replace("file:stale", "file:abc123"),
+    )
+
+    assert plan.trace_event_id_by_row_id == {10: "ea62bd91"}
+
+
+def test_a_blank_source_event_id_falls_back_to_derivation():
+    plan = plan_assistant_question_replay(
+        rows=[_row(10, source_event_id="   ")],
+        traces=[_trace("ea62bd91")],
+    )
+
+    assert plan.trace_event_id_by_row_id == {10: "ea62bd91"}
+
+
+def test_a_source_event_id_naming_a_missing_trace_event_claims_nothing():
+    # Not a derivation fallback: the row states which event it came from, and
+    # that event is not in this snapshot. Guessing a text-identical neighbour
+    # would hand the row a different round's identity.
+    plan = plan_assistant_question_replay(
+        rows=[_row(10, source_event_id="pruned")],
+        traces=[_trace("ea62bd91")],
+    )
+
+    assert plan.superseded_trace_event_ids == frozenset()
+    assert plan.trace_event_id_by_row_id == {}
+
+
+class _Row:
+    def __init__(
+        self,
+        id,
+        content,
+        message_type="question",
+        role="assistant",
+        source_event_id=None,
+    ):
+        self.id = id
+        self.content = content
+        self.message_type = message_type
+        self.role = role
+        self.source_event_id = source_event_id
+
+
+class _Event:
+    def __init__(self, event_id, event_type="agent_message"):
+        self.event_id = event_id
+        self.event_type = event_type
+
+
+def _question_data(
+    message="Round 1: please confirm", interactions=INTERACTIONS, **extra
+):
+    data = {"message": message, "metadata": {"interactions": interactions}}
+    data.update(extra)
+    return data
+
+
+def test_snapshot_adapter_pairs_row_and_trace_from_orm_shapes():
+    plan = plan_snapshot_question_replay(
+        chat_messages=[
+            _Row(
+                10,
+                build_assistant_transcript_content(
+                    "Round 1: please confirm", INTERACTIONS
+                ),
+            ),
+        ],
+        trace_events=[_Event("ea62bd91")],
+        trace_data_by_event_id={"ea62bd91": _question_data()},
+    )
+
+    assert plan.trace_event_id_by_row_id == {10: "ea62bd91"}
+
+
+def test_snapshot_adapter_ignores_user_rows():
+    plan = plan_snapshot_question_replay(
+        chat_messages=[
+            _Row(
+                10, "Round 1: please confirm", message_type="user_message", role="user"
+            )
+        ],
+        trace_events=[_Event("ea62bd91")],
+        trace_data_by_event_id={"ea62bd91": _question_data()},
+    )
+
+    assert plan.trace_event_id_by_row_id == {}
+
+
+def test_snapshot_adapter_never_lets_an_audit_only_event_claim_a_row():
+    # The audit-only twin must not absorb the claim and strand the real one.
+    plan = plan_snapshot_question_replay(
+        chat_messages=[
+            _Row(
+                10,
+                build_assistant_transcript_content(
+                    "Round 1: please confirm", INTERACTIONS
+                ),
+            ),
+        ],
+        trace_events=[_Event("audit-1"), _Event("ea62bd91")],
+        trace_data_by_event_id={
+            "audit-1": _question_data(__audit_only__=True),
+            "ea62bd91": _question_data(),
+        },
+    )
+
+    assert plan.trace_event_id_by_row_id == {10: "ea62bd91"}
+
+
+def test_snapshot_adapter_skips_events_with_no_normalized_payload():
+    plan = plan_snapshot_question_replay(
+        chat_messages=[
+            _Row(
+                10,
+                build_assistant_transcript_content(
+                    "Round 1: please confirm", INTERACTIONS
+                ),
+            ),
+        ],
+        trace_events=[_Event("missing")],
+        trace_data_by_event_id={},
+    )
+
+    assert plan.trace_event_id_by_row_id == {}
+
+
+def test_a_legacy_row_never_claims_a_later_round_s_trace_when_its_own_is_absent():
+    # Round 1's trace can be missing from the snapshot (filtered out of the
+    # public scope, audit-only, or pruned) while round 2's is present. Letting
+    # row 1 claim round 2's event id hands it another round's identity, and on
+    # the client the two questions then collapse into one bubble -- the #2250
+    # failure, reintroduced. Claim nothing instead: replaying both is the
+    # pre-fix behaviour, and it never loses a turn.
+    plan = plan_assistant_question_replay(
+        rows=[_row(10), _row(12)],
+        traces=[_trace("79652fd2")],
+    )
+
+    assert plan.superseded_trace_event_ids == frozenset()
+    assert plan.trace_event_id_by_row_id == {}
+
+
+def test_one_row_facing_two_identical_traces_claims_neither():
+    # Ambiguous the other way round: nothing says which trace is this row's.
+    plan = plan_assistant_question_replay(
+        rows=[_row(10)],
+        traces=[_trace("ea62bd91"), _trace("79652fd2")],
+    )
+
+    assert plan.trace_event_id_by_row_id == {}
+
+
+def test_an_explicit_claim_still_lets_its_legacy_neighbour_derive():
+    # The symmetry gate counts only what is left unclaimed, so a row carrying
+    # source_event_id must not starve a legacy row asking the same question.
+    plan = plan_assistant_question_replay(
+        rows=[_row(10, source_event_id="ea62bd91"), _row(12)],
+        traces=[_trace("ea62bd91"), _trace("79652fd2")],
+    )
+
+    assert plan.trace_event_id_by_row_id == {10: "ea62bd91", 12: "79652fd2"}


### PR DESCRIPTION
Fixes #2292.

## Scope

Historical replay emits one event per assistant **question**, instead of one per producer. Nothing else about replay changes: assistant answers keep the dedupe they have today (row dropped, trace kept) and their streaming identity is untouched.

### Out of scope, already tracked

- **#2173** — `PROVIDER_DISPLAY_NAMES` is missing five builtin OAuth providers (`salesforce`, `deputy`, `xero`, `myob`, `employment-hero`), so `connect-apps-field.test.tsx > has a display name for every builtin OAuth provider in the backend registry` is red on `main`. Verified still red at `b33df2ae` with this branch's frontend changes reverted. Pre-dates this work; the issue predates it too.

## What was wrong

`_persist_agent_outbound_event` writes a waiting question twice from one event: a `TraceEvent` holding the raw prompt, and a `TaskChatMessage` whose content additionally carries the rendered interaction list appended by `build_assistant_transcript_content` (`core/agent/transcript.py:72`).

The two therefore **never compare equal**, which made replay's content dedupe (`(role, content, attachment_fingerprint) in trace_message_keys`) structurally dead for questions — it can only match when the texts are identical, and for a question they never are. Both events shipped.

The client could not collapse them either: the ids differ (`chat_message_10` vs the trace uuid), the texts differ, and assistant messages minted a fresh id on every arrival. The user side got a stable identity in #2254; the assistant side had none.

On the widget session page this accumulates. `onConnect` early-returns for `history: "none"` **before** `CLEAR_MESSAGES`, while the server pushes the whole snapshot unconditionally after connect, so each reconnect appends another copy — matching the reported "three times after a second reconnect".

## The change

**Replay keeps the transcript row and drops its trace twin.** The row is the sanitized producer: its synthesized payload sets `expect_response: False`, so a historical question cannot flip the client back into `waiting_for_user`, whereas the trace payload is passed through untouched by `normalize_public_trace_event`. The surviving event inherits the trace event's `event_id`, which is the stable identity the client reconciles on.

Rows now record `source_event_id`. Legacy rows predating the column pair by **re-deriving** the transcript text from each trace event — reproducing the exact transformation that wrote the row, not matching rendered text loosely — so existing sessions stop duplicating too, with no backfill. Nothing is backfilled deliberately: consecutive rounds routinely ask the same question verbatim, so a text backfill would hand some rows another round's identity.

That derivation pairs only when a text has **exactly one unclaimed trace per row asking it**. See "What the preflight caught" below.

The frontend mints a stable assistant message id from that event identity and reconciles a re-delivery onto the already-mounted bubble, so an open clarification form is not remounted under the visitor.

The snapshot cache scope is bumped `public-v1` → `public-v2` so cached pre-fix snapshots, which still carry both copies, are invalidated.

## What the preflight caught

An earlier revision of the derivation let a legacy row claim a **later round's** trace when its own was absent from the snapshot (filtered out of the public scope, audit-only, or pruned) and a later round repeated the question verbatim. On the client the two questions then merged into one bubble — a lost turn, which is #2250's failure reintroduced by the fix for #2292.

The symmetry gate closes it: when a text does not have exactly one unclaimed trace per row asking it, nothing is claimed and both copies replay, exactly as before this PR. Refusing costs only the legacy dedupe for that text; it never loses a turn. Pinned by `test_a_legacy_row_never_claims_a_later_round_s_trace_when_its_own_is_absent`.

## Known limits

- Channel bots persist their own question rows through `persist_assistant_message` with no originating trace event to name (`channels/telegram/utils.py:252`), so those stay on the derivation path permanently. A coverage limit, not a correctness one — the symmetry gate refuses an ambiguous pairing rather than guessing.
- `ai_message` (final answers) still mint a fresh client id and can still duplicate across reconnects when their text differs from the row's. Pre-existing, deliberately left alone: their trace events carry streaming identity this change must not disturb.

## Tests

Every new test was verified to **fail without the fix**, not merely to pass with it:

- `test_assistant_question_replay_snapshot.py` drives the real `_persist_agent_outbound_event` and `send_historical_data_as_stream`: 2 events → 1 on the legacy path, 4 → 2 for two rounds.
- `app-context-chat.test.tsx` reproduces the issue's literal symptom through the real `AppProvider`: **3 copies after two reconnects → 1**.
- A further test pins that the post-replay `task_waiting_for_user` re-assert does not become a third bubble now that the trace copy is gone (it reads the same transcript text via `get_latest_waiting_question`). Mutation-checked: diverge the text and it fails.
- `test_assistant_question_replay.py` covers the pairing rules directly, including the two ambiguity cases the gate refuses.

## Verification

- `tests/web`: only 5 failures, all `no library called "cairo" was found` — no native cairo on the dev machine; they fail identically with `websocket.py` reverted to base.
- Frontend suite: 2932 passed, 1 failure — #2173 above.
- `ruff check` / `ruff format` / `mypy` on all changed Python; `tsc --noEmit` clean; `eslint` unchanged at its 58 pre-existing problems, none near these edits.
- Migration: single alembic head, inspector-guarded like its siblings on this table.

## Size

1304 changed lines, 296 (22.7%) in pre-existing files — above the ~10% target. The two hub files take 40 (`websocket.py`, 10,895 lines) and 44 (`app-context-chat.tsx`, 6,959 lines) thin additive lines; the rest of the logic is a new module. 61% of the diff is tests.
