### PR TITLE
feat(calendar): add conflict-checking foundations and OAuth scopes

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.svg,*.png,*.jpg,*.jpeg,*.gif,*.ico,*.webp,pyproject.toml,*node_modules*,uploads/,generated_db_for_test/,memory_store/,data/lancedb/,**/package-lock.json
-ignore-words-list = fo,nd,te,hav,hte,wil,clol,loove,assertIn,ser,mis,pres,wit,asend,createable,fle
+ignore-words-list = fo,nd,te,hav,hte,wil,clol,loove,assertIn,ser,mis,pres,wit,asend,createable

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.svg,*.png,*.jpg,*.jpeg,*.gif,*.ico,*.webp,pyproject.toml,*node_modules*,uploads/,generated_db_for_test/,memory_store/,data/lancedb/,**/package-lock.json
-ignore-words-list = fo,nd,te,hav,hte,wil,clol,loove,assertIn,ser,mis,pres,wit,asend,createable
+ignore-words-list = fo,nd,te,hav,hte,wil,clol,loove,assertIn,ser,mis,pres,wit,asend,createable,fle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,11 @@ dependencies = [
   "matplotlib>=3.5.0",
   "google-auth-oauthlib>=1.2.0",
   "google-api-python-client>=2.145.0",
+  # zoneinfo's IANA timezone database - stdlib zoneinfo relies on the OS's
+  # tz data, which minimal container images may not ship; this guarantees
+  # it's present regardless of platform (calendar/outlook conflict-check
+  # timezone math needs real zone offsets, not just zone names).
+  "tzdata>=2024.1",
   "boxlite>=0.6.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "boxlite>=0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
   "filelock>=3.0.0",

--- a/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
+++ b/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
@@ -34,6 +34,9 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260907_add_calendar_freebusy_scope"
+# This migration was originally authored before the later-dated assistant
+# source migration landed. Pointing at the current main head keeps the graph
+# linear; migration filenames are descriptive labels, not execution order.
 down_revision: Union[str, None] = "20260911_assistant_source_event"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
+++ b/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
@@ -22,7 +22,7 @@ before attendee free/busy checks stop 403ing for them; this migration does
 not (and cannot) retroactively fix already-issued tokens.
 
 Revision ID: 20260907_add_calendar_freebusy_scope
-Revises: 20260909_seed_shopify_mcp_app
+Revises: 20260911_assistant_source_event
 Create Date: 2026-09-07
 
 """

--- a/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
+++ b/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
@@ -34,7 +34,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260907_add_calendar_freebusy_scope"
-down_revision: Union[str, None] = "20260909_seed_shopify_mcp_app"
+down_revision: Union[str, None] = "20260911_assistant_source_event"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
+++ b/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
@@ -1,0 +1,128 @@
+"""add calendar.freebusy to the Google Calendar connector's OAuth scope
+
+The scheduling-conflict check added to the calendar connector's create/update
+tools calls Google's ``freebusy.query`` endpoint to check attendees'
+availability. That endpoint is not authorized by ``.../auth/calendar.events``
+alone (per Google's own Calendar API scope reference) - it needs one of
+``calendar``, ``calendar.readonly``, ``calendar.freebusy``, or
+``calendar.events.freebusy``. ``calendar.freebusy`` is the minimal addition
+that covers it without also granting broader calendar read access.
+
+For a builtin app, the scope actually requested at authorize time is sourced
+live from ``builtin_mcp_registry.py``, not from this table -- this migration
+only converges the persisted ``public_mcp_apps.oauth_scopes`` row so
+``validate_builtin_public_mcp_apps`` stops reporting drift against that
+registry value on an already-seeded database.
+
+Unlike the earlier narrowing migration (20260817_narrow_google_calendar_scope),
+this one WIDENS the scope: an already-issued ``user_oauth`` grant only has
+the narrower ``calendar.events`` scope and does not automatically pick up
+the new one. Existing users must reconnect the Google Calendar connector
+before attendee free/busy checks stop 403ing for them; this migration does
+not (and cannot) retroactively fix already-issued tokens.
+
+Revision ID: 20260907_add_calendar_freebusy_scope
+Revises: 20260909_seed_shopify_mcp_app
+Create Date: 2026-09-07
+
+"""
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260907_add_calendar_freebusy_scope"
+down_revision: Union[str, None] = "20260909_seed_shopify_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+)
+
+APP_ID = "google-calendar"
+OLD_SCOPES = ("https://www.googleapis.com/auth/calendar.events",)
+NEW_SCOPES = (
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+)
+
+
+def _columns_present(
+    bind: sa.engine.Connection, table_name: str, required_columns: set[str]
+) -> bool:
+    """Whether ``table_name`` exists and has all of ``required_columns``.
+
+    Used by _set_calendar_scopes(), the online path upgrade() and
+    downgrade() both call: this migration must be a no-op (not an error)
+    against a database mid-way through a schema this old, or an admin's
+    reduced-schema table, rather than assume a table shape that matches
+    only the current model.
+    """
+    inspector = sa.inspect(bind)
+    if table_name not in set(inspector.get_table_names()):
+        return False
+    columns = {column["name"] for column in inspector.get_columns(table_name)}
+    return required_columns.issubset(columns)
+
+
+def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str) -> object:
+    # Match the online sa.JSON binding contract: values are stored as JSON,
+    # not as a bare SQL string literal, on every supported dialect.
+    serialized_literal = op.inline_literal(json.dumps(scopes))
+    if dialect_name == "postgresql":
+        return sa.cast(serialized_literal, sa.JSON())
+    return serialized_literal
+
+
+def _set_calendar_scopes_offline(scopes: Sequence[str]) -> None:
+    dialect_name = op.get_context().dialect.name
+    statement = (
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
+        .values(oauth_scopes=_offline_scopes_literal(scopes, dialect_name))
+    )
+    op.execute(statement)
+
+
+def _set_calendar_scopes(scopes: Sequence[str]) -> None:
+    """Write ``scopes`` to the google-calendar row's oauth_scopes column.
+
+    oauth_scopes is in admin_mcp's _BUILTIN_PROTECTED_FIELDS, so an operator
+    can never have customized it via the admin PATCH endpoint -- safe to
+    overwrite unconditionally, with no prior-value check, in both
+    directions. Online-only: the caller has already handled the offline
+    (``--sql``) path, since there's no live ``bind`` to use here otherwise.
+    """
+    bind = op.get_bind()
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=scopes)
+    )
+
+
+def upgrade() -> None:
+    # Offline (--sql) generation has a MockConnection, so reflection is
+    # unavailable -- emit the unconditional UPDATE instead of inspecting.
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(NEW_SCOPES)
+        return
+
+    _set_calendar_scopes(NEW_SCOPES)
+
+
+def downgrade() -> None:
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(OLD_SCOPES)
+        return
+
+    _set_calendar_scopes(OLD_SCOPES)

--- a/src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py
+++ b/src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py
@@ -1,0 +1,139 @@
+"""add calendar.calendars.readonly to the Google Calendar connector's OAuth scope
+
+The all-day conflict-check path calls Google's ``calendars.get`` endpoint (via
+``_primary_calendar_info``) to widen an all-day boundary using the primary
+calendar's own configured timezone (the same call also resolves the
+connected account's own address, used to tell whether the caller is
+actually a given event's organizer). That endpoint is not authorized by
+``.../auth/calendar.events`` or ``.../auth/calendar.freebusy`` (per Google's
+own Calendar API scope reference for ``calendars.get``) -- it needs one of
+``calendar``, ``calendar.readonly``, ``calendar.app.created``,
+``calendar.calendars``, or ``calendar.calendars.readonly``.
+``calendar.calendars.readonly`` is the minimal addition that covers it
+without also granting event read access beyond what ``calendar.events``
+already does.
+
+For a builtin app, the scope actually requested at authorize time is sourced
+live from ``builtin_mcp_registry.py``, not from this table -- this migration
+only converges the persisted ``public_mcp_apps.oauth_scopes`` row so
+``validate_builtin_public_mcp_apps`` stops reporting drift against that
+registry value on an already-seeded database.
+
+Like 20260907_add_calendar_freebusy_scope, this WIDENS the scope: an
+already-issued ``user_oauth`` grant does not automatically pick up the new
+scope. Existing users must reconnect the Google Calendar connector before
+all-day conflict checks stop 403ing for them; this migration does not (and
+cannot) retroactively fix already-issued tokens. Unlike the freebusy gap,
+which degraded to "attendee unchecked but still books", the calendar.py
+caller now rejects the write outright on this missing-scope signal rather
+than silently proceeding (see google_calendar_update_events).
+
+Revision ID: 20260909_add_calendar_calendars_readonly_scope
+Revises: 20260907_add_calendar_freebusy_scope
+Create Date: 2026-09-09
+
+"""
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260909_add_calendar_calendars_readonly_scope"
+down_revision: Union[str, None] = "20260907_add_calendar_freebusy_scope"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+)
+
+APP_ID = "google-calendar"
+OLD_SCOPES = (
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+)
+NEW_SCOPES = (
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+    "https://www.googleapis.com/auth/calendar.calendars.readonly",
+)
+
+
+def _columns_present(
+    bind: sa.engine.Connection, table_name: str, required_columns: set[str]
+) -> bool:
+    """Whether ``table_name`` exists and has all of ``required_columns``.
+
+    Used by _set_calendar_scopes(), the online path upgrade() and
+    downgrade() both call: this migration must be a no-op (not an error)
+    against a database mid-way through a schema this old, or an admin's
+    reduced-schema table, rather than assume a table shape that matches
+    only the current model.
+    """
+    inspector = sa.inspect(bind)
+    if table_name not in set(inspector.get_table_names()):
+        return False
+    columns = {column["name"] for column in inspector.get_columns(table_name)}
+    return required_columns.issubset(columns)
+
+
+def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str) -> object:
+    # Match the online sa.JSON binding contract: values are stored as JSON,
+    # not as a bare SQL string literal, on every supported dialect.
+    serialized_literal = op.inline_literal(json.dumps(scopes))
+    if dialect_name == "postgresql":
+        return sa.cast(serialized_literal, sa.JSON())
+    return serialized_literal
+
+
+def _set_calendar_scopes_offline(scopes: Sequence[str]) -> None:
+    dialect_name = op.get_context().dialect.name
+    statement = (
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
+        .values(oauth_scopes=_offline_scopes_literal(scopes, dialect_name))
+    )
+    op.execute(statement)
+
+
+def _set_calendar_scopes(scopes: Sequence[str]) -> None:
+    """Write ``scopes`` to the google-calendar row's oauth_scopes column.
+
+    oauth_scopes is in admin_mcp's _BUILTIN_PROTECTED_FIELDS, so an operator
+    can never have customized it via the admin PATCH endpoint -- safe to
+    overwrite unconditionally, with no prior-value check, in both
+    directions. Online-only: the caller has already handled the offline
+    (``--sql``) path, since there's no live ``bind`` to use here otherwise.
+    """
+    bind = op.get_bind()
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=scopes)
+    )
+
+
+def upgrade() -> None:
+    # Offline (--sql) generation has a MockConnection, so reflection is
+    # unavailable -- emit the unconditional UPDATE instead of inspecting.
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(NEW_SCOPES)
+        return
+
+    _set_calendar_scopes(NEW_SCOPES)
+
+
+def downgrade() -> None:
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(OLD_SCOPES)
+        return
+
+    _set_calendar_scopes(OLD_SCOPES)

--- a/src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py
+++ b/src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py
@@ -1,10 +1,10 @@
 """add calendar.calendars.readonly to the Google Calendar connector's OAuth scope
 
-The all-day conflict-check path calls Google's ``calendars.get`` endpoint (via
-``_primary_calendar_info``) to widen an all-day boundary using the primary
-calendar's own configured timezone (the same call also resolves the
-connected account's own address, used to tell whether the caller is
-actually a given event's organizer). That endpoint is not authorized by
+The follow-up all-day conflict-check implementation calls Google's
+``calendars.get`` endpoint to widen an all-day boundary using the primary
+calendar's own configured timezone. The same call resolves the connected
+account's own address so the connector can determine whether the caller is
+actually a given event's organizer. That endpoint is not authorized by
 ``.../auth/calendar.events`` or ``.../auth/calendar.freebusy`` (per Google's
 own Calendar API scope reference for ``calendars.get``) -- it needs one of
 ``calendar``, ``calendar.readonly``, ``calendar.app.created``,
@@ -23,10 +23,9 @@ Like 20260907_add_calendar_freebusy_scope, this WIDENS the scope: an
 already-issued ``user_oauth`` grant does not automatically pick up the new
 scope. Existing users must reconnect the Google Calendar connector before
 all-day conflict checks stop 403ing for them; this migration does not (and
-cannot) retroactively fix already-issued tokens. Unlike the freebusy gap,
-which degraded to "attendee unchecked but still books", the calendar.py
-caller now rejects the write outright on this missing-scope signal rather
-than silently proceeding (see google_calendar_update_events).
+cannot) retroactively fix already-issued tokens. The follow-up connector
+implementation rejects writes when this required scope is missing rather
+than silently proceeding.
 
 Revision ID: 20260909_add_calendar_calendars_readonly_scope
 Revises: 20260907_add_calendar_freebusy_scope

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -491,7 +491,11 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "transport": "oauth",
             "provider_name": "google",
             "category": "Scheduling",
-            "oauth_scopes": ["https://www.googleapis.com/auth/calendar.events"],
+            "oauth_scopes": [
+                "https://www.googleapis.com/auth/calendar.events",
+                "https://www.googleapis.com/auth/calendar.freebusy",
+                "https://www.googleapis.com/auth/calendar.calendars.readonly",
+            ],
             "is_visible_in_connector": True,
             "launch_config": {
                 "command": "python",

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -2,10 +2,65 @@ import json
 import os
 import re
 import urllib.request
+from datetime import date, datetime, time, timedelta
 from typing import Any
 from urllib.parse import quote
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ....config import get_tool_max_output_length
+
+
+class InsufficientScopeError(ValueError):
+    """Raised by a connector's ``_find_conflicts`` on a whole-batch
+    missing-scope error (see that function's own docstring for why this
+    is raised at all rather than degrading to unchecked).
+
+    Carries whatever ``conflicts``/``unchecked_attendees`` had already
+    been confirmed before the error - a caller accumulating results
+    across multiple ``_find_conflicts`` calls for one create/update (e.g.
+    one call for newly-added attendees, another per delta segment for
+    retained attendees) needs this to still report an already-confirmed
+    real conflict (found before the error, in this call or an earlier
+    one) instead of silently discarding it just because a *later*,
+    unrelated check also hit the same scope problem. Reporting a known
+    conflict is always safe regardless of what else couldn't be checked;
+    only the "nothing confirmed yet, can't tell if this is safe" case
+    should still reject the write outright.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        conflicts: list[dict[str, Any]],
+        unchecked_attendees: list[str],
+    ) -> None:
+        super().__init__(message)
+        self.conflicts = conflicts
+        self.unchecked_attendees = unchecked_attendees
+
+
+def merge_scope_error(
+    exc: InsufficientScopeError,
+    conflicts: list[dict[str, Any]],
+    unchecked_attendees: list[str],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Fold an `InsufficientScopeError` caught mid-accumulation into the
+    running `conflicts`/`unchecked_attendees` a connector's create/update
+    tool is building up (potentially across more than one `_find_conflicts`
+    call) - merging the error's own already-confirmed findings in first, so
+    a real conflict found before the error is never lost regardless of
+    which of possibly several calls actually raised.
+
+    Re-raises `exc` itself (preserving its original traceback/cause) when
+    the merged `conflicts` is still empty: nothing was confirmed yet, so
+    there is no already-known problem safe to report instead of rejecting
+    the write outright.
+    """
+    conflicts = [*conflicts, *exc.conflicts]
+    unchecked_attendees = [*unchecked_attendees, *exc.unchecked_attendees]
+    if not conflicts:
+        raise exc
+    return conflicts, unchecked_attendees
 
 
 def require_clean_identifier(value: str, field_name: str) -> str:
@@ -116,6 +171,398 @@ def success_with_capped_dict(field_name: str, data: Any) -> str:
         truncated = True
         response = _build(working, truncated)
     return response
+
+
+def normalize_addresses(addresses: list[str] | str) -> list[str]:
+    """Split/strip a comma-separated string or list of email addresses into a
+    clean list, dropping anything blank and case-insensitive duplicates
+    (keeping the first casing seen - email addresses are case-insensitive,
+    so a caller passing the same person twice with different casing, e.g.
+    from a human-written invite list, must not become two separate
+    attendee entries downstream)."""
+    if isinstance(addresses, str):
+        raw = [address.strip() for address in addresses.split(",") if address.strip()]
+    else:
+        raw = [address.strip() for address in addresses if address and address.strip()]
+    seen: set[str] = set()
+    deduped = []
+    for address in raw:
+        key = address.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(address)
+    return deduped
+
+
+def conflict_response(
+    conflicts: list[dict[str, Any]],
+    unchecked_attendees: list[str],
+    start: str,
+    end: str,
+) -> str:
+    """Build the status="conflict" envelope a calendar-writing MCP tool
+    returns instead of creating/updating an event, so the calling agent
+    reports the conflict to the user rather than silently double-booking.
+
+    `unchecked_attendees` is usually the self-explanatory kind (an
+    attendee absent from the provider's response, or its own per-attendee
+    error) - a missing-OAuth-scope 403 covering the whole call is instead
+    raised as `InsufficientScopeError` before ever reaching here, since
+    writing an event whose availability could never actually be checked
+    would defeat the point of this feature. The one exception: a caller
+    that catches `InsufficientScopeError` because `conflicts` was already
+    non-empty (a real conflict was confirmed before the scope error hit)
+    may pass that error's own `unchecked_attendees` through here too - at
+    that point the write is already correctly blocked by the known
+    conflict, so being honest about who else couldn't be checked is safe.
+
+    `conflicts` and `unchecked_attendees` are both uncapped input (an
+    organizer with a busy shared calendar or a wide window can turn up
+    far more overlapping events than a caller needs to see; a missing-
+    scope error partway through a large invite list can likewise mark
+    an entire remaining batch unchecked) - unlike every other response
+    path here, which routes through `success_with_capped_dict`, this
+    shape has multiple top-level fields under a non-"success" status
+    that function doesn't support, so the payload is capped locally
+    instead: whichever of `conflicts`/`unchecked_attendees` is currently
+    larger (by its own serialized size) is halved each step, so a
+    single real conflict isn't fully dropped just to make room for a
+    still-oversized `unchecked_attendees` list (unconditionally halving
+    `conflicts` first would zero out a 1-item list in a single step,
+    regardless of whether that was actually necessary) - the small
+    `hint` field is never touched.
+    """
+    payload: dict[str, Any] = {
+        "status": "conflict",
+        "message": f"{len(conflicts)} existing event(s) overlap {start} - {end}",
+        "conflicts": conflicts,
+        "unchecked_attendees": unchecked_attendees,
+        "hint": (
+            "Do not retry with the same time slot. Report these conflicts to "
+            "the user and ask them to pick a different time or confirm they "
+            "want to proceed anyway. Only call this tool again with "
+            "ignore_conflicts=true after the user has explicitly confirmed "
+            "they still want this slot."
+        ),
+        # Always present (not just when truncation actually happens),
+        # matching every other capped response path in this package
+        # (see success_with_capped_dict) - a caller that learned
+        # "truncated is always in the payload" from those shouldn't have
+        # to special-case this one.
+        "truncated": False,
+    }
+    response = json.dumps(payload, ensure_ascii=False)
+    max_output_length = get_tool_max_output_length()
+    if len(response) <= max_output_length:
+        return response
+
+    remaining_conflicts = conflicts
+    remaining_unchecked = unchecked_attendees
+    while (remaining_conflicts or remaining_unchecked) and len(
+        response
+    ) > max_output_length:
+        conflicts_size = len(json.dumps(remaining_conflicts, ensure_ascii=False))
+        unchecked_size = len(json.dumps(remaining_unchecked, ensure_ascii=False))
+        if remaining_conflicts and conflicts_size >= unchecked_size:
+            remaining_conflicts = remaining_conflicts[: len(remaining_conflicts) // 2]
+        else:
+            remaining_unchecked = remaining_unchecked[: len(remaining_unchecked) // 2]
+        payload["conflicts"] = remaining_conflicts
+        payload["unchecked_attendees"] = remaining_unchecked
+        payload["truncated"] = True
+        response = json.dumps(payload, ensure_ascii=False)
+    return response
+
+
+def attendees_were_given(attendees: list[str] | str | None) -> bool:
+    """Whether `attendees` was actually provided by the caller for an
+    update, treating an empty string the same as not-provided at all -
+    matching every other optional field's truthy convention here (and the
+    create path's own check) - rather than as "clear every attendee".
+    That's still expressible, just via an explicit empty list: `[]` is a
+    deliberate, differently-typed value that must keep working."""
+    return attendees is not None and attendees != ""
+
+
+def attendees_to_add(
+    attendees: list[str] | str | None, existing_attendee_emails: set[str]
+) -> list[str]:
+    """The newly-added addresses from an update's `attendees` argument,
+    normalized and deduped, that aren't already in
+    `existing_attendee_emails` - what actually needs writing when
+    `attendees` only ever adds attendees and never removes any. Returns
+    [] for anything `attendees_were_given` treats as not-provided (None,
+    ""), matching its own convention, as well as for a caller-supplied
+    list/string that turns out to name only people already on the event.
+    """
+    if not attendees_were_given(attendees):
+        return []
+    assert attendees is not None  # narrows for mypy; attendees_were_given implies this
+    return [
+        address
+        for address in normalize_addresses(attendees)
+        if address.lower() not in existing_attendee_emails
+    ]
+
+
+_OVERLONG_FRACTIONAL_SECONDS = re.compile(r"(\.\d{6})\d+")
+
+
+def datetime_key_for_comparison(value: str | None) -> datetime | str | None:
+    """Return a value suitable for equality-comparing two datetime strings
+    that may be written in different but equivalent formats.
+
+    A caller re-submitting the same instant it just read back from an API
+    (or a value it typed by hand) can differ in formatting alone - "Z" vs
+    "+00:00", a different (but equal-instant) zone offset, missing vs
+    present fractional seconds - while meaning the same moment. Comparing
+    such strings directly treats a same-instant resubmission as a real
+    change, which for a scheduling-conflict check means re-querying (and,
+    worse, misjudging self-conflicts against) a window that never actually
+    moved.
+
+    Parses to a `datetime` and returns it: two aware datetimes compare
+    equal when they denote the same instant regardless of differing zone
+    offsets, which a string/isoformat() comparison would not catch. Two
+    naive datetimes (Outlook's dateTime values, which carry no offset of
+    their own) compare directly, which is correct since both sides here
+    always come from the same source. An aware value never equals a naive
+    one, which is fine - these are simply never the same source's values
+    (never worse than the plain-string comparison this replaces).
+
+    Returns the original value unchanged if it doesn't parse (None stays
+    None, and a genuinely malformed value still compares by raw string,
+    same as before this normalization existed - never worse, never a
+    crash).
+
+    Outlook commonly reports 7-digit (100-nanosecond) fractional seconds
+    (e.g. ".0000000"), one more digit than a `datetime` microsecond can
+    hold. `fromisoformat`'s tolerance for that is a CPython-version detail
+    the caller shouldn't need to know about, so any fractional-seconds run
+    longer than 6 digits is truncated to 6 before parsing, rather than
+    relying on the current interpreter to accept (and correctly truncate)
+    the extra digits itself.
+    """
+    if value is None:
+        return None
+    normalized = value
+    if normalized[-1:] in ("Z", "z"):
+        # Only the trailing UTC marker, not a blanket .replace("Z", ...) -
+        # a naive str.replace would also touch a "Z"/"z" anywhere else in
+        # the string, which happens to never occur in a valid ISO
+        # datetime today but is needless coupling to that happening to
+        # stay true.
+        normalized = normalized[:-1] + "+00:00"
+    normalized = _OVERLONG_FRACTIONAL_SECONDS.sub(r"\1", normalized)
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return value
+
+
+def reject_reversed_window(start_value: str, end_value: str) -> None:
+    """Raise ValueError when `end_value` is not after `start_value` - an
+    event window's basic ordering sanity, checked before forwarding it to
+    the provider API as-is (both on create, and on update's effective
+    window regardless of ignore_conflicts - this isn't a conflict-check
+    decision a caller can opt out of).
+
+    Deliberately permissive when either side doesn't parse to a real,
+    comparable instant (stays silent rather than rejecting) - matching
+    this module's other datetime comparisons, which treat "can't tell"
+    as "don't block", not "assume invalid". That includes the case where
+    both sides parse but one is offset-aware and the other naive (e.g. a
+    ``Z``-suffixed value alongside a naive one): Python raises
+    ``TypeError`` comparing those with ``<=`` even though both are real
+    ``datetime`` instances, so the ``isinstance`` check alone isn't
+    enough to guarantee a safe comparison - see ``window_delta_segments``,
+    which guards the identical hazard the same way.
+    """
+    start_key = datetime_key_for_comparison(start_value)
+    end_key = datetime_key_for_comparison(end_value)
+    if not (isinstance(start_key, datetime) and isinstance(end_key, datetime)):
+        return
+    try:
+        if end_key <= start_key:
+            raise ValueError(
+                f"end ({end_value!r}) must be after start ({start_value!r})."
+            )
+    except TypeError:
+        return
+
+
+def require_offset_datetime(value: str, field_name: str) -> None:
+    """Raise ValueError when `value` parses to a real instant but doesn't
+    carry a UTC offset or "Z" suffix.
+
+    A caller-supplied boundary that's naive isn't just non-compliant with
+    the documented RFC3339 contract: this module's own internal instants
+    (e.g. an existing event's boundary via `_event_boundary`) are always
+    offset-bearing, so a naive value compared against one raises
+    `TypeError` deep inside a downstream comparison (see
+    `window_delta_segments`'s aware-vs-naive guard) - which conservatively
+    falls back to using the naive value as-is, so it eventually reaches
+    the provider API's timeMin/timeMax and fails there with an opaque
+    error instead of this clear, actionable one.
+
+    Silent (no-op) when `value` doesn't parse to a real instant at all -
+    that's a different failure a caller will already hit downstream with
+    its own clear error, not this function's job to preempt.
+    """
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return
+    if parsed.tzinfo is None:
+        raise ValueError(
+            f"{field_name} ({value!r}) must include a UTC offset or 'Z' "
+            "suffix (RFC3339), e.g. '2026-08-27T10:00:00+00:00' or "
+            "'2026-08-27T10:00:00Z'."
+        )
+
+
+def resolve_zoneinfo(name: str) -> ZoneInfo:
+    """Resolve a Google Calendar timeZone value (an IANA Time Zone
+    Database name, per Google's own EventDateTime docs) to a real
+    ``ZoneInfo``, for use anywhere a working zone is required (not just a
+    best-effort comparison) - e.g. attaching a real UTC offset to a naive
+    datetime string.
+
+    Raises ``ValueError`` rather than silently defaulting to UTC when the
+    name can't be resolved: a wrong silent guess here is exactly the class
+    of bug (a query or write running in the wrong real-world window) this
+    helper exists to prevent.
+    """
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise ValueError(
+            f"Timezone {name!r} isn't a recognized IANA zone name."
+        ) from exc
+
+
+def offset_datetime_string(value: str, tz_name: str) -> str:
+    """Combine a naive datetime string (no embedded UTC offset - Outlook's
+    dateTimeTimeZone.dateTime is always this shape, paired with a separate
+    timeZone field) with its zone name into an offset-bearing ISO 8601
+    string.
+
+    Needed anywhere a naive value has to be sent to an API that (unlike
+    Outlook's own structured ``{"dateTime", "timeZone"}`` request bodies)
+    takes a single datetime string and infers UTC when it carries no
+    offset of its own. Graph's own docs for List calendarView's
+    startDateTime/endDateTime query parameters say exactly this: they're
+    "interpreted using the timezone offset specified in the value" and
+    "aren't impacted by the value of the Prefer ... header" - a naive
+    value there is silently read as UTC regardless of what timezone the
+    caller actually meant.
+
+    Raises ``ValueError`` (via ``resolve_zoneinfo``) rather than falling
+    back to UTC when ``tz_name`` can't be resolved - and also raises if
+    ``value`` turns out to already carry its own offset/``Z``, rather
+    than silently relabeling those same clock digits with `tz_name`'s
+    offset instead of converting them (``.replace(tzinfo=...)`` changes
+    what zone a datetime is interpreted in without changing the instant
+    it names, e.g. turning "10:00 UTC" into "10:00 <tz_name>" - a real
+    shift, not a no-op, whenever the two offsets differ). No public tool
+    parameter is documented as requiring a naive value, so a caller
+    passing one with an offset already attached is a real, reachable
+    input here, not just a theoretical one.
+    """
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is not None:
+        raise ValueError(
+            f"{value!r} already carries a UTC offset; pass a naive "
+            "datetime string (no trailing 'Z' or +HH:MM) together with "
+            "its timezone name instead of embedding an offset in both."
+        )
+    return parsed.replace(tzinfo=resolve_zoneinfo(tz_name)).isoformat()
+
+
+def calendar_day_bounds(
+    date_value: str, tz_name: str, *, days: int = 1
+) -> tuple[str, str]:
+    """Return (start, end) offset-bearing ISO instants spanning ``days``
+    full calendar day(s) starting at ``date_value``'s date, in ``tz_name``.
+
+    ``date_value`` may be a bare "YYYY-MM-DD" or a full datetime string
+    (only its date component is used). Used to widen an all-day event's
+    (or an all-day toggle's) boundary into a real queryable window: an
+    all-day event occupies the *calendar's own* day, not a UTC day, so a
+    hardcoded "T00:00:00Z" is only correct for a UTC calendar.
+    """
+    zone = resolve_zoneinfo(tz_name)
+    day: date = datetime.fromisoformat(date_value).date()
+    start = datetime.combine(day, time.min, tzinfo=zone)
+    end = start + timedelta(days=days)
+    return start.isoformat(), end.isoformat()
+
+
+def window_delta_segments(
+    existing_start: datetime | str | None,
+    existing_end: datetime | str | None,
+    new_start: datetime | str | None,
+    new_end: datetime | str | None,
+) -> list[tuple[datetime, datetime]]:
+    """The portion(s) of the half-open [new_start, new_end) window that
+    fall OUTSIDE [existing_start, existing_end) - the only territory an
+    attendee already on the event needs a fresh free/busy check against.
+
+    An attendee already on the event will always show this very event's
+    own busy block for any instant inside the OLD window - querying that
+    overlap can't distinguish "busy because of this event" from a real
+    conflict, the exact self-conflict bug this function exists to avoid.
+    But a window can move in a way that's neither identical/subset (no
+    new territory at all) nor fully disjoint (the whole new window is new
+    territory) - a partial nudge like 10:00-10:30 -> 10:15-10:45 makes
+    10:30-10:45 new territory while 10:15-10:30 is still old ground, and
+    checking the retained attendee only over the confirmed-safe old
+    portion (or not at all) would silently miss a genuine conflict
+    sitting in that new segment. This computes exactly that new territory
+    so the caller can check retained attendees against precisely it,
+    while newly-added attendees (who have no footprint on this event at
+    all) still get the FULL new window checked regardless of any of this
+    - they need every instant in it verified, delta or not.
+
+    Returns:
+    - ``[]`` when the new window is confirmed to add no territory beyond
+      the old one (identical or a subset) - nothing new for a retained
+      attendee to be checked against.
+    - Up to two disjoint segments when the new window extends past the
+      old one's start, end, or both (e.g. extending a meeting on both
+      sides in one call).
+    - The whole ``[new_start, new_end)`` as a single segment when the two
+      windows are confirmed to not overlap at all (matching "moved
+      somewhere completely disjoint -> check the whole thing"), OR when
+      any value isn't a real, mutually-comparable ``datetime`` (parsing
+      failure, or one side aware and the other naive) - "can't confirm
+      the delta is smaller than the whole window" must never silently
+      shrink what gets checked, so treat it as needing the full window.
+    - ``[]`` in the same can't-tell scenario if there's no valid new
+      window at all to fall back to (``new_start``/``new_end`` themselves
+      aren't real instants) - there is nothing meaningful to check.
+    """
+    if not (isinstance(new_start, datetime) and isinstance(new_end, datetime)):
+        return []
+    if not (
+        isinstance(existing_start, datetime) and isinstance(existing_end, datetime)
+    ):
+        return [(new_start, new_end)]
+    try:
+        fully_disjoint = new_end <= existing_start or new_start >= existing_end
+        if fully_disjoint:
+            return [(new_start, new_end)]
+        segments = []
+        if new_start < existing_start:
+            segments.append((new_start, existing_start))
+        if new_end > existing_end:
+            segments.append((existing_end, new_end))
+        return segments
+    except TypeError:
+        # Real datetimes that still can't be compared (aware vs. naive) -
+        # same "can't confirm smaller than the whole window" fallback.
+        return [(new_start, new_end)]
 
 
 def clamp_limit(limit: int, *, max_limit: int) -> int:

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -496,7 +496,12 @@ def calendar_day_bounds(
     zone = resolve_zoneinfo(tz_name)
     day: date = datetime.fromisoformat(date_value).date()
     start = datetime.combine(day, time.min, tzinfo=zone)
-    end = start + timedelta(days=days)
+    # Advance the local calendar date before attaching the timezone again.
+    # Adding a timedelta to an aware datetime preserves the original
+    # offset across DST transitions, which can produce the wrong local
+    # midnight for the end boundary.
+    end_day = day + timedelta(days=days)
+    end = datetime.combine(end_day, time.min, tzinfo=zone)
     return start.isoformat(), end.isoformat()
 
 

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -299,10 +299,11 @@ def attendees_to_add(
     if not attendees_were_given(attendees):
         return []
     assert attendees is not None  # narrows for mypy; attendees_were_given implies this
+    existing = {email.strip().lower() for email in existing_attendee_emails}
     return [
         address
         for address in normalize_addresses(attendees)
-        if address.lower() not in existing_attendee_emails
+        if address.lower() not in existing
     ]
 
 

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -230,8 +230,10 @@ def conflict_response(
     single real conflict isn't fully dropped just to make room for a
     still-oversized `unchecked_attendees` list (unconditionally halving
     `conflicts` first would zero out a 1-item list in a single step,
-    regardless of whether that was actually necessary) - the small
-    `hint` field is never touched.
+    regardless of whether that was actually necessary). If the fixed
+    envelope itself is too large, the response falls back to a compact,
+    valid JSON object instead of relying on the framework to truncate the
+    serialized JSON at an arbitrary character boundary.
     """
     payload: dict[str, Any] = {
         "status": "conflict",
@@ -272,6 +274,23 @@ def conflict_response(
         payload["unchecked_attendees"] = remaining_unchecked
         payload["truncated"] = True
         response = json.dumps(payload, ensure_ascii=False)
+
+    if len(response) > max_output_length:
+        compact_payloads = (
+            {
+                "status": "conflict",
+                "message": "Scheduling conflict detected; details truncated.",
+                "conflicts": [],
+                "unchecked_attendees": [],
+                "truncated": True,
+            },
+            {"status": "conflict", "truncated": True},
+            {},
+        )
+        for compact_payload in compact_payloads:
+            compact_response = json.dumps(compact_payload, ensure_ascii=False)
+            if len(compact_response) <= max_output_length:
+                return compact_response
     return response
 
 

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -10,7 +10,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from ....config import get_tool_max_output_length
 
 
-class InsufficientScopeError(ValueError):
+class InsufficientScopeError(RuntimeError):
     """Raised by a connector's ``_find_conflicts`` on a whole-batch
     missing-scope error (see that function's own docstring for why this
     is raised at all rather than degrading to unchecked).
@@ -285,12 +285,15 @@ def conflict_response(
                 "truncated": True,
             },
             {"status": "conflict", "truncated": True},
-            {},
         )
         for compact_payload in compact_payloads:
             compact_response = json.dumps(compact_payload, ensure_ascii=False)
             if len(compact_response) <= max_output_length:
                 return compact_response
+        # A configured limit smaller than this JSON object cannot preserve
+        # both valid JSON and the response's required status. Keep the
+        # smallest contract-preserving response rather than returning `{}`.
+        return json.dumps({"status": "conflict"}, ensure_ascii=False)
     return response
 
 
@@ -299,8 +302,9 @@ def attendees_were_given(attendees: list[str] | str | None) -> bool:
     update, treating an empty string the same as not-provided at all -
     matching every other optional field's truthy convention here (and the
     create path's own check) - rather than as "clear every attendee".
-    That's still expressible, just via an explicit empty list: `[]` is a
-    deliberate, differently-typed value that must keep working."""
+    An explicit empty list is still considered supplied, even though the
+    current additive attendee API treats it as a no-op rather than removing
+    existing attendees."""
     return attendees is not None and attendees != ""
 
 
@@ -456,7 +460,7 @@ def resolve_zoneinfo(name: str) -> ZoneInfo:
     """
     try:
         return ZoneInfo(name)
-    except (ZoneInfoNotFoundError, ValueError) as exc:
+    except (ZoneInfoNotFoundError, TypeError, ValueError) as exc:
         raise ValueError(
             f"Timezone {name!r} isn't a recognized IANA zone name."
         ) from exc
@@ -512,6 +516,8 @@ def calendar_day_bounds(
     all-day event occupies the *calendar's own* day, not a UTC day, so a
     hardcoded "T00:00:00Z" is only correct for a UTC calendar.
     """
+    if days <= 0:
+        raise ValueError("days must be a positive integer")
     zone = resolve_zoneinfo(tz_name)
     day: date = datetime.fromisoformat(date_value).date()
     start = datetime.combine(day, time.min, tzinfo=zone)
@@ -550,6 +556,9 @@ def window_delta_segments(
     all) still get the FULL new window checked regardless of any of this
     - they need every instant in it verified, delta or not.
 
+    ISO strings are normalized internally before comparison, so callers do
+    not have to coordinate a separate parsing step.
+
     Returns:
     - ``[]`` when the new window is confirmed to add no territory beyond
       the old one (identical or a subset) - nothing new for a retained
@@ -560,7 +569,7 @@ def window_delta_segments(
     - The whole ``[new_start, new_end)`` as a single segment when the two
       windows are confirmed to not overlap at all (matching "moved
       somewhere completely disjoint -> check the whole thing"), OR when
-      any value isn't a real, mutually-comparable ``datetime`` (parsing
+      any value isn't a real, mutually-comparable instant (parsing
       failure, or one side aware and the other naive) - "can't confirm
       the delta is smaller than the whole window" must never silently
       shrink what gets checked, so treat it as needing the full window.
@@ -568,6 +577,24 @@ def window_delta_segments(
       window at all to fall back to (``new_start``/``new_end`` themselves
       aren't real instants) - there is nothing meaningful to check.
     """
+    existing_start = (
+        datetime_key_for_comparison(existing_start)
+        if isinstance(existing_start, str)
+        else existing_start
+    )
+    existing_end = (
+        datetime_key_for_comparison(existing_end)
+        if isinstance(existing_end, str)
+        else existing_end
+    )
+    new_start = (
+        datetime_key_for_comparison(new_start)
+        if isinstance(new_start, str)
+        else new_start
+    )
+    new_end = (
+        datetime_key_for_comparison(new_end) if isinstance(new_end, str) else new_end
+    )
     if not (isinstance(new_start, datetime) and isinstance(new_end, datetime)):
         return []
     if not (

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -276,7 +276,7 @@ def conflict_response(
         response = json.dumps(payload, ensure_ascii=False)
 
     if len(response) > max_output_length:
-        compact_payloads = (
+        compact_payloads: tuple[dict[str, Any], ...] = (
             {
                 "status": "conflict",
                 "message": "Scheduling conflict detected; details truncated.",

--- a/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
+++ b/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
@@ -374,4 +374,4 @@ def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
     assert migration.revision == "20260907_add_calendar_freebusy_scope"
-    assert migration.down_revision == "20260909_seed_shopify_mcp_app"
+    assert migration.down_revision == "20260911_assistant_source_event"

--- a/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
+++ b/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
@@ -1,4 +1,4 @@
-"""Tests for narrowing the Google Calendar connector's OAuth scope."""
+"""Tests for adding calendar.freebusy to the Google Calendar connector's scope."""
 
 import importlib.util
 import json
@@ -13,16 +13,19 @@ from alembic.operations import Operations
 
 MIGRATION_PATH = (
     Path(__file__).parent.parent.parent
-    / "src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py"
+    / "src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py"
 )
 
-OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
-NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+OLD_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+NEW_SCOPES = [
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+]
 
 
 def _load_migration_module():
     spec = importlib.util.spec_from_file_location(
-        "narrow_google_calendar_scope_migration", MIGRATION_PATH
+        "add_calendar_freebusy_scope_migration", MIGRATION_PATH
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -49,9 +52,7 @@ def _scopes_by_app_id(connection, table: sa.Table) -> dict[str, object]:
     return {row.app_id: row.oauth_scopes for row in rows}
 
 
-def test_upgrade_narrows_google_calendar_scope_without_touching_other_apps(
-    tmp_path,
-) -> None:
+def test_upgrade_adds_freebusy_scope_without_touching_other_apps(tmp_path) -> None:
     migration = _load_migration_module()
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     metadata = sa.MetaData()
@@ -149,7 +150,7 @@ def test_upgrade_skips_when_oauth_scopes_column_is_absent() -> None:
     assert stored["app_id"] == "google-calendar"
 
 
-def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
+def test_downgrade_restores_the_events_only_scope(tmp_path) -> None:
     migration = _load_migration_module()
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     metadata = sa.MetaData()
@@ -171,7 +172,7 @@ def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
     assert scopes["google-calendar"] == OLD_SCOPES
 
 
-def test_downgrade_restores_the_full_calendar_scope_without_touching_other_apps(
+def test_downgrade_restores_the_events_only_scope_without_touching_other_apps(
     tmp_path,
 ) -> None:
     migration = _load_migration_module()
@@ -198,6 +199,56 @@ def test_downgrade_restores_the_full_calendar_scope_without_touching_other_apps(
     assert scopes["gmail"] == ["gmail-scope"]
 
 
+def test_upgrade_downgrade_upgrade_converges_on_the_new_scope(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+
+
+def test_upgrade_after_downgrade_does_not_touch_other_apps(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            [
+                {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+                {"app_id": "gmail", "oauth_scopes": ["gmail-scope"]},
+            ],
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+    assert scopes["gmail"] == ["gmail-scope"]
+
+
 def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     migration = _load_migration_module()
     output = StringIO()
@@ -213,7 +264,7 @@ def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    assert "calendar.events" in sql
+    assert "calendar.freebusy" in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -264,13 +315,11 @@ def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    # "auth/calendar" alone is a substring of both OLD_SCOPES and NEW_SCOPES
-    # ("auth/calendar.events"), so it can't distinguish which one was
-    # emitted; assert the narrower scope is absent to catch a swapped
-    # OLD_SCOPES/NEW_SCOPES argument in downgrade()'s
-    # _set_calendar_scopes_offline() call.
-    assert "auth/calendar" in sql
-    assert "calendar.events" not in sql
+    # Assert the freebusy scope is absent, not just present-or-absent by
+    # accident, to catch a swapped OLD_SCOPES/NEW_SCOPES argument in
+    # downgrade()'s _set_calendar_scopes_offline() call.
+    assert "calendar.events" in sql
+    assert "calendar.freebusy" not in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -306,18 +355,15 @@ def test_offline_sqlite_downgrade_round_trips_json_scope_value() -> None:
     assert json.loads(stored[0]) == OLD_SCOPES
 
 
-def test_migration_fields_match_this_files_expectations() -> None:
-    # This migration has since been superseded by
-    # 20260907_add_calendar_freebusy_scope, which adds calendar.freebusy on
-    # top of what this one set - so migration.NEW_SCOPES is no longer
-    # expected to equal the live registry value; that comparison now lives
-    # in the newer migration's own test instead.
-    #
-    # This file's own OLD_SCOPES/NEW_SCOPES (used throughout the tests
-    # above) are a separate copy of the migration's constants, not a
-    # reference to them -- if the migration's values ever changed without
-    # this file's copy following, every test above would keep passing
-    # against a stale expectation instead of failing loudly.
+def test_migration_fields_match_this_files_constants() -> None:
+    """This migration is no longer the last word on the google-calendar
+    scope (20260909_add_calendar_calendars_readonly_scope widens it
+    further) - checking against the *live* registry belongs on the most
+    recent scope-widening migration's own test, not here. This just
+    guards against this file's own OLD_SCOPES/NEW_SCOPES (used throughout
+    the tests above) silently drifting from the migration's real
+    constants, which are a separate copy, not a reference.
+    """
     migration = _load_migration_module()
 
     assert list(migration.OLD_SCOPES) == OLD_SCOPES
@@ -327,5 +373,5 @@ def test_migration_fields_match_this_files_expectations() -> None:
 def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
-    assert migration.revision == "20260817_narrow_google_calendar_scope"
-    assert migration.down_revision == "20260825_add_slack_channels_join_scope"
+    assert migration.revision == "20260907_add_calendar_freebusy_scope"
+    assert migration.down_revision == "20260909_seed_shopify_mcp_app"

--- a/tests/alembic/test_20260909_add_calendar_calendars_readonly_scope.py
+++ b/tests/alembic/test_20260909_add_calendar_calendars_readonly_scope.py
@@ -229,6 +229,33 @@ def test_upgrade_downgrade_upgrade_converges_on_the_new_scope(tmp_path) -> None:
     assert scopes["google-calendar"] == NEW_SCOPES
 
 
+def test_upgrade_after_downgrade_does_not_touch_other_apps(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            [
+                {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+                {"app_id": "gmail", "oauth_scopes": ["gmail-scope"]},
+            ],
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+    assert scopes["gmail"] == ["gmail-scope"]
+
+
 def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     migration = _load_migration_module()
     output = StringIO()

--- a/tests/alembic/test_20260909_add_calendar_calendars_readonly_scope.py
+++ b/tests/alembic/test_20260909_add_calendar_calendars_readonly_scope.py
@@ -1,4 +1,5 @@
-"""Tests for narrowing the Google Calendar connector's OAuth scope."""
+"""Tests for adding calendar.calendars.readonly to the Google Calendar
+connector's scope."""
 
 import importlib.util
 import json
@@ -13,16 +14,23 @@ from alembic.operations import Operations
 
 MIGRATION_PATH = (
     Path(__file__).parent.parent.parent
-    / "src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py"
+    / "src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py"
 )
 
-OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
-NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+OLD_SCOPES = [
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+]
+NEW_SCOPES = [
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+    "https://www.googleapis.com/auth/calendar.calendars.readonly",
+]
 
 
 def _load_migration_module():
     spec = importlib.util.spec_from_file_location(
-        "narrow_google_calendar_scope_migration", MIGRATION_PATH
+        "add_calendar_calendars_readonly_scope_migration", MIGRATION_PATH
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -49,7 +57,7 @@ def _scopes_by_app_id(connection, table: sa.Table) -> dict[str, object]:
     return {row.app_id: row.oauth_scopes for row in rows}
 
 
-def test_upgrade_narrows_google_calendar_scope_without_touching_other_apps(
+def test_upgrade_adds_calendars_readonly_scope_without_touching_other_apps(
     tmp_path,
 ) -> None:
     migration = _load_migration_module()
@@ -149,7 +157,7 @@ def test_upgrade_skips_when_oauth_scopes_column_is_absent() -> None:
     assert stored["app_id"] == "google-calendar"
 
 
-def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
+def test_downgrade_restores_the_freebusy_only_scope(tmp_path) -> None:
     migration = _load_migration_module()
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     metadata = sa.MetaData()
@@ -171,7 +179,7 @@ def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
     assert scopes["google-calendar"] == OLD_SCOPES
 
 
-def test_downgrade_restores_the_full_calendar_scope_without_touching_other_apps(
+def test_downgrade_restores_the_freebusy_only_scope_without_touching_other_apps(
     tmp_path,
 ) -> None:
     migration = _load_migration_module()
@@ -198,6 +206,29 @@ def test_downgrade_restores_the_full_calendar_scope_without_touching_other_apps(
     assert scopes["gmail"] == ["gmail-scope"]
 
 
+def test_upgrade_downgrade_upgrade_converges_on_the_new_scope(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+
+
 def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     migration = _load_migration_module()
     output = StringIO()
@@ -213,7 +244,7 @@ def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    assert "calendar.events" in sql
+    assert "calendar.calendars.readonly" in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -264,13 +295,11 @@ def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    # "auth/calendar" alone is a substring of both OLD_SCOPES and NEW_SCOPES
-    # ("auth/calendar.events"), so it can't distinguish which one was
-    # emitted; assert the narrower scope is absent to catch a swapped
-    # OLD_SCOPES/NEW_SCOPES argument in downgrade()'s
-    # _set_calendar_scopes_offline() call.
-    assert "auth/calendar" in sql
-    assert "calendar.events" not in sql
+    # Assert the calendars.readonly scope is absent, not just present-or-
+    # absent by accident, to catch a swapped OLD_SCOPES/NEW_SCOPES argument
+    # in downgrade()'s _set_calendar_scopes_offline() call.
+    assert "calendar.freebusy" in sql
+    assert "calendar.calendars.readonly" not in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -306,20 +335,22 @@ def test_offline_sqlite_downgrade_round_trips_json_scope_value() -> None:
     assert json.loads(stored[0]) == OLD_SCOPES
 
 
-def test_migration_fields_match_this_files_expectations() -> None:
-    # This migration has since been superseded by
-    # 20260907_add_calendar_freebusy_scope, which adds calendar.freebusy on
-    # top of what this one set - so migration.NEW_SCOPES is no longer
-    # expected to equal the live registry value; that comparison now lives
-    # in the newer migration's own test instead.
-    #
-    # This file's own OLD_SCOPES/NEW_SCOPES (used throughout the tests
-    # above) are a separate copy of the migration's constants, not a
-    # reference to them -- if the migration's values ever changed without
-    # this file's copy following, every test above would keep passing
-    # against a stale expectation instead of failing loudly.
-    migration = _load_migration_module()
+def test_migration_fields_match_registry() -> None:
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
 
+    migration = _load_migration_module()
+    registry_row = next(
+        row
+        for row in get_builtin_public_mcp_app_rows()
+        if row["app_id"] == "google-calendar"
+    )
+
+    assert list(migration.NEW_SCOPES) == registry_row["oauth_scopes"]
+    # This file's own OLD_SCOPES/NEW_SCOPES (used throughout the tests above)
+    # are a separate copy of the migration's constants, not a reference to
+    # them -- if the migration's values ever changed without this file's
+    # copy following, every test above would keep passing against a stale
+    # expectation instead of failing loudly.
     assert list(migration.OLD_SCOPES) == OLD_SCOPES
     assert list(migration.NEW_SCOPES) == NEW_SCOPES
 
@@ -327,5 +358,5 @@ def test_migration_fields_match_this_files_expectations() -> None:
 def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
-    assert migration.revision == "20260817_narrow_google_calendar_scope"
-    assert migration.down_revision == "20260825_add_slack_channels_join_scope"
+    assert migration.revision == "20260909_add_calendar_calendars_readonly_scope"
+    assert migration.down_revision == "20260907_add_calendar_freebusy_scope"

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -480,3 +480,27 @@ def test_conflict_response_caps_unchecked_attendees_when_conflicts_alone_is_not_
         == unchecked_attendees[: len(response["unchecked_attendees"])]
     )
     assert len(json.dumps(response, ensure_ascii=False)) <= 2000
+
+
+def test_conflict_response_uses_valid_compact_json_below_fixed_envelope(
+    monkeypatch,
+):
+    monkeypatch.setenv("XAGENT_TOOL_MAX_OUTPUT_LENGTH", "300")
+    response_text = utils.conflict_response(
+        [
+            {
+                "calendar": "organizer",
+                "summary": "Busy",
+                "start": "2026-08-27T10:00:00+00:00",
+                "end": "2026-08-27T10:30:00+00:00",
+            }
+        ],
+        ["unreachable@example.com"],
+        "2026-08-27T10:00:00+00:00",
+        "2026-08-27T10:30:00+00:00",
+    )
+
+    response = json.loads(response_text)
+    assert response["status"] == "conflict"
+    assert response["truncated"] is True
+    assert len(response_text) <= 300

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -365,13 +365,10 @@ def test_require_offset_datetime_is_permissive_on_unparseable_input():
 
 def test_calendar_day_bounds_spans_a_short_day_across_a_dst_spring_forward():
     """2026-03-08 is when America/New_York springs forward (clocks skip
-    02:00-03:00), so the calendar day is only 23 hours long. `start +
-    timedelta(days=1)` on an aware datetime only advances the wall-clock
-    date/time components (per datetime's documented semantics) and
-    re-derives the UTC offset lazily via ZoneInfo - a naive
-    `timedelta(hours=24)` would instead land on 01:00 the following day,
-    silently mis-widening an all-day event's boundary by an hour on every
-    DST-transition day in a zone that observes it."""
+    02:00-03:00), so the calendar day is only 23 hours long. The end
+    boundary must be constructed from the next local calendar date so the
+    timezone can apply the new UTC offset; adding 24 elapsed hours would
+    land at 01:00 on the following day and mis-widen the query window."""
     start, end = utils.calendar_day_bounds("2026-03-08", "America/New_York")
     assert start == "2026-03-08T00:00:00-05:00"
     assert end == "2026-03-09T00:00:00-04:00"

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 import pytest
@@ -115,3 +116,370 @@ def test_url_path_id_output_survives_requests_url_normalization():
 
     with pytest.raises(ValueError):
         utils.url_path_id("..", "record_id")
+
+
+def test_datetime_key_for_comparison_truncates_seven_digit_fractional_seconds():
+    """Outlook commonly reports 100-nanosecond (7-digit) fractional
+    seconds, one more digit than a microsecond can hold - this must not
+    depend on whichever CPython version happens to run it."""
+    key = utils.datetime_key_for_comparison("2026-08-27T10:00:00.0000000")
+    assert key == utils.datetime_key_for_comparison("2026-08-27T10:00:00")
+
+
+def test_datetime_key_for_comparison_treats_equal_instants_as_equal_across_offsets():
+    z_form = utils.datetime_key_for_comparison("2026-08-27T02:00:00Z")
+    offset_form = utils.datetime_key_for_comparison("2026-08-27T10:00:00+08:00")
+    assert z_form == offset_form
+
+
+def test_datetime_key_for_comparison_falls_back_to_raw_string_on_malformed_input():
+    assert utils.datetime_key_for_comparison("not-a-date") == "not-a-date"
+
+
+def test_datetime_key_for_comparison_passes_none_through():
+    assert utils.datetime_key_for_comparison(None) is None
+
+
+def test_normalize_addresses_drops_case_insensitive_duplicates():
+    """Regression test: email addresses are case-insensitive, so the same
+    person listed twice with different casing must not become two separate
+    attendee entries downstream - keeps the first casing seen."""
+    assert utils.normalize_addresses(
+        ["Chelsea@Example.com", "chelsea@example.com", "new@example.com"]
+    ) == ["Chelsea@Example.com", "new@example.com"]
+
+
+def test_normalize_addresses_dedup_works_for_comma_separated_string_input():
+    assert utils.normalize_addresses("a@x.com, A@X.com, b@x.com") == [
+        "a@x.com",
+        "b@x.com",
+    ]
+
+
+def test_attendees_were_given_treats_empty_string_as_not_provided():
+    assert utils.attendees_were_given(None) is False
+    assert utils.attendees_were_given("") is False
+
+
+def test_attendees_were_given_treats_empty_list_as_provided():
+    """An explicit [] is a deliberate "clear everyone" - distinct from
+    not-provided, unlike an empty string."""
+    assert utils.attendees_were_given([]) is True
+    assert utils.attendees_were_given(["a@x.com"]) is True
+    assert utils.attendees_were_given("a@x.com") is True
+
+
+def test_attendees_to_add_filters_out_existing_and_normalizes():
+    assert utils.attendees_to_add(
+        ["Old@Example.com", "new@example.com"], {"old@example.com"}
+    ) == ["new@example.com"]
+
+
+def test_attendees_to_add_returns_empty_for_not_provided_or_empty():
+    assert utils.attendees_to_add(None, {"old@example.com"}) == []
+    assert utils.attendees_to_add("", {"old@example.com"}) == []
+    assert utils.attendees_to_add([], {"old@example.com"}) == []
+
+
+def _key(value: str):
+    return utils.datetime_key_for_comparison(value)
+
+
+def test_window_delta_segments_empty_for_unchanged_or_shrunk_window():
+    """A retained attendee's own busy block already covers everything
+    inside the old window - a new window that's identical, or a strict
+    subset of it, adds no territory worth checking them against."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    assert utils.window_delta_segments(old_start, old_end, old_start, old_end) == []
+
+    shrunk_start = _key("2026-08-27T10:05:00+00:00")
+    shrunk_end = _key("2026-08-27T10:25:00+00:00")
+    assert (
+        utils.window_delta_segments(old_start, old_end, shrunk_start, shrunk_end) == []
+    )
+
+
+def test_window_delta_segments_returns_the_new_only_portion_of_a_partial_nudge():
+    """10:00-10:30 nudged to 10:15-10:45 - only 10:30-10:45 is new
+    territory a retained attendee could have a genuine conflict in;
+    10:15-10:30 is still covered by their busy block for this event."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    new_start, new_end = (
+        _key("2026-08-27T10:15:00+00:00"),
+        _key("2026-08-27T10:45:00+00:00"),
+    )
+
+    segments = utils.window_delta_segments(old_start, old_end, new_start, new_end)
+
+    assert segments == [(old_end, new_end)]
+
+
+def test_window_delta_segments_returns_two_segments_when_widened_on_both_sides():
+    """Extending a meeting earlier AND later in the same call creates new
+    territory on both sides of the old window."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    new_start, new_end = (
+        _key("2026-08-27T09:45:00+00:00"),
+        _key("2026-08-27T10:45:00+00:00"),
+    )
+
+    segments = utils.window_delta_segments(old_start, old_end, new_start, new_end)
+
+    assert len(segments) == 2
+    assert segments[0] == (new_start, old_start)
+    assert segments[1] == (old_end, new_end)
+
+
+def test_window_delta_segments_returns_the_whole_window_for_a_disjoint_move():
+    """A move to somewhere with zero overlap with the old window means the
+    entire new window is new territory - this test also confirms the
+    move-by-15-minutes example from the actual reported bug is caught:
+    the delta segment here is the same shape as the disjoint case."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    new_start, new_end = (
+        _key("2026-08-27T14:00:00+00:00"),
+        _key("2026-08-27T14:30:00+00:00"),
+    )
+
+    assert utils.window_delta_segments(old_start, old_end, new_start, new_end) == [
+        (new_start, new_end)
+    ]
+
+
+def test_window_delta_segments_is_conservative_on_unparseable_or_mismatched_keys():
+    """ "Can't confirm the delta is smaller than the whole window" must
+    never silently shrink what gets checked - falls back to the whole new
+    window, both for a key that never parsed to a real datetime, and for
+    two real datetimes that can't be compared (aware vs. naive raises
+    TypeError on `<`)."""
+    new_start, new_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    assert utils.window_delta_segments(
+        "not-a-date", "also-not", new_start, new_end
+    ) == [(new_start, new_end)]
+
+    naive_start = _key("2026-08-27T09:00:00")
+    naive_end = _key("2026-08-27T11:00:00")
+    assert utils.window_delta_segments(naive_start, naive_end, new_start, new_end) == [
+        (new_start, new_end)
+    ]
+
+
+def test_window_delta_segments_empty_when_new_window_itself_is_unparseable():
+    """No valid new window at all means nothing meaningful to check,
+    regardless of the old window."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    assert (
+        utils.window_delta_segments(old_start, old_end, "not-a-date", "also-not") == []
+    )
+
+
+def test_window_delta_segments_empty_when_only_one_of_the_new_window_parses():
+    """Regression test: the guard is `new_start AND new_end` both being
+    real datetimes - a MIXED pair (one parses, one doesn't) must still
+    return [], not fall through and try to build a segment out of a
+    half-valid window. A prior test only exercised BOTH sides failing
+    together, which can't tell `and` apart from a mistakenly-broadened
+    `or` in that guard - this fixture, with exactly one side invalid,
+    can."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    new_start = _key("2026-08-27T14:00:00+00:00")
+    assert utils.window_delta_segments(old_start, old_end, new_start, "also-not") == []
+    assert (
+        utils.window_delta_segments(old_start, old_end, "not-a-date", new_start) == []
+    )
+
+
+def test_reject_reversed_window_raises_when_end_is_not_after_start():
+    with pytest.raises(ValueError, match="must be after"):
+        utils.reject_reversed_window(
+            "2026-08-27T10:30:00+00:00", "2026-08-27T10:00:00+00:00"
+        )
+    with pytest.raises(ValueError, match="must be after"):
+        utils.reject_reversed_window(
+            "2026-08-27T10:00:00+00:00", "2026-08-27T10:00:00+00:00"
+        )
+
+
+def test_reject_reversed_window_allows_a_forward_window():
+    utils.reject_reversed_window(
+        "2026-08-27T10:00:00+00:00", "2026-08-27T10:30:00+00:00"
+    )
+
+
+def test_reject_reversed_window_is_permissive_on_unparseable_input():
+    """Can't-tell must never read as "reject" - only a confirmed reversal
+    should raise."""
+    utils.reject_reversed_window("not-a-date", "also-not-a-date")
+
+
+def test_reject_reversed_window_is_permissive_when_aware_and_naive_are_mixed():
+    """Regression test: both sides parse to real `datetime` instances, but
+    comparing an offset-aware one against a naive one with `<=` raises
+    `TypeError` in Python - the `isinstance` check alone doesn't guard
+    against this, only checking that both are `datetime` instances of the
+    SAME awareness does. Must stay permissive here, not crash with a raw
+    TypeError, matching `window_delta_segments`'s handling of the
+    identical hazard."""
+    utils.reject_reversed_window("2026-08-27T10:30:00", "2026-08-27T10:30:00Z")
+    utils.reject_reversed_window("2026-08-27T10:30:00Z", "2026-08-27T10:00:00")
+
+
+def test_require_offset_datetime_rejects_a_naive_value():
+    with pytest.raises(ValueError, match="start_time"):
+        utils.require_offset_datetime("2026-08-27T10:30:00", "start_time")
+
+
+def test_require_offset_datetime_accepts_an_offset_or_z_suffixed_value():
+    utils.require_offset_datetime("2026-08-27T10:30:00+08:00", "start_time")
+    utils.require_offset_datetime("2026-08-27T10:30:00Z", "start_time")
+
+
+def test_require_offset_datetime_is_permissive_on_unparseable_input():
+    """A value that doesn't even parse is a different failure a caller
+    will already hit downstream with its own clear error - not this
+    function's job to preempt with a possibly-confusing offset-specific
+    message."""
+    utils.require_offset_datetime("not-a-date", "start_time")
+
+
+def test_calendar_day_bounds_spans_a_short_day_across_a_dst_spring_forward():
+    """2026-03-08 is when America/New_York springs forward (clocks skip
+    02:00-03:00), so the calendar day is only 23 hours long. `start +
+    timedelta(days=1)` on an aware datetime only advances the wall-clock
+    date/time components (per datetime's documented semantics) and
+    re-derives the UTC offset lazily via ZoneInfo - a naive
+    `timedelta(hours=24)` would instead land on 01:00 the following day,
+    silently mis-widening an all-day event's boundary by an hour on every
+    DST-transition day in a zone that observes it."""
+    start, end = utils.calendar_day_bounds("2026-03-08", "America/New_York")
+    assert start == "2026-03-08T00:00:00-05:00"
+    assert end == "2026-03-09T00:00:00-04:00"
+
+
+def test_offset_datetime_string_attaches_the_zone_offset_to_a_naive_value():
+    assert (
+        utils.offset_datetime_string("2026-08-27T10:00:00", "Asia/Singapore")
+        == "2026-08-27T10:00:00+08:00"
+    )
+
+
+def test_offset_datetime_string_rejects_input_that_already_carries_an_offset():
+    """Regression test: no public tool parameter is documented as requiring
+    a naive value, so a caller passing one with a trailing 'Z' or an
+    explicit offset is a real, reachable mistake - not a theoretical one.
+    `.replace(tzinfo=...)` doesn't convert an aware datetime, it just
+    relabels the same clock digits under a different zone, silently
+    shifting the real instant by however much the two offsets differ
+    (e.g. "10:00:00Z" relabeled as Asia/Shanghai reads as 10:00 Shanghai
+    time - actually 8 hours earlier). Must fail loudly instead."""
+    with pytest.raises(ValueError, match="already carries a UTC offset"):
+        utils.offset_datetime_string("2026-08-27T10:00:00Z", "Asia/Shanghai")
+    with pytest.raises(ValueError, match="already carries a UTC offset"):
+        utils.offset_datetime_string("2026-08-27T10:00:00+00:00", "Asia/Shanghai")
+
+
+def test_conflict_response_uncapped_when_it_fits(monkeypatch):
+    monkeypatch.setenv("XAGENT_TOOL_MAX_OUTPUT_LENGTH", "50000")
+    conflicts = [{"calendar": "organizer", "summary": "1:1", "start": "a", "end": "b"}]
+    response = json.loads(
+        utils.conflict_response(
+            conflicts, [], "2026-08-27T10:00:00", "2026-08-27T10:30:00"
+        )
+    )
+    assert response["conflicts"] == conflicts
+    assert response["truncated"] is False
+
+
+def test_conflict_response_caps_an_oversized_conflicts_list(monkeypatch):
+    """Regression test: unlike every other response path in this module,
+    conflict_response used to return an uncapped payload - a busy shared
+    calendar or wide window can turn up far more overlapping events than
+    fit the platform's output budget. Only `conflicts` (the field that
+    can actually grow large) should be halved to fit; small fields like
+    `hint`/`unchecked_attendees` must survive untouched."""
+    monkeypatch.setenv("XAGENT_TOOL_MAX_OUTPUT_LENGTH", "2000")
+    conflicts = [
+        {
+            "calendar": f"person{i}@example.com",
+            "summary": "Busy block " + "x" * 50,
+            "start": "2026-08-27T10:00:00+00:00",
+            "end": "2026-08-27T10:30:00+00:00",
+        }
+        for i in range(100)
+    ]
+    response = json.loads(
+        utils.conflict_response(
+            conflicts,
+            ["unreachable@example.com"],
+            "2026-08-27T10:00:00",
+            "2026-08-27T10:30:00",
+        )
+    )
+
+    assert response["status"] == "conflict"
+    assert response["truncated"] is True
+    assert len(response["conflicts"]) < len(conflicts)
+    assert response["conflicts"] == conflicts[: len(response["conflicts"])]
+    assert response["unchecked_attendees"] == ["unreachable@example.com"]
+    assert len(json.dumps(response, ensure_ascii=False)) <= 2000
+
+
+def test_conflict_response_caps_unchecked_attendees_when_conflicts_alone_is_not_enough(
+    monkeypatch,
+):
+    """Regression test: a single real conflict combined with a huge
+    unchecked_attendees list (e.g. every remaining attendee in a large
+    invite batch, marked unchecked after a mid-batch scope error) can
+    still exceed the output budget even after `conflicts` has been
+    shrunk to nothing - unchecked_attendees must also be capped, not
+    left untouched forever."""
+    monkeypatch.setenv("XAGENT_TOOL_MAX_OUTPUT_LENGTH", "2000")
+    conflicts = [
+        {
+            "calendar": "organizer",
+            "summary": "1:1 with Hazel",
+            "start": "2026-08-27T10:00:00+00:00",
+            "end": "2026-08-27T10:30:00+00:00",
+        }
+    ]
+    unchecked_attendees = [f"person{i}@example.com" for i in range(200)]
+
+    response = json.loads(
+        utils.conflict_response(
+            conflicts,
+            unchecked_attendees,
+            "2026-08-27T10:00:00",
+            "2026-08-27T10:30:00",
+        )
+    )
+
+    assert response["status"] == "conflict"
+    assert response["truncated"] is True
+    assert response["conflicts"] == conflicts
+    assert len(response["unchecked_attendees"]) < len(unchecked_attendees)
+    assert (
+        response["unchecked_attendees"]
+        == unchecked_attendees[: len(response["unchecked_attendees"])]
+    )
+    assert len(json.dumps(response, ensure_ascii=False)) <= 2000

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -171,7 +171,7 @@ def test_attendees_were_given_treats_empty_list_as_provided():
 
 def test_attendees_to_add_filters_out_existing_and_normalizes():
     assert utils.attendees_to_add(
-        ["Old@Example.com", "new@example.com"], {"old@example.com"}
+        ["Old@Example.com", "new@example.com"], {"OLD@EXAMPLE.COM"}
     ) == ["new@example.com"]
 
 

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -122,8 +122,8 @@ def test_datetime_key_for_comparison_truncates_seven_digit_fractional_seconds():
     """Outlook commonly reports 100-nanosecond (7-digit) fractional
     seconds, one more digit than a microsecond can hold - this must not
     depend on whichever CPython version happens to run it."""
-    key = utils.datetime_key_for_comparison("2026-08-27T10:00:00.0000000")
-    assert key == utils.datetime_key_for_comparison("2026-08-27T10:00:00")
+    key = utils.datetime_key_for_comparison("2026-08-27T10:00:00.1234567")
+    assert key == utils.datetime_key_for_comparison("2026-08-27T10:00:00.123456")
 
 
 def test_datetime_key_for_comparison_treats_equal_instants_as_equal_across_offsets():
@@ -181,6 +181,35 @@ def test_attendees_to_add_returns_empty_for_not_provided_or_empty():
     assert utils.attendees_to_add([], {"old@example.com"}) == []
 
 
+def test_merge_scope_error_reraises_when_no_conflict_is_known():
+    error = utils.InsufficientScopeError(
+        "reconnect required", [], ["unchecked@example.com"]
+    )
+
+    with pytest.raises(utils.InsufficientScopeError) as raised:
+        utils.merge_scope_error(error, [], [])
+
+    assert raised.value is error
+
+
+def test_merge_scope_error_preserves_confirmed_results():
+    existing_conflict = {"calendar": "organizer"}
+    error_conflict = {"calendar": "attendee@example.com"}
+    error = utils.InsufficientScopeError(
+        "reconnect required", [error_conflict], ["unchecked@example.com"]
+    )
+
+    conflicts, unchecked = utils.merge_scope_error(
+        error, [existing_conflict], ["already-unchecked@example.com"]
+    )
+
+    assert conflicts == [existing_conflict, error_conflict]
+    assert unchecked == [
+        "already-unchecked@example.com",
+        "unchecked@example.com",
+    ]
+
+
 def _key(value: str):
     return utils.datetime_key_for_comparison(value)
 
@@ -218,6 +247,20 @@ def test_window_delta_segments_returns_the_new_only_portion_of_a_partial_nudge()
     segments = utils.window_delta_segments(old_start, old_end, new_start, new_end)
 
     assert segments == [(old_end, new_end)]
+
+
+def test_window_delta_segments_normalizes_iso_strings_internally():
+    assert utils.window_delta_segments(
+        "2026-08-27T10:00:00+00:00",
+        "2026-08-27T10:30:00+00:00",
+        "2026-08-27T10:15:00+00:00",
+        "2026-08-27T10:45:00+00:00",
+    ) == [
+        (
+            utils.datetime_key_for_comparison("2026-08-27T10:30:00+00:00"),
+            utils.datetime_key_for_comparison("2026-08-27T10:45:00+00:00"),
+        )
+    ]
 
 
 def test_window_delta_segments_returns_two_segments_when_widened_on_both_sides():
@@ -372,6 +415,23 @@ def test_calendar_day_bounds_spans_a_short_day_across_a_dst_spring_forward():
     start, end = utils.calendar_day_bounds("2026-03-08", "America/New_York")
     assert start == "2026-03-08T00:00:00-05:00"
     assert end == "2026-03-09T00:00:00-04:00"
+
+
+def test_calendar_day_bounds_spans_a_long_day_across_a_dst_fall_back():
+    start, end = utils.calendar_day_bounds("2026-11-01", "America/New_York")
+    assert start == "2026-11-01T00:00:00-04:00"
+    assert end == "2026-11-02T00:00:00-05:00"
+
+
+@pytest.mark.parametrize("days", [0, -1])
+def test_calendar_day_bounds_rejects_non_positive_days(days):
+    with pytest.raises(ValueError, match="positive"):
+        utils.calendar_day_bounds("2026-08-27", "UTC", days=days)
+
+
+def test_resolve_zoneinfo_reports_missing_name_as_value_error():
+    with pytest.raises(ValueError, match="recognized IANA"):
+        utils.resolve_zoneinfo(None)  # type: ignore[arg-type]
 
 
 def test_offset_datetime_string_attaches_the_zone_offset_to_a_naive_value():

--- a/uv.lock
+++ b/uv.lock
@@ -4064,9 +4064,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
+    { name = "click" },
+    { name = "pillow" },
+    { name = "pyobjc-framework-vision" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -5404,7 +5404,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -5421,8 +5421,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -5439,8 +5439,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -5457,10 +5457,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreml" },
+    { name = "pyobjc-framework-quartz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [
@@ -6897,13 +6897,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", upload-time = "2026-05-12T16:20:07Z" },
@@ -6931,13 +6931,13 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:aaa9c1f5e8c518d7be1e3c3e1b090ca7d63b6e353a1abd6cfdaf902405093467", upload-time = "2026-05-12T23:16:01Z" },
@@ -6981,9 +6981,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:df0c166b6bdf7c47f88e81e8b43bc085451d5c50d0c5d1691bc474c1227d6fed", upload-time = "2026-05-12T16:20:37Z" },
@@ -7011,9 +7011,9 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "pillow", marker = "sys_platform != 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:99d05d071ff34305334ee1854f5edf7c2767b96ba59fe92e76d84a1fa72c8e06", upload-time = "2026-05-12T16:20:36Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -4064,9 +4064,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "pyobjc-framework-vision" },
+    { name = "click", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -5404,7 +5404,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -5421,8 +5421,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -5439,8 +5439,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -5457,10 +5457,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreml" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [
@@ -6897,13 +6897,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", upload-time = "2026-05-12T16:20:07Z" },
@@ -6931,13 +6931,13 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:aaa9c1f5e8c518d7be1e3c3e1b090ca7d63b6e353a1abd6cfdaf902405093467", upload-time = "2026-05-12T23:16:01Z" },
@@ -6981,9 +6981,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:df0c166b6bdf7c47f88e81e8b43bc085451d5c50d0c5d1691bc474c1227d6fed", upload-time = "2026-05-12T16:20:37Z" },
@@ -7011,9 +7011,9 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "pillow", marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:99d05d071ff34305334ee1854f5edf7c2767b96ba59fe92e76d84a1fa72c8e06", upload-time = "2026-05-12T16:20:36Z" },
@@ -7828,6 +7828,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tiktoken" },
     { name = "tqdm" },
+    { name = "tzdata" },
     { name = "uvicorn" },
     { name = "volcengine-python-sdk", extra = ["ark"] },
     { name = "websockets" },
@@ -8094,6 +8095,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'router'", specifier = ">=4.51" },
     { name = "typer", marker = "extra == 'all'", specifier = ">=0.9.0" },
     { name = "typer", marker = "extra == 'document-processing'", specifier = ">=0.9.0" },
+    { name = "tzdata", specifier = ">=2024.1" },
     { name = "unstructured", marker = "extra == 'all'", specifier = ">=0.15.0" },
     { name = "unstructured", marker = "extra == 'document-processing'", specifier = ">=0.15.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },


### PR DESCRIPTION
This is the foundation PR for splitting #2309. It adds shared Calendar conflict-checking utilities, OAuth scope migrations, registry updates, and focused utility/migration tests. No Calendar write behavior is changed yet.