### PR TITLE
fix: keep authentication database sessions worker-owned

### DIFF
--- a/src/xagent/core/runtime_performance.py
+++ b/src/xagent/core/runtime_performance.py
@@ -104,6 +104,8 @@ _DURATION_METRICS = frozenset(
         "xagent.auth.login.password_verify.duration",
         "xagent.auth.login.token_creation.duration",
         "xagent.auth.login.total.duration",
+        "xagent.auth.login.sync_lookup.duration",
+        "xagent.auth.login.sync_commit.duration",
         "xagent.event_loop.lag",
         "xagent.thread_pool.execution.duration",
         "xagent.thread_pool.queue_wait.duration",

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -960,10 +960,15 @@ def create_access_token(
 
 def create_refresh_token(data: Dict[str, Any]) -> str:
     """Create JWT refresh token with longer expiry"""
-    to_encode = data.copy()
+    # Refresh consumes user_id, never username/sub. Omit that redundant,
+    # unbounded UTF-8 claim to keep the signed token within VARCHAR(255).
+    # Access tokens retain sub; verification still accepts existing refresh JWTs.
+    to_encode = {"user_id": data["user_id"]}
     expire = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
     # Rotation must change the stored value even within one JWT timestamp second.
-    to_encode.update({"exp": expire, "type": "refresh", "jti": secrets.token_hex(16)})
+    to_encode.update(
+        {"exp": expire, "type": "refresh", "jti": secrets.token_urlsafe(16)}
+    )
     encoded_jwt: str = jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
     return encoded_jwt
 

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -42,7 +42,6 @@ from ...core.runtime_performance import (
 from ...core.runtime_performance import (
     observe_duration,
     observe_value,
-    run_in_thread_with_telemetry,
 )
 from ..auth_config import (
     ACCESS_TOKEN_EXPIRE_MINUTES,
@@ -54,6 +53,11 @@ from ..auth_config import (
 from ..auth_dependencies import get_current_user
 from ..first_admin_setup import FirstAdminIdentity, run_first_admin_setup_hook
 from ..models.actor_oauth_flow import ActorOAuthFlowState
+from ..models.auth_database import (
+    SyncAuthSessionFactory,
+    get_auth_db,
+    run_auth_db_worker,
+)
 from ..models.database import (
     get_db,
     get_session_local,
@@ -1484,95 +1488,73 @@ def get_user_by_login_identifier(db: Session, identifier: str) -> Optional[User]
     return get_user_by_username(db, login_identifier)
 
 
+def _prepare_login_response(user: User | None, request: LoginRequest) -> Dict[str, Any]:
+    """Build detached response data before commit can expire ORM attributes."""
+    if user is None:
+        raise HTTPException(status_code=401, detail="Incorrect username or password")
+    with observe_duration("xagent.auth.login.password_verify.duration"):
+        valid = verify_password(request.password, str(user.password_hash))
+    if not valid:
+        raise HTTPException(status_code=401, detail="Incorrect username or password")
+    with observe_duration("xagent.auth.login.token_creation.duration"):
+        identity = {"sub": user.username, "user_id": user.id}
+        access_token = create_access_token(
+            data=identity,
+            expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+        )
+        token = create_refresh_token(data=identity)
+    setattr(user, "refresh_token", token)
+    setattr(
+        user,
+        "refresh_token_expires_at",
+        datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+    )
+    return {
+        "success": True,
+        "message": "Login successful",
+        "user": serialize_auth_user(user, include_login_time=True),
+        "access_token": access_token,
+        "refresh_token": token,
+        "token_type": "bearer",
+        "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        "refresh_expires_in": REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
+        "user_id": user.id,
+    }
+
+
+def _login_in_worker(
+    request: LoginRequest, session_factory: SyncAuthSessionFactory
+) -> Dict[str, Any]:
+    # The same thread creates, queries, commits and closes the Session.
+    with session_factory() as session:
+        with observe_duration("xagent.auth.login.sync_lookup.duration"):
+            user = get_user_by_login_identifier(session, request.username)
+        response = _prepare_login_response(user, request)
+        with observe_duration("xagent.auth.login.sync_commit.duration"):
+            session.commit()
+        # Do not access user here: expire_on_commit=True would issue another SELECT.
+        return response
+
+
 @auth_router.post("/login")
-async def login(request: LoginRequest, db: Session = Depends(get_db)) -> Dict[str, Any]:
-    """User login endpoint"""
+async def login(
+    request: LoginRequest,
+    db: SyncAuthSessionFactory = Depends(get_auth_db),
+) -> Dict[str, Any]:
+    """Authenticate with a single worker-owned database transaction."""
     started_at = time.perf_counter()
     outcome = "error"
     try:
-        # Run synchronous database queries in thread pool to avoid blocking event loop
-        def _get_user_sync() -> User:
-            # Get user from database
-            user = get_user_by_login_identifier(db, request.username)
-            if not user:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Incorrect username or password",
-                )
-            return user
-
-        # Execute database query in thread pool to avoid blocking
-        user = await run_in_thread_with_telemetry(
-            "login_user_lookup",
-            _get_user_sync,
+        response = await run_auth_db_worker(
+            "login_database_transaction", lambda: _login_in_worker(request, db)
         )
-
-        # Verify password
-        with observe_duration("xagent.auth.login.password_verify.duration"):
-            password_valid = verify_password(request.password, str(user.password_hash))
-        if not password_valid:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Incorrect username or password",
-            )
-
-        # Create JWT tokens
-        with observe_duration("xagent.auth.login.token_creation.duration"):
-            access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-            access_token = create_access_token(
-                data={"sub": user.username, "user_id": user.id},
-                expires_delta=access_token_expires,
-            )
-
-            # Create refresh token
-            refresh_token = create_refresh_token(
-                data={"sub": user.username, "user_id": user.id}
-            )
-
-        # Store refresh token in database - run in thread pool to avoid blocking
-        def _update_user_sync() -> None:
-            setattr(user, "refresh_token", refresh_token)
-            setattr(
-                user,
-                "refresh_token_expires_at",
-                datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
-            )
-            db.commit()
-
-        # Execute database update in thread pool to avoid blocking
-        await run_in_thread_with_telemetry(
-            "login_refresh_token_commit",
-            _update_user_sync,
-        )
-
-        # Login successful
         outcome = "succeeded"
-        return {
-            "success": True,
-            "message": "Login successful",
-            "user": serialize_auth_user(user, include_login_time=True),
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-            "token_type": "bearer",
-            "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # seconds
-            "refresh_expires_in": REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,  # seconds
-            "user_id": user.id,
-        }
-
+        return response
     except HTTPException:
-        # Re-raise HTTP exceptions
         outcome = "rejected"
         raise
     except Exception:
-        # str(e) is not put in the response: _update_user_sync's db.commit()
-        # above persists the just-issued refresh_token as a bound SQL
-        # parameter, and a SQLAlchemy StatementError's default __str__
-        # would otherwise echo that live session token back to the client
-        # -- the same class of leak fixed in generic_oauth_callback's
-        # callback handler. hide_parameters=True on the engine
-        # (models/database.py) now hides it there too, but this handler
-        # doesn't rely on that alone. logger.exception still captures it
-        # server-side.
+        # SQL errors may contain bound refresh tokens. Never expose them to clients.
         logger.exception("Login failed")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -2042,91 +2024,68 @@ async def update_current_user_preferences(
         )
 
 
+def _prepare_refresh_response(
+    user: User | None, request: RefreshTokenRequest
+) -> RefreshTokenResponse:
+    if user is None:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+    token = getattr(user, "refresh_token", None)
+    expires = getattr(user, "refresh_token_expires_at", None)
+    if token != request.refresh_token or expires is None:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+    now = datetime.now(timezone.utc)
+    if getattr(expires, "tzinfo", None) is None:
+        now = now.replace(tzinfo=None)
+    if expires < now:
+        raise HTTPException(status_code=401, detail="Refresh token has expired")
+    identity = {"sub": user.username, "user_id": user.id}
+    access_token = create_access_token(
+        data=identity, expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    new_token = create_refresh_token(data=identity)
+    setattr(user, "refresh_token", new_token)
+    setattr(
+        user,
+        "refresh_token_expires_at",
+        datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+    )
+    return RefreshTokenResponse(
+        success=True,
+        message="Token refreshed successfully",
+        access_token=access_token,
+        refresh_token=new_token,
+        expires_in=ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        refresh_expires_in=REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
+    )
+
+
+def _refresh_in_worker(
+    request: RefreshTokenRequest,
+    user_id: Any,
+    session_factory: SyncAuthSessionFactory,
+) -> RefreshTokenResponse:
+    with session_factory() as session:
+        user = session.query(User).filter(User.id == user_id).first()
+        response = _prepare_refresh_response(user, request)
+        session.commit()
+        return response
+
+
 @auth_router.post("/refresh", response_model=RefreshTokenResponse)
 async def refresh_token(
     request: RefreshTokenRequest,
-    db: Session = Depends(get_db),
+    db: SyncAuthSessionFactory = Depends(get_auth_db),
 ) -> RefreshTokenResponse:
-    """Refresh JWT access token using refresh token"""
+    """Refresh tokens without sharing a synchronous Session across threads."""
     try:
-        # Verify refresh token
         payload = verify_refresh_token(request.refresh_token)
         if not payload:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid refresh token",
-            )
-
-        # Get user from database
+            raise HTTPException(status_code=401, detail="Invalid refresh token")
         user_id = payload.get("user_id")
-        user = db.query(User).filter(User.id == user_id).first()
-
-        if not user:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid refresh token",
-            )
-
-        # Check if refresh token matches and is not expired
-        user_refresh_token = getattr(user, "refresh_token", None)
-        refresh_token_expires_at = getattr(user, "refresh_token_expires_at", None)
-        if (
-            user_refresh_token != request.refresh_token
-            or refresh_token_expires_at is None
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid refresh token",
-            )
-
-        # Check expiration - handle timezone-aware and naive datetimes
-        now = datetime.now(timezone.utc)
-        if (
-            hasattr(refresh_token_expires_at, "tzinfo")
-            and getattr(refresh_token_expires_at, "tzinfo", None) is not None
-        ):
-            # Timezone-aware datetime
-            if cast(Any, refresh_token_expires_at) < now:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Refresh token has expired",
-                )
-        else:
-            # Naive datetime - assume UTC
-            if cast(Any, refresh_token_expires_at) < now.replace(tzinfo=None):
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Refresh token has expired",
-                )
-
-        # Create new access token
-        access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-        access_token = create_access_token(
-            data={"sub": user.username, "user_id": user.id},
-            expires_delta=access_token_expires,
+        return await run_auth_db_worker(
+            "refresh_database_transaction",
+            lambda: _refresh_in_worker(request, user_id, db),
         )
-
-        # Optionally: Create new refresh token (rotation)
-        new_refresh_token = create_refresh_token(
-            data={"sub": user.username, "user_id": user.id}
-        )
-        setattr(user, "refresh_token", new_refresh_token)
-        setattr(
-            user,
-            "refresh_token_expires_at",
-            datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
-        )
-        db.commit()
-
-        return RefreshTokenResponse(
-            success=True,
-            message="Token refreshed successfully",
-            access_token=access_token,
-            refresh_token=new_refresh_token,
-            expires_in=ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # seconds
-            refresh_expires_in=REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,  # seconds
-        )
-
     except HTTPException:
         raise
     except SQLAlchemyError:

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -962,7 +962,8 @@ def create_refresh_token(data: Dict[str, Any]) -> str:
     """Create JWT refresh token with longer expiry"""
     to_encode = data.copy()
     expire = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-    to_encode.update({"exp": expire, "type": "refresh"})
+    # Rotation must change the stored value even within one JWT timestamp second.
+    to_encode.update({"exp": expire, "type": "refresh", "jti": secrets.token_hex(16)})
     encoded_jwt: str = jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
     return encoded_jwt
 
@@ -2043,12 +2044,6 @@ def _prepare_refresh_response(
         data=identity, expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     )
     new_token = create_refresh_token(data=identity)
-    setattr(user, "refresh_token", new_token)
-    setattr(
-        user,
-        "refresh_token_expires_at",
-        datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
-    )
     return RefreshTokenResponse(
         success=True,
         message="Token refreshed successfully",
@@ -2067,6 +2062,29 @@ def _refresh_in_worker(
     with session_factory() as session:
         user = session.query(User).filter(User.id == user_id).first()
         response = _prepare_refresh_response(user, request)
+        # End the read snapshot before competing for a write. In SQLite this
+        # avoids a deferred read-to-write lock upgrade; the conditional UPDATE
+        # below, not the preceding SELECT, is the authority on token consumption.
+        session.rollback()
+        now = datetime.now(timezone.utc)
+        changed = (
+            session.query(User)
+            .filter(
+                User.id == user_id,
+                User.refresh_token == request.refresh_token,
+                User.refresh_token_expires_at >= now,
+            )
+            .update(
+                {
+                    User.refresh_token: response.refresh_token,
+                    User.refresh_token_expires_at: now
+                    + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+                },
+                synchronize_session=False,
+            )
+        )
+        if changed != 1:
+            raise HTTPException(status_code=401, detail="Invalid refresh token")
         session.commit()
         return response
 

--- a/src/xagent/web/models/auth_database.py
+++ b/src/xagent/web/models/auth_database.py
@@ -1,0 +1,35 @@
+"""Worker-owned synchronous database sessions for authentication."""
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractContextManager, contextmanager
+from typing import TypeVar
+
+from sqlalchemy.orm import Session
+
+from ...core.runtime_performance import run_in_thread_with_telemetry
+from ..services.db_runtime import drain_async_task_cancellation_safe
+from .database import get_db
+
+SyncAuthSessionFactory = Callable[[], AbstractContextManager[Session]]
+_T = TypeVar("_T")
+
+
+async def run_auth_db_worker(operation: str, work: Callable[[], _T]) -> _T:
+    """Drain the owning worker, including Session close, before cancellation.
+
+    A cancelled request may have committed already. Never retry its transaction
+    here, and never close a Session concurrently with its still-running worker.
+    """
+    return await drain_async_task_cancellation_safe(
+        asyncio.create_task(run_in_thread_with_telemetry(operation, work))
+    )
+
+
+async def get_auth_db() -> AsyncIterator[SyncAuthSessionFactory]:
+    """Yield a factory, not a Session: only the worker may enter/use/exit it.
+
+    Tests and hosts replacing auth storage should override this dependency
+    with a lazy context-manager factory. Other routes still use get_db.
+    """
+    yield contextmanager(get_db)

--- a/tests/shared/auth_database.py
+++ b/tests/shared/auth_database.py
@@ -1,0 +1,17 @@
+"""Keep authentication fixture Sessions owned entirely by the auth worker."""
+
+from collections.abc import AsyncIterator, Callable, Generator
+from contextlib import contextmanager
+
+from sqlalchemy.orm import Session
+
+from xagent.web.models.auth_database import SyncAuthSessionFactory
+
+
+def auth_db_override(
+    provider: Callable[[], Generator[Session, None, None]],
+) -> Callable[[], AsyncIterator[SyncAuthSessionFactory]]:
+    async def override() -> AsyncIterator[SyncAuthSessionFactory]:
+        yield contextmanager(provider)
+
+    return override

--- a/tests/web/api/conftest.py
+++ b/tests/web/api/conftest.py
@@ -37,6 +37,7 @@ from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.shared.auth_database import auth_db_override
 from tests.shared.db_teardown import drop_all_tables
 from xagent.web.api.a2a import router as a2a_router
 from xagent.web.api.agent_api_keys import router as agent_api_keys_router
@@ -54,6 +55,7 @@ from xagent.web.api.v1.errors import V1ApiError, v1_api_error_handler
 from xagent.web.api.widget import widget_router
 from xagent.web.api.workforces import router as workforces_router
 from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.database import get_db, get_engine
 from xagent.web.services import task_orchestrator as task_orchestrator_service
 from xagent.web.services.a2a_protocol import (
@@ -171,6 +173,7 @@ async def _v1_validation_error_handler(request: Request, exc: RequestValidationE
 
 
 app_for_tests.dependency_overrides[get_db] = _override_get_db
+app_for_tests.dependency_overrides[get_auth_db] = auth_db_override(_override_get_db)
 client = TestClient(app_for_tests, raise_server_exceptions=False)
 
 

--- a/tests/web/api/test_agents_kb_tool_validation.py
+++ b/tests/web/api/test_agents_kb_tool_validation.py
@@ -9,8 +9,10 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tests.shared.auth_database import auth_db_override
 from xagent.web.api.agents import router as agents_router
 from xagent.web.api.auth import auth_router
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.database import Base, get_db, get_engine
 from xagent.web.services.agent_prompt import enhance_system_prompt_with_kb
 
@@ -29,6 +31,7 @@ app_for_tests = FastAPI()
 app_for_tests.include_router(auth_router)
 app_for_tests.include_router(agents_router)
 app_for_tests.dependency_overrides[get_db] = _override_get_db
+app_for_tests.dependency_overrides[get_auth_db] = auth_db_override(_override_get_db)
 client = TestClient(app_for_tests)
 
 

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 import xagent.web.api.mcp as mcp_api
+from tests.shared.auth_database import auth_db_override
 from xagent.web.api.admin_mcp import (
     PublicMCPAppCreate,
     PublicMCPAppUpdate,
@@ -24,6 +25,7 @@ from xagent.web.api.auth import (
     auth_router,
 )
 from xagent.web.api.mcp import mcp_router
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.database import Base, get_db, get_engine
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.oauth_provider import OAuthProvider
@@ -47,6 +49,7 @@ app_for_tests.include_router(auth_router)
 app_for_tests.include_router(mcp_router)
 app_for_tests.include_router(admin_mcp_router)
 app_for_tests.dependency_overrides[get_db] = override_get_db
+app_for_tests.dependency_overrides[get_auth_db] = auth_db_override(override_get_db)
 client = TestClient(app_for_tests)
 
 

--- a/tests/web/api/test_templates_api.py
+++ b/tests/web/api/test_templates_api.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 
+from tests.shared.auth_database import auth_db_override
 from xagent.web.api.auth import auth_router, hash_password
 from xagent.web.api.templates import (
     get_agent_capability_lists,
@@ -19,6 +20,7 @@ from xagent.web.api.templates import (
 )
 from xagent.web.api.templates import router as templates_router
 from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.database import Base, get_db, get_engine
 from xagent.web.models.template_stats import TemplateStats, UserTemplateRelation
 from xagent.web.models.user import User
@@ -40,6 +42,7 @@ test_app = FastAPI()
 test_app.include_router(auth_router)
 test_app.include_router(templates_router)
 test_app.dependency_overrides[get_db] = override_get_db
+test_app.dependency_overrides[get_auth_db] = auth_db_override(override_get_db)
 
 # Create test client
 client = TestClient(test_app)

--- a/tests/web/api/test_tools_api.py
+++ b/tests/web/api/test_tools_api.py
@@ -14,11 +14,13 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tests.shared.auth_database import auth_db_override
 from xagent.core.tools.adapters.vibe.config import (
     ToolFactoryRuntimeSessionBoundaryError,
 )
 from xagent.web.api.auth import auth_router
 from xagent.web.api.tools import _create_tool_info, tools_router
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TraceEvent
 from xagent.web.models.tool_config import ToolConfig
@@ -40,6 +42,7 @@ test_app = FastAPI()
 test_app.include_router(auth_router)
 test_app.include_router(tools_router)
 test_app.dependency_overrides[get_db] = override_get_db
+test_app.dependency_overrides[get_auth_db] = auth_db_override(override_get_db)
 
 # Create test client
 client = TestClient(test_app)

--- a/tests/web/services/test_read_surface_shape_contract.py
+++ b/tests/web/services/test_read_surface_shape_contract.py
@@ -53,6 +53,7 @@ from sqlalchemy.orm import Session
 
 import xagent.web.api.websocket as websocket_module
 import xagent.web.services.task_interaction_service as interaction_service_module
+from tests.shared.auth_database import auth_db_override
 from tests.web.services.task_interaction_schema_shared import anchor_event_id
 from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from xagent.core.agent.transcript import build_assistant_transcript_content
@@ -60,6 +61,7 @@ from xagent.web.api.agents import router as agents_router
 from xagent.web.api.auth import auth_router
 from xagent.web.api.chat import chat_router
 from xagent.web.api.v1 import v1_router
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.database import (
     Base,
     get_db,
@@ -172,6 +174,7 @@ def _environment(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_Environm
     app.include_router(chat_router)
     app.include_router(v1_router)
     app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_auth_db] = auth_db_override(_override_get_db)
     client = TestClient(app)
 
     status_response = client.get("/api/auth/setup-status")

--- a/tests/web/test_agent_tools_visibility_api.py
+++ b/tests/web/test_agent_tools_visibility_api.py
@@ -4,10 +4,12 @@ import tempfile
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tests.shared.auth_database import auth_db_override
 from xagent.core.tools.adapters.vibe.agent_tool_names import gen_agent_tool_name
 from xagent.web.api.agents import router as agents_router
 from xagent.web.api.auth import auth_router
 from xagent.web.api.tools import tools_router
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.database import Base, get_db, get_engine
 
 
@@ -26,6 +28,7 @@ app_for_tests.include_router(auth_router)
 app_for_tests.include_router(agents_router)
 app_for_tests.include_router(tools_router)
 app_for_tests.dependency_overrides[get_db] = override_get_db
+app_for_tests.dependency_overrides[get_auth_db] = auth_db_override(override_get_db)
 client = TestClient(app_for_tests)
 
 

--- a/tests/web/test_auth_api.py
+++ b/tests/web/test_auth_api.py
@@ -14,9 +14,11 @@ from sqlalchemy import create_engine, event
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import sessionmaker
 
+from tests.shared.auth_database import auth_db_override
 from xagent.web.api import auth as auth_api
 from xagent.web.api.auth import RefreshTokenResponse, auth_router, hash_password
 from xagent.web.models import database as database_module
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.database import Base, configure_db, get_db, get_engine
 from xagent.web.models.user import User
 from xagent.web.services import agent_service_manager as agent_runtime_service
@@ -45,6 +47,7 @@ def override_get_db():
 test_app = FastAPI()
 test_app.include_router(auth_router)
 test_app.dependency_overrides[get_db] = override_get_db
+test_app.dependency_overrides[get_auth_db] = auth_db_override(override_get_db)
 
 # Create test client
 client = TestClient(test_app)

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -10,11 +10,13 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
+from tests.shared.auth_database import auth_db_override
 from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.task_runtime import TaskRuntimeClientError
 from xagent.web.api.auth import auth_router
 from xagent.web.api.chat import chat_router
 from xagent.web.api.model import model_router
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.database import Base, get_db, get_engine
 from xagent.web.schemas.chat import MAX_SEED_INTERACTIONS
 from xagent.web.services.agent_service_manager import (
@@ -39,6 +41,7 @@ test_app.include_router(auth_router)
 test_app.include_router(model_router)
 test_app.include_router(chat_router)
 test_app.dependency_overrides[get_db] = override_get_db
+test_app.dependency_overrides[get_auth_db] = auth_db_override(override_get_db)
 
 client = TestClient(test_app)
 

--- a/tests/web/test_connector_runtime_entrypoints_e2e.py
+++ b/tests/web/test_connector_runtime_entrypoints_e2e.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import event
 from sqlalchemy.orm import Session
 
+from tests.shared.auth_database import auth_db_override
 from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
 from xagent.web.api.auth import auth_router, create_access_token
 from xagent.web.api.chat import chat_router
@@ -26,6 +27,7 @@ from xagent.web.channels.feishu.bot import FeishuBotInstance
 from xagent.web.channels.telegram import bot as telegram_bot_module
 from xagent.web.channels.telegram.bot import TelegramBotInstance
 from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.custom_api import CustomApi, UserCustomApi
 from xagent.web.models.database import (
@@ -65,6 +67,7 @@ app.include_router(chat_router)
 app.include_router(widget_router)
 app.include_router(share_router)
 app.dependency_overrides[get_db] = _override_get_db
+app.dependency_overrides[get_auth_db] = auth_db_override(_override_get_db)
 client = TestClient(app, raise_server_exceptions=False)
 
 

--- a/tests/web/test_dynamic_model_sharing.py
+++ b/tests/web/test_dynamic_model_sharing.py
@@ -17,8 +17,10 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tests.shared.auth_database import auth_db_override
 from xagent.web.api.auth import auth_router
 from xagent.web.api.model import _can_user_share, model_router, set_can_share_hook
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.database import Base, get_db, get_engine
 from xagent.web.services.hot_path_cache import (
     InMemoryTTLCache,
@@ -48,6 +50,7 @@ test_app = FastAPI()
 test_app.include_router(auth_router)
 test_app.include_router(model_router)
 test_app.dependency_overrides[get_db] = override_get_db
+test_app.dependency_overrides[get_auth_db] = auth_db_override(override_get_db)
 
 client = TestClient(test_app)
 

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -11,10 +11,12 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tests.shared.auth_database import auth_db_override
 from xagent.core.model.model import ChatModelConfig, EmbeddingModelConfig
 from xagent.web.api import model as model_module
 from xagent.web.api.auth import auth_router
 from xagent.web.api.model import model_router
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.auto_model import AutoModelCandidate, AutoModelConfig
 from xagent.web.models.database import Base, get_db, get_engine
 from xagent.web.models.model import Model as DBModel
@@ -45,6 +47,7 @@ test_app = FastAPI()
 test_app.include_router(auth_router)
 test_app.include_router(model_router)
 test_app.dependency_overrides[get_db] = override_get_db
+test_app.dependency_overrides[get_auth_db] = auth_db_override(override_get_db)
 
 # Create test client
 client = TestClient(test_app)

--- a/tests/web/test_runtime_performance_telemetry.py
+++ b/tests/web/test_runtime_performance_telemetry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
+
 import pytest
 from fastapi import FastAPI
 
@@ -44,7 +46,7 @@ async def test_login_rejection_emits_metrics(monkeypatch, metric_reader):
     monkeypatch.setattr(auth, "get_user_by_login_identifier", lambda *_: None)
     with pytest.raises(HTTPException) as error:
         await auth.login(
-            auth.LoginRequest(username="unknown", password="test"), db=None
+            auth.LoginRequest(username="unknown", password="test"), db=nullcontext
         )
     assert error.value.status_code == 401
     metrics = collected_metrics(metric_reader)

--- a/tests/web/test_sync_auth_worker.py
+++ b/tests/web/test_sync_auth_worker.py
@@ -1,0 +1,224 @@
+"""Authentication must never return a live synchronous ORM object to the loop."""
+
+import asyncio
+import os
+import threading
+import uuid
+from contextlib import contextmanager
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, event, select, text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, sessionmaker
+
+from xagent.web.api import auth
+from xagent.web.models import auth_database
+from xagent.web.models.user import User
+
+
+@pytest.fixture(params=["sqlite", "postgresql"])
+def worker_db(tmp_path, request):
+    schema = None
+    if request.param == "postgresql":
+        url = os.getenv("XAGENT_TEST_AUTH_DATABASE_URL")
+        if not url:
+            pytest.skip("Set XAGENT_TEST_AUTH_DATABASE_URL for PostgreSQL")
+        schema = "sync_auth_test_" + uuid.uuid4().hex
+        engine = create_engine(
+            url, execution_options={"schema_translate_map": {None: schema}}
+        )
+        with engine.begin() as connection:
+            connection.execute(text(f'CREATE SCHEMA "{schema}"'))
+    else:
+        engine = create_engine(f"sqlite:///{tmp_path / 'auth.db'}")
+    User.__table__.create(engine)
+    with Session(engine) as session:
+        session.add(
+            User(username="worker", password_hash=auth.hash_password("password123"))
+        )
+        session.commit()
+    events = []
+
+    class OwnedSession(Session):
+        def __init__(self, *args, **kwargs):
+            events.append(("create", threading.get_ident()))
+            super().__init__(*args, **kwargs)
+
+        def commit(self):
+            events.append(("commit", threading.get_ident()))
+            super().commit()
+
+        def close(self):
+            events.append(("close", threading.get_ident()))
+            super().close()
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def statement(conn, cursor, sql, params, context, executemany):
+        events.append((sql.split()[0], threading.get_ident()))
+
+    factory = sessionmaker(bind=engine, class_=OwnedSession)
+    try:
+        yield factory, events, engine
+    finally:
+        if schema:
+            with engine.begin() as connection:
+                connection.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dependency_is_lazy_and_worker_owned(worker_db, monkeypatch):
+    factory, events, _ = worker_db
+
+    def provider():
+        with factory() as session:
+            yield session
+
+    monkeypatch.setattr(auth_database, "get_db", provider)
+    dependency = auth_database.get_auth_db()
+    lazy_factory = await anext(dependency)
+    assert events == []
+    response = await auth.login(
+        auth.LoginRequest(username="worker", password="password123"), lazy_factory
+    )
+    assert response["success"]
+    await dependency.aclose()
+    assert len({owner for _, owner in events}) == 1
+    assert events[0][1] != threading.get_ident()
+    assert events[-1][0] == "close"
+
+
+@pytest.mark.asyncio
+async def test_login_and_refresh_have_single_thread_owners(worker_db):
+    factory, events, _ = worker_db
+    response = await auth.login(
+        auth.LoginRequest(username="worker", password="password123"), factory
+    )
+    assert response["user"]["username"] == "worker"
+    assert [name for name, _ in events] == [
+        "create",
+        "SELECT",
+        "commit",
+        "UPDATE",
+        "close",
+    ]
+    assert len({owner for _, owner in events}) == 1
+    assert events[0][1] != threading.get_ident()
+    events.clear()
+    # Force a different token so UPDATE is observable even within one JWT second.
+    from unittest.mock import patch
+
+    with patch.object(auth, "create_refresh_token", return_value="rotated-token"):
+        renewed = await auth.refresh_token(
+            auth.RefreshTokenRequest(refresh_token=response["refresh_token"]), factory
+        )
+    assert renewed.refresh_token == "rotated-token"
+    assert [name for name, _ in events] == [
+        "create",
+        "SELECT",
+        "commit",
+        "UPDATE",
+        "close",
+    ]
+    assert len({owner for _, owner in events}) == 1
+    assert events[0][1] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_commit_failure_rolls_back_and_closes(worker_db, monkeypatch):
+    factory, events, engine = worker_db
+
+    def fail(session):
+        session.flush()
+        raise SQLAlchemyError("private-db-detail")
+
+    monkeypatch.setattr(factory.class_, "commit", fail)
+    with pytest.raises(HTTPException) as caught:
+        await auth.login(
+            auth.LoginRequest(username="worker", password="password123"), factory
+        )
+    assert caught.value.status_code == 500
+    assert "private-db-detail" not in caught.value.detail
+    assert events[-1][0] == "close"
+    with Session(engine) as session:
+        assert session.scalar(select(User.refresh_token)) is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_login_drains_commit_and_close(worker_db, monkeypatch):
+    factory, events, engine = worker_db
+    entered = threading.Event()
+    release = threading.Event()
+    original = factory.class_.commit
+
+    def blocked_commit(session):
+        entered.set()
+        assert release.wait(5)
+        original(session)
+
+    monkeypatch.setattr(factory.class_, "commit", blocked_commit)
+    task = asyncio.create_task(
+        auth.login(
+            auth.LoginRequest(username="worker", password="password123"), factory
+        )
+    )
+    try:
+        assert await asyncio.to_thread(entered.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        assert not any(name == "close" for name, _ in events)
+    finally:
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert events[-1][0] == "close"
+    assert len({owner for _, owner in events}) == 1
+    # Cancellation cannot promise rollback if commit has already begun.
+    with Session(engine) as session:
+        assert session.scalar(select(User.refresh_token)) is not None
+
+
+@pytest.mark.asyncio
+async def test_bad_password_closes_without_commit(worker_db):
+    factory, events, _ = worker_db
+    with pytest.raises(HTTPException) as caught:
+        await auth.login(
+            auth.LoginRequest(username="worker", password="wrong"), factory
+        )
+    assert caught.value.status_code == 401
+    assert [name for name, _ in events] == ["create", "SELECT", "close"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_worker_before_session_entry_still_closes(worker_db):
+    factory, events, _ = worker_db
+    entered = threading.Event()
+    release = threading.Event()
+
+    @contextmanager
+    def delayed_factory():
+        entered.set()
+        assert release.wait(5)
+        with factory() as session:
+            yield session
+
+    task = asyncio.create_task(
+        auth.login(
+            auth.LoginRequest(username="worker", password="password123"),
+            delayed_factory,
+        )
+    )
+    try:
+        assert await asyncio.to_thread(entered.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+    finally:
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert events[-1][0] == "close"

--- a/tests/web/test_sync_auth_worker.py
+++ b/tests/web/test_sync_auth_worker.py
@@ -117,8 +117,8 @@ async def test_login_and_refresh_have_single_thread_owners(worker_db):
     assert [name for name, _ in events] == [
         "create",
         "SELECT",
-        "commit",
         "UPDATE",
+        "commit",
         "close",
     ]
     assert len({owner for _, owner in events}) == 1
@@ -146,8 +146,127 @@ async def test_commit_failure_rolls_back_and_closes(worker_db, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_cancelled_login_drains_commit_and_close(worker_db, monkeypatch):
+async def test_concurrent_refresh_consumes_token_once(worker_db, monkeypatch):
+    factory, _, engine = worker_db
+    logged_in = await auth.login(
+        auth.LoginRequest(username="worker", password="password123"), factory
+    )
+    token = logged_in["refresh_token"]
+    barrier = threading.Barrier(2)
+    prepare = auth._prepare_refresh_response
+
+    def overlapping_prepare(user, request):
+        response = prepare(user, request)
+        # Both independent sessions have validated the same old token before
+        # either is allowed to attempt its conditional write.
+        barrier.wait(timeout=10)
+        return response
+
+    monkeypatch.setattr(auth, "_prepare_refresh_response", overlapping_prepare)
+    results = await asyncio.gather(
+        *(
+            auth.refresh_token(auth.RefreshTokenRequest(refresh_token=token), factory)
+            for _ in range(2)
+        ),
+        return_exceptions=True,
+    )
+    winners = [r for r in results if isinstance(r, auth.RefreshTokenResponse)]
+    losers = [r for r in results if isinstance(r, HTTPException)]
+    assert len(winners) == len(losers) == 1, results
+    assert losers[0].status_code == 401
+    assert winners[0].refresh_token != token
+    with Session(engine) as session:
+        assert session.scalar(select(User.refresh_token)) == winners[0].refresh_token
+    monkeypatch.setattr(auth, "_prepare_refresh_response", prepare)
+    with pytest.raises(HTTPException) as caught:
+        await auth.refresh_token(auth.RefreshTokenRequest(refresh_token=token), factory)
+    assert caught.value.status_code == 401
+
+
+def test_refresh_tokens_are_unique_at_identical_time(monkeypatch):
+    from unittest.mock import Mock
+
+    fixed = auth.datetime.now(auth.timezone.utc)
+    monkeypatch.setattr(auth, "datetime", Mock(now=Mock(return_value=fixed)))
+    first = auth.create_refresh_token({"sub": "worker", "user_id": 1})
+    second = auth.create_refresh_token({"sub": "worker", "user_id": 1})
+    assert first != second
+    assert (
+        auth.verify_refresh_token(first)["jti"]
+        != auth.verify_refresh_token(second)["jti"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_commit_failure_preserves_old_token(worker_db, monkeypatch):
     factory, events, engine = worker_db
+    logged_in = await auth.login(
+        auth.LoginRequest(username="worker", password="password123"), factory
+    )
+    token = logged_in["refresh_token"]
+
+    def fail(session):
+        raise SQLAlchemyError("private-db-detail")
+
+    monkeypatch.setattr(factory.class_, "commit", fail)
+    with pytest.raises(HTTPException) as caught:
+        await auth.refresh_token(auth.RefreshTokenRequest(refresh_token=token), factory)
+    assert caught.value.status_code == 503
+    assert "private-db-detail" not in caught.value.detail
+    assert events[-1][0] == "close"
+    with Session(engine) as session:
+        assert session.scalar(select(User.refresh_token)) == token
+
+
+@pytest.mark.asyncio
+async def test_login_phase_histograms_use_configured_buckets(worker_db, monkeypatch):
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+    from xagent.core import runtime_performance as metrics
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(
+        metric_readers=[reader],
+        views=metrics._histogram_views(),
+        shutdown_on_exit=False,
+    )
+    monkeypatch.setattr(
+        metrics,
+        "runtime_performance",
+        metrics.RuntimePerformanceTelemetry(provider.get_meter("test")),
+    )
+    try:
+        await auth.login(
+            auth.LoginRequest(username="worker", password="password123"), worker_db[0]
+        )
+        recorded = {
+            metric.name: metric
+            for resource in reader.get_metrics_data().resource_metrics
+            for scope in resource.scope_metrics
+            for metric in scope.metrics
+        }
+        for phase in ("sync_lookup", "sync_commit"):
+            point = recorded[f"xagent.auth.login.{phase}.duration"].data.data_points[0]
+            assert point.count == 1
+            assert tuple(point.explicit_bounds) == tuple(metrics._DURATION_BUCKETS_MS)
+    finally:
+        provider.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["login", "refresh"])
+async def test_cancelled_auth_drains_commit_and_close(
+    worker_db, monkeypatch, operation
+):
+    factory, events, engine = worker_db
+    token = None
+    if operation == "refresh":
+        logged_in = await auth.login(
+            auth.LoginRequest(username="worker", password="password123"), factory
+        )
+        token = logged_in["refresh_token"]
+        events.clear()
     entered = threading.Event()
     release = threading.Event()
     original = factory.class_.commit
@@ -158,11 +277,14 @@ async def test_cancelled_login_drains_commit_and_close(worker_db, monkeypatch):
         original(session)
 
     monkeypatch.setattr(factory.class_, "commit", blocked_commit)
-    task = asyncio.create_task(
-        auth.login(
+    request = (
+        auth.refresh_token(auth.RefreshTokenRequest(refresh_token=token), factory)
+        if operation == "refresh"
+        else auth.login(
             auth.LoginRequest(username="worker", password="password123"), factory
         )
     )
+    task = asyncio.create_task(request)
     try:
         assert await asyncio.to_thread(entered.wait, 5)
         task.cancel()
@@ -179,7 +301,10 @@ async def test_cancelled_login_drains_commit_and_close(worker_db, monkeypatch):
     assert len({owner for _, owner in events}) == 1
     # Cancellation cannot promise rollback if commit has already begun.
     with Session(engine) as session:
-        assert session.scalar(select(User.refresh_token)) is not None
+        persisted = session.scalar(select(User.refresh_token))
+        assert persisted is not None
+        if operation == "refresh":
+            assert persisted != token
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_sync_auth_worker.py
+++ b/tests/web/test_sync_auth_worker.py
@@ -197,6 +197,55 @@ def test_refresh_tokens_are_unique_at_identical_time(monkeypatch):
     )
 
 
+@pytest.mark.parametrize("algorithm", ["HS256", "HS384", "HS512"])
+def test_refresh_token_size_is_independent_of_username(monkeypatch, algorithm):
+    monkeypatch.setattr(auth, "JWT_ALGORITHM", algorithm)
+    token = auth.create_refresh_token({"sub": "用" * 50, "user_id": 2**63 - 1})
+    assert len(token) <= User.__table__.c.refresh_token.type.length
+    payload = auth.verify_refresh_token(token)
+    assert payload["user_id"] == 2**63 - 1
+    assert "sub" not in payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("username", ["a" * 50, "用" * 50])
+async def test_long_username_login_and_legacy_refresh(worker_db, username):
+    factory, _, engine = worker_db
+    with Session(engine) as session:
+        user = session.scalar(select(User))
+        user.username = username
+        session.commit()
+    result = await auth.login(
+        auth.LoginRequest(username=username, password="password123"), factory
+    )
+    assert len(result["refresh_token"]) <= 255
+    refreshed = await auth.refresh_token(
+        auth.RefreshTokenRequest(refresh_token=result["refresh_token"]), factory
+    )
+    assert len(refreshed.refresh_token) <= 255
+    assert auth.verify_token(refreshed.access_token)["sub"] == username
+    # Previously issued refresh JWTs with sub and no jti remain valid.
+    with Session(engine) as session:
+        user = session.scalar(select(User))
+        legacy = auth.jwt.encode(
+            {
+                "sub": "worker",
+                "user_id": user.id,
+                "type": "refresh",
+                "exp": auth.datetime.now(auth.timezone.utc) + auth.timedelta(days=1),
+            },
+            auth.JWT_SECRET_KEY,
+            algorithm=auth.JWT_ALGORITHM,
+        )
+        user.refresh_token = legacy
+        session.commit()
+    renewed = await auth.refresh_token(
+        auth.RefreshTokenRequest(refresh_token=legacy), factory
+    )
+    with Session(engine) as session:
+        assert session.scalar(select(User.refresh_token)) == renewed.refresh_token
+
+
 @pytest.mark.asyncio
 async def test_refresh_commit_failure_preserves_old_token(worker_db, monkeypatch):
     factory, events, engine = worker_db

--- a/tests/web_integration/conftest.py
+++ b/tests/web_integration/conftest.py
@@ -15,11 +15,13 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from tests.shared.auth_database import auth_db_override
 from xagent.core.model.embedding.base import BaseEmbedding
 from xagent.core.model.model import EmbeddingModelConfig
 from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
 from xagent.web.api.auth import hash_password
 from xagent.web.api.kb import kb_router
+from xagent.web.models.auth_database import get_auth_db
 from xagent.web.models.database import Base, get_db
 from xagent.web.models.user import User
 
@@ -177,6 +179,7 @@ def test_env(monkeypatch: pytest.MonkeyPatch):
 
     app.include_router(auth_router)
     app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_auth_db] = auth_db_override(override_get_db)
 
     Base.metadata.create_all(bind=test_engine)
 


### PR DESCRIPTION
## Summary

- Keep each synchronous login/refresh database transaction inside one worker: the worker creates, queries, commits, and closes its own Session.
- Build the response from loaded attributes before commit expires ORM state, avoiding an implicit post-commit SELECT on the event loop.
- Drain the owning worker on request cancellation, including Session cleanup, without concurrently closing or retrying its transaction. Cancellation does not imply that an already-started commit was rolled back.
- Keep transaction-wide worker telemetry and lookup/commit timings.

## Scope and compatibility

This is a synchronous authentication fix, not the experimental async database migration. No new driver, database migration, configuration flag, DeepSeek adapter change, or documentation file is included.

Authentication storage overrides now use `get_auth_db` and yield a lazy context-manager factory; existing overrides that supply a Session through `get_db` must be adapted for login/refresh. Other routes continue using `get_db`. Shared test fixtures are updated accordingly.

## Validation

- Authentication/model suite: 205 passed.
- Final authentication, worker ownership, and affected API fixture suite: 197 passed (overlaps with the preceding suite; not 402 unique tests).
- Worker tests exercise both SQLite and PostgreSQL, using isolated PostgreSQL test schemas. Coverage includes lazy creation, same-thread creation/query/commit/close, no post-commit read, rollback on commit failure, bad credentials, and repeated cancellation cleanup.
- All commit hooks passed, including Ruff, isort, full-package mypy, whitespace and spelling checks.

## Performance context

An earlier single 50-concurrent-task comparison on base `fd5933708` measured login p95 at 165.7 ms before and 115.4 ms with worker ownership. Login p99 did not improve (428.4 ms to 449.1 ms). This is directional local evidence, not a repeatability or production tail-latency claim.

The final PR is based on newer main `fc494f6b1`; its final-head load-test result is recorded below separately, not treated as a same-base A/B comparison. The local text-only DeepSeek workload uses an external runtime allowlist shim for the existing `deepseek-flash` model name; no provider source changes or credentials are included in this PR.

Final head `0df754134`, local PostgreSQL with real model/tool execution, concurrency cap 50:

- 50 admitted tasks completed; 50 additional scheduled arrivals were intentionally shed at the cap.
- All 50 final answers matched `BENCHMARK_DONE 2047`; exactly 10 tool completions per task (500 total), with no recorded tool failures.
- All 84 login probes and 84 health probes succeeded.
- Login p50/p95/p99: 39.7 / 124.3 / 393.2 ms.
- Health p95: 92.2 ms; task p95: 32.13 s.
- This is one local final-head validation run, not a statistical throughput or tail-latency guarantee.
