### PR TITLE
ref: move reply recovery into runner services

### DIFF
--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -5,22 +5,22 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from time import monotonic
-from typing import Any, Mapping, assert_never
+from typing import Any, Mapping
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import String, and_, cast, func, or_
+from sqlalchemy import String, and_, cast, or_
 
 from ...core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
     CheckpointReadError,
 )
-from ...core.agent.runner import UserMessageInjectionOutcome
 from ..models.agent import Agent
 from ..models.database import get_session_local
 from ..models.task import Task, TaskStatus
+from ..services import task_resume as task_resume_service
 from ..services.a2a_protocol import (
     A2A_VERSION,
     ALL_TASK_STATES,
@@ -45,7 +45,6 @@ from ..services.a2a_protocol import (
 )
 from ..services.client_error_messages import CLIENT_SAFE_AUTO_MODEL_UNAVAILABLE
 from ..services.db_runtime import (
-    cancel_and_drain_async_task,
     drain_async_task_cancellation_safe,
     run_db_io_cancellation_safe,
 )
@@ -60,30 +59,7 @@ from ..services.task_command_transport import (
     retry_failed_task_command,
 )
 from ..services.task_execution_controller import (
-    TaskControlState,
     task_execution_controller,
-)
-from ..services.task_interaction_close import (
-    ActiveInteractionAbsent,
-    ActiveInteractionFound,
-    ActiveInteractionUnavailable,
-    active_interaction_id_sync,
-    clear_interaction_marker_if_unpaired,
-    close_legacy_resume_interaction,
-)
-from ..services.task_interaction_schema import interaction_requests_table_exists
-from ..services.task_lease_service import (
-    TaskLease,
-    TaskLeaseHeartbeatOutcome,
-    TaskLeaseLostError,
-    acquire_task_lease_cancellation_safe,
-    acquire_task_lease_no_commit,
-    bind_task_lease_context,
-    release_task_lease_no_commit,
-    run_task_lease_heartbeat,
-    run_while_task_lease_owned,
-    stop_task_lease_heartbeat,
-    task_lease_attempt_predicate,
 )
 from ..services.task_orchestrator import (
     TaskTurnError,
@@ -161,263 +137,6 @@ def _require_bound_agent(path_agent_id: int, agent: AgentPrincipalSnapshot) -> N
         raise a2a_error("agent_not_found", "Agent not found.", status_code=404)
 
 
-async def _schedule_waiting_a2a_resume(
-    *,
-    task_id: int,
-    agent_service: Any,
-    task_owner_user_id: int,
-    task_lease: TaskLease,
-    heartbeat_stop: asyncio.Event,
-    heartbeat_task: asyncio.Task[TaskLeaseHeartbeatOutcome],
-    resumable_status: TaskStatus,
-) -> None:
-    from ..services.task_execution import (
-        background_task_manager,
-        execute_resume_background,
-    )
-
-    if task_lease.task_id != task_id or task_lease.run_id is None:
-        raise ValueError("A2A resume scheduling requires an exact task lease")
-    if not background_task_manager.reserve_resume(task_id):
-        raise RuntimeError(f"Task {task_id} already has a resume in progress")
-    previous_task = background_task_manager.running_tasks.get(task_id)
-    bg_task: asyncio.Task[None] | None = None
-    try:
-        bg_task = asyncio.create_task(
-            execute_resume_background(
-                task_id=task_id,
-                agent_service=agent_service,
-                task_owner_user_id=task_owner_user_id,
-                expected_run_id=task_lease.run_id,
-                previous_task=previous_task,
-                preacquired_lease=task_lease,
-                preacquired_heartbeat_stop=heartbeat_stop,
-                preacquired_heartbeat_task=heartbeat_task,
-                # The prelease claimed this task out of an input-required
-                # status; hand that over so a checkpoint the resume cannot
-                # read restores it instead of failing it terminally.
-                preacquired_prior_status=resumable_status,
-            )
-        )
-        background_task_manager.register_reserved_resume(
-            task_id,
-            bg_task,
-            run_id=task_lease.run_id,
-        )
-    except BaseException:
-        if bg_task is not None:
-            await cancel_and_drain_async_task(bg_task)
-        background_task_manager.release_resume_reservation(task_id)
-        raise
-
-
-def _acquire_a2a_resume_prelease_sync(
-    *,
-    task_id: int,
-    agent_id: int,
-    resumable_status: TaskStatus,
-    previous_run_id: str | None,
-) -> TaskLease | None:
-    """Claim and commit one exact A2A resume lease in a worker transaction."""
-
-    resumable_control_states = {
-        TaskControlState.IDLE.value,
-        (
-            TaskControlState.PAUSED.value
-            if resumable_status == TaskStatus.PAUSED
-            else TaskControlState.WAITING_FOR_USER.value
-        ),
-    }
-    SessionLocal = get_session_local()
-    with SessionLocal() as db:
-        claimed = (
-            db.query(Task)
-            .filter(
-                Task.id == task_id,
-                Task.agent_id == agent_id,
-                Task.source == "a2a",
-                Task.status == resumable_status,
-                Task.control_state.in_(resumable_control_states),
-            )
-            .update(
-                {
-                    Task.control_state: TaskControlState.RESUME_REQUESTED.value,
-                    Task.state_version: func.coalesce(Task.state_version, 0) + 1,
-                },
-                synchronize_session=False,
-            )
-        )
-        if claimed != 1:
-            db.rollback()
-            return None
-        task_lease = acquire_task_lease_no_commit(
-            db,
-            task_id,
-            expected_run_id=previous_run_id,
-        )
-        if task_lease is None or task_lease.run_id is None:
-            db.rollback()
-            return None
-        db.commit()
-        return task_lease
-
-
-def _restore_a2a_resume_prelease_sync(
-    task_lease: TaskLease,
-    *,
-    status: TaskStatus = TaskStatus.WAITING_FOR_USER,
-) -> bool:
-    """Release one exact A2A prelease in a worker-owned short Session.
-
-    A successful restore retains the run id and its tagged checkpoint, so a
-    retry with the same A2A message id is idempotent at the runner boundary.
-    If ownership changed, no row is mutated and the current owner remains the
-    sole lifecycle authority.
-
-    Two callers reach this today: the isolated wrapper right below, used by
-    the no-checkpoint and checkpoint-read-error fallbacks; and the cancel
-    settlement callback ``acquire_task_lease_cancellation_safe`` passes to
-    ``_resume_input_required_a2a_task``'s lease acquisition, which fires on
-    a cancellation with no ``posted`` outcome to consult at all -- the
-    marker clear below has to hold on that path too, not only on the two
-    ``posted``-gated fallbacks.
-    """
-
-    SessionLocal = get_session_local()
-    with SessionLocal() as db:
-        restored = release_task_lease_no_commit(
-            db,
-            task_lease,
-            status=status,
-        )
-        if restored:
-            # Mirror of the WebSocket lease restore: this is an abandoned
-            # resume, not a completed one, so only the marker may need
-            # reconciling -- see clear_interaction_marker_if_unpaired's
-            # docstring for the NOT EXISTS semantics. No lock read precedes
-            # this statement; release_task_lease_no_commit's own tasks
-            # UPDATE writes only non-key columns and is already the first
-            # statement this transaction directs at tasks or
-            # task_interaction_requests.
-            assert task_lease.run_id is not None
-            clear_interaction_marker_if_unpaired(
-                db, task_id=task_lease.task_id, run_id=task_lease.run_id
-            )
-            db.commit()
-        else:
-            db.rollback()
-        return restored
-
-
-async def _restore_a2a_resume_prelease_isolated(
-    task_lease: TaskLease,
-    *,
-    status: TaskStatus,
-) -> bool:
-    return await run_db_io_cancellation_safe(
-        lambda: _restore_a2a_resume_prelease_sync(
-            task_lease,
-            status=status,
-        )
-    )
-
-
-# The exact non-key column set the resume-input fence UPDATE below writes.
-# Shared with test_interaction_close_lock_ordering.py's static guard, which
-# asserts the UPDATE's values keys equal this set exactly: the fence's
-# no-lock-read argument (see the inline comment inside
-# _update_a2a_resume_input_sync) depends on every one of these columns being
-# a non-key column, so a future change widening the UPDATE's values must
-# widen this constant too, deliberately, not just add a key to a dict
-# literal the guard never looks at again.
-RESUME_INPUT_FENCE_UPDATE_COLUMNS = frozenset({"input", "output", "error_message"})
-
-
-def _update_a2a_resume_input_sync(
-    task_lease: TaskLease,
-    text: str,
-    interaction_id: int | None,
-    injection_outcome: UserMessageInjectionOutcome,
-) -> bool:
-    """Persist A2A input only while the exact prelease remains current.
-
-    ``interaction_id`` is the active interaction row the caller observed
-    before injecting the message, passed in rather than read here: this
-    function's session does not open until after the injection has already
-    committed. See ``task_interaction_close``'s module docstring for why
-    the read has to precede the injection.
-
-    ``injection_outcome`` is the caller's own ``post_user_message`` report,
-    not re-derived here: a replayed turn id must not retire the close, and
-    only the call that produced the short circuit can say whether this was
-    one.
-    """
-
-    SessionLocal = get_session_local()
-    with SessionLocal() as db:
-        updated = (
-            db.query(Task)
-            .filter(
-                Task.id == task_lease.task_id,
-                Task.status == TaskStatus.RUNNING,
-                Task.runner_id == task_lease.runner_id,
-                task_lease_attempt_predicate(task_lease),
-                Task.run_id == task_lease.run_id,
-            )
-            .update(
-                {
-                    Task.input: text,
-                    Task.output: None,
-                    Task.error_message: None,
-                },
-                synchronize_session=False,
-            )
-        )
-        if updated != 1:
-            db.rollback()
-            return False
-        # This update() call is the fence above, not a new transaction: a
-        # rollback here would undo it together with the input write, which
-        # is the point -- ownership and the interaction close are one
-        # atomic fact. No run_db_io_cancellation_safe wrap: the caller
-        # already wraps this whole function in one. No lock read either --
-        # the fence UPDATE above writes only non-key columns (input,
-        # output, error_message) and is already the first statement this
-        # transaction directs at tasks or task_interaction_requests, so it
-        # satisfies the same ordering and strength obligation a dedicated
-        # lock read would. If a future change adds a key column (or any
-        # column covered by a unique index) to that UPDATE's values, this
-        # judgment call must be redone -- the lock strength that UPDATE
-        # takes would change.
-        #
-        # The table-presence gate sits here, immediately before the close
-        # call and after the fence UPDATE, not at the top of the function:
-        # the gate only inspects the catalog and takes no row lock, so it
-        # does not count as preceding the fence UPDATE in the sense the
-        # ordering obligation above means.
-        assert task_lease.run_id is not None
-        if interaction_requests_table_exists(db):
-            # A retried A2A message replays this site's deterministic turn
-            # id (f"a2a:{task_id}:{message_id}"), and inject_user_message
-            # short-circuits a repeated turn id without persisting
-            # anything. interaction_id above was read fresh by this
-            # attempt, so on such a replay it names whatever the resumed
-            # agent has staged since rather than the question this call
-            # answered, and closing on it would retire a live question.
-            # See task_interaction_close's module docstring for the rule,
-            # the other sites, and why the v1 reply resume-input path
-            # needs no guard at all.
-            if injection_outcome is UserMessageInjectionOutcome.POSTED_FRESH:
-                close_legacy_resume_interaction(
-                    db,
-                    task_id=task_lease.task_id,
-                    run_id=task_lease.run_id,
-                    interaction_id=interaction_id,
-                )
-        db.commit()
-        return True
-
-
 async def _resume_input_required_a2a_task(
     *,
     agent_id: int,
@@ -427,192 +146,31 @@ async def _resume_input_required_a2a_task(
     message_id: str,
 ) -> bool:
     task_id = int(task.id)
-    resumable_status = task.status
-    if resumable_status not in {
-        TaskStatus.PAUSED,
-        TaskStatus.WAITING_FOR_USER,
-    }:
-        return False
-    task_lease = await acquire_task_lease_cancellation_safe(
-        lambda: _acquire_a2a_resume_prelease_sync(
-            task_id=task_id,
+    try:
+        return await task_resume_service.resume_a2a_task(
             agent_id=agent_id,
-            resumable_status=resumable_status,
+            task_owner_user_id=task_owner_user_id,
+            task_id=task_id,
             previous_run_id=task.run_id,
-        ),
-        lambda acquired: _restore_a2a_resume_prelease_sync(
-            acquired,
-            status=resumable_status,
-        ),
-    )
-    if task_lease is None or task_lease.run_id is None:
+            resumable_status=task.status,
+            text=text,
+            message_id=message_id,
+        )
+    except task_resume_service.TaskResumeBusyError as exc:
         raise a2a_error(
             "unsupported_operation",
             "Task is currently running and cannot accept a new message.",
             status_code=400,
             details={"taskId": task_id},
-        )
-
-    heartbeat_stop = asyncio.Event()
-    heartbeat_task = asyncio.create_task(
-        run_task_lease_heartbeat(task_lease, heartbeat_stop)
-    )
-    ownership_transferred = False
-    prelease_cleanup_done = False
-
-    async def stop_and_restore_prelease() -> bool:
-        nonlocal prelease_cleanup_done
-        if prelease_cleanup_done:
-            return False
-        prelease_cleanup_done = True
-        try:
-            outcome = await stop_task_lease_heartbeat(
-                heartbeat_task,
-                heartbeat_stop,
-            )
-        except BaseException:
-            logger.error(
-                "A2A prelease heartbeat failed before task %s could be restored; "
-                "retaining run %s for TTL recovery",
-                task_id,
-                task_lease.run_id,
-                exc_info=True,
-            )
-            return False
-        if outcome.requires_ttl_recovery:
-            logger.error(
-                "A2A prelease for task %s became unhealthy; retaining run %s "
-                "for TTL recovery (lost=%s, pool_timeout=%s)",
-                task_id,
-                task_lease.run_id,
-                outcome.lease_lost,
-                outcome.pool_timeout is not None,
-            )
-            return False
-        return await _restore_a2a_resume_prelease_isolated(
-            task_lease,
-            status=resumable_status,
-        )
-
-    try:
-        # Read before the injection below, not inside
-        # _update_a2a_resume_input_sync, whose session opens only afterwards.
-        # See task_interaction_close's module docstring for why.
-        #
-        # This site's turn id is deterministic (f"a2a:{task_id}:{message_id}"
-        # below), so a retried A2A message replays the same turn.
-        # AgentRunner.inject_user_message reports that replay explicitly
-        # (see UserMessageInjectionOutcome) instead of folding it into the
-        # same truthy value a fresh write produces, and
-        # _update_a2a_resume_input_sync reads that report to decide whether
-        # to skip its close call -- see the guard inside that function for
-        # why a replay must skip it.
-        active_interaction_read = await run_db_io_cancellation_safe(
-            lambda: active_interaction_id_sync(task_id)
-        )
-        # Translate the three-state read into the `int | None` this site's
-        # close call takes. Absent and Unavailable both become `None` here
-        # -- but that is not folding Unavailable into Absent, it is this
-        # call's own contract: `None` means "bind the close to no primary
-        # key", so it matches zero rows and retires no question either
-        # way, which is the safe outcome for a read that could not be
-        # made, not a claim that nothing was ever active. What then
-        # happens to the task's marker differs between the two, and this
-        # value is not what decides it -- the clear beside the close runs
-        # its own check (see active_interaction_id_sync's docstring).
-        # Written as three branches, not
-        # `interaction_id if isinstance(..., ActiveInteractionFound) else
-        # None`, so a reader (and mypy) sees Unavailable handled on its own
-        # line rather than merged into Absent's.
-        if isinstance(active_interaction_read, ActiveInteractionFound):
-            active_interaction_id = active_interaction_read.interaction_id
-        elif isinstance(active_interaction_read, ActiveInteractionAbsent):
-            active_interaction_id = None
-        elif isinstance(active_interaction_read, ActiveInteractionUnavailable):
-            active_interaction_id = None
-            logger.info(
-                "active interaction read unavailable (reason=%s) for "
-                "task_id=%s; the legacy resume close will match no row",
-                active_interaction_read.reason,
-                task_id,
-            )
-        else:
-            assert_never(active_interaction_read)
-
-        async def inject_user_message() -> tuple[Any, UserMessageInjectionOutcome]:
-            from ..services.agent_service_manager import get_agent_manager
-
-            agent_service = await get_agent_manager().get_agent_for_task(
-                task_id,
-                None,
-                task_owner_user_id=task_owner_user_id,
-            )
-            posted = await agent_service.post_user_message(
-                str(task_id),
-                execution_message=text,
-                display_message=text,
-                turn_id=f"a2a:{task_id}:{message_id}",
-                request_interrupt=False,
-                reason="A2A input-required response",
-            )
-            return agent_service, posted
-
-        with bind_task_lease_context(task_lease):
-            agent_service, posted = await run_while_task_lease_owned(
-                inject_user_message(),
-                heartbeat_task,
-            )
-
-        if not posted:
-            # Untagged or otherwise unreadable legacy checkpoints are never
-            # resumed under a fabricated run or transcript fallback. Release
-            # the exact prelease back to the prior input-required state and
-            # fail closed so a caller must start a new task explicitly.
-            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
-            if not await drain_async_task_cancellation_safe(cleanup_task):
-                raise TaskLeaseLostError(
-                    f"Task {task_id} lease changed before A2A fallback"
-                )
-            raise a2a_error(
-                "unsupported_operation",
-                "No run-fenced checkpoint is available for this task.",
-                status_code=400,
-                details={"taskId": task_id},
-            )
-
-        updated = await run_db_io_cancellation_safe(
-            lambda: _update_a2a_resume_input_sync(
-                task_lease, text, active_interaction_id, posted
-            )
-        )
-        if not updated:
-            raise TaskLeaseLostError(
-                f"Task {task_id} lease changed before A2A resume scheduling"
-            )
-
-        await _schedule_waiting_a2a_resume(
-            task_id=task_id,
-            agent_service=agent_service,
-            task_owner_user_id=task_owner_user_id,
-            task_lease=task_lease,
-            heartbeat_stop=heartbeat_stop,
-            heartbeat_task=heartbeat_task,
-            resumable_status=resumable_status,
-        )
-        ownership_transferred = True
+        ) from exc
+    except task_resume_service.TaskResumeNotResumableError as exc:
+        raise a2a_error(
+            "unsupported_operation",
+            "No run-fenced checkpoint is available for this task.",
+            status_code=400,
+            details={"taskId": task_id},
+        ) from exc
     except CheckpointReadError as exc:
-        # Ownership was never transferred, so restore the exact prelease
-        # to the prior input-required status exactly like the absent-
-        # checkpoint fallback above, then translate the failure instead of
-        # letting it escape as a raw exception. Same ownership_transferred/
-        # prelease_cleanup_done guard as the sibling except BaseException
-        # handler below, for symmetry.
-        if not ownership_transferred and not prelease_cleanup_done:
-            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
-            if not await drain_async_task_cancellation_safe(cleanup_task):
-                raise TaskLeaseLostError(
-                    f"Task {task_id} lease changed before A2A checkpoint-failure fallback"
-                ) from exc
         if isinstance(exc, CheckpointCorruptError):
             raise a2a_error(
                 "unsupported_operation",
@@ -651,22 +209,13 @@ async def _resume_input_required_a2a_task(
             status_code=503,
             details={"taskId": task_id},
         ) from exc
-    except BaseException as exc:
-        if not ownership_transferred and not prelease_cleanup_done:
-            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
-            await drain_async_task_cancellation_safe(cleanup_task)
-        if isinstance(exc, AutoModelUnavailableError):
-            raise a2a_error(
-                "unsupported_operation",
-                CLIENT_SAFE_AUTO_MODEL_UNAVAILABLE,
-                status_code=409,
-                details={"code": "auto_model_unavailable"},
-            ) from exc
-        raise
-    finally:
-        if not ownership_transferred and not prelease_cleanup_done:
-            await stop_task_lease_heartbeat(heartbeat_task, heartbeat_stop)
-    return True
+    except AutoModelUnavailableError as exc:
+        raise a2a_error(
+            "unsupported_operation",
+            CLIENT_SAFE_AUTO_MODEL_UNAVAILABLE,
+            status_code=409,
+            details={"code": "auto_model_unavailable"},
+        ) from exc
 
 
 def _validate_a2a_version(request: Request) -> None:

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -1,49 +1,8 @@
-"""``POST /v1/chat/tasks/{task_id}/reply``: answer a waiting task's question.
-
-A task in ``waiting_for_user`` has a paused execution, not an idle one --
-its agent asked a question via ``ask_user_question`` / a ``send_message``
-call with ``expect_response=True`` and is suspended waiting for the
-answer. Answering it means resuming that exact paused run, not starting
-a new turn the way ``POST /v1/chat/tasks/{task_id}/messages`` does. This
-module implements that resume, mirroring the shape of the A2A
-``message:send`` input-required resume in ``web/api/a2a.py``
-(``_resume_input_required_a2a_task``) with four differences:
-
-  - Scoped to ``Task.source == "sdk"`` plus the v1 SDK ownership rules
-    (agent-bound or workforce-bound key) instead of A2A's
-    ``Task.source == "a2a"`` plus a bare ``agent_id`` match.
-  - Only ``WAITING_FOR_USER`` is accepted; ``PAUSED`` is left to the
-    existing append endpoint, which already handles it and already has
-    its own failure policy for that status.
-  - Errors are translated to the stable ``V1ApiError`` envelope instead
-    of A2A's own error shape.
-  - The synthetic ``turn_id`` is derived from a fresh UUID
-    (``v1:reply:{task_id}:{uuid4()}``) rather than an A2A message id,
-    because the v1 request body carries no client-supplied message
-    identity to derive one from. This endpoint intentionally does not
-    implement idempotency: a client-side retry after a timeout can post
-    the answer twice. Callers that want to avoid that should ``GET`` the
-    task and confirm it has left ``waiting_for_user`` before retrying.
-
-The rest of the resume mechanics -- the two-phase prelease (claim, then
-either commit past it or restore it exactly), the heartbeat guarding the
-injection, and the fail-closed handling of every checkpoint outcome --
-are intentionally duplicated from ``a2a.py`` rather than factored into a
-shared helper. The two call sites answer to different protocols with
-independently evolving error contracts; a shared helper would couple
-them.
-"""
+"""SDK reply authorization and protocol mapping for runner-owned recovery."""
 
 from __future__ import annotations
 
-import asyncio
-import logging
-from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, assert_never
-from uuid import uuid4
-
-from sqlalchemy import func
 
 from ....core.agent.checkpoint import (
     CheckpointAccessRefusedError,
@@ -51,84 +10,16 @@ from ....core.agent.checkpoint import (
     CheckpointReadError,
 )
 from ...models.database import get_session_local
-from ...models.task import Task, TaskStatus
+from ...models.task import TaskStatus
 from ...schemas.v1 import ReplyRequest, ReplyResponse
-from ...services import agent_service_manager as agent_runtime_service
-from ...services import task_execution as task_execution_service
+from ...services import task_resume as task_resume_service
 from ...services.db_runtime import (
-    cancel_and_drain_async_task,
-    drain_async_task_cancellation_safe,
     run_db_io_cancellation_safe,
 )
 from ...services.llm_utils import AutoModelUnavailableError
-from ...services.task_execution_controller import TaskControlState
-from ...services.task_interaction_close import (
-    ActiveInteractionAbsent,
-    ActiveInteractionFound,
-    ActiveInteractionUnavailable,
-    active_interaction_id_sync,
-    clear_interaction_marker_if_unpaired,
-    close_legacy_resume_interaction,
-)
-from ...services.task_interaction_schema import interaction_requests_table_exists
-from ...services.task_lease_service import (
-    TaskLease,
-    TaskLeaseHeartbeatOutcome,
-    TaskLeaseLostError,
-    acquire_task_lease_cancellation_safe,
-    acquire_task_lease_no_commit,
-    bind_task_lease_context,
-    release_task_lease_no_commit,
-    run_task_lease_heartbeat,
-    run_while_task_lease_owned,
-    stop_task_lease_heartbeat,
-    task_lease_attempt_predicate,
-)
 from .deps import ApiKeyPrincipal, record_key_usage
 from .errors import V1ApiError, V1ErrorCode
 from .tasks import _resolve_task_or_404, _validate_owner_scope
-
-logger = logging.getLogger(__name__)
-
-# Control states a waiting task may be claimed from. Mirrors the a2a
-# resume prelease's acceptance set for WAITING_FOR_USER: a task parked
-# there sits at either the plain WAITING_FOR_USER control state, or, on
-# a database left over from an interrupted prior resume attempt, IDLE.
-_RESUMABLE_CONTROL_STATES = frozenset(
-    {
-        TaskControlState.IDLE.value,
-        TaskControlState.WAITING_FOR_USER.value,
-    }
-)
-
-
-@dataclass(frozen=True)
-class _ReplyContext:
-    """Detached, already-authorized inputs the resume phase needs."""
-
-    task_id: int
-    agent_id: int
-    task_owner_user_id: int
-    run_id: str | None
-    text: str
-
-
-def _status_rejection(status: TaskStatus) -> V1ApiError:
-    """Map a non-waiting task status to its reply-rejection error.
-
-    RUNNING is the one truly transient case (a real turn is in flight;
-    retrying later can succeed), so it keeps the generic retryable
-    ``task_busy``. Every other non-waiting status means "there is
-    nothing to reply to right now" -- ``no_pending_interaction``, not
-    retryable as such. The caller's remedy differs by status: for
-    paused / completed / failed, ``append`` starts the next turn; for
-    pending, the task hasn't started executing yet -- it is not in
-    ``_APPENDABLE_STATUSES`` either, so there is no turn to append to
-    yet. The only remedy is to wait for it to leave pending.
-    """
-    if status == TaskStatus.RUNNING:
-        return V1ApiError(V1ErrorCode.TASK_BUSY, 409)
-    return V1ApiError(V1ErrorCode.NO_PENDING_INTERACTION, 409)
 
 
 def _prepare_reply_context_sync(
@@ -136,12 +27,11 @@ def _prepare_reply_context_sync(
     task_id: int,
     principal: ApiKeyPrincipal,
     request: ReplyRequest,
-) -> _ReplyContext:
-    """Authorize the call and validate the body against the task's status.
+) -> task_resume_service.TaskReplyInput:
+    """Authorize the call and validate the reply body.
 
     A pure read -- no mutation happens here. The actual state transition
-    is the prelease claim in :func:`_acquire_reply_prelease_sync`, run
-    afterwards under ``acquire_task_lease_cancellation_safe``.
+    is the prelease claim in the runner, which owns the recovery lifecycle.
     """
     SessionLocal = get_session_local()
     with SessionLocal() as db:
@@ -161,294 +51,14 @@ def _prepare_reply_context_sync(
                     "(POST .../messages) instead"
                 ),
             )
-        if task.status != TaskStatus.WAITING_FOR_USER:
-            raise _status_rejection(task.status)
-        return _ReplyContext(
+        return task_resume_service.TaskReplyInput(
             task_id=int(task.id),
             agent_id=int(task.agent_id),
             task_owner_user_id=int(task.user_id),
             run_id=str(task.run_id) if task.run_id is not None else None,
+            status=task.status,
             text=request.message.content,
         )
-
-
-# Four different mechanisms keep this claim from racing every other writer
-# that can touch a WAITING_FOR_USER task, none of which overlap by accident:
-#
-# 1. Append (task_orchestrator._claim_turn_no_commit): its claim filters
-#    Task.status.in_(_APPENDABLE_STATUSES), and this PR removed
-#    WAITING_FOR_USER from that set. A row this claim can match (status ==
-#    WAITING_FOR_USER) is therefore structurally outside append's status
-#    filter -- the two claims can never both succeed on the same row, by
-#    construction of the two status sets being disjoint.
-# 2. A second reply on the same task: the claim below is a single
-#    conditional UPDATE (status == WAITING_FOR_USER AND control_state in
-#    _RESUMABLE_CONTROL_STATES); whichever request's UPDATE commits first
-#    flips control_state away from those values, so a concurrent request's
-#    UPDATE matches zero rows and returns None. Covered by
-#    test_concurrent_reply_race_exactly_one_winner.
-# 3. A2A's own resume (a2a._acquire_a2a_resume_prelease_sync): its claim
-#    filters Task.source == "a2a"; this claim filters Task.source == "sdk".
-#    A task row has exactly one source value, so the two filters can never
-#    both match the same row.
-# 4. The WebSocket live-control resume path: unlike the three cases above,
-#    it does NOT filter by Task.source at all, so it is not excluded from a
-#    "sdk" row by a source predicate. Its exclusivity instead comes from
-#    two other mechanisms: the in-process reservation in
-#    background_task_manager (reserve_resume / resume_tasks) that allows
-#    only one live resume coroutine per task_id, and the exact-run-fenced
-#    lease acquired below, which a second claimant with a stale or missing
-#    run_id cannot pass.
-def _acquire_reply_prelease_sync(
-    *,
-    task_id: int,
-    agent_id: int,
-    previous_run_id: str | None,
-    result_holder: dict[str, Any],
-) -> TaskLease | None:
-    """Claim and commit one exact reply-resume lease in a worker transaction.
-
-    ``agent_id`` re-checks the task row against the value
-    ``_resolve_task_or_404`` already authorized for this call -- ownership
-    itself (agent-bound vs workforce-bound key) was established there;
-    this claim only needs to confirm the row's identity hasn't moved
-    since, which a scalar ``agent_id`` match does without a join.
-
-    ``result_holder`` is filled in with the post-claim ``state_version``
-    / ``control_state`` before commit, so the caller can report the
-    response's real values without a second query racing the
-    background resume this claim is about to hand off to. It stays
-    empty when the claim fails.
-    """
-    SessionLocal = get_session_local()
-    with SessionLocal() as db:
-        claimed = (
-            db.query(Task)
-            .filter(
-                Task.id == task_id,
-                Task.agent_id == agent_id,
-                Task.source == "sdk",
-                Task.status == TaskStatus.WAITING_FOR_USER,
-                Task.control_state.in_(_RESUMABLE_CONTROL_STATES),
-            )
-            .update(
-                {
-                    Task.control_state: TaskControlState.RESUME_REQUESTED.value,
-                    Task.state_version: func.coalesce(Task.state_version, 0) + 1,
-                },
-                synchronize_session=False,
-            )
-        )
-        if claimed != 1:
-            db.rollback()
-            return None
-        # A legacy row with run_id already NULL passes previous_run_id=None
-        # here. acquire_task_lease_no_commit mints a fresh UUID for that
-        # case rather than reusing anything, and (since the row isn't a
-        # live RUNNING row with a run id) also clears both checkpoint
-        # pointer columns (last_checkpoint_event_id /
-        # last_checkpoint_trace_event_id) as part of the same UPDATE. If
-        # this reply later fails closed, releasing the lease back to
-        # waiting_for_user does not restore those two columns -- they stay
-        # cleared. The premise that used to justify this as costless -- "a
-        # row with no run_id never had a run-fenced checkpoint to recover in
-        # the first place" -- no longer holds: the root-checkpoint read path
-        # can resolve an untagged partition and read a checkpoint row
-        # written before the run-partition field existed, so such a row can
-        # have something resumable to lose. What survives of the original
-        # reasoning is narrower and is about where the resume looks rather
-        # than whether anything is there: with both pointer columns
-        # cleared, that read path's by-primary-key anchor has nothing to
-        # anchor on and falls back to its own legacy scan, which is keyed
-        # on task/checkpoint-type/execution-id and partition rather than on
-        # either cleared column. That scan reaches the row the pointer used
-        # to name only when the row carries an execution identity of its
-        # own: the scan filters on one, while the pointer path names a row
-        # unconditionally and is deliberately the more permissive of the
-        # two (see ``_load_pk_anchored_checkpoint``'s own docstring). For a
-        # row predating that field, the cleared pointer was the only way to
-        # reach it. Whether to keep clearing unconditionally has not been
-        # re-decided under the corrected premise (see #2024); this comment
-        # records the premise correctly rather than standing on the retired
-        # one.
-        task_lease = acquire_task_lease_no_commit(
-            db,
-            task_id,
-            expected_run_id=previous_run_id,
-        )
-        if task_lease is None or task_lease.run_id is None:
-            db.rollback()
-            return None
-        refreshed = (
-            db.query(Task.state_version, Task.control_state)
-            .filter(Task.id == task_id)
-            .one()
-        )
-        result_holder["state_version"] = int(refreshed.state_version or 0)
-        result_holder["control_state"] = str(refreshed.control_state or "idle")
-        db.commit()
-        return task_lease
-
-
-def _restore_reply_prelease_sync(task_lease: TaskLease) -> bool:
-    """Release one exact reply prelease in a worker-owned short Session.
-
-    A successful restore retains the run id and its tagged checkpoint, so
-    a client retry after a lost response is idempotent at the runner
-    boundary. If ownership changed, no row is mutated and the current
-    owner remains the sole lifecycle authority.
-
-    Mirrors the A2A prelease restore (``a2a._restore_a2a_resume_prelease_sync``):
-    a successful restore is an abandoned resume, not a completed one, so it
-    also reconciles the interaction marker via
-    ``clear_interaction_marker_if_unpaired`` -- see that function's docstring
-    for the NOT EXISTS semantics. No lock read precedes this call:
-    ``release_task_lease_no_commit``'s own tasks UPDATE writes only
-    non-key columns and is already the first statement this transaction
-    directs at tasks or task_interaction_requests.
-    """
-    SessionLocal = get_session_local()
-    with SessionLocal() as db:
-        restored = release_task_lease_no_commit(
-            db,
-            task_lease,
-            status=TaskStatus.WAITING_FOR_USER,
-        )
-        if restored:
-            assert task_lease.run_id is not None
-            clear_interaction_marker_if_unpaired(
-                db, task_id=task_lease.task_id, run_id=task_lease.run_id
-            )
-            db.commit()
-        else:
-            db.rollback()
-        return restored
-
-
-async def _restore_reply_prelease_isolated(task_lease: TaskLease) -> bool:
-    return await run_db_io_cancellation_safe(
-        lambda: _restore_reply_prelease_sync(task_lease)
-    )
-
-
-# The exact non-key column set the resume-input fence UPDATE below writes.
-# Shared with test_interaction_close_lock_ordering.py's static guard, which
-# asserts the UPDATE's values keys equal this set exactly -- see
-# a2a.RESUME_INPUT_FENCE_UPDATE_COLUMNS for the fence's no-lock-read
-# argument this set backs.
-RESUME_INPUT_FENCE_UPDATE_COLUMNS = frozenset({"input", "output", "error_message"})
-
-
-def _update_reply_input_sync(
-    task_lease: TaskLease, text: str, interaction_id: int | None
-) -> bool:
-    """Persist the reply's input only while the exact prelease remains current.
-
-    ``interaction_id`` is the active interaction row the caller observed
-    before injecting the message, passed in rather than read here: this
-    function's session does not open until after the injection has already
-    committed. See ``task_interaction_close``'s module docstring for why
-    the read has to precede the injection.
-    """
-    SessionLocal = get_session_local()
-    with SessionLocal() as db:
-        updated = (
-            db.query(Task)
-            .filter(
-                Task.id == task_lease.task_id,
-                Task.status == TaskStatus.RUNNING,
-                Task.runner_id == task_lease.runner_id,
-                task_lease_attempt_predicate(task_lease),
-                Task.run_id == task_lease.run_id,
-            )
-            .update(
-                {
-                    Task.input: text,
-                    Task.output: None,
-                    Task.error_message: None,
-                },
-                synchronize_session=False,
-            )
-        )
-        if updated != 1:
-            db.rollback()
-            return False
-        # Mirrors a2a._update_a2a_resume_input_sync's fence-ordering argument:
-        # this update() call is the fence, not a new transaction, so a
-        # rollback here would undo it together with the input write -- the
-        # point is that ownership and the interaction close are one atomic
-        # fact. No lock read either -- the fence UPDATE above writes only
-        # non-key columns (input, output, error_message) and is already the
-        # first statement this transaction directs at tasks or
-        # task_interaction_requests, so it satisfies the same ordering and
-        # strength obligation a dedicated lock read would. The table-presence
-        # gate sits here, immediately before the close call and after the
-        # fence UPDATE, for the same reason as the A2A site: the gate only
-        # inspects the catalog and takes no row lock, so it does not count
-        # as preceding the fence UPDATE in the sense the ordering obligation
-        # means.
-        assert task_lease.run_id is not None
-        if interaction_requests_table_exists(db):
-            close_legacy_resume_interaction(
-                db,
-                task_id=task_lease.task_id,
-                run_id=task_lease.run_id,
-                interaction_id=interaction_id,
-            )
-        db.commit()
-        return True
-
-
-async def _schedule_waiting_reply_resume(
-    *,
-    task_id: int,
-    agent_service: Any,
-    task_owner_user_id: int,
-    task_lease: TaskLease,
-    heartbeat_stop: asyncio.Event,
-    heartbeat_task: "asyncio.Task[TaskLeaseHeartbeatOutcome]",
-) -> None:
-    if task_lease.task_id != task_id or task_lease.run_id is None:
-        raise ValueError("Reply resume scheduling requires an exact task lease")
-    if not task_execution_service.background_task_manager.reserve_resume(task_id):
-        # A same-process resume is already registered for this task despite
-        # the exclusive DB claim above -- report it the same way a caller
-        # would read a lost race on the claim itself, rather than a bare
-        # 500: retrying (after the other resume settles) can succeed.
-        raise V1ApiError(V1ErrorCode.TASK_BUSY, 409)
-    previous_task = task_execution_service.background_task_manager.running_tasks.get(
-        task_id
-    )
-    bg_task: "asyncio.Task[None] | None" = None
-    try:
-        bg_task = asyncio.create_task(
-            task_execution_service.execute_resume_background(
-                task_id=task_id,
-                agent_service=agent_service,
-                task_owner_user_id=task_owner_user_id,
-                expected_run_id=task_lease.run_id,
-                previous_task=previous_task,
-                preacquired_lease=task_lease,
-                preacquired_heartbeat_stop=heartbeat_stop,
-                preacquired_heartbeat_task=heartbeat_task,
-                # The prelease claimed this task out of waiting_for_user;
-                # hand that over so a checkpoint the resume cannot read
-                # restores it instead of failing it terminally.
-                preacquired_prior_status=TaskStatus.WAITING_FOR_USER,
-            )
-        )
-        task_execution_service.background_task_manager.register_reserved_resume(
-            task_id,
-            bg_task,
-            run_id=task_lease.run_id,
-        )
-    except BaseException:
-        if bg_task is not None:
-            await cancel_and_drain_async_task(bg_task)
-        task_execution_service.background_task_manager.release_resume_reservation(
-            task_id
-        )
-        raise
 
 
 async def reply_to_task(
@@ -496,153 +106,15 @@ async def reply_to_task(
         )
     )
 
-    prelease_info: dict[str, Any] = {}
-    task_lease = await acquire_task_lease_cancellation_safe(
-        lambda: _acquire_reply_prelease_sync(
-            task_id=ctx.task_id,
-            agent_id=ctx.agent_id,
-            previous_run_id=ctx.run_id,
-            result_holder=prelease_info,
-        ),
-        lambda acquired: _restore_reply_prelease_sync(acquired),
-    )
-    if task_lease is None or task_lease.run_id is None:
-        raise V1ApiError(V1ErrorCode.TASK_BUSY, 409)
-
-    heartbeat_stop = asyncio.Event()
-    heartbeat_task = asyncio.create_task(
-        run_task_lease_heartbeat(task_lease, heartbeat_stop)
-    )
-    ownership_transferred = False
-    prelease_cleanup_done = False
-
-    async def stop_and_restore_prelease() -> bool:
-        nonlocal prelease_cleanup_done
-        if prelease_cleanup_done:
-            return False
-        prelease_cleanup_done = True
-        try:
-            outcome = await stop_task_lease_heartbeat(heartbeat_task, heartbeat_stop)
-        except BaseException:
-            logger.error(
-                "Reply prelease heartbeat failed before task %s could be "
-                "restored; retaining run %s for TTL recovery",
-                task_id,
-                task_lease.run_id,
-                exc_info=True,
-            )
-            return False
-        if outcome.requires_ttl_recovery:
-            logger.error(
-                "Reply prelease for task %s became unhealthy; retaining "
-                "run %s for TTL recovery (lost=%s, pool_timeout=%s)",
-                task_id,
-                task_lease.run_id,
-                outcome.lease_lost,
-                outcome.pool_timeout is not None,
-            )
-            return False
-        return await _restore_reply_prelease_isolated(task_lease)
-
     try:
-        # Read before the injection below, not inside
-        # _update_reply_input_sync, whose session opens only afterwards.
-        # See task_interaction_close's module docstring for why.
-        active_interaction_read = await run_db_io_cancellation_safe(
-            lambda: active_interaction_id_sync(task_id)
-        )
-        # Translate the three-state read into the `int | None` this site's
-        # close call takes. Absent and Unavailable both become `None` here
-        # -- but that is not folding Unavailable into Absent, it is this
-        # call's own contract: `None` means "bind the close to no primary
-        # key", so it matches zero rows and retires no question either
-        # way, which is the safe outcome for a read that could not be
-        # made, not a claim that nothing was ever active. What then
-        # happens to the task's marker differs between the two, and this
-        # value is not what decides it -- the clear beside the close runs
-        # its own check (see active_interaction_id_sync's docstring).
-        # Written as three branches, not
-        # `interaction_id if isinstance(..., ActiveInteractionFound) else
-        # None`, so a reader (and mypy) sees Unavailable handled on its own
-        # line rather than merged into Absent's.
-        if isinstance(active_interaction_read, ActiveInteractionFound):
-            active_interaction_id = active_interaction_read.interaction_id
-        elif isinstance(active_interaction_read, ActiveInteractionAbsent):
-            active_interaction_id = None
-        elif isinstance(active_interaction_read, ActiveInteractionUnavailable):
-            active_interaction_id = None
-            logger.info(
-                "active interaction read unavailable (reason=%s) for "
-                "task_id=%s; the legacy resume close will match no row",
-                active_interaction_read.reason,
-                task_id,
-            )
-        else:
-            assert_never(active_interaction_read)
-
-        async def inject_user_message() -> tuple[Any, bool]:
-            agent_service = (
-                await agent_runtime_service.get_agent_manager().get_agent_for_task(
-                    task_id,
-                    None,
-                    task_owner_user_id=ctx.task_owner_user_id,
-                )
-            )
-            posted = await agent_service.post_user_message(
-                str(task_id),
-                execution_message=ctx.text,
-                display_message=ctx.text,
-                turn_id=f"v1:reply:{task_id}:{uuid4()}",
-                request_interrupt=False,
-                reason="V1 interaction response",
-            )
-            return agent_service, bool(posted)
-
-        with bind_task_lease_context(task_lease):
-            agent_service, posted = await run_while_task_lease_owned(
-                inject_user_message(),
-                heartbeat_task,
-            )
-
-        if not posted:
-            # No run-fenced checkpoint is available to resume onto. Never
-            # fabricate a run or fall back to a transcript replay: release
-            # the exact prelease back to waiting_for_user and fail closed
-            # so the caller must start a new task explicitly.
-            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
-            if not await drain_async_task_cancellation_safe(cleanup_task):
-                raise TaskLeaseLostError(
-                    f"Task {task_id} lease changed before reply fallback"
-                )
-            raise V1ApiError(V1ErrorCode.INTERACTION_NOT_RESUMABLE, 409)
-
-        updated = await run_db_io_cancellation_safe(
-            lambda: _update_reply_input_sync(
-                task_lease, ctx.text, active_interaction_id
-            )
-        )
-        if not updated:
-            raise TaskLeaseLostError(
-                f"Task {task_id} lease changed before reply resume scheduling"
-            )
-
-        await _schedule_waiting_reply_resume(
-            task_id=task_id,
-            agent_service=agent_service,
-            task_owner_user_id=ctx.task_owner_user_id,
-            task_lease=task_lease,
-            heartbeat_stop=heartbeat_stop,
-            heartbeat_task=heartbeat_task,
-        )
-        ownership_transferred = True
+        result = await task_resume_service.resume_task_reply(ctx)
+    except task_resume_service.TaskResumeBusyError as exc:
+        raise V1ApiError(V1ErrorCode.TASK_BUSY, 409) from exc
+    except task_resume_service.TaskResumeNotWaitingError as exc:
+        raise V1ApiError(V1ErrorCode.NO_PENDING_INTERACTION, 409) from exc
+    except task_resume_service.TaskResumeNotResumableError as exc:
+        raise V1ApiError(V1ErrorCode.INTERACTION_NOT_RESUMABLE, 409) from exc
     except CheckpointReadError as exc:
-        if not ownership_transferred and not prelease_cleanup_done:
-            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
-            if not await drain_async_task_cancellation_safe(cleanup_task):
-                raise TaskLeaseLostError(
-                    f"Task {task_id} lease changed before reply "
-                    "checkpoint-failure fallback"
-                ) from exc
         if isinstance(exc, CheckpointCorruptError):
             raise V1ApiError(V1ErrorCode.INTERACTION_NOT_RESUMABLE, 409) from exc
         if isinstance(exc, CheckpointAccessRefusedError):
@@ -655,16 +127,8 @@ async def reply_to_task(
         # failure, so an unrecognized failure mode never silently
         # collapses into a data-losing branch.
         raise V1ApiError(V1ErrorCode.TEMPORARILY_UNAVAILABLE, 503) from exc
-    except BaseException as exc:
-        if not ownership_transferred and not prelease_cleanup_done:
-            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
-            await drain_async_task_cancellation_safe(cleanup_task)
-        if isinstance(exc, AutoModelUnavailableError):
-            raise V1ApiError(V1ErrorCode.AUTO_MODEL_UNAVAILABLE, 409) from exc
-        raise
-    finally:
-        if not ownership_transferred and not prelease_cleanup_done:
-            await stop_task_lease_heartbeat(heartbeat_task, heartbeat_stop)
+    except AutoModelUnavailableError as exc:
+        raise V1ApiError(V1ErrorCode.AUTO_MODEL_UNAVAILABLE, 409) from exc
 
     await record_key_usage(str(principal.key.key_prefix))
 
@@ -676,7 +140,7 @@ async def reply_to_task(
         ),
         status=TaskStatus.RUNNING.value,
         accepted_at=datetime.now(timezone.utc),
-        run_id=task_lease.run_id,
-        state_version=prelease_info["state_version"],
-        control_state=prelease_info["control_state"],
+        run_id=result.run_id,
+        state_version=result.state_version,
+        control_state=result.control_state,
     )

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -4,7 +4,7 @@ Four production sites inject a WebSocket, A2A, or v1 SDK user message
 straight into a checkpoint instead of going through the native interaction
 protocol's answer path: the online WebSocket injection, the deferred
 WebSocket injection (``execute_resume_background``), the A2A resume-input
-path, and the v1 ``POST .../reply`` resume-input path (``task_reply.py``).
+path, and the v1 ``POST .../reply`` resume-input path (``task_resume.py``).
 Each of those sites, once its own message write has succeeded, must retire
 the run's active ``task_interaction_requests`` row (if any) as
 ``terminated`` / ``answered_via_legacy_resume`` and clear
@@ -52,11 +52,11 @@ close call (``mark_user_message_delivery_sync``) the identical log-only
 way, for the identical reason; see the inline comments beside each pair.
 The A2A and v1 reply sites are different: each close call runs inside its
 own resume-input fence transaction (``_update_a2a_resume_input_sync`` in
-``a2a.py``, ``_update_reply_input_sync`` in ``task_reply.py``), committed
+``task_resume.py``, ``_update_reply_input_sync`` in the same module), committed
 together with the ownership fence UPDATE that precedes it -- that is what
 makes those two sites stronger than the WebSocket sites, not a claim that
 the close is atomic with the message injection itself. The message
-injection (``post_user_message`` at ``a2a.py:464`` / ``task_reply.py:512``)
+injection (``post_user_message`` in ``task_resume.py``)
 commits on its own, earlier, in ``AgentRunner._persist_injected_context``;
 only after that commit has already landed does the caller open the fence
 transaction that writes the resumed input and closes the interaction row
@@ -94,7 +94,7 @@ site cannot quietly become dangerous if it is ever changed to derive its
 own key.
 
 The fourth production caller, the v1 ``POST .../reply`` resume-input
-path (``task_reply.py``), carries no guard at all and needs none: it
+path (``task_resume.py``), carries no guard at all and needs none: it
 builds its turn id as ``f"v1:reply:{task_id}:{uuid4()}"``, a value that
 is fresh on every single call, so it can never present a repeated turn
 id and can never reach the short circuit that produces a replay.
@@ -321,7 +321,7 @@ def active_interaction_id_sync(task_id: int) -> ActiveInteractionRead:
 
     Opens and closes its own short session. Three legacy-resume injection
     paths call it from a point where they hold no session of their own: the
-    two fence-transaction paths (``a2a.py``, ``v1/task_reply.py``) open
+    two fence-transaction paths (both in ``task_resume.py``) open
     their fence only after the injection has already committed, and the
     WebSocket online chat injection holds none at all. The fourth
     legacy-resume path -- the WebSocket deferred injection reached through

--- a/src/xagent/web/services/task_resume.py
+++ b/src/xagent/web/services/task_resume.py
@@ -1,0 +1,999 @@
+"""Runner-owned A2A and SDK reply recovery.
+
+The two recovery flows retain their existing claim, injection and cleanup
+semantics. Callers provide detached inputs and translate failures to their
+protocol; leases, agents and background tasks stay inside this module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, assert_never
+from uuid import uuid4
+
+from sqlalchemy import func
+
+from ...core.agent.checkpoint import CheckpointReadError
+from ...core.agent.runner import UserMessageInjectionOutcome
+from ..models.database import get_session_local
+from ..models.task import Task, TaskStatus
+from . import agent_service_manager as agent_runtime_service
+from . import task_execution as task_execution_service
+from .db_runtime import (
+    cancel_and_drain_async_task,
+    drain_async_task_cancellation_safe,
+    run_db_io_cancellation_safe,
+)
+from .task_execution_controller import TaskControlState
+from .task_interaction_close import (
+    ActiveInteractionAbsent,
+    ActiveInteractionFound,
+    ActiveInteractionUnavailable,
+    active_interaction_id_sync,
+    clear_interaction_marker_if_unpaired,
+    close_legacy_resume_interaction,
+)
+from .task_interaction_schema import interaction_requests_table_exists
+from .task_lease_service import (
+    TaskLease,
+    TaskLeaseHeartbeatOutcome,
+    TaskLeaseLostError,
+    acquire_task_lease_cancellation_safe,
+    acquire_task_lease_no_commit,
+    bind_task_lease_context,
+    release_task_lease_no_commit,
+    run_task_lease_heartbeat,
+    run_while_task_lease_owned,
+    stop_task_lease_heartbeat,
+    task_lease_attempt_predicate,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TaskResumeBusyError(Exception):
+    """Another execution owns the task or has already claimed its resume."""
+
+
+class TaskResumeNotWaitingError(Exception):
+    """The SDK task has no pending reply to resume."""
+
+
+class TaskResumeNotResumableError(Exception):
+    """No run-fenced checkpoint accepted the reply."""
+
+
+@dataclass(frozen=True)
+class TaskReplyInput:
+    """Authorized task snapshot and reply, detached from the request session."""
+
+    task_id: int
+    agent_id: int
+    task_owner_user_id: int
+    run_id: str | None
+    status: TaskStatus
+    text: str
+
+
+@dataclass(frozen=True)
+class TaskReplyResumeResult:
+    """Claim state captured before the registered resume can advance it."""
+
+    run_id: str
+    state_version: int
+    control_state: str
+
+
+# Control states a waiting task may be claimed from. Mirrors the a2a
+# resume prelease's acceptance set for WAITING_FOR_USER: a task parked
+# there sits at either the plain WAITING_FOR_USER control state, or, on
+# a database left over from an interrupted prior resume attempt, IDLE.
+_RESUMABLE_CONTROL_STATES = frozenset(
+    {
+        TaskControlState.IDLE.value,
+        TaskControlState.WAITING_FOR_USER.value,
+    }
+)
+
+
+async def _schedule_waiting_a2a_resume(
+    *,
+    task_id: int,
+    agent_service: Any,
+    task_owner_user_id: int,
+    task_lease: TaskLease,
+    heartbeat_stop: asyncio.Event,
+    heartbeat_task: asyncio.Task[TaskLeaseHeartbeatOutcome],
+    resumable_status: TaskStatus,
+) -> None:
+    from .task_execution import (
+        background_task_manager,
+        execute_resume_background,
+    )
+
+    if task_lease.task_id != task_id or task_lease.run_id is None:
+        raise ValueError("A2A resume scheduling requires an exact task lease")
+    if not background_task_manager.reserve_resume(task_id):
+        raise RuntimeError(f"Task {task_id} already has a resume in progress")
+    previous_task = background_task_manager.running_tasks.get(task_id)
+    bg_task: asyncio.Task[None] | None = None
+    try:
+        bg_task = asyncio.create_task(
+            execute_resume_background(
+                task_id=task_id,
+                agent_service=agent_service,
+                task_owner_user_id=task_owner_user_id,
+                expected_run_id=task_lease.run_id,
+                previous_task=previous_task,
+                preacquired_lease=task_lease,
+                preacquired_heartbeat_stop=heartbeat_stop,
+                preacquired_heartbeat_task=heartbeat_task,
+                # The prelease claimed this task out of an input-required
+                # status; hand that over so a checkpoint the resume cannot
+                # read restores it instead of failing it terminally.
+                preacquired_prior_status=resumable_status,
+            )
+        )
+        background_task_manager.register_reserved_resume(
+            task_id,
+            bg_task,
+            run_id=task_lease.run_id,
+        )
+    except BaseException:
+        if bg_task is not None:
+            await cancel_and_drain_async_task(bg_task)
+        background_task_manager.release_resume_reservation(task_id)
+        raise
+
+
+def _acquire_a2a_resume_prelease_sync(
+    *,
+    task_id: int,
+    agent_id: int,
+    resumable_status: TaskStatus,
+    previous_run_id: str | None,
+) -> TaskLease | None:
+    """Claim and commit one exact A2A resume lease in a worker transaction."""
+
+    resumable_control_states = {
+        TaskControlState.IDLE.value,
+        (
+            TaskControlState.PAUSED.value
+            if resumable_status == TaskStatus.PAUSED
+            else TaskControlState.WAITING_FOR_USER.value
+        ),
+    }
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        claimed = (
+            db.query(Task)
+            .filter(
+                Task.id == task_id,
+                Task.agent_id == agent_id,
+                Task.source == "a2a",
+                Task.status == resumable_status,
+                Task.control_state.in_(resumable_control_states),
+            )
+            .update(
+                {
+                    Task.control_state: TaskControlState.RESUME_REQUESTED.value,
+                    Task.state_version: func.coalesce(Task.state_version, 0) + 1,
+                },
+                synchronize_session=False,
+            )
+        )
+        if claimed != 1:
+            db.rollback()
+            return None
+        task_lease = acquire_task_lease_no_commit(
+            db,
+            task_id,
+            expected_run_id=previous_run_id,
+        )
+        if task_lease is None or task_lease.run_id is None:
+            db.rollback()
+            return None
+        db.commit()
+        return task_lease
+
+
+def _restore_a2a_resume_prelease_sync(
+    task_lease: TaskLease,
+    *,
+    status: TaskStatus = TaskStatus.WAITING_FOR_USER,
+) -> bool:
+    """Release one exact A2A prelease in a worker-owned short Session.
+
+    A successful restore retains the run id and its tagged checkpoint, so a
+    retry with the same A2A message id is idempotent at the runner boundary.
+    If ownership changed, no row is mutated and the current owner remains the
+    sole lifecycle authority.
+
+    Two callers reach this today: the isolated wrapper right below, used by
+    the no-checkpoint and checkpoint-read-error fallbacks; and the cancel
+    settlement callback ``acquire_task_lease_cancellation_safe`` passes to
+    ``resume_a2a_task``'s lease acquisition, which fires on
+    a cancellation with no ``posted`` outcome to consult at all -- the
+    marker clear below has to hold on that path too, not only on the two
+    ``posted``-gated fallbacks.
+    """
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        restored = release_task_lease_no_commit(
+            db,
+            task_lease,
+            status=status,
+        )
+        if restored:
+            # Mirror of the WebSocket lease restore: this is an abandoned
+            # resume, not a completed one, so only the marker may need
+            # reconciling -- see clear_interaction_marker_if_unpaired's
+            # docstring for the NOT EXISTS semantics. No lock read precedes
+            # this statement; release_task_lease_no_commit's own tasks
+            # UPDATE writes only non-key columns and is already the first
+            # statement this transaction directs at tasks or
+            # task_interaction_requests.
+            assert task_lease.run_id is not None
+            clear_interaction_marker_if_unpaired(
+                db, task_id=task_lease.task_id, run_id=task_lease.run_id
+            )
+            db.commit()
+        else:
+            db.rollback()
+        return restored
+
+
+async def _restore_a2a_resume_prelease_isolated(
+    task_lease: TaskLease,
+    *,
+    status: TaskStatus,
+) -> bool:
+    return await run_db_io_cancellation_safe(
+        lambda: _restore_a2a_resume_prelease_sync(
+            task_lease,
+            status=status,
+        )
+    )
+
+
+# The exact non-key column set the resume-input fence UPDATE below writes.
+# Shared with test_interaction_close_lock_ordering.py's static guard, which
+# asserts the UPDATE's values keys equal this set exactly: the fence's
+# no-lock-read argument (see the inline comment inside
+# _update_a2a_resume_input_sync) depends on every one of these columns being
+# a non-key column, so a future change widening the UPDATE's values must
+# widen this constant too, deliberately, not just add a key to a dict
+# literal the guard never looks at again.
+RESUME_INPUT_FENCE_UPDATE_COLUMNS = frozenset({"input", "output", "error_message"})
+
+
+def _update_a2a_resume_input_sync(
+    task_lease: TaskLease,
+    text: str,
+    interaction_id: int | None,
+    injection_outcome: UserMessageInjectionOutcome,
+) -> bool:
+    """Persist A2A input only while the exact prelease remains current.
+
+    ``interaction_id`` is the active interaction row the caller observed
+    before injecting the message, passed in rather than read here: this
+    function's session does not open until after the injection has already
+    committed. See ``task_interaction_close``'s module docstring for why
+    the read has to precede the injection.
+
+    ``injection_outcome`` is the caller's own ``post_user_message`` report,
+    not re-derived here: a replayed turn id must not retire the close, and
+    only the call that produced the short circuit can say whether this was
+    one.
+    """
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        updated = (
+            db.query(Task)
+            .filter(
+                Task.id == task_lease.task_id,
+                Task.status == TaskStatus.RUNNING,
+                Task.runner_id == task_lease.runner_id,
+                task_lease_attempt_predicate(task_lease),
+                Task.run_id == task_lease.run_id,
+            )
+            .update(
+                {
+                    Task.input: text,
+                    Task.output: None,
+                    Task.error_message: None,
+                },
+                synchronize_session=False,
+            )
+        )
+        if updated != 1:
+            db.rollback()
+            return False
+        # This update() call is the fence above, not a new transaction: a
+        # rollback here would undo it together with the input write, which
+        # is the point -- ownership and the interaction close are one
+        # atomic fact. No run_db_io_cancellation_safe wrap: the caller
+        # already wraps this whole function in one. No lock read either --
+        # the fence UPDATE above writes only non-key columns (input,
+        # output, error_message) and is already the first statement this
+        # transaction directs at tasks or task_interaction_requests, so it
+        # satisfies the same ordering and strength obligation a dedicated
+        # lock read would. If a future change adds a key column (or any
+        # column covered by a unique index) to that UPDATE's values, this
+        # judgment call must be redone -- the lock strength that UPDATE
+        # takes would change.
+        #
+        # The table-presence gate sits here, immediately before the close
+        # call and after the fence UPDATE, not at the top of the function:
+        # the gate only inspects the catalog and takes no row lock, so it
+        # does not count as preceding the fence UPDATE in the sense the
+        # ordering obligation above means.
+        assert task_lease.run_id is not None
+        if interaction_requests_table_exists(db):
+            # A retried A2A message replays this site's deterministic turn
+            # id (f"a2a:{task_id}:{message_id}"), and inject_user_message
+            # short-circuits a repeated turn id without persisting
+            # anything. interaction_id above was read fresh by this
+            # attempt, so on such a replay it names whatever the resumed
+            # agent has staged since rather than the question this call
+            # answered, and closing on it would retire a live question.
+            # See task_interaction_close's module docstring for the rule,
+            # the other sites, and why the v1 reply resume-input path
+            # needs no guard at all.
+            if injection_outcome is UserMessageInjectionOutcome.POSTED_FRESH:
+                close_legacy_resume_interaction(
+                    db,
+                    task_id=task_lease.task_id,
+                    run_id=task_lease.run_id,
+                    interaction_id=interaction_id,
+                )
+        db.commit()
+        return True
+
+
+async def resume_a2a_task(
+    *,
+    agent_id: int,
+    task_owner_user_id: int,
+    task_id: int,
+    previous_run_id: str | None,
+    resumable_status: TaskStatus,
+    text: str,
+    message_id: str,
+) -> bool:
+    if resumable_status not in {
+        TaskStatus.PAUSED,
+        TaskStatus.WAITING_FOR_USER,
+    }:
+        return False
+    task_lease = await acquire_task_lease_cancellation_safe(
+        lambda: _acquire_a2a_resume_prelease_sync(
+            task_id=task_id,
+            agent_id=agent_id,
+            resumable_status=resumable_status,
+            previous_run_id=previous_run_id,
+        ),
+        lambda acquired: _restore_a2a_resume_prelease_sync(
+            acquired,
+            status=resumable_status,
+        ),
+    )
+    if task_lease is None or task_lease.run_id is None:
+        raise TaskResumeBusyError
+
+    heartbeat_stop = asyncio.Event()
+    heartbeat_task = asyncio.create_task(
+        run_task_lease_heartbeat(task_lease, heartbeat_stop)
+    )
+    ownership_transferred = False
+    prelease_cleanup_done = False
+
+    async def stop_and_restore_prelease() -> bool:
+        nonlocal prelease_cleanup_done
+        if prelease_cleanup_done:
+            return False
+        prelease_cleanup_done = True
+        try:
+            outcome = await stop_task_lease_heartbeat(
+                heartbeat_task,
+                heartbeat_stop,
+            )
+        except BaseException:
+            logger.error(
+                "A2A prelease heartbeat failed before task %s could be restored; "
+                "retaining run %s for TTL recovery",
+                task_id,
+                task_lease.run_id,
+                exc_info=True,
+            )
+            return False
+        if outcome.requires_ttl_recovery:
+            logger.error(
+                "A2A prelease for task %s became unhealthy; retaining run %s "
+                "for TTL recovery (lost=%s, pool_timeout=%s)",
+                task_id,
+                task_lease.run_id,
+                outcome.lease_lost,
+                outcome.pool_timeout is not None,
+            )
+            return False
+        return await _restore_a2a_resume_prelease_isolated(
+            task_lease,
+            status=resumable_status,
+        )
+
+    try:
+        # Read before the injection below, not inside
+        # _update_a2a_resume_input_sync, whose session opens only afterwards.
+        # See task_interaction_close's module docstring for why.
+        #
+        # This site's turn id is deterministic (f"a2a:{task_id}:{message_id}"
+        # below), so a retried A2A message replays the same turn.
+        # AgentRunner.inject_user_message reports that replay explicitly
+        # (see UserMessageInjectionOutcome) instead of folding it into the
+        # same truthy value a fresh write produces, and
+        # _update_a2a_resume_input_sync reads that report to decide whether
+        # to skip its close call -- see the guard inside that function for
+        # why a replay must skip it.
+        active_interaction_read = await run_db_io_cancellation_safe(
+            lambda: active_interaction_id_sync(task_id)
+        )
+        # Translate the three-state read into the `int | None` this site's
+        # close call takes. Absent and Unavailable both become `None` here
+        # -- but that is not folding Unavailable into Absent, it is this
+        # call's own contract: `None` means "bind the close to no primary
+        # key", so it matches zero rows and retires no question either
+        # way, which is the safe outcome for a read that could not be
+        # made, not a claim that nothing was ever active. What then
+        # happens to the task's marker differs between the two, and this
+        # value is not what decides it -- the clear beside the close runs
+        # its own check (see active_interaction_id_sync's docstring).
+        # Written as three branches, not
+        # `interaction_id if isinstance(..., ActiveInteractionFound) else
+        # None`, so a reader (and mypy) sees Unavailable handled on its own
+        # line rather than merged into Absent's.
+        if isinstance(active_interaction_read, ActiveInteractionFound):
+            active_interaction_id = active_interaction_read.interaction_id
+        elif isinstance(active_interaction_read, ActiveInteractionAbsent):
+            active_interaction_id = None
+        elif isinstance(active_interaction_read, ActiveInteractionUnavailable):
+            active_interaction_id = None
+            logger.info(
+                "active interaction read unavailable (reason=%s) for "
+                "task_id=%s; the legacy resume close will match no row",
+                active_interaction_read.reason,
+                task_id,
+            )
+        else:
+            assert_never(active_interaction_read)
+
+        async def inject_user_message() -> tuple[Any, UserMessageInjectionOutcome]:
+            from .agent_service_manager import get_agent_manager
+
+            agent_service = await get_agent_manager().get_agent_for_task(
+                task_id,
+                None,
+                task_owner_user_id=task_owner_user_id,
+            )
+            posted = await agent_service.post_user_message(
+                str(task_id),
+                execution_message=text,
+                display_message=text,
+                turn_id=f"a2a:{task_id}:{message_id}",
+                request_interrupt=False,
+                reason="A2A input-required response",
+            )
+            return agent_service, posted
+
+        with bind_task_lease_context(task_lease):
+            agent_service, posted = await run_while_task_lease_owned(
+                inject_user_message(),
+                heartbeat_task,
+            )
+
+        if not posted:
+            # Untagged or otherwise unreadable legacy checkpoints are never
+            # resumed under a fabricated run or transcript fallback. Release
+            # the exact prelease back to the prior input-required state and
+            # fail closed so a caller must start a new task explicitly.
+            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
+            if not await drain_async_task_cancellation_safe(cleanup_task):
+                raise TaskLeaseLostError(
+                    f"Task {task_id} lease changed before A2A fallback"
+                )
+            raise TaskResumeNotResumableError
+
+        updated = await run_db_io_cancellation_safe(
+            lambda: _update_a2a_resume_input_sync(
+                task_lease, text, active_interaction_id, posted
+            )
+        )
+        if not updated:
+            raise TaskLeaseLostError(
+                f"Task {task_id} lease changed before A2A resume scheduling"
+            )
+
+        await _schedule_waiting_a2a_resume(
+            task_id=task_id,
+            agent_service=agent_service,
+            task_owner_user_id=task_owner_user_id,
+            task_lease=task_lease,
+            heartbeat_stop=heartbeat_stop,
+            heartbeat_task=heartbeat_task,
+            resumable_status=resumable_status,
+        )
+        ownership_transferred = True
+    except CheckpointReadError as exc:
+        # Ownership was never transferred, so restore the exact prelease
+        # to the prior input-required status exactly like the absent-
+        # checkpoint fallback above, then let the API translate the failure.
+        # Keep the same ownership_transferred/prelease_cleanup_done guard as
+        # the sibling except BaseException handler below.
+        if not ownership_transferred and not prelease_cleanup_done:
+            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
+            if not await drain_async_task_cancellation_safe(cleanup_task):
+                raise TaskLeaseLostError(
+                    f"Task {task_id} lease changed before A2A checkpoint-failure fallback"
+                ) from exc
+        raise
+    except BaseException:
+        if not ownership_transferred and not prelease_cleanup_done:
+            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
+            await drain_async_task_cancellation_safe(cleanup_task)
+        raise
+    finally:
+        if not ownership_transferred and not prelease_cleanup_done:
+            await stop_task_lease_heartbeat(heartbeat_task, heartbeat_stop)
+    return True
+
+
+# Four different mechanisms keep this claim from racing every other writer
+# that can touch a WAITING_FOR_USER task, none of which overlap by accident:
+#
+# 1. Append (task_orchestrator._claim_turn_no_commit): its claim filters
+#    Task.status.in_(_APPENDABLE_STATUSES), and this PR removed
+#    WAITING_FOR_USER from that set. A row this claim can match (status ==
+#    WAITING_FOR_USER) is therefore structurally outside append's status
+#    filter -- the two claims can never both succeed on the same row, by
+#    construction of the two status sets being disjoint.
+# 2. A second reply on the same task: the claim below is a single
+#    conditional UPDATE (status == WAITING_FOR_USER AND control_state in
+#    _RESUMABLE_CONTROL_STATES); whichever request's UPDATE commits first
+#    flips control_state away from those values, so a concurrent request's
+#    UPDATE matches zero rows and returns None. Covered by
+#    test_concurrent_reply_race_exactly_one_winner.
+# 3. A2A's own resume (_acquire_a2a_resume_prelease_sync): its claim
+#    filters Task.source == "a2a"; this claim filters Task.source == "sdk".
+#    A task row has exactly one source value, so the two filters can never
+#    both match the same row.
+# 4. The WebSocket live-control resume path: unlike the three cases above,
+#    it does NOT filter by Task.source at all, so it is not excluded from a
+#    "sdk" row by a source predicate. Its exclusivity instead comes from
+#    two other mechanisms: the in-process reservation in
+#    background_task_manager (reserve_resume / resume_tasks) that allows
+#    only one live resume coroutine per task_id, and the exact-run-fenced
+#    lease acquired below, which a second claimant with a stale or missing
+#    run_id cannot pass.
+def _acquire_reply_prelease_sync(
+    *,
+    task_id: int,
+    agent_id: int,
+    previous_run_id: str | None,
+    result_holder: dict[str, Any],
+) -> TaskLease | None:
+    """Claim and commit one exact reply-resume lease in a worker transaction.
+
+    ``agent_id`` re-checks the task row against the value
+    ``_resolve_task_or_404`` already authorized for this call -- ownership
+    itself (agent-bound vs workforce-bound key) was established there;
+    this claim only needs to confirm the row's identity hasn't moved
+    since, which a scalar ``agent_id`` match does without a join.
+
+    ``result_holder`` is filled in with the post-claim ``state_version``
+    / ``control_state`` before commit, so the caller can report the
+    response's real values without a second query racing the
+    background resume this claim is about to hand off to. It stays
+    empty when the claim fails.
+    """
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        claimed = (
+            db.query(Task)
+            .filter(
+                Task.id == task_id,
+                Task.agent_id == agent_id,
+                Task.source == "sdk",
+                Task.status == TaskStatus.WAITING_FOR_USER,
+                Task.control_state.in_(_RESUMABLE_CONTROL_STATES),
+            )
+            .update(
+                {
+                    Task.control_state: TaskControlState.RESUME_REQUESTED.value,
+                    Task.state_version: func.coalesce(Task.state_version, 0) + 1,
+                },
+                synchronize_session=False,
+            )
+        )
+        if claimed != 1:
+            db.rollback()
+            return None
+        # A legacy row with run_id already NULL passes previous_run_id=None
+        # here. acquire_task_lease_no_commit mints a fresh UUID for that
+        # case rather than reusing anything, and (since the row isn't a
+        # live RUNNING row with a run id) also clears both checkpoint
+        # pointer columns (last_checkpoint_event_id /
+        # last_checkpoint_trace_event_id) as part of the same UPDATE. If
+        # this reply later fails closed, releasing the lease back to
+        # waiting_for_user does not restore those two columns -- they stay
+        # cleared. The premise that used to justify this as costless -- "a
+        # row with no run_id never had a run-fenced checkpoint to recover in
+        # the first place" -- no longer holds: the root-checkpoint read path
+        # can resolve an untagged partition and read a checkpoint row
+        # written before the run-partition field existed, so such a row can
+        # have something resumable to lose. What survives of the original
+        # reasoning is narrower and is about where the resume looks rather
+        # than whether anything is there: with both pointer columns
+        # cleared, that read path's by-primary-key anchor has nothing to
+        # anchor on and falls back to its own legacy scan, which is keyed
+        # on task/checkpoint-type/execution-id and partition rather than on
+        # either cleared column. That scan reaches the row the pointer used
+        # to name only when the row carries an execution identity of its
+        # own: the scan filters on one, while the pointer path names a row
+        # unconditionally and is deliberately the more permissive of the
+        # two (see ``_load_pk_anchored_checkpoint``'s own docstring). For a
+        # row predating that field, the cleared pointer was the only way to
+        # reach it. Whether to keep clearing unconditionally has not been
+        # re-decided under the corrected premise (see #2024); this comment
+        # records the premise correctly rather than standing on the retired
+        # one.
+        task_lease = acquire_task_lease_no_commit(
+            db,
+            task_id,
+            expected_run_id=previous_run_id,
+        )
+        if task_lease is None or task_lease.run_id is None:
+            db.rollback()
+            return None
+        refreshed = (
+            db.query(Task.state_version, Task.control_state)
+            .filter(Task.id == task_id)
+            .one()
+        )
+        result_holder["state_version"] = int(refreshed.state_version or 0)
+        result_holder["control_state"] = str(refreshed.control_state or "idle")
+        db.commit()
+        return task_lease
+
+
+def _restore_reply_prelease_sync(task_lease: TaskLease) -> bool:
+    """Release one exact reply prelease in a worker-owned short Session.
+
+    A successful restore retains the run id and its tagged checkpoint, so
+    a client retry after a lost response is idempotent at the runner
+    boundary. If ownership changed, no row is mutated and the current
+    owner remains the sole lifecycle authority.
+
+    Mirrors the A2A prelease restore (``_restore_a2a_resume_prelease_sync``):
+    a successful restore is an abandoned resume, not a completed one, so it
+    also reconciles the interaction marker via
+    ``clear_interaction_marker_if_unpaired`` -- see that function's docstring
+    for the NOT EXISTS semantics. No lock read precedes this call:
+    ``release_task_lease_no_commit``'s own tasks UPDATE writes only
+    non-key columns and is already the first statement this transaction
+    directs at tasks or task_interaction_requests.
+    """
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        restored = release_task_lease_no_commit(
+            db,
+            task_lease,
+            status=TaskStatus.WAITING_FOR_USER,
+        )
+        if restored:
+            assert task_lease.run_id is not None
+            clear_interaction_marker_if_unpaired(
+                db, task_id=task_lease.task_id, run_id=task_lease.run_id
+            )
+            db.commit()
+        else:
+            db.rollback()
+        return restored
+
+
+async def _restore_reply_prelease_isolated(task_lease: TaskLease) -> bool:
+    return await run_db_io_cancellation_safe(
+        lambda: _restore_reply_prelease_sync(task_lease)
+    )
+
+
+def _update_reply_input_sync(
+    task_lease: TaskLease, text: str, interaction_id: int | None
+) -> bool:
+    """Persist the reply's input only while the exact prelease remains current.
+
+    ``interaction_id`` is the active interaction row the caller observed
+    before injecting the message, passed in rather than read here: this
+    function's session does not open until after the injection has already
+    committed. See ``task_interaction_close``'s module docstring for why
+    the read has to precede the injection.
+    """
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        updated = (
+            db.query(Task)
+            .filter(
+                Task.id == task_lease.task_id,
+                Task.status == TaskStatus.RUNNING,
+                Task.runner_id == task_lease.runner_id,
+                task_lease_attempt_predicate(task_lease),
+                Task.run_id == task_lease.run_id,
+            )
+            .update(
+                {
+                    Task.input: text,
+                    Task.output: None,
+                    Task.error_message: None,
+                },
+                synchronize_session=False,
+            )
+        )
+        if updated != 1:
+            db.rollback()
+            return False
+        # Mirrors _update_a2a_resume_input_sync's fence-ordering argument:
+        # this update() call is the fence, not a new transaction, so a
+        # rollback here would undo it together with the input write -- the
+        # point is that ownership and the interaction close are one atomic
+        # fact. No lock read either -- the fence UPDATE above writes only
+        # non-key columns (input, output, error_message) and is already the
+        # first statement this transaction directs at tasks or
+        # task_interaction_requests, so it satisfies the same ordering and
+        # strength obligation a dedicated lock read would. The table-presence
+        # gate sits here, immediately before the close call and after the
+        # fence UPDATE, for the same reason as the A2A site: the gate only
+        # inspects the catalog and takes no row lock, so it does not count
+        # as preceding the fence UPDATE in the sense the ordering obligation
+        # means.
+        assert task_lease.run_id is not None
+        if interaction_requests_table_exists(db):
+            close_legacy_resume_interaction(
+                db,
+                task_id=task_lease.task_id,
+                run_id=task_lease.run_id,
+                interaction_id=interaction_id,
+            )
+        db.commit()
+        return True
+
+
+async def _schedule_waiting_reply_resume(
+    *,
+    task_id: int,
+    agent_service: Any,
+    task_owner_user_id: int,
+    task_lease: TaskLease,
+    heartbeat_stop: asyncio.Event,
+    heartbeat_task: "asyncio.Task[TaskLeaseHeartbeatOutcome]",
+) -> None:
+    if task_lease.task_id != task_id or task_lease.run_id is None:
+        raise ValueError("Reply resume scheduling requires an exact task lease")
+    if not task_execution_service.background_task_manager.reserve_resume(task_id):
+        # A same-process resume is already registered for this task despite
+        # the exclusive DB claim above -- report it the same way a caller
+        # would read a lost race on the claim itself, rather than a bare
+        # 500: retrying (after the other resume settles) can succeed.
+        raise TaskResumeBusyError
+    previous_task = task_execution_service.background_task_manager.running_tasks.get(
+        task_id
+    )
+    bg_task: "asyncio.Task[None] | None" = None
+    try:
+        bg_task = asyncio.create_task(
+            task_execution_service.execute_resume_background(
+                task_id=task_id,
+                agent_service=agent_service,
+                task_owner_user_id=task_owner_user_id,
+                expected_run_id=task_lease.run_id,
+                previous_task=previous_task,
+                preacquired_lease=task_lease,
+                preacquired_heartbeat_stop=heartbeat_stop,
+                preacquired_heartbeat_task=heartbeat_task,
+                # The prelease claimed this task out of waiting_for_user;
+                # hand that over so a checkpoint the resume cannot read
+                # restores it instead of failing it terminally.
+                preacquired_prior_status=TaskStatus.WAITING_FOR_USER,
+            )
+        )
+        task_execution_service.background_task_manager.register_reserved_resume(
+            task_id,
+            bg_task,
+            run_id=task_lease.run_id,
+        )
+    except BaseException:
+        if bg_task is not None:
+            await cancel_and_drain_async_task(bg_task)
+        task_execution_service.background_task_manager.release_resume_reservation(
+            task_id
+        )
+        raise
+
+
+async def resume_task_reply(ctx: TaskReplyInput) -> TaskReplyResumeResult:
+    """Resume an authorized SDK reply and return after background registration.
+
+    Each SDK request gets a fresh turn ID, preserving its existing lack of
+    client-message deduplication. The observed status preserves the initial
+    rejection semantics; the subsequent conditional claim checks current state.
+    """
+    task_id = ctx.task_id
+    if ctx.status != TaskStatus.WAITING_FOR_USER:
+        if ctx.status == TaskStatus.RUNNING:
+            raise TaskResumeBusyError
+        raise TaskResumeNotWaitingError
+
+    prelease_info: dict[str, Any] = {}
+    task_lease = await acquire_task_lease_cancellation_safe(
+        lambda: _acquire_reply_prelease_sync(
+            task_id=ctx.task_id,
+            agent_id=ctx.agent_id,
+            previous_run_id=ctx.run_id,
+            result_holder=prelease_info,
+        ),
+        lambda acquired: _restore_reply_prelease_sync(acquired),
+    )
+    if task_lease is None or task_lease.run_id is None:
+        raise TaskResumeBusyError
+
+    heartbeat_stop = asyncio.Event()
+    heartbeat_task = asyncio.create_task(
+        run_task_lease_heartbeat(task_lease, heartbeat_stop)
+    )
+    ownership_transferred = False
+    prelease_cleanup_done = False
+
+    async def stop_and_restore_prelease() -> bool:
+        nonlocal prelease_cleanup_done
+        if prelease_cleanup_done:
+            return False
+        prelease_cleanup_done = True
+        try:
+            outcome = await stop_task_lease_heartbeat(heartbeat_task, heartbeat_stop)
+        except BaseException:
+            logger.error(
+                "Reply prelease heartbeat failed before task %s could be "
+                "restored; retaining run %s for TTL recovery",
+                task_id,
+                task_lease.run_id,
+                exc_info=True,
+            )
+            return False
+        if outcome.requires_ttl_recovery:
+            logger.error(
+                "Reply prelease for task %s became unhealthy; retaining "
+                "run %s for TTL recovery (lost=%s, pool_timeout=%s)",
+                task_id,
+                task_lease.run_id,
+                outcome.lease_lost,
+                outcome.pool_timeout is not None,
+            )
+            return False
+        return await _restore_reply_prelease_isolated(task_lease)
+
+    try:
+        # Read before the injection below, not inside
+        # _update_reply_input_sync, whose session opens only afterwards.
+        # See task_interaction_close's module docstring for why.
+        active_interaction_read = await run_db_io_cancellation_safe(
+            lambda: active_interaction_id_sync(task_id)
+        )
+        # Translate the three-state read into the `int | None` this site's
+        # close call takes. Absent and Unavailable both become `None` here
+        # -- but that is not folding Unavailable into Absent, it is this
+        # call's own contract: `None` means "bind the close to no primary
+        # key", so it matches zero rows and retires no question either
+        # way, which is the safe outcome for a read that could not be
+        # made, not a claim that nothing was ever active. What then
+        # happens to the task's marker differs between the two, and this
+        # value is not what decides it -- the clear beside the close runs
+        # its own check (see active_interaction_id_sync's docstring).
+        # Written as three branches, not
+        # `interaction_id if isinstance(..., ActiveInteractionFound) else
+        # None`, so a reader (and mypy) sees Unavailable handled on its own
+        # line rather than merged into Absent's.
+        if isinstance(active_interaction_read, ActiveInteractionFound):
+            active_interaction_id = active_interaction_read.interaction_id
+        elif isinstance(active_interaction_read, ActiveInteractionAbsent):
+            active_interaction_id = None
+        elif isinstance(active_interaction_read, ActiveInteractionUnavailable):
+            active_interaction_id = None
+            logger.info(
+                "active interaction read unavailable (reason=%s) for "
+                "task_id=%s; the legacy resume close will match no row",
+                active_interaction_read.reason,
+                task_id,
+            )
+        else:
+            assert_never(active_interaction_read)
+
+        async def inject_user_message() -> tuple[Any, bool]:
+            agent_service = (
+                await agent_runtime_service.get_agent_manager().get_agent_for_task(
+                    task_id,
+                    None,
+                    task_owner_user_id=ctx.task_owner_user_id,
+                )
+            )
+            posted = await agent_service.post_user_message(
+                str(task_id),
+                execution_message=ctx.text,
+                display_message=ctx.text,
+                turn_id=f"v1:reply:{task_id}:{uuid4()}",
+                request_interrupt=False,
+                reason="V1 interaction response",
+            )
+            return agent_service, bool(posted)
+
+        with bind_task_lease_context(task_lease):
+            agent_service, posted = await run_while_task_lease_owned(
+                inject_user_message(),
+                heartbeat_task,
+            )
+
+        if not posted:
+            # No run-fenced checkpoint is available to resume onto. Never
+            # fabricate a run or fall back to a transcript replay: release
+            # the exact prelease back to waiting_for_user and fail closed
+            # so the caller must start a new task explicitly.
+            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
+            if not await drain_async_task_cancellation_safe(cleanup_task):
+                raise TaskLeaseLostError(
+                    f"Task {task_id} lease changed before reply fallback"
+                )
+            raise TaskResumeNotResumableError
+
+        updated = await run_db_io_cancellation_safe(
+            lambda: _update_reply_input_sync(
+                task_lease, ctx.text, active_interaction_id
+            )
+        )
+        if not updated:
+            raise TaskLeaseLostError(
+                f"Task {task_id} lease changed before reply resume scheduling"
+            )
+
+        await _schedule_waiting_reply_resume(
+            task_id=task_id,
+            agent_service=agent_service,
+            task_owner_user_id=ctx.task_owner_user_id,
+            task_lease=task_lease,
+            heartbeat_stop=heartbeat_stop,
+            heartbeat_task=heartbeat_task,
+        )
+        ownership_transferred = True
+    except CheckpointReadError as exc:
+        if not ownership_transferred and not prelease_cleanup_done:
+            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
+            if not await drain_async_task_cancellation_safe(cleanup_task):
+                raise TaskLeaseLostError(
+                    f"Task {task_id} lease changed before reply "
+                    "checkpoint-failure fallback"
+                ) from exc
+        raise
+    except BaseException:
+        if not ownership_transferred and not prelease_cleanup_done:
+            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
+            await drain_async_task_cancellation_safe(cleanup_task)
+        raise
+    finally:
+        if not ownership_transferred and not prelease_cleanup_done:
+            await stop_task_lease_heartbeat(heartbeat_task, heartbeat_stop)
+
+    return TaskReplyResumeResult(
+        run_id=task_lease.run_id,
+        state_version=prelease_info["state_version"],
+        control_state=prelease_info["control_state"],
+    )

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -37,6 +37,7 @@ from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import a2a_task_cancel as a2a_cancel_service
 from xagent.web.services import task_command_execution as command_execution_service
 from xagent.web.services import task_execution as task_execution_service
+from xagent.web.services import task_resume
 from xagent.web.services.a2a_protocol import (
     A2A_MAX_MESSAGE_TEXT_LENGTH,
     A2AApiError,
@@ -688,7 +689,9 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
             "xagent.web.services.agent_service_manager.get_agent_manager",
             return_value=agent_manager,
         ),
-        patch("xagent.web.api.a2a._schedule_waiting_a2a_resume") as schedule_resume,
+        patch(
+            "xagent.web.services.task_resume._schedule_waiting_a2a_resume"
+        ) as schedule_resume,
         patch(
             "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
             new=begin_turn,
@@ -786,7 +789,7 @@ def test_checkpoint_resume_schedule_failure_exactly_restores_waiting_task() -> N
             return_value=agent_manager,
         ),
         patch(
-            "xagent.web.api.a2a._schedule_waiting_a2a_resume",
+            "xagent.web.services.task_resume._schedule_waiting_a2a_resume",
             side_effect=fail_schedule,
         ),
     ):
@@ -870,7 +873,7 @@ def test_update_a2a_resume_input_rolls_back_the_interaction_close_with_the_fence
         run_id="run-atomicity",
         attempt_id="test-attempt",
     )
-    updated = a2a_api._update_a2a_resume_input_sync(
+    updated = task_resume._update_a2a_resume_input_sync(
         stale_lease,
         "attempted text",
         row_id,
@@ -942,7 +945,7 @@ def test_message_send_closes_the_legacy_resume_interaction_row_on_successful_inj
             "xagent.web.services.agent_service_manager.get_agent_manager",
             return_value=agent_manager,
         ),
-        patch("xagent.web.api.a2a._schedule_waiting_a2a_resume"),
+        patch("xagent.web.services.task_resume._schedule_waiting_a2a_resume"),
         patch(
             "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
             new=begin_turn,
@@ -1030,13 +1033,13 @@ def test_message_send_skips_the_close_on_a_replayed_injection() -> None:
             "xagent.web.services.agent_service_manager.get_agent_manager",
             return_value=agent_manager,
         ),
-        patch("xagent.web.api.a2a._schedule_waiting_a2a_resume"),
+        patch("xagent.web.services.task_resume._schedule_waiting_a2a_resume"),
         patch(
             "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
             new=AsyncMock(),
         ),
         patch(
-            "xagent.web.api.a2a.close_legacy_resume_interaction",
+            "xagent.web.services.task_resume.close_legacy_resume_interaction",
         ) as close_mock,
     ):
         response = client.post(
@@ -1142,16 +1145,17 @@ def test_message_send_reads_the_interaction_row_before_injecting(
             "xagent.web.services.agent_service_manager.get_agent_manager",
             return_value=agent_manager,
         ),
-        patch("xagent.web.api.a2a._schedule_waiting_a2a_resume"),
+        patch("xagent.web.services.task_resume._schedule_waiting_a2a_resume"),
         patch("xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn", new=AsyncMock()),
         patch(
-            "xagent.web.api.a2a.active_interaction_id_sync",
+            "xagent.web.services.task_resume.active_interaction_id_sync",
             side_effect=record_read,
         ),
         patch(
-            "xagent.web.api.a2a.close_legacy_resume_interaction", return_value=1
+            "xagent.web.services.task_resume.close_legacy_resume_interaction",
+            return_value=1,
         ) as close_mock,
-        caplog.at_level(logging.INFO, logger="xagent.web.api.a2a"),
+        caplog.at_level(logging.INFO, logger="xagent.web.services.task_resume"),
     ):
         response = client.post(
             f"/api/a2a/agents/{agent_id}/message:send",
@@ -1317,7 +1321,9 @@ def test_recovered_paused_checkpoint_resumes_without_transcript_fallback() -> No
             "xagent.web.services.agent_service_manager.get_agent_manager",
             return_value=agent_manager,
         ),
-        patch("xagent.web.api.a2a._schedule_waiting_a2a_resume") as schedule_resume,
+        patch(
+            "xagent.web.services.task_resume._schedule_waiting_a2a_resume"
+        ) as schedule_resume,
         patch(
             "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
             new=begin_turn,
@@ -1671,7 +1677,7 @@ def test_prelease_restore_from_a_cancelled_acquisition_leaves_marker_untouched()
         run_id="run-cancelled-acquire",
         attempt_id="test-attempt",
     )
-    restored = a2a_api._restore_a2a_resume_prelease_sync(
+    restored = task_resume._restore_a2a_resume_prelease_sync(
         acquired_lease, status=TaskStatus.WAITING_FOR_USER
     )
 

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -1,11 +1,11 @@
 """Integration tests for ``POST /v1/chat/tasks/{task_id}/reply``.
 
 Mirrors the structure of ``tests/web/api/test_a2a_api.py``'s
-input-required resume tests, since ``task_reply.py`` copies that
-resume's mechanics. Where a2a's test patches
-``xagent.web.api.a2a._schedule_waiting_a2a_resume`` to avoid spinning
+input-required resume tests; both drive the runner-owned recovery
+mechanics through their original protocol entry points. Where a2a's test patches
+``xagent.web.services.task_resume._schedule_waiting_a2a_resume`` to avoid spinning
 up a real background execution, these tests patch the analogous
-``xagent.web.api.v1.task_reply._schedule_waiting_reply_resume``.
+``xagent.web.services.task_resume._schedule_waiting_reply_resume``.
 """
 
 import asyncio
@@ -30,6 +30,7 @@ from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.schemas.v1 import ReplyRequest
 from xagent.web.services import task_execution as task_execution_service
+from xagent.web.services import task_resume
 from xagent.web.services.client_error_messages import CLIENT_SAFE_AUTO_MODEL_UNAVAILABLE
 from xagent.web.services.llm_utils import AutoModelUnavailableError
 from xagent.web.services.task_execution_controller import TaskControlState
@@ -218,7 +219,7 @@ def test_reply_happy_path_resumes_the_same_run(mock_start_task):
     with (
         agent_patch,
         patch(
-            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            "xagent.web.services.task_resume._schedule_waiting_reply_resume",
             new=AsyncMock(),
         ) as schedule_resume,
     ):
@@ -250,6 +251,8 @@ def test_reply_happy_path_resumes_the_same_run(mock_start_task):
         task = db.query(Task).filter(Task.id == task_id).one()
         assert task.status == TaskStatus.RUNNING
         assert task.run_id == "run-original"
+        assert body["state_version"] == task.state_version
+        assert body["control_state"] == task.control_state
         assert task.input == "yes, continue"
         assert task.output is None
         assert task.error_message is None
@@ -275,7 +278,7 @@ def test_reply_turn_id_is_never_reused_across_retries(mock_start_task):
     with (
         agent_patch,
         patch(
-            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            "xagent.web.services.task_resume._schedule_waiting_reply_resume",
             new=AsyncMock(),
         ),
     ):
@@ -308,7 +311,7 @@ def test_reply_turn_id_is_never_reused_across_retries(mock_start_task):
     with (
         agent_patch,
         patch(
-            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            "xagent.web.services.task_resume._schedule_waiting_reply_resume",
             new=AsyncMock(),
         ),
     ):
@@ -371,7 +374,7 @@ def test_reply_waiting_status_is_not_rejected_by_the_status_gate(mock_start_task
     with (
         agent_patch,
         patch(
-            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            "xagent.web.services.task_resume._schedule_waiting_reply_resume",
             new=AsyncMock(),
         ),
     ):
@@ -591,7 +594,7 @@ def test_reply_closes_the_legacy_resume_interaction_row_on_successful_injection(
     with (
         agent_patch,
         patch(
-            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            "xagent.web.services.task_resume._schedule_waiting_reply_resume",
             new=AsyncMock(),
         ),
     ):
@@ -678,18 +681,18 @@ def test_reply_reads_the_interaction_row_before_injecting(
     with (
         agent_patch,
         patch(
-            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            "xagent.web.services.task_resume._schedule_waiting_reply_resume",
             new=AsyncMock(),
         ),
         patch(
-            "xagent.web.api.v1.task_reply.active_interaction_id_sync",
+            "xagent.web.services.task_resume.active_interaction_id_sync",
             side_effect=record_read,
         ),
         patch(
-            "xagent.web.api.v1.task_reply.close_legacy_resume_interaction",
+            "xagent.web.services.task_resume.close_legacy_resume_interaction",
             return_value=1,
         ) as close_mock,
-        caplog.at_level(logging.INFO, logger="xagent.web.api.v1.task_reply"),
+        caplog.at_level(logging.INFO, logger="xagent.web.services.task_resume"),
     ):
         resp = client.post(
             f"/v1/chat/tasks/{task_id}/reply",
@@ -763,7 +766,7 @@ def test_update_reply_input_rolls_back_the_interaction_close_with_the_fence() ->
     stale_lease = TaskLease(
         task_id=task_id, runner_id="a-different-runner", run_id="run-reply-atomicity"
     )
-    updated = task_reply_module._update_reply_input_sync(
+    updated = task_resume._update_reply_input_sync(
         stale_lease, "attempted text", row_id
     )
 
@@ -991,7 +994,7 @@ async def test_concurrent_reply_race_exactly_one_winner(mock_start_task):
     with (
         agent_patch,
         patch(
-            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            "xagent.web.services.task_resume._schedule_waiting_reply_resume",
             new=AsyncMock(),
         ),
     ):
@@ -1091,7 +1094,7 @@ async def test_reply_resume_binds_the_coordinator_to_the_leased_run() -> None:
             side_effect=execute_resume_background,
         ),
     ):
-        await task_reply_module._schedule_waiting_reply_resume(
+        await task_resume._schedule_waiting_reply_resume(
             task_id=4242,
             agent_service=MagicMock(),
             task_owner_user_id=1,

--- a/tests/web/services/test_interaction_close_lock_ordering.py
+++ b/tests/web/services/test_interaction_close_lock_ordering.py
@@ -19,8 +19,7 @@ _update_reply_input_sync's inline comment):
   takes one explicit FOR NO KEY UPDATE / key_share=True lock read before
   calling into the close-and-clear function -- one lock read, not two,
   because the obligation moved into the shared helper.
-* The A2A resume-input site (a2a.py) and the v1 reply resume-input site
-  (task_reply.py) each take no lock read of their own: the resume-input
+* The A2A and v1 reply resume-input sites (task_resume.py) each take no lock read of their own: the resume-input
   fence UPDATE each already issues, ahead of its close call, is the first
   statement that transaction directs at tasks or task_interaction_requests,
   and (being a non-key-column UPDATE) already carries the ordering and
@@ -61,12 +60,11 @@ import ast
 from pathlib import Path
 
 import xagent
-from xagent.web.api import a2a
-from xagent.web.api.v1 import task_reply
 from xagent.web.services import (
     task_command_execution,
     task_execution,
     task_interaction_close,
+    task_resume,
 )
 
 CLOSE_MODULE_NAME = "task_interaction_close"
@@ -78,7 +76,7 @@ UNLOCKED_CLOSE_FUNCTION = "close_legacy_resume_interaction"
 # statement the transaction directs at tasks or task_interaction_requests.
 # Any other name added here must carry the same kind of argument, not just
 # a passing test.
-APPROVED_UNLOCKED_CALLERS = frozenset({"a2a", "task_reply"})
+APPROVED_UNLOCKED_CALLERS = frozenset({"task_resume"})
 
 POST_USER_MESSAGE_CALL_NAME = "post_user_message"
 CLOSE_FAMILY_CALL_NAMES = frozenset(
@@ -90,8 +88,8 @@ CLOSE_FAMILY_CALL_NAMES = frozenset(
 )
 # web/ modules that call post_user_message but are exempt from the
 # close-family wiring obligation checked below. Empty by construction:
-# every known post_user_message call site today (a2a.py, task_command_execution.py,
-# task_execution.py, task_reply.py) wires in a close-family call. A new call
+# every known post_user_message call site today (task_resume.py,
+# task_command_execution.py, task_execution.py) wires in a close-family call. A new call
 # site should wire one in too, not be added here as an exception.
 APPROVED_UNWIRED_POST_USER_MESSAGE_CALLERS: frozenset[str] = frozenset()
 
@@ -229,7 +227,9 @@ def test_a2a_resume_input_fence_precedes_the_close_call() -> None:
 
     Moving the fence UPDATE after the close call turns this red.
     """
-    fn = _find_function(ast.parse(_source(a2a)), "_update_a2a_resume_input_sync")
+    fn = _find_function(
+        ast.parse(_source(task_resume)), "_update_a2a_resume_input_sync"
+    )
     fence_update_lines = [
         node.lineno
         for node in ast.walk(fn)
@@ -301,7 +301,9 @@ def test_a2a_resume_input_close_is_gated_by_table_exists_check() -> None:
     Deleting the ``if interaction_requests_table_exists(db):`` guard, or
     moving the close call outside its body, turns this red.
     """
-    fn = _find_function(ast.parse(_source(a2a)), "_update_a2a_resume_input_sync")
+    fn = _find_function(
+        ast.parse(_source(task_resume)), "_update_a2a_resume_input_sync"
+    )
     guard_line = _table_exists_guard_line_for_close_call(
         fn, close_call_attr="close_legacy_resume_interaction"
     )
@@ -313,13 +315,13 @@ def test_a2a_resume_input_close_is_gated_by_table_exists_check() -> None:
 
 
 def test_reply_resume_input_close_is_gated_by_table_exists_check() -> None:
-    """Same obligation as the A2A site, above, for task_reply.py's
+    """Same obligation as the A2A site, above, for task_resume.py's
     fence-and-close pair.
 
     Deleting the ``if interaction_requests_table_exists(db):`` guard, or
     moving the close call outside its body, turns this red.
     """
-    fn = _find_function(ast.parse(_source(task_reply)), "_update_reply_input_sync")
+    fn = _find_function(ast.parse(_source(task_resume)), "_update_reply_input_sync")
     guard_line = _table_exists_guard_line_for_close_call(
         fn, close_call_attr="close_legacy_resume_interaction"
     )
@@ -352,20 +354,24 @@ def test_a2a_resume_input_fence_writes_exactly_the_approved_columns() -> None:
     column it writes is a non-key column. Adding a key column -- or any
     column covered by a unique index -- to the UPDATE's values without
     re-justifying that argument and widening
-    a2a.RESUME_INPUT_FENCE_UPDATE_COLUMNS to match must turn this red.
+    task_resume.RESUME_INPUT_FENCE_UPDATE_COLUMNS to match must turn this red.
     """
-    fn = _find_function(ast.parse(_source(a2a)), "_update_a2a_resume_input_sync")
-    assert _fence_update_value_columns(fn) == set(a2a.RESUME_INPUT_FENCE_UPDATE_COLUMNS)
+    fn = _find_function(
+        ast.parse(_source(task_resume)), "_update_a2a_resume_input_sync"
+    )
+    assert _fence_update_value_columns(fn) == set(
+        task_resume.RESUME_INPUT_FENCE_UPDATE_COLUMNS
+    )
 
 
 def test_reply_resume_input_fence_precedes_the_close_call() -> None:
     """The v1 reply resume-input fence UPDATE must precede the close call it
     satisfies the lock obligation for -- the same argument as the A2A site,
-    applied to task_reply.py's own fence-and-close pair.
+    applied to task_resume.py's own fence-and-close pair.
 
     Moving the fence UPDATE after the close call turns this red.
     """
-    fn = _find_function(ast.parse(_source(task_reply)), "_update_reply_input_sync")
+    fn = _find_function(ast.parse(_source(task_resume)), "_update_reply_input_sync")
     fence_update_lines = [
         node.lineno
         for node in ast.walk(fn)
@@ -394,11 +400,11 @@ def test_reply_resume_input_fence_writes_exactly_the_approved_columns() -> None:
     column it writes is a non-key column, the same argument the A2A site
     makes. Adding a key column -- or any column covered by a unique index --
     to the UPDATE's values without re-justifying that argument and widening
-    task_reply.RESUME_INPUT_FENCE_UPDATE_COLUMNS to match must turn this red.
+    task_resume.RESUME_INPUT_FENCE_UPDATE_COLUMNS to match must turn this red.
     """
-    fn = _find_function(ast.parse(_source(task_reply)), "_update_reply_input_sync")
+    fn = _find_function(ast.parse(_source(task_resume)), "_update_reply_input_sync")
     assert _fence_update_value_columns(fn) == set(
-        task_reply.RESUME_INPUT_FENCE_UPDATE_COLUMNS
+        task_resume.RESUME_INPUT_FENCE_UPDATE_COLUMNS
     )
 
 
@@ -445,7 +451,7 @@ def test_unlocked_close_is_only_called_from_the_approved_sites() -> None:
     (see the module docstring above). Scans every source file under the
     installed xagent package, so a new caller added anywhere without
     updating APPROVED_UNLOCKED_CALLERS is caught regardless of which
-    package it lands in, not only websocket.py, a2a.py, and task_reply.py.
+    package it lands in, not only task_resume.py and the execution modules.
 
     Known blind spot, not fixed here: this matches the call as written
     (``close_legacy_resume_interaction(...)`` or
@@ -480,8 +486,8 @@ def test_every_post_user_message_caller_wires_the_close_family() -> None:
     This is a module-level check, not a call-site-level one: it proves a
     close-family call exists somewhere in the module, not that it runs on
     every code path that reaches post_user_message. Today's four call
-    sites across four modules (a2a.py, task_command_execution.py, task_execution.py,
-    task_reply.py)
+    sites across three modules (task_resume.py, task_command_execution.py,
+    task_execution.py)
     each carry their own per-site argument for why their wiring is
     complete; see the tests
     above and task_interaction_close.py's module docstring.

--- a/tests/web/services/test_interaction_rollout_guards.py
+++ b/tests/web/services/test_interaction_rollout_guards.py
@@ -28,6 +28,7 @@ import xagent.web.models.task_interaction as task_interaction_module
 import xagent.web.services.chat_history_service as chat_history_service_module
 import xagent.web.services.task_interaction_read as task_interaction_read_module
 import xagent.web.services.task_interaction_service as task_interaction_service_module
+import xagent.web.services.task_resume as task_resume_module
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (3, 11),
@@ -42,6 +43,7 @@ _IMPORT_GUARD_MODULES = {
     "chat.py": chat_module,
     "chat_history_service.py": chat_history_service_module,
     "a2a.py": a2a_module,
+    "task_resume.py": task_resume_module,
     # The tuple adapter and the fifth consumption point. Both are read
     # side: the adapter answers "what is this task asking" and the v1
     # snapshot builder consumes it, and neither may reach for the

--- a/tests/web/services/test_lease_attempt_pairing.py
+++ b/tests/web/services/test_lease_attempt_pairing.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import pytest
 
 from xagent.web.api import a2a
-from xagent.web.services import task_lease_service, task_orchestrator
+from xagent.web.services import task_lease_service, task_orchestrator, task_resume
 
 LEASE_COLUMNS = frozenset({"runner_id", "lease_attempt_id"})
 
@@ -34,6 +34,7 @@ CARRIER_METHOD_NAMES = frozenset({"values", "update"})
 SUBJECT_MODULES = [
     task_lease_service,
     task_orchestrator,
+    task_resume,
     a2a,
 ]
 

--- a/tests/web/services/test_task_execution_boundary.py
+++ b/tests/web/services/test_task_execution_boundary.py
@@ -26,7 +26,7 @@ def test_execution_services_and_tracer_load_without_api_routes() -> None:
                             raise AssertionError(f"Execution imported API route: {fullname}")
 
                 sys.meta_path.insert(0, RejectRoutes())
-                from xagent.web.services import agent_service_manager, task_execution, task_orchestrator
+                from xagent.web.services import agent_service_manager, task_execution, task_orchestrator, task_resume
                 from xagent.web.services.external_task_cancel import _broadcast_external_cancel_terminal_event
                 import asyncio
                 from unittest.mock import AsyncMock, patch
@@ -130,7 +130,7 @@ def test_web_host_registers_event_delivery_on_import() -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_control_commands_execute_without_api_routes() -> None:
+def test_control_and_reply_commands_execute_without_api_routes() -> None:
     result = subprocess.run(
         [
             sys.executable,
@@ -163,6 +163,11 @@ def test_control_commands_execute_without_api_routes() -> None:
                 TaskCommandKind,
             )
             from xagent.web.services import agent_service_manager
+            from xagent.core.agent.runner import UserMessageInjectionOutcome
+            from xagent.web.services import task_execution, task_resume
+            from xagent.web.services.task_lease_service import (
+                stop_task_lease_heartbeat, release_task_lease_no_commit,
+            )
 
 
             async def main():
@@ -247,6 +252,60 @@ def test_control_commands_execute_without_api_routes() -> None:
                         assert canceled.agent_config["a2a_state"] == "TASK_STATE_CANCELED"
                         assert canceled.state_version == 1
                         assert db.query(TaskChatMessage).filter_by(task_id=ids[0]).count() == 1
+                    # Both reply paths run their real claims, writes and scheduling
+                    # without loading HTTP routes. Only the Agent and execution
+                    # leaf are replaced, so no model or external tools are needed.
+                    with get_session_local()() as db:
+                        replies = [
+                            Task(
+                                user_id=uid, agent_id=1, source=source,
+                                title="reply", status=TaskStatus.WAITING_FOR_USER,
+                                control_state="waiting_for_user", run_id=f"reply-{source}",
+                            )
+                            for source in ["a2a", "sdk"]
+                        ]
+                        db.add_all(replies)
+                        db.flush()
+                        reply_ids = [task.id for task in replies]
+                        db.commit()
+
+                    async def finish_resume(**kwargs):
+                        await stop_task_lease_heartbeat(
+                            kwargs["preacquired_heartbeat_task"],
+                            kwargs["preacquired_heartbeat_stop"],
+                        )
+                        with get_session_local()() as db:
+                            assert release_task_lease_no_commit(
+                                db, kwargs["preacquired_lease"], status=TaskStatus.COMPLETED,
+                            )
+                            db.commit()
+
+                    agent.post_user_message.return_value = UserMessageInjectionOutcome.POSTED_FRESH
+                    with (
+                        patch.object(agent_service_manager, "get_agent_manager") as manager,
+                        patch.object(task_execution, "execute_resume_background", side_effect=finish_resume),
+                    ):
+                        manager.return_value.get_agent_for_task = AsyncMock(return_value=agent)
+                        assert await task_resume.resume_a2a_task(
+                            agent_id=1, task_owner_user_id=uid, task_id=reply_ids[0],
+                            previous_run_id="reply-a2a", resumable_status=TaskStatus.WAITING_FOR_USER,
+                            text="A2A answer", message_id="answer-1",
+                        )
+                        a2a_resume = task_execution.background_task_manager.resume_tasks[reply_ids[0]]
+                        result = await task_resume.resume_task_reply(task_resume.TaskReplyInput(
+                            task_id=reply_ids[1], agent_id=1, task_owner_user_id=uid,
+                            run_id="reply-sdk", status=TaskStatus.WAITING_FOR_USER, text="SDK answer",
+                        ))
+                        assert result.run_id == "reply-sdk"
+                        assert result.control_state == "running"
+                        sdk_resume = task_execution.background_task_manager.resume_tasks[reply_ids[1]]
+                        await asyncio.gather(a2a_resume, sdk_resume)
+                    with get_session_local()() as db:
+                        for tid, answer in zip(reply_ids, ["A2A answer", "SDK answer"]):
+                            row = db.get(Task, tid)
+                            assert row.input == answer
+                            assert row.status == TaskStatus.COMPLETED
+                            assert row.runner_id is None
                     assert not any(
                         name == "xagent.web.api" or name.startswith("xagent.web.api.")
                         for name in sys.modules

--- a/tests/web/services/test_task_lease_epoch.py
+++ b/tests/web/services/test_task_lease_epoch.py
@@ -14,6 +14,7 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.services import agent_service_manager as agent_runtime_service
 from xagent.web.services import task_execution as task_execution_service
 from xagent.web.services import task_lease_service as leases
+from xagent.web.services import task_resume
 from xagent.web.services.task_command_execution import _task_lease_snapshot
 
 engine = engine_fixture
@@ -219,8 +220,6 @@ def test_old_acquisition_cannot_commit_any_execution_result(
     from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE, CHECKPOINT_TYPE
     from xagent.core.agent.runner import UserMessageInjectionOutcome
     from xagent.core.agent.trace import TraceEvent as CoreTraceEvent
-    from xagent.web.api import a2a
-    from xagent.web.api.v1 import task_reply
     from xagent.web.models.chat_message import TaskChatMessage
     from xagent.web.models.task import TraceEvent
     from xagent.web.models.task_execution_event import TaskExecutionEvent
@@ -233,8 +232,7 @@ def test_old_acquisition_cannot_commit_any_execution_result(
     factory, tid = lease_database
     monkeypatch.setattr(task_execution_service, "get_db", lambda: iter([factory()]))
     monkeypatch.setattr(task_execution_service, "get_session_local", lambda: factory)
-    monkeypatch.setattr(a2a, "get_session_local", lambda: factory)
-    monkeypatch.setattr(task_reply, "get_session_local", lambda: factory)
+    monkeypatch.setattr(task_resume, "get_session_local", lambda: factory)
     with factory() as db:
         old = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
         current = leases.acquire_task_lease(
@@ -289,11 +287,11 @@ def test_old_acquisition_cannot_commit_any_execution_result(
                 tid, "stale", task_lease=old
             )
         elif writer == "a2a_input":
-            assert not a2a._update_a2a_resume_input_sync(
+            assert not task_resume._update_a2a_resume_input_sync(
                 old, "stale", None, UserMessageInjectionOutcome.NOT_POSTED
             )
         elif writer == "reply_input":
-            assert not task_reply._update_reply_input_sync(old, "stale", None)
+            assert not task_resume._update_reply_input_sync(old, "stale", None)
         elif writer == "usage":
             from xagent.web.tracking.task_tracker import (
                 TokenUsage,


### PR DESCRIPTION
A2A and SDK reply endpoints currently own the first half of recovery: acquiring leases, starting heartbeats, injecting checkpoint messages, persisting input, closing interactions, and scheduling background execution. Move these flows into the runner-side `task_resume` service so the API passes detached inputs and translates results and errors into its existing protocol responses.

The two recovery implementations retain their existing lease predicates, transaction ordering, checkpoint failure handling, cancellation cleanup, and message identity semantics. A2A message deduplication and SDK reply response fields remain unchanged. This is a code relocation with narrow input/result/error adapters; task creation and separate runner processes are outside this change.

Migrate test imports, mocks, log capture targets, and source guards to the new module. Extend the headless runtime test to execute both recovery paths with API-route imports prohibited.

Validation:
- Focused review suite: 302 passed, 39 skipped.
- Expanded regression suite: 613 passed, 47 skipped; two existing WebSocket log-capture assertions failed identically on the unmodified base commit. Both are parameters of `test_live_resume_reads_the_interaction_row_before_injecting` in `test_websocket_owner_actor.py`, which still captures the old API logger.
- All applicable pre-commit checks passed, including full-project mypy.
- AST comparison confirmed unchanged lease, restoration, input-update, and interaction-close helper logic after import normalization.
