### PR TITLE
test(calendar): cover conflict detection and safe write paths

### DIFF
--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1741,102 +1741,6 @@ def test_ignore_conflicts_cannot_bypass_a_missing_stored_counterpart(monkeypatch
     service.events.return_value.update.assert_not_called()
 
 
-def test_incomplete_check_response_caps_unchecked_attendees_before_write(
-    fake_service, monkeypatch
-):
-    """A large set of unchecked calendars returns a bounded pre-write
-    response instead of allowing the update and warning afterward."""
-    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 300)
-    fake_service._events._get_result = {
-        "id": "self-1",
-        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
-        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
-        "attendees": [],
-    }
-    fake_service._freebusy = FakeFreebusy({"calendars": {}})
-
-    raw = calendar.google_calendar_update_events(
-        event_id="self-1",
-        attendees=[f"person{i}@example.com" for i in range(200)],
-    )
-    result = json.loads(raw)
-
-    assert len(raw) <= 300
-    assert result["status"] == "conflict_check_incomplete"
-    assert result["truncated"] is True
-    assert fake_service._events.update_calls == []
-
-
-def test_event_response_counts_hangout_link_in_the_output_cap(monkeypatch):
-    """A derived top-level Meet link must be included in the size budget;
-    otherwise appending it after event truncation can exceed the limit."""
-    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 300)
-    hangout_link = "https://meet.google.com/abc-defg-hij"
-    service = _fake_service(
-        {
-            "id": "evt1",
-            "hangoutLink": hangout_link,
-            "attendees": [{"email": f"person{i}@example.com"} for i in range(200)],
-        }
-    )
-    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
-
-    raw = calendar.google_calendar_create_events(
-        summary="1:1",
-        start_time="2026-09-07T15:00:00+08:00",
-        end_time="2026-09-07T16:00:00+08:00",
-    )
-    result = json.loads(raw)
-
-    assert len(raw) <= 300
-    assert result["status"] == "success"
-    assert result["hangout_link"] == hangout_link
-    assert result["truncated"] is True
-
-
-def test_event_response_fits_a_small_cap_with_a_large_conference_field(monkeypatch):
-    """Fixed response fields must be discardable when even one large value
-    would otherwise leave the success envelope above the output limit."""
-    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 100)
-    service = _fake_service(
-        {"id": "evt1", "hangoutLink": "https://meet.google.com/" + "x" * 200}
-    )
-    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
-
-    raw = calendar.google_calendar_create_events(
-        summary="1:1",
-        start_time="2026-09-07T15:00:00+08:00",
-        end_time="2026-09-07T16:00:00+08:00",
-    )
-    result = json.loads(raw)
-
-    assert len(raw) <= 100
-    assert result["status"] == "success"
-    assert result["truncated"] is True
-
-
-def test_incomplete_check_response_fits_a_small_cap_for_one_attendee(
-    fake_service, monkeypatch
-):
-    """The pre-write failure envelope stays bounded even when there is only
-    one collection item left, which cannot be reduced by list halving."""
-    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 100)
-    fake_service._freebusy = FakeFreebusy({"calendars": {}})
-
-    raw = calendar.google_calendar_create_events(
-        summary="Kickoff",
-        start_time="2026-08-27T10:00:00+08:00",
-        end_time="2026-08-27T10:30:00+08:00",
-        attendees=["person-with-a-long-address@example.com"],
-    )
-    result = json.loads(raw)
-
-    assert len(raw) <= 100
-    assert result["status"] == "conflict_check_incomplete"
-    assert result["truncated"] is True
-    assert fake_service._events.insert_calls == []
-
-
 class _Exec:
     def __init__(self, result: dict[str, Any], *, raise_error: Exception | None = None):
         self._result = result
@@ -1850,38 +1754,21 @@ class _Exec:
 
 
 class FakeEvents:
-    def __init__(
-        self,
-        *,
-        list_result: dict[str, Any] | None = None,
-        get_result: dict[str, Any] | None = None,
-        insert_result: dict[str, Any] | None = None,
-        update_result: dict[str, Any] | None = None,
-        list_error: Exception | None = None,
-        update_error: Exception | None = None,
-    ):
-        self._list_result = list_result if list_result is not None else {"items": []}
-        # Keyed by the request's own pageToken (None for the first page) -
-        # lets a test simulate a multi-page events.list response instead
-        # of always returning the same page regardless of pageToken. Only
-        # used when set; _list_result covers every single-page test.
-        self._list_results_by_page_token: dict[str | None, dict[str, Any]] | None = None
-        self._get_result = get_result or {}
-        self._insert_result = insert_result or {"id": "created"}
-        self._update_result = update_result or {"id": "updated"}
-        self._list_error = list_error
-        self._update_error = update_error
+    def __init__(self):
+        self._list_result: dict[str, Any] = {"items": []}
+        self._get_result: dict[str, Any] = {}
+        self._insert_result: dict[str, Any] = {"id": "created"}
+        self._update_result: dict[str, Any] = {"id": "updated"}
+        self._list_error: Exception | None = None
+        self._update_error: Exception | None = None
         self.list_calls: list[dict[str, Any]] = []
         self.insert_calls: list[dict[str, Any]] = []
         self.update_calls: list[dict[str, Any]] = []
-        self.last_update_request: _Exec | None = None
 
     def list(self, **kwargs: Any) -> _Exec:
         self.list_calls.append(kwargs)
         if self._list_error is not None:
             raise self._list_error
-        if self._list_results_by_page_token is not None:
-            return _Exec(self._list_results_by_page_token[kwargs.get("pageToken")])
         return _Exec(self._list_result)
 
     def get(self, **kwargs: Any) -> _Exec:
@@ -1893,16 +1780,7 @@ class FakeEvents:
 
     def update(self, **kwargs: Any) -> _Exec:
         self.update_calls.append(kwargs)
-        self.last_update_request = _Exec(
-            self._update_result, raise_error=self._update_error
-        )
-        return self.last_update_request
-
-
-class _FakeHttpResp:
-    def __init__(self, status: int):
-        self.status = status
-        self.reason = "error"
+        return _Exec(self._update_result, raise_error=self._update_error)
 
 
 def _insufficient_scope_error() -> HttpError:
@@ -1914,7 +1792,7 @@ def _insufficient_scope_error() -> HttpError:
     is exactly what makes a naive `"insufficientPermissions" in str(exc)`
     substring check unreliable (see `_is_insufficient_scope_error`)."""
     return HttpError(
-        _FakeHttpResp(403),
+        _HttpResponse(403),
         (
             b'{"error": {"code": 403, '
             b'"message": "Request had insufficient authentication scopes.", '
@@ -1934,7 +1812,7 @@ def _legacy_only_insufficient_scope_error() -> HttpError:
     """Older/less-instrumented responses may still carry only the legacy
     field - must keep matching this shape too, not just the dual one."""
     return HttpError(
-        _FakeHttpResp(403),
+        _HttpResponse(403),
         (
             b'{"error": {"errors": [{"reason": "insufficientPermissions"}], '
             b'"message": "Request had insufficient authentication scopes."}}'
@@ -1988,15 +1866,10 @@ class FakeCalendars:
 
 
 class FakeService:
-    def __init__(
-        self,
-        events: FakeEvents | None = None,
-        freebusy: FakeFreebusy | None = None,
-        calendars: FakeCalendars | None = None,
-    ):
-        self._events = events or FakeEvents()
-        self._freebusy = freebusy or FakeFreebusy()
-        self._calendars = calendars or FakeCalendars()
+    def __init__(self):
+        self._events = FakeEvents()
+        self._freebusy = FakeFreebusy()
+        self._calendars = FakeCalendars()
 
     def events(self) -> FakeEvents:
         return self._events
@@ -2013,6 +1886,103 @@ def fake_service(monkeypatch):
     service = FakeService()
     monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
     return service
+
+
+def test_incomplete_check_response_caps_unchecked_attendees_before_write(
+    fake_service, monkeypatch
+):
+    """A large set of unchecked calendars returns a bounded pre-write
+    response instead of allowing the update and warning afterward."""
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 300)
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    raw = calendar.google_calendar_update_events(
+        event_id="self-1",
+        attendees=[f"person{i}@example.com" for i in range(200)],
+    )
+    result = json.loads(raw)
+
+    assert len(raw) <= 300
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["truncated"] is True
+    assert fake_service._events.update_calls == []
+
+
+def test_event_response_counts_hangout_link_in_the_output_cap(
+    fake_service, monkeypatch
+):
+    """A derived top-level Meet link must be included in the size budget;
+    otherwise appending it after event truncation can exceed the limit."""
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 300)
+    hangout_link = "https://meet.google.com/abc-defg-hij"
+    fake_service._events._insert_result = {
+        "id": "evt1",
+        "hangoutLink": hangout_link,
+        "attendees": [{"email": f"person{i}@example.com"} for i in range(200)],
+    }
+
+    raw = calendar.google_calendar_create_events(
+        summary="1:1",
+        start_time="2026-09-07T15:00:00+08:00",
+        end_time="2026-09-07T16:00:00+08:00",
+    )
+    result = json.loads(raw)
+
+    assert len(raw) <= 300
+    assert result["status"] == "success"
+    assert result["hangout_link"] == hangout_link
+    assert result["truncated"] is True
+
+
+def test_event_response_fits_a_small_cap_with_a_large_conference_field(
+    fake_service, monkeypatch
+):
+    """Fixed response fields must be discardable when even one large value
+    would otherwise leave the success envelope above the output limit."""
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 100)
+    fake_service._events._insert_result = {
+        "id": "evt1",
+        "hangoutLink": "https://meet.google.com/" + "x" * 200,
+    }
+
+    raw = calendar.google_calendar_create_events(
+        summary="1:1",
+        start_time="2026-09-07T15:00:00+08:00",
+        end_time="2026-09-07T16:00:00+08:00",
+    )
+    result = json.loads(raw)
+
+    assert len(raw) <= 100
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+
+
+def test_incomplete_check_response_fits_a_small_cap_for_one_attendee(
+    fake_service, monkeypatch
+):
+    """The pre-write failure envelope stays bounded even when there is only
+    one collection item left, which cannot be reduced by list halving."""
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 100)
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    raw = calendar.google_calendar_create_events(
+        summary="Kickoff",
+        start_time="2026-08-27T10:00:00+08:00",
+        end_time="2026-08-27T10:30:00+08:00",
+        attendees=["person-with-a-long-address@example.com"],
+    )
+    result = json.loads(raw)
+
+    assert len(raw) <= 100
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["truncated"] is True
+    assert fake_service._events.insert_calls == []
 
 
 def _confirmed_event(
@@ -2502,6 +2472,7 @@ def test_update_events_same_window_only_checks_newly_added_attendee(fake_service
         calendar.google_calendar_update_events(
             event_id="self-1",
             attendees=["old@example.com", "new@example.com"],
+            notify_attendees=True,
         )
     )
 
@@ -2513,25 +2484,33 @@ def test_update_events_same_window_only_checks_newly_added_attendee(fake_service
         for item in call["body"]["items"]
     }
     assert queried_emails == {"new@example.com"}
+    assert fake_service._events.update_calls[0]["sendUpdates"] == "all"
 
 
+@pytest.mark.parametrize(
+    "organizer",
+    [
+        pytest.param({"email": "me@example.com"}, id="explicit-organizer"),
+        pytest.param(None, id="implicit-calendar-owner"),
+    ],
+)
 def test_update_events_adding_the_organizer_as_an_attendee_does_not_self_conflict(
-    fake_service,
+    fake_service, organizer
 ):
-    """Regression test: freebusy.query has no concept of "exclude this
-    event", unlike the organizer-calendar path (excluded by id/
-    recurringEventId). Adding the organizer's own email as a "new"
-    attendee would otherwise be checked via freebusy and always find
-    this very event's own busy block on their calendar - the organizer's
-    own availability is already covered by the organizer-calendar check,
-    so they must be excluded from the freebusy batch."""
-    fake_service._events._get_result = {
+    """Adding the connected account as an attendee must use the organizer
+    events-list check, whether Google returns an explicit organizer field or
+    implies that the calendar owner organized the event. A freebusy query would
+    see this event's own busy block and falsely report a conflict.
+    """
+    existing_event = {
         "id": "self-1",
         "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
         "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
         "attendees": [],
-        "organizer": {"email": "me@example.com"},
     }
+    if organizer is not None:
+        existing_event["organizer"] = organizer
+    fake_service._events._get_result = existing_event
     fake_service._events._list_result = {"items": []}
     fake_service._freebusy = FakeFreebusy(
         {
@@ -2543,66 +2522,14 @@ def test_update_events_adding_the_organizer_as_an_attendee_does_not_self_conflic
                             "end": "2026-08-27T10:30:00+08:00",
                         }
                     ]
-                },
+                }
             }
         }
     )
 
     result = json.loads(
         calendar.google_calendar_update_events(
-            event_id="self-1",
-            attendees=["me@example.com"],
-        )
-    )
-
-    assert result["status"] == "success"
-    assert fake_service._freebusy.query_calls == []
-    # The organizer's own calendar must still have been checked - just via
-    # the id/recurringEventId-excluding events.list path instead of the
-    # self-conflicting freebusy one - not skipped outright.
-    assert len(fake_service._events.list_calls) == 1
-
-
-def test_update_events_adding_self_as_attendee_with_no_organizer_field_does_not_self_conflict(
-    fake_service,
-):
-    """Regression test: Google omits the top-level `organizer` field
-    whenever the organizer is just the calendar owner - the overwhelmingly
-    common case, and the ONE this exclusion must also cover, not just the
-    explicit-organizer-field case the sibling test above pins. Without
-    resolving the caller's own identity as a fallback organizer address
-    here, adding the caller's own email as a "new" attendee would never
-    be excluded from the freebusy batch and would always find this very
-    event's own busy block on their calendar."""
-    fake_service._events._get_result = {
-        "id": "self-1",
-        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
-        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
-        "attendees": [],
-        # No "organizer" field at all - implicit organizer is the caller,
-        # whose own resolved address defaults to "me@example.com" (see
-        # FakeCalendars).
-    }
-    fake_service._events._list_result = {"items": []}
-    fake_service._freebusy = FakeFreebusy(
-        {
-            "calendars": {
-                "me@example.com": {
-                    "busy": [
-                        {
-                            "start": "2026-08-27T10:00:00+08:00",
-                            "end": "2026-08-27T10:30:00+08:00",
-                        }
-                    ]
-                },
-            }
-        }
-    )
-
-    result = json.loads(
-        calendar.google_calendar_update_events(
-            event_id="self-1",
-            attendees=["me@example.com"],
+            event_id="self-1", attendees=["me@example.com"]
         )
     )
 
@@ -2897,7 +2824,7 @@ def test_update_events_non_scope_error_on_the_organizer_backfill_is_also_skipped
         # No "organizer" field at all - triggers the backfill attempt.
     }
     fake_service._calendars = FakeCalendars(
-        raise_error=HttpError(_FakeHttpResp(500), b'{"error": {"message": "boom"}}')
+        raise_error=HttpError(_HttpResponse(500), b'{"error": {"message": "boom"}}')
     )
 
     result = json.loads(
@@ -3361,6 +3288,7 @@ def test_freebusy_missing_scope_rejects_the_write_even_with_ignore_conflicts_fal
     )
 
     assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
     assert fake_service._events.insert_calls == []
 
 
@@ -3429,32 +3357,28 @@ def test_freebusy_missing_scope_legacy_only_body_still_rejects(fake_service):
     )
 
     assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
     assert fake_service._events.insert_calls == []
 
 
-def test_is_insufficient_scope_error_rejects_unrelated_403():
-    other = HttpError(
-        _FakeHttpResp(403),
-        b'{"error": {"errors": [{"reason": "forbiddenForNonOrganizer"}]}}',
-    )
-    assert calendar._is_insufficient_scope_error(other) is False
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param(
+            b'{"error": {"errors": [{"reason": "forbiddenForNonOrganizer"}]}}',
+            id="unrelated-reason",
+        ),
+        pytest.param(b"not json", id="malformed-body"),
+        pytest.param(
+            b'{"error": {"errors": true, "details": 42}}',
+            id="non-list-error-fields",
+        ),
+    ],
+)
+def test_is_insufficient_scope_error_rejects_unrecognized_bodies(content):
+    error = HttpError(_HttpResponse(403), content)
 
-
-def test_is_insufficient_scope_error_tolerates_malformed_body():
-    malformed = HttpError(_FakeHttpResp(403), b"not json")
-    assert calendar._is_insufficient_scope_error(malformed) is False
-
-
-def test_is_insufficient_scope_error_tolerates_non_list_error_fields():
-    """Regression test: valid JSON whose "errors"/"details" field is
-    present but isn't an array (e.g. a boolean/object, from a malformed
-    or unexpected error body) must not crash - `x or []` treats a truthy
-    non-list value as itself, and iterating a non-iterable raises
-    TypeError; must fall through to "can't tell, so False" instead."""
-    non_list_fields = HttpError(
-        _FakeHttpResp(403), b'{"error": {"errors": true, "details": 42}}'
-    )
-    assert calendar._is_insufficient_scope_error(non_list_fields) is False
+    assert calendar._is_insufficient_scope_error(error) is False
 
 
 def test_freebusy_other_http_errors_still_propagate(fake_service):
@@ -3467,7 +3391,7 @@ def test_freebusy_other_http_errors_still_propagate(fake_service):
     would match the reason check, so it actually exercises the status
     gate."""
     other_error = HttpError(
-        _FakeHttpResp(500),
+        _HttpResponse(500),
         (
             b'{"error": {"message": "boom", '
             b'"errors": [{"reason": "insufficientPermissions"}]}}'
@@ -3486,6 +3410,46 @@ def test_freebusy_other_http_errors_still_propagate(fake_service):
 
     assert result["status"] == "error"
     assert "reconnect" not in result["message"].lower()
+
+
+def test_organizer_events_non_scope_http_error_still_propagates(fake_service):
+    fake_service._events._list_error = HttpError(
+        _HttpResponse(403),
+        b'{"error": {"errors": [{"reason": "forbiddenForNonOrganizer"}]}}',
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" not in result["message"].lower()
+    assert fake_service._events.insert_calls == []
+
+
+def test_update_events_non_precondition_http_error_still_propagates(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "etag": '"version-1"',
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+    }
+    fake_service._events._update_error = HttpError(
+        _HttpResponse(500), b'{"error": {"message": "backend unavailable"}}'
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="self-1", summary="Renamed")
+    )
+
+    assert result["status"] == "error"
+    assert "backend unavailable" in result["message"].lower()
+    assert "changed while its availability was being checked" not in result["message"]
+    assert len(fake_service._events.update_calls) == 1
 
 
 def test_freebusy_attendee_absent_from_response_is_marked_unchecked(fake_service):
@@ -3604,6 +3568,9 @@ def test_update_events_allows_replacing_both_boundaries_on_an_all_day_event(
     )
 
     assert result["status"] == "success"
+    update_call = fake_service._events.update_calls[0]
+    assert update_call["body"]["start"] == {"dateTime": "2026-08-27T10:00:00+08:00"}
+    assert update_call["body"]["end"] == {"dateTime": "2026-08-27T10:30:00+08:00"}
 
 
 def test_update_events_widens_all_day_boundary_in_the_calendars_own_timezone(
@@ -3799,6 +3766,7 @@ def test_update_events_all_day_with_a_different_organizer_shares_one_calendar_lo
     )
 
     assert result["status"] == "conflict_check_incomplete"
+    assert "2026-08-28T00:00:00+08:00 - 2026-08-29T00:00:00+08:00" in result["message"]
     assert len(fake_service._calendars.get_calls) == 1
     assert result["unchecked_attendees"] == ["boss@example.com"]
     assert fake_service._events.list_calls == []
@@ -3934,7 +3902,7 @@ def test_update_events_calendar_timezone_lookup_non_scope_error_also_falls_back_
         "attendees": [],
     }
     fake_service._calendars = FakeCalendars(
-        raise_error=HttpError(_FakeHttpResp(500), b'{"error": {"message": "boom"}}')
+        raise_error=HttpError(_HttpResponse(500), b'{"error": {"message": "boom"}}')
     )
 
     result = json.loads(

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1739,3 +1739,2729 @@ def test_ignore_conflicts_cannot_bypass_a_missing_stored_counterpart(monkeypatch
     assert result["status"] == "error"
     assert "valid stored counterpart" in result["message"]
     service.events.return_value.update.assert_not_called()
+
+
+def test_incomplete_check_response_caps_unchecked_attendees_before_write(
+    fake_service, monkeypatch
+):
+    """A large set of unchecked calendars returns a bounded pre-write
+    response instead of allowing the update and warning afterward."""
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 300)
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    raw = calendar.google_calendar_update_events(
+        event_id="self-1",
+        attendees=[f"person{i}@example.com" for i in range(200)],
+    )
+    result = json.loads(raw)
+
+    assert len(raw) <= 300
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["truncated"] is True
+    assert fake_service._events.update_calls == []
+
+
+def test_event_response_counts_hangout_link_in_the_output_cap(monkeypatch):
+    """A derived top-level Meet link must be included in the size budget;
+    otherwise appending it after event truncation can exceed the limit."""
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 300)
+    hangout_link = "https://meet.google.com/abc-defg-hij"
+    service = _fake_service(
+        {
+            "id": "evt1",
+            "hangoutLink": hangout_link,
+            "attendees": [{"email": f"person{i}@example.com"} for i in range(200)],
+        }
+    )
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    raw = calendar.google_calendar_create_events(
+        summary="1:1",
+        start_time="2026-09-07T15:00:00+08:00",
+        end_time="2026-09-07T16:00:00+08:00",
+    )
+    result = json.loads(raw)
+
+    assert len(raw) <= 300
+    assert result["status"] == "success"
+    assert result["hangout_link"] == hangout_link
+    assert result["truncated"] is True
+
+
+def test_event_response_fits_a_small_cap_with_a_large_conference_field(monkeypatch):
+    """Fixed response fields must be discardable when even one large value
+    would otherwise leave the success envelope above the output limit."""
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 100)
+    service = _fake_service(
+        {"id": "evt1", "hangoutLink": "https://meet.google.com/" + "x" * 200}
+    )
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    raw = calendar.google_calendar_create_events(
+        summary="1:1",
+        start_time="2026-09-07T15:00:00+08:00",
+        end_time="2026-09-07T16:00:00+08:00",
+    )
+    result = json.loads(raw)
+
+    assert len(raw) <= 100
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+
+
+def test_incomplete_check_response_fits_a_small_cap_for_one_attendee(
+    fake_service, monkeypatch
+):
+    """The pre-write failure envelope stays bounded even when there is only
+    one collection item left, which cannot be reduced by list halving."""
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 100)
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    raw = calendar.google_calendar_create_events(
+        summary="Kickoff",
+        start_time="2026-08-27T10:00:00+08:00",
+        end_time="2026-08-27T10:30:00+08:00",
+        attendees=["person-with-a-long-address@example.com"],
+    )
+    result = json.loads(raw)
+
+    assert len(raw) <= 100
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["truncated"] is True
+    assert fake_service._events.insert_calls == []
+
+
+class _Exec:
+    def __init__(self, result: dict[str, Any], *, raise_error: Exception | None = None):
+        self._result = result
+        self._raise_error = raise_error
+        self.headers: dict[str, str] = {}
+
+    def execute(self) -> dict[str, Any]:
+        if self._raise_error is not None:
+            raise self._raise_error
+        return self._result
+
+
+class FakeEvents:
+    def __init__(
+        self,
+        *,
+        list_result: dict[str, Any] | None = None,
+        get_result: dict[str, Any] | None = None,
+        insert_result: dict[str, Any] | None = None,
+        update_result: dict[str, Any] | None = None,
+        list_error: Exception | None = None,
+        update_error: Exception | None = None,
+    ):
+        self._list_result = list_result if list_result is not None else {"items": []}
+        # Keyed by the request's own pageToken (None for the first page) -
+        # lets a test simulate a multi-page events.list response instead
+        # of always returning the same page regardless of pageToken. Only
+        # used when set; _list_result covers every single-page test.
+        self._list_results_by_page_token: dict[str | None, dict[str, Any]] | None = None
+        self._get_result = get_result or {}
+        self._insert_result = insert_result or {"id": "created"}
+        self._update_result = update_result or {"id": "updated"}
+        self._list_error = list_error
+        self._update_error = update_error
+        self.list_calls: list[dict[str, Any]] = []
+        self.insert_calls: list[dict[str, Any]] = []
+        self.update_calls: list[dict[str, Any]] = []
+        self.last_update_request: _Exec | None = None
+
+    def list(self, **kwargs: Any) -> _Exec:
+        self.list_calls.append(kwargs)
+        if self._list_error is not None:
+            raise self._list_error
+        if self._list_results_by_page_token is not None:
+            return _Exec(self._list_results_by_page_token[kwargs.get("pageToken")])
+        return _Exec(self._list_result)
+
+    def get(self, **kwargs: Any) -> _Exec:
+        return _Exec(self._get_result)
+
+    def insert(self, **kwargs: Any) -> _Exec:
+        self.insert_calls.append(kwargs)
+        return _Exec(self._insert_result)
+
+    def update(self, **kwargs: Any) -> _Exec:
+        self.update_calls.append(kwargs)
+        self.last_update_request = _Exec(
+            self._update_result, raise_error=self._update_error
+        )
+        return self.last_update_request
+
+
+class _FakeHttpResp:
+    def __init__(self, status: int):
+        self.status = status
+        self.reason = "error"
+
+
+def _insufficient_scope_error() -> HttpError:
+    """A real Google API 403 for this case carries the reason on BOTH the
+    legacy `errors[].reason` field and a newer `details[].reason`
+    ErrorInfo entry at once - not one or the other. `HttpError`'s own
+    `_get_reason()` picks `details` over `errors` whenever both are
+    present, dropping the legacy reason from `str(exc)` entirely, which
+    is exactly what makes a naive `"insufficientPermissions" in str(exc)`
+    substring check unreliable (see `_is_insufficient_scope_error`)."""
+    return HttpError(
+        _FakeHttpResp(403),
+        (
+            b'{"error": {"code": 403, '
+            b'"message": "Request had insufficient authentication scopes.", '
+            b'"errors": [{"message": "Insufficient Permission", '
+            b'"domain": "global", "reason": "insufficientPermissions"}], '
+            b'"status": "PERMISSION_DENIED", '
+            b'"details": [{"@type": "type.googleapis.com/google.rpc.ErrorInfo", '
+            b'"reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT", '
+            b'"domain": "googleapis.com", '
+            b'"metadata": {"service": "calendar-json.googleapis.com", '
+            b'"method": "calendar.v3.Freebusy.Query"}}]}}'
+        ),
+    )
+
+
+def _legacy_only_insufficient_scope_error() -> HttpError:
+    """Older/less-instrumented responses may still carry only the legacy
+    field - must keep matching this shape too, not just the dual one."""
+    return HttpError(
+        _FakeHttpResp(403),
+        (
+            b'{"error": {"errors": [{"reason": "insufficientPermissions"}], '
+            b'"message": "Request had insufficient authentication scopes."}}'
+        ),
+    )
+
+
+class FakeFreebusy:
+    def __init__(
+        self,
+        result: dict[str, Any] | None = None,
+        *,
+        raise_error: Exception | None = None,
+    ):
+        self._result = result or {"calendars": {}}
+        self._raise_error = raise_error
+        self.query_calls: list[dict[str, Any]] = []
+
+    def query(self, **kwargs: Any) -> _Exec:
+        self.query_calls.append(kwargs)
+        if self._raise_error is not None:
+            raise self._raise_error
+        return _Exec(self._result)
+
+
+class FakeCalendars:
+    def __init__(
+        self,
+        timezone: str = "UTC",
+        *,
+        email: str = "me@example.com",
+        raise_error: Exception | None = None,
+    ):
+        self._timezone = timezone
+        # The connected account's own address (the "id" field
+        # calendars().get returns on a real primary calendar) - defaults
+        # to the same
+        # "me@example.com" convention most fixtures already use for the
+        # caller/organizer, so a test that never customizes this and
+        # never means to simulate a different-organizer scenario keeps
+        # caller_is_organizer=True without having to set this explicitly.
+        self._email = email
+        self._raise_error = raise_error
+        self.get_calls: list[dict[str, Any]] = []
+
+    def get(self, **kwargs: Any) -> _Exec:
+        self.get_calls.append(kwargs)
+        if self._raise_error is not None:
+            raise self._raise_error
+        return _Exec({"id": self._email, "timeZone": self._timezone})
+
+
+class FakeService:
+    def __init__(
+        self,
+        events: FakeEvents | None = None,
+        freebusy: FakeFreebusy | None = None,
+        calendars: FakeCalendars | None = None,
+    ):
+        self._events = events or FakeEvents()
+        self._freebusy = freebusy or FakeFreebusy()
+        self._calendars = calendars or FakeCalendars()
+
+    def events(self) -> FakeEvents:
+        return self._events
+
+    def freebusy(self) -> FakeFreebusy:
+        return self._freebusy
+
+    def calendars(self) -> FakeCalendars:
+        return self._calendars
+
+
+@pytest.fixture
+def fake_service(monkeypatch):
+    service = FakeService()
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+    return service
+
+
+def _confirmed_event(
+    event_id="existing-1",
+    summary="1:1 with Hazel",
+    transparency=None,
+    status="confirmed",
+):
+    event: dict[str, Any] = {
+        "id": event_id,
+        "summary": summary,
+        "status": status,
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+    }
+    if transparency:
+        event["transparency"] = transparency
+    return event
+
+
+def test_create_events_ignores_transparent_organizer_event(fake_service):
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(transparency="transparent")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.insert_calls) == 1
+
+
+def test_create_events_ignores_cancelled_organizer_event(fake_service):
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(status="cancelled")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_create_events_detects_attendee_freebusy_conflict(fake_service):
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "chelsea@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "chelsea@example.com"
+    assert fake_service._events.insert_calls == []
+
+
+def test_create_events_unchecked_attendee_blocks_creation(fake_service):
+    """An external/unshared calendar cannot be treated as available."""
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "outsider@gmail.com": {"errors": [{"reason": "notFound"}]},
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
+    assert fake_service._events.insert_calls == []
+
+
+def test_create_events_ignore_conflicts_skips_the_check_entirely(fake_service):
+    fake_service._events._list_result = {"items": [_confirmed_event()]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert len(fake_service._events.insert_calls) == 1
+
+
+def test_create_events_rejects_a_reversed_window(fake_service):
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:30:00+08:00",
+            end_time="2026-08-27T10:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after" in result["message"]
+    assert fake_service._events.list_calls == []
+    assert fake_service._events.insert_calls == []
+
+
+def test_create_events_rejects_an_offsetless_start_time(fake_service):
+    """Regression test: an offsetless start_time compared naive-against-
+    aware deep inside a downstream comparison would previously fall
+    through to Google's own freebusy/events.list APIs (which require an
+    RFC3339 offset on timeMin/timeMax) and fail there with an opaque
+    error, instead of this clear, actionable one raised up front."""
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00",  # no offset
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "start_time" in result["message"]
+    assert fake_service._events.insert_calls == []
+
+
+def test_create_events_prefers_the_offset_error_over_the_reversed_window_one(
+    fake_service,
+):
+    """Regression test: two NAIVE values that also happen to be reversed
+    compare just fine (no TypeError, so reject_reversed_window's
+    permissive aware-vs-naive handling never kicks in) and would
+    otherwise raise the generic "must be after" message before the more
+    specific, actionable offset error ever got a chance to run - offset
+    validation must happen first."""
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:30:00",  # naive AND reversed
+            end_time="2026-08-27T10:00:00",  # naive
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "start_time" in result["message"]
+    assert "offset" in result["message"]
+    assert fake_service._events.insert_calls == []
+
+
+def test_update_events_rejects_an_offsetless_start_time(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00",  # no offset
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "start_time" in result["message"]
+    assert fake_service._events.update_calls == []
+    assert fake_service._freebusy.query_calls == []
+
+
+def test_update_events_excludes_the_event_being_moved_from_its_own_conflicts(
+    fake_service,
+):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+    }
+    fake_service._events._list_result = {
+        "items": [
+            {
+                "id": "self-1",
+                "summary": "old slot",
+                "status": "confirmed",
+                "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+                "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+            },
+            _confirmed_event(event_id="other-1", summary="Board sync"),
+        ]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["Board sync"]
+
+
+def test_update_events_excludes_a_recurring_events_own_instances_from_its_conflicts(
+    fake_service,
+):
+    """Regression test: events.list(singleEvents=True) expands a recurring
+    event into instances that carry their OWN id
+    ("<masterId>_<recurrenceStamp>"), never the master's - rescheduling
+    the master itself (the normal way to address a recurring series)
+    must not report it as conflicting with its own instances just
+    because `id` alone never matches `exclude_event_id`. recurringEventId
+    is the field that actually names the master on each instance."""
+    fake_service._events._get_result = {
+        "id": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+    }
+    fake_service._events._list_result = {
+        "items": [
+            {
+                "id": "series-1_20260827T010000Z",
+                "recurringEventId": "series-1",
+                "summary": "Weekly sync (this instance)",
+                "status": "confirmed",
+                "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+                "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+            },
+            _confirmed_event(event_id="other-1", summary="Board sync"),
+        ]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["Board sync"]
+
+
+def test_update_events_refuses_to_move_a_recurring_masters_time(fake_service):
+    """Regression test: the conflict check only ever evaluates the single
+    window this call computes - it has no way to expand a recurring
+    master's RRULE and check every occurrence it generates. Moving the
+    master's own time (recurrence present on the fetched event) must be
+    refused outright rather than silently succeed having only verified
+    one occurrence, since a later occurrence at the new time could have a
+    real conflict this call never looked at."""
+    fake_service._events._get_result = {
+        "id": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TH"],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "recurring" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_refuses_to_add_an_attendee_to_a_recurring_master(fake_service):
+    """Companion to the test above: adding a genuinely new attendee to a
+    recurring master is refused for the same reason - their availability
+    can only be checked against the one occurrence this call computes,
+    not the whole series."""
+    fake_service._events._get_result = {
+        "id": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TH"],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "recurring" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_allows_metadata_only_edits_on_a_recurring_master(fake_service):
+    """A pure metadata edit (no time/attendee change) on a recurring
+    master is unaffected by the new restriction - it never needed the
+    per-occurrence conflict check the restriction exists to guard."""
+    fake_service._events._get_result = {
+        "id": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TH"],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1",
+            summary="Renamed series",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_allows_equivalent_rfc3339_times_on_a_recurring_master(
+    fake_service,
+):
+    """Equivalent RFC3339 spellings do not constitute a recurring-series
+    move after both timestamps have been normalized."""
+    fake_service._events._get_result = {
+        "id": "series-1",
+        "start": {"dateTime": "2026-08-27T01:00:00Z"},
+        "end": {"dateTime": "2026-08-27T01:30:00Z"},
+        "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TH"],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1",
+            start_time="2026-08-27T01:00:00+00:00",
+            end_time="2026-08-27T01:30:00+00:00",
+            summary="Renamed series",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_recurring_master_restriction_can_be_bypassed_with_ignore_conflicts(
+    fake_service,
+):
+    """ignore_conflicts=True is the caller's explicit escape hatch for a
+    check that can't run at all - including this one, once the user has
+    confirmed they've verified every occurrence themselves."""
+    fake_service._events._get_result = {
+        "id": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TH"],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_moving_a_single_occurrence_is_unaffected_by_the_recurring_master_restriction(
+    fake_service,
+):
+    """A single occurrence (addressed by its own event id, carrying
+    recurringEventId rather than its own recurrence) is a single event
+    like any other for conflict-checking purposes - the restriction only
+    targets the master itself."""
+    fake_service._events._get_result = {
+        "id": "series-1_20260827T010000Z",
+        "recurringEventId": "series-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+    }
+    fake_service._events._list_result = {"items": []}
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="series-1_20260827T010000Z",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_metadata_only_edit_never_checks_conflicts(fake_service):
+    """A pure metadata edit (no time/attendee change) must never run the
+    conflict check at all - not just tolerate it, since even running the
+    check would spuriously self-conflict against the event's own attendees
+    (see the two tests below)."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "chelsea@example.com"}],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="New Title",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+    assert fake_service._events.update_calls[0]["sendUpdates"] == "none"
+
+
+def test_update_events_same_window_only_checks_newly_added_attendee(fake_service):
+    """Adding an attendee without moving the event must only check the new
+    attendee's free/busy - checking an existing attendee against the
+    unchanged window would always find the event's own busy block on their
+    calendar and falsely report a conflict."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "old@example.com"}],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "old@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+                "new@example.com": {"busy": []},
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["old@example.com", "new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    queried_emails = {
+        item["id"]
+        for call in fake_service._freebusy.query_calls
+        for item in call["body"]["items"]
+    }
+    assert queried_emails == {"new@example.com"}
+
+
+def test_update_events_adding_the_organizer_as_an_attendee_does_not_self_conflict(
+    fake_service,
+):
+    """Regression test: freebusy.query has no concept of "exclude this
+    event", unlike the organizer-calendar path (excluded by id/
+    recurringEventId). Adding the organizer's own email as a "new"
+    attendee would otherwise be checked via freebusy and always find
+    this very event's own busy block on their calendar - the organizer's
+    own availability is already covered by the organizer-calendar check,
+    so they must be excluded from the freebusy batch."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "me@example.com"},
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "me@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._freebusy.query_calls == []
+    # The organizer's own calendar must still have been checked - just via
+    # the id/recurringEventId-excluding events.list path instead of the
+    # self-conflicting freebusy one - not skipped outright.
+    assert len(fake_service._events.list_calls) == 1
+
+
+def test_update_events_adding_self_as_attendee_with_no_organizer_field_does_not_self_conflict(
+    fake_service,
+):
+    """Regression test: Google omits the top-level `organizer` field
+    whenever the organizer is just the calendar owner - the overwhelmingly
+    common case, and the ONE this exclusion must also cover, not just the
+    explicit-organizer-field case the sibling test above pins. Without
+    resolving the caller's own identity as a fallback organizer address
+    here, adding the caller's own email as a "new" attendee would never
+    be excluded from the freebusy batch and would always find this very
+    event's own busy block on their calendar."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+        # No "organizer" field at all - implicit organizer is the caller,
+        # whose own resolved address defaults to "me@example.com" (see
+        # FakeCalendars).
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "me@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._freebusy.query_calls == []
+    assert len(fake_service._events.list_calls) == 1
+
+
+def test_update_events_adding_the_organizer_as_an_attendee_still_catches_a_real_conflict(
+    fake_service,
+):
+    """Regression test: excluding the organizer from the freebusy batch
+    must not also skip checking their calendar altogether. Before this
+    fix, adding ONLY the organizer as a new attendee (window otherwise
+    unchanged) left both `attendees_to_check` empty (organizer filtered
+    out) and `check_organizer` false (window unchanged), so a genuinely
+    different conflicting event on the organizer's own calendar was
+    silently missed entirely."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "me@example.com"},
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1", summary="Board sync")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["Board sync"]
+    assert fake_service._freebusy.query_calls == []
+
+
+def test_update_events_on_someone_elses_event_actually_checks_the_real_organizer(
+    fake_service,
+):
+    """Regression test: check_organizer queries calendarId="primary",
+    which is always the AUTHENTICATED CALLER's own calendar, not
+    necessarily this event's organizer - a guest with edit permission
+    (guestsCanModify) can update an event they didn't organize. Before
+    this fix, the organizer's email was unconditionally excluded from
+    freebusy and merely reported as unchecked in this scenario, even
+    though freebusy.query accepts any calendar/email id - not just
+    "primary" - so the real organizer (boss@example.com) CAN be checked
+    the same way a retained attendee is: over just the delta segment
+    beyond the event's old window, so their own pre-existing footprint
+    on this same event doesn't self-conflict. A genuine busy block of
+    theirs in the new-only territory must now be caught as a real
+    conflict, not silently missed."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "boss@example.com"}],
+        "organizer": {"email": "boss@example.com"},
+    }
+    # Default FakeCalendars() resolves the connected account's own
+    # address as "me@example.com" - different from the organizer above.
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "boss@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T14:10:00+08:00",
+                            "end": "2026-08-27T14:20:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["calendar"] for c in result["conflicts"]] == ["boss@example.com"]
+    assert result["unchecked_attendees"] == []
+    # Never queried "primary" (the caller's own calendar) as if it were
+    # the organizer's - the real organizer was checked via freebusy
+    # instead, using their own real address.
+    assert fake_service._events.list_calls == []
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["items"] == [{"id": "boss@example.com"}]
+
+
+def test_update_events_on_someone_elses_event_reports_the_real_organizer_unchecked_when_freebusy_has_no_data_for_them(
+    fake_service,
+):
+    """Companion to the test above: the real organizer IS now queried via
+    freebusy over the delta segment, but if their calendar is absent from
+    the response (the same per-attendee gap _find_conflicts already
+    handles for any other attendee), they must still be reported as
+    unchecked rather than silently treated as clear."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "boss@example.com"}],
+        "organizer": {"email": "boss@example.com"},
+    }
+    # FakeFreebusy defaults to an empty "calendars" dict - boss@example.com
+    # is absent from it, same as a real per-attendee visibility gap.
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["unchecked_attendees"] == ["boss@example.com"]
+    assert fake_service._events.update_calls == []
+    assert fake_service._events.list_calls == []
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["items"] == [{"id": "boss@example.com"}]
+
+
+def test_update_events_organizer_newly_added_with_unchanged_window_is_still_unverifiable(
+    fake_service,
+):
+    """Regression test for the one residual case the delta-segment fix
+    above can't cover: the real organizer is added as a "new" attendee
+    but the window itself never moves. window_delta_segments finds no
+    new territory at all in that case (correctly - a retained party's
+    existing footprint already covers an unchanged window), so unlike a
+    genuine window move, there is no safe way to freebusy-check them
+    without risking a self-conflict on their own pre-existing copy of
+    this same event. Must still be reported as unchecked, not silently
+    treated as clear, and not freebusy-queried at all."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "boss@example.com"},
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["boss@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["unchecked_attendees"] == ["boss@example.com"]
+    assert fake_service._events.update_calls == []
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+
+
+def test_update_events_organizer_self_false_needs_no_identity_api_call(
+    fake_service,
+):
+    """Regression test: Google's own organizer.self field ("Whether the
+    organizer corresponds to the calendar on which this copy of the
+    event appears") directly answers caller_is_organizer - when present,
+    no calendars().get(calendarId="primary") call is needed at all for
+    identity purposes, unlike the email-comparison fallback this uses
+    when organizer.self is absent. The organizer IS still freebusy-
+    checked over the delta segment (a separate mechanism from identity
+    resolution) - absent from the default empty freebusy response here,
+    so still reported as unchecked."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "boss@example.com"}],
+        "organizer": {"email": "boss@example.com", "self": False},
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["unchecked_attendees"] == ["boss@example.com"]
+    assert fake_service._events.update_calls == []
+    assert fake_service._events.list_calls == []
+    # The whole point: organizer.self answered caller_is_organizer
+    # directly, so the connected account's own identity never needed
+    # looking up via calendars().get() at all.
+    assert fake_service._calendars.get_calls == []
+
+
+def test_update_events_organizer_self_false_with_no_email_still_checks_the_new_attendee(
+    fake_service,
+):
+    """Regression test: organizer.self=False with no organizer.email at
+    all must NOT trigger the "backfill organizer_email to the caller's
+    own address" fallback - that fallback exists for the "no organizer
+    info whatsoever" case, and backfilling here would wrongly exclude a
+    genuinely different, newly-added attendee ("me@example.com" - the
+    caller's own address, added as an ordinary attendee to someone
+    else's event) from the freebusy batch, silently skipping a real
+    conflict check for them."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"self": False},
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {"calendars": {"me@example.com": {"busy": []}}}
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+    queried_emails = {
+        item["id"]
+        for call in fake_service._freebusy.query_calls
+        for item in call["body"]["items"]
+    }
+    assert queried_emails == {"me@example.com"}
+    assert fake_service._calendars.get_calls == []
+
+
+def test_update_events_missing_scope_on_the_organizer_backfill_is_skipped_with_ignore_conflicts(
+    fake_service,
+):
+    """Regression test: the organizer-email backfill (resolving the
+    caller's own address when the event has no organizer info at all)
+    calls the same calendars().get(calendarId="primary") endpoint as the
+    all-day-timezone lookup, and must respect ignore_conflicts the same
+    way that sibling call site already does - a token missing
+    calendar.calendars.readonly must not hard-fail a call the caller
+    explicitly opted out of checking."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        # No "organizer" field at all - triggers the backfill attempt.
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_non_scope_error_on_the_organizer_backfill_is_also_skipped_with_ignore_conflicts(
+    fake_service,
+):
+    """Companion to the test above: the backfill must forgive ANY failure
+    of calendars().get(), not just the specifically-recognized missing-
+    scope one - _primary_calendar_info re-raises any other HttpError
+    (rate limiting, a transient 5xx, an unrelated 403) unchanged rather
+    than converting it to InsufficientScopeError, and that's still "this
+    lookup couldn't run" every bit as much as a missing scope is."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        # No "organizer" field at all - triggers the backfill attempt.
+    }
+    fake_service._calendars = FakeCalendars(
+        raise_error=HttpError(_FakeHttpResp(500), b'{"error": {"message": "boom"}}')
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_missing_scope_on_the_organizer_backfill_rejects_the_write_by_default(
+    fake_service,
+):
+    """Companion to the two tests above: without ignore_conflicts, a
+    missing-scope failure on the organizer-email backfill must reject
+    the write outright, same as its two sibling calendars().get() call
+    sites (the all-day-timezone lookup and the identity-fallback
+    comparison) already do - not silently proceed as if the caller had
+    opted out of the check."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        # No "organizer" field at all - triggers the backfill attempt.
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_organizer_self_true_needs_no_identity_api_call(
+    fake_service,
+):
+    """Companion to the test above: organizer.self=True must resolve
+    caller_is_organizer without an identity API call either, and let the
+    organizer-calendar check run normally."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "me@example.com", "self": True},
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["1:1 with Hazel"]
+    assert fake_service._calendars.get_calls == []
+
+
+def test_update_events_on_someone_elses_event_still_catches_another_attendees_conflict(
+    fake_service,
+):
+    """Companion to the test above: the real organizer being unverifiable
+    must not swallow a genuinely different, checkable attendee's real
+    conflict."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "boss@example.com"}],
+        "organizer": {"email": "boss@example.com"},
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "coworker@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T14:10:00+08:00",
+                            "end": "2026-08-27T14:20:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",
+            end_time="2026-08-27T14:30:00+08:00",
+            attendees=["coworker@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["calendar"] for c in result["conflicts"]] == ["coworker@example.com"]
+    assert set(result["unchecked_attendees"]) == {"boss@example.com"}
+
+
+def test_update_events_treats_existing_attendee_case_insensitively(fake_service):
+    """Regression test for a review finding: an existing attendee re-passed
+    with different casing must still be recognized as "already there" -
+    otherwise it's treated as newly-added, gets checked against the
+    unchanged window, and always self-conflicts on its own busy block for
+    this very event. Uses two DIFFERENT non-canonical casings (neither one
+    plain-lowercase, and the two not equal to each other without folding)
+    on the stored side vs. the resubmitted side - a fixture where either
+    side happens to already be lowercase can't tell a correct fold on
+    that side from a mutation that drops .lower() on it specifically,
+    since a dropped .lower() on an already-lowercase value is invisible."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "OLD@EXAMPLE.COM"}],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                # This event's own busy block on the existing attendee's
+                # calendar - present so the test would fail with a false
+                # "conflict" if the case-insensitive exclusion regressed.
+                "old@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+                "new@example.com": {"busy": []},
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["Old@Example.Com", "new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    queried_emails = {
+        item["id"]
+        for call in fake_service._freebusy.query_calls
+        for item in call["body"]["items"]
+    }
+    assert queried_emails == {"new@example.com"}
+
+
+def test_update_events_reports_original_casing_in_conflicts(fake_service):
+    """Regression test: falling back to the event's existing attendees (no
+    attendees param passed) while moving the time must report a conflict
+    using the originally-stored casing, not the lowercased form used
+    internally for the case-insensitive membership check."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "John.Smith@Example.com"}],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "john.smith@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "John.Smith@Example.com"
+
+
+def test_update_events_moving_time_checks_organizer_and_all_attendees(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert len(fake_service._events.list_calls) == 1
+    queried_emails = {
+        item["id"]
+        for call in fake_service._freebusy.query_calls
+        for item in call["body"]["items"]
+    }
+    assert queried_emails == {"existing@example.com"}
+
+
+def test_update_events_rejects_a_reversed_window(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:30:00+08:00",
+            end_time="2026-08-27T10:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after" in result["message"]
+    assert fake_service._events.list_calls == []
+    assert fake_service._events.update_calls == []
+
+
+def test_freebusy_lookup_is_case_insensitive(fake_service):
+    """Not confirmed against real Google API behavior, but the lookup should
+    be defensive either way: a case-mismatched key must not silently
+    swallow a real conflict."""
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "Chelsea@Example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_organizer_events_list_tolerates_null_items(fake_service):
+    """Regression test for a review finding: the API can return an explicit
+    "items": null instead of omitting the key, which must not crash the
+    tool with a TypeError."""
+    fake_service._events._list_result = {"items": None}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_freebusy_tolerates_null_calendars(fake_service):
+    """Regression test for a review finding: freebusy.query can return an
+    explicit "calendars": null, which must not crash the tool with an
+    AttributeError."""
+    fake_service._freebusy = FakeFreebusy({"calendars": None})
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["unchecked_attendees"] == ["chelsea@example.com"]
+    assert fake_service._events.insert_calls == []
+
+
+def test_update_events_ignore_conflicts_skips_the_check(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+    }
+    fake_service._events._list_result = {"items": [_confirmed_event()]}
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_organizer_declined_but_opaque_event_is_still_a_conflict(fake_service):
+    """Google documents `responseStatus` and `transparency` as independent
+    fields with no guaranteed link - declining an invite doesn't reliably
+    clear its transparency, so a still-opaque declined event must still be
+    treated as busy rather than assumed free."""
+    event = _confirmed_event()
+    event["attendees"] = [
+        {"email": "me@example.com", "self": True, "responseStatus": "declined"}
+    ]
+    fake_service._events._list_result = {"items": [event]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_organizer_declined_and_transparent_event_is_not_a_conflict(fake_service):
+    event = _confirmed_event(transparency="transparent")
+    event["attendees"] = [
+        {"email": "me@example.com", "self": True, "responseStatus": "declined"}
+    ]
+    fake_service._events._list_result = {"items": [event]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_organizer_accepted_event_is_still_a_conflict(fake_service):
+    event = _confirmed_event()
+    event["attendees"] = [
+        {"email": "me@example.com", "self": True, "responseStatus": "accepted"}
+    ]
+    fake_service._events._list_result = {"items": [event]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_freebusy_missing_scope_rejects_the_write(fake_service):
+    """A whole-batch 403 means our own credential/scope is insufficient,
+    not that a particular attendee's calendar is merely invisible - proceed
+    would silently skip the entire conflict check, defeating the feature.
+    The write must be rejected rather than degraded to unchecked."""
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.insert_calls == []
+
+
+def test_organizer_events_missing_scope_rejects_the_write(fake_service):
+    fake_service._events._list_error = _insufficient_scope_error()
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["hazel@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "calendar.events permission" in result["message"]
+    assert "reconnect" in result["message"]
+    assert fake_service._events.insert_calls == []
+    assert fake_service._freebusy.query_calls == []
+
+
+def test_freebusy_missing_scope_rejects_the_write_even_with_ignore_conflicts_false(
+    fake_service,
+):
+    """`ignore_conflicts` is the caller's explicit escape hatch - without it,
+    a scope-insufficient 403 must reject rather than silently proceed."""
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+            ignore_conflicts=False,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert fake_service._events.insert_calls == []
+
+
+def test_freebusy_missing_scope_can_be_bypassed_with_ignore_conflicts(fake_service):
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.insert_calls) == 1
+
+
+def test_freebusy_missing_scope_still_reports_an_already_confirmed_conflict(
+    fake_service,
+):
+    """Regression test: a real conflict already confirmed before the scope
+    error hit (here, the organizer's own calendar, which doesn't need the
+    freebusy scope at all) must not be silently discarded just because a
+    later, unrelated attendee check then hit the same missing-scope 403 -
+    reporting a known conflict is always safe, and blindly rejecting
+    instead would tell the caller to retry with ignore_conflicts=true,
+    which would then book straight over the real conflict nobody ever
+    mentioned."""
+    fake_service._events._list_result = {"items": [_confirmed_event()]}
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert result["unchecked_attendees"] == ["chelsea@example.com"]
+    assert "reconnect" in result["check_error"].lower()
+    assert fake_service._events.insert_calls == []
+
+
+def test_freebusy_missing_scope_legacy_only_body_still_rejects(fake_service):
+    """The dual-format body is what a real Calendar API 403 actually
+    carries, but a response with only the legacy `errors[]` field must
+    still be recognized - not just the newer `details[]` shape."""
+    fake_service._freebusy = FakeFreebusy(
+        raise_error=_legacy_only_insufficient_scope_error()
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert fake_service._events.insert_calls == []
+
+
+def test_is_insufficient_scope_error_rejects_unrelated_403():
+    other = HttpError(
+        _FakeHttpResp(403),
+        b'{"error": {"errors": [{"reason": "forbiddenForNonOrganizer"}]}}',
+    )
+    assert calendar._is_insufficient_scope_error(other) is False
+
+
+def test_is_insufficient_scope_error_tolerates_malformed_body():
+    malformed = HttpError(_FakeHttpResp(403), b"not json")
+    assert calendar._is_insufficient_scope_error(malformed) is False
+
+
+def test_is_insufficient_scope_error_tolerates_non_list_error_fields():
+    """Regression test: valid JSON whose "errors"/"details" field is
+    present but isn't an array (e.g. a boolean/object, from a malformed
+    or unexpected error body) must not crash - `x or []` treats a truthy
+    non-list value as itself, and iterating a non-iterable raises
+    TypeError; must fall through to "can't tell, so False" instead."""
+    non_list_fields = HttpError(
+        _FakeHttpResp(403), b'{"error": {"errors": true, "details": 42}}'
+    )
+    assert calendar._is_insufficient_scope_error(non_list_fields) is False
+
+
+def test_freebusy_other_http_errors_still_propagate(fake_service):
+    """A 500 whose body happens to carry a scope-shaped reason must NOT be
+    treated as the missing-scope case - the gate is `status == 403` AND a
+    matching reason, not the reason alone. A body with no "errors"/
+    "details" field at all (as an arbitrary 500 body typically has) would
+    fail the reason check regardless of status, so it can't tell an
+    intact `status == 403` gate from a broken one; this fixture's body
+    would match the reason check, so it actually exercises the status
+    gate."""
+    other_error = HttpError(
+        _FakeHttpResp(500),
+        (
+            b'{"error": {"message": "boom", '
+            b'"errors": [{"reason": "insufficientPermissions"}]}}'
+        ),
+    )
+    fake_service._freebusy = FakeFreebusy(raise_error=other_error)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" not in result["message"].lower()
+
+
+def test_freebusy_attendee_absent_from_response_is_marked_unchecked(fake_service):
+    """An attendee simply missing from calendars (no entry at all, not even
+    an "errors" key) must not be silently reported as free."""
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["ghost@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["unchecked_attendees"] == ["ghost@example.com"]
+    assert fake_service._events.insert_calls == []
+
+
+def test_update_events_checks_conflicts_for_an_all_day_event(fake_service):
+    """Regression test: an all-day event stores its bounds under "date", not
+    "dateTime" - previously existing_start/existing_end came back None for
+    it, so the whole conflict check (and thus adding attendees) silently
+    skipped, even though sendUpdates="all" would still fire real invites.
+
+    Adding an attendee without moving the (all-day) window only checks the
+    newly-added attendee, same as the timed-event case - so this asserts
+    the freebusy query actually ran, with the date widened into a valid
+    RFC3339 bound, rather than an organizer-side conflict.
+    """
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "new@example.com": {
+                    "busy": [
+                        {"start": "2026-08-27T09:00:00Z", "end": "2026-08-27T10:00:00Z"}
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    # The fake calendar's own timezone also happens to be UTC, so a
+    # skipped lookup (needs_real_calendar_timezone wrongly False, falling
+    # through to the hardcoded "UTC" literal) would produce this exact
+    # same timeMin/timeMax undetected - assert the lookup actually ran,
+    # not just that its result looks right.
+    assert fake_service._calendars.get_calls
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["timeMin"] == "2026-08-27T00:00:00+00:00"
+    assert query_call["body"]["timeMax"] == "2026-08-28T00:00:00+00:00"
+
+
+def test_update_events_rejects_single_boundary_change_on_an_all_day_event(
+    fake_service,
+):
+    """Regression test: an all-day event's start/end are {"date": ...} -
+    writing only one of start_time/end_time would overwrite just that side
+    with {"dateTime": ...} while the other side keeps its {"date": ...}
+    shape, which Google rejects as a malformed mixed body. Must fail
+    loudly with an actionable message instead of sending that request."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "all-day" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_allows_replacing_both_boundaries_on_an_all_day_event(
+    fake_service,
+):
+    """Both start_time and end_time together are a full, unambiguous
+    replacement of an all-day event's bounds, so this must succeed."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {"items": []}
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_update_events_widens_all_day_boundary_in_the_calendars_own_timezone(
+    fake_service,
+):
+    """Regression test: an all-day event's date is a day on the
+    *calendar's own* calendar, not a UTC day - hardcoding "T00:00:00Z"
+    shifts the queried window by the calendar's own UTC offset instead of
+    asking what timezone the calendar is actually configured in."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(timezone="Asia/Singapore")
+    fake_service._freebusy = FakeFreebusy(
+        {"calendars": {"new@example.com": {"busy": []}}}
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["timeMin"] == "2026-08-27T00:00:00+08:00"
+    assert query_call["body"]["timeMax"] == "2026-08-28T00:00:00+08:00"
+    assert fake_service._calendars.get_calls  # actually looked it up
+
+
+def test_update_events_organizer_only_new_attendee_on_all_day_event_widens_correctly(
+    fake_service,
+):
+    """Regression test: adding ONLY the organizer as a new attendee on an
+    all-day event, with the window otherwise unchanged, must still look
+    up the calendar's real timezone before checking their calendar - the
+    organizer-check that `organizer_newly_added` triggers on its own
+    (attendees_to_check ends up empty, the organizer is filtered out of
+    it) needs a correctly-widened window just as much as an ordinary new
+    attendee would, not one silently defaulted to UTC."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+        "organizer": {"email": "me@example.com"},
+    }
+    fake_service._calendars = FakeCalendars(timezone="Asia/Singapore")
+    fake_service._events._list_result = {"items": []}
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["me@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls  # actually looked it up
+    list_call = fake_service._events.list_calls[0]
+    assert list_call["timeMin"] == "2026-08-27T00:00:00+08:00"
+    assert list_call["timeMax"] == "2026-08-28T00:00:00+08:00"
+
+
+def test_update_events_all_day_with_existing_attendees_resubmitted_unchanged_skips_the_timezone_lookup(
+    fake_service,
+):
+    """Regression test: an all-day event that already has attendees,
+    resubmitted with neither a new window nor new attendees (e.g. a
+    summary-only edit), must not trigger the calendar's real timezone
+    lookup at all - a resubmission that never moves the window makes any
+    retained attendee's delta segment trivially empty regardless of
+    timezone precision, so needs_real_calendar_timezone correctly stays
+    False here. Pins that this genuinely common "just editing the title"
+    case doesn't regress into an unnecessary API call (or a scope-403 for
+    a token that predates calendar.calendars.readonly, on an edit that
+    never needed timezone precision at all)."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="Renamed",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls == []
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+
+
+def test_update_events_metadata_only_edit_on_someone_elses_event_skips_the_identity_lookup(
+    fake_service,
+):
+    """Regression test: caller_is_organizer must only be resolved (via a
+    calendars().get(calendarId="primary") call) when the organizer
+    actually needs (re)verifying at all (window_changed or
+    organizer_newly_added) - a metadata-only edit (here, just a summary
+    change) on an event with a different organizer must not pay for that
+    API call when nothing downstream would use its result."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "boss@example.com"}],
+        "organizer": {"email": "boss@example.com"},
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="Renamed",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls == []
+
+
+def test_update_events_organizer_identity_comparison_is_case_insensitive(
+    fake_service,
+):
+    """Regression test: the caller-is-organizer comparison must fold case
+    on both sides - a mutation dropping either side's .lower() would pass
+    every other organizer-identity test in this file, since they all
+    happen to use already-lowercase addresses on both sides."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "Me@Example.com"},
+    }
+    fake_service._calendars = FakeCalendars(email="me@EXAMPLE.com")
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    # caller_is_organizer must resolve True despite the differing case,
+    # so the organizer conflict is found via "primary" (check_organizer)
+    # rather than the caller being wrongly treated as a different person
+    # (which would instead report "Me@Example.com" as unchecked).
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["1:1 with Hazel"]
+    assert result.get("unchecked_attendees", []) == []
+
+
+def test_update_events_all_day_with_a_different_organizer_shares_one_calendar_lookup(
+    fake_service,
+):
+    """Regression test: an all-day event whose organizer differs from the
+    caller needs BOTH the real calendar timezone (to widen the all-day
+    boundary) and the caller's own identity (to know they aren't the
+    organizer) - both come from the same calendars().get(calendarId=
+    "primary") call, so this must fire exactly once, not twice, and the
+    real organizer must still end up in unchecked_attendees using a
+    correctly-widened (non-UTC-defaulted) window."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+        "organizer": {"email": "boss@example.com"},
+    }
+    fake_service._calendars = FakeCalendars(
+        timezone="Asia/Singapore", email="me@example.com"
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-28T00:00:00+08:00",  # moves the all-day window
+            end_time="2026-08-29T00:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict_check_incomplete"
+    assert len(fake_service._calendars.get_calls) == 1
+    assert result["unchecked_attendees"] == ["boss@example.com"]
+    assert fake_service._events.list_calls == []
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_missing_scope_at_the_identity_check_rejects_the_write(
+    fake_service,
+):
+    """Regression test: the calendars.get call also drives caller-is-
+    organizer identity resolution (not just all-day timezone widening) -
+    a missing calendar.calendars.readonly scope must reject the write via
+    THIS call site too, on a plain timed event whose organizer differs
+    from the caller (needs_real_calendar_timezone stays False here, so
+    only the identity check would ever trigger this lookup)."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+        "organizer": {"email": "boss@example.com"},
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_calendar_timezone_lookup_missing_scope_rejects_the_write(
+    fake_service,
+):
+    """The calendars.get call needed to widen an all-day boundary needs its
+    own calendar.calendars.readonly scope - a token that predates that
+    migration must reject the write outright, same as a missing
+    freebusy scope, rather than silently guessing at UTC."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_summary_only_edit_of_all_day_event_never_looks_up_calendar_timezone(
+    fake_service,
+):
+    """Regression test: a summary/location/description-only edit of an
+    all-day event never moves its window or touches attendees, so it has
+    no use for the calendar's real timezone - looking it up anyway would
+    needlessly block this benign edit behind a calendar.calendars.readonly
+    scope-403 for every pre-migration token, a far bigger blast radius
+    than the migration's stated purpose (all-day conflict checks)."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="Renamed",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls == []
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_calendar_timezone_lookup_missing_scope_falls_back_with_ignore_conflicts(
+    fake_service,
+):
+    """ignore_conflicts is the caller's explicit escape hatch - it must not
+    be defeated by an unrelated all-day-timezone-lookup failure; the
+    write still proceeds, just without a real calendar timezone."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_calendar_timezone_lookup_non_scope_error_also_falls_back_with_ignore_conflicts(
+    fake_service,
+):
+    """Companion to the test above: the timezone lookup must forgive ANY
+    failure of calendars().get(), not just the specifically-recognized
+    missing-scope one - a bare HttpError (rate limiting, a transient
+    5xx, an unrelated 403) is still "this lookup couldn't run" too, and
+    must not defeat ignore_conflicts either."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(
+        raise_error=HttpError(_FakeHttpResp(500), b'{"error": {"message": "boom"}}')
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_timed_event_never_looks_up_calendar_timezone(fake_service):
+    """The calendar-timezone lookup is only needed to widen an all-day
+    boundary - a plain timed-event update must not pay for it."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="self-1", summary="Renamed")
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls == []
+
+
+def test_update_events_partial_overlap_nudge_only_checks_the_new_delta_segment(
+    fake_service,
+):
+    """Regression test: nudging a meeting to a window that still overlaps
+    its old one (e.g. 10:00-10:30 -> 10:15-10:45) must only check existing
+    attendees against the genuinely new sliver (10:30-10:45) - the
+    retained 10:15-10:30 overlap still contains this event's own busy
+    block on their calendars, which isn't a real conflict. Checking the
+    delta segment (rather than skipping the check outright) still catches
+    a real conflict that happens to land in the newly-added time."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {"items": []}
+    # The fake, unlike the real freebusy.query endpoint, doesn't filter its
+    # configured busy blocks down to the requested [timeMin, timeMax) - so
+    # this leaves it empty and instead asserts directly on the query's
+    # timeMin/timeMax below. That's the actual behavior under our control;
+    # Google's own server is responsible for only returning busy blocks
+    # that overlap whatever window we send it.
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:15:00+08:00",
+            end_time="2026-08-27T10:45:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict_check_incomplete"
+    assert len(fake_service._freebusy.query_calls) == 1
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["timeMin"] == "2026-08-27T10:30:00+08:00"
+    assert query_call["body"]["timeMax"] == "2026-08-27T10:45:00+08:00"
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_partial_overlap_nudge_still_catches_a_real_conflict(
+    fake_service,
+):
+    """The delta segment isn't just a smaller no-op window - a genuine
+    conflict that only exists in the newly-added time must still be
+    caught."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "existing@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:35:00+08:00",
+                            "end": "2026-08-27T10:40:00+08:00",
+                        }
+                    ]
+                },
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:15:00+08:00",
+            end_time="2026-08-27T10:45:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "existing@example.com"
+
+
+def test_update_events_disjoint_move_checks_existing_attendees(fake_service):
+    """The counterpart to the partial-overlap test: moving to a window
+    that's completely disjoint from the old one IS safe to check every
+    existing attendee against, since this event's own busy block can't
+    show up in a window it doesn't occupy."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "existing@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T14:00:00+08:00",
+                            "end": "2026-08-27T14:30:00+08:00",
+                        }
+                    ]
+                },
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "existing@example.com"
+
+
+def test_update_events_empty_string_attendees_is_treated_as_not_provided(
+    fake_service,
+):
+    """Regression test: an accidental empty string (a stray default from a
+    template, or an LLM passing "" instead of omitting the argument) must
+    not be treated as a genuine attendees argument - attendees only ever
+    adds people, so there'd be nothing to add either way, but this
+    confirms the event's existing attendee data is left alone rather than
+    triggering any attendee-processing path at all."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com", "responseStatus": "accepted"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="self-1", attendees="")
+    )
+
+    assert result["status"] == "success"
+    update_call = fake_service._events.update_calls[0]
+    assert update_call["body"]["attendees"] == [
+        {"email": "existing@example.com", "responseStatus": "accepted"}
+    ]
+    assert update_call["sendUpdates"] == "none"
+
+
+def test_update_events_preserves_attendee_rsvp_state_on_resubmission(fake_service):
+    """Re-passing the same attendee list must not wipe responseStatus etc.
+    by replacing the whole array with bare {"email": ...} objects."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [
+            {
+                "email": "existing@example.com",
+                "responseStatus": "accepted",
+                "comment": "looking forward to it",
+            }
+        ],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["existing@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    update_call = fake_service._events.update_calls[0]
+    assert update_call["body"]["attendees"] == [
+        {
+            "email": "existing@example.com",
+            "responseStatus": "accepted",
+            "comment": "looking forward to it",
+        }
+    ]
+    # Byte-identical resubmission is not a real change - no notification.
+    assert update_call["sendUpdates"] == "none"
+
+
+def test_update_events_treats_equivalent_timestamp_formats_as_unchanged(
+    fake_service,
+):
+    """A same-instant resubmission written in a different (but equivalent)
+    format must not be treated as a real time change - that would run the
+    organizer check on the same window and self-conflict."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T02:00:00+00:00"},
+        "end": {"dateTime": "2026-08-27T02:30:00+00:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",  # same instant, "Z"-free offset form
+            end_time="2026-08-27T10:30:00+08:00",
+            location="Room 4",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+    assert fake_service._events.update_calls[0]["sendUpdates"] == "none"
+
+
+def test_update_events_summary_only_edit_never_revalidates_the_existing_window(
+    fake_service,
+):
+    """Regression test: an update that never touches start_time/end_time
+    isn't about to write any window at all, so it must not re-validate
+    the event's already-stored start/end - a zero-duration or malformed
+    pre-existing window (e.g. from another client/tool) would otherwise
+    reject an unrelated summary edit that never asked to change the
+    time."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:00:00+08:00"},  # zero-duration
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="Renamed",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_update_events_respects_sibling_timezone_on_an_offsetless_datetime(
+    fake_service,
+):
+    """Regression test: Google's own docs say dateTime "may" omit its
+    offset when a sibling timeZone field is present instead - treating
+    that offsetless value as if it belonged to some other zone (e.g. the
+    calendar's, or UTC) would misjudge a same-instant resubmission as a
+    real time change and run the organizer check against the event's own
+    now-"moved" window. The sibling zone here (Asia/Singapore, +08:00) is
+    deliberately NOT the code's own UTC fallback, so this only passes if
+    the sibling timeZone field is actually read rather than ignored -
+    falling back to UTC would compute a different instant and treat this
+    resubmission as a real move."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "Asia/Singapore"},
+        "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "Asia/Singapore"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T02:00:00+08:00",  # same instant, explicit offset
+            end_time="2026-08-27T02:30:00+08:00",
+            location="Room 4",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+    assert fake_service._events.update_calls[0]["sendUpdates"] == "none"
+
+
+def test_update_events_missing_scope_rejects_the_write(fake_service):
+    """A whole-batch 403 while checking the newly-added attendee is our own
+    credential's problem, not a per-attendee visibility gap - with nothing
+    else already confirmed, the write must be rejected outright."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_missing_scope_still_reports_an_already_confirmed_conflict(
+    fake_service,
+):
+    """Regression test: a real conflict already confirmed before the scope
+    error hit (here, the organizer's own calendar, which doesn't need the
+    freebusy scope at all) must not be silently discarded just because a
+    later, unrelated attendee check then hit the same missing-scope 403 -
+    reporting a known conflict is always safe, and blindly rejecting
+    instead would tell the caller to retry with ignore_conflicts=true,
+    which would then book straight over the real conflict nobody ever
+    mentioned."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
+    assert "reconnect" in result["check_error"].lower()
+
+
+def test_update_events_missing_scope_on_retained_attendees_still_reports_the_first_calls_conflict(
+    fake_service,
+):
+    """Regression test for the multi-call accumulation path specifically
+    (as opposed to a single _find_conflicts call's own internal one): a
+    real conflict found by the FIRST call (organizer, via events.list,
+    which needs no extra scope) must survive being merged with a SECOND,
+    separate call's InsufficientScopeError (the retained-attendee delta
+    segment, via freebusy.query) at google_calendar_update_events' own
+    accumulation layer - not just within a single _find_conflicts call."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert result["unchecked_attendees"] == ["existing@example.com"]
+
+
+def test_update_events_missing_scope_in_first_call_still_checks_retained_attendees(
+    fake_service,
+):
+    """Regression test: when the FIRST _find_conflicts call (newly-added
+    attendees + organizer) raises InsufficientScopeError but already
+    carries an already-confirmed organizer conflict, the accumulation
+    layer must still attempt the SECOND call (retained attendees' delta
+    segments) rather than returning immediately - otherwise a retained
+    attendee is silently dropped from the response entirely: neither
+    reported as conflicting nor as unchecked, contradicting the whole
+    feature's guarantee that an unverified attendee is always surfaced."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",  # disjoint move
+            end_time="2026-08-27T14:30:00+08:00",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert set(result["unchecked_attendees"]) == {
+        "new@example.com",
+        "existing@example.com",
+    }
+
+
+def test_update_events_missing_scope_can_be_bypassed_with_ignore_conflicts(
+    fake_service,
+):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_conflict_response_still_reports_unchecked_attendees(
+    fake_service,
+):
+    """A conflict found via one source (the organizer's own calendar) must
+    not suppress unchecked_attendees info for a different attendee whose
+    calendar couldn't be read (absent from the freebusy response, a
+    per-attendee gap rather than a whole-batch 403) - a caller acting on
+    the conflict still needs to know that attendee was never actually
+    checked."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["ghost@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["unchecked_attendees"] == ["ghost@example.com"]
+
+
+def test_update_events_widening_both_boundaries_does_not_duplicate_unchecked_attendees(
+    fake_service,
+):
+    """Regression test: widening a window on BOTH sides produces two
+    delta segments (window_delta_segments), and a retained attendee who's
+    unverifiable for a reason unrelated to which segment ran (here,
+    absent from every freebusy response) gets checked - and appended to
+    unchecked_attendees - once per segment, not once overall."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "ghost@example.com"}],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T09:45:00+08:00",  # widened earlier...
+            end_time="2026-08-27T10:45:00+08:00",  # ...and later
+        )
+    )
+
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["unchecked_attendees"] == ["ghost@example.com"]
+    assert fake_service._events.update_calls == []


### PR DESCRIPTION
Adds 90 focused regression cases for the Calendar conflict-detection and safe-write behavior merged in #2339.

Coverage includes create and update conflict paths, organizer and attendee handling, timezone and all-day boundaries, OAuth scope failures and unrelated HTTP error propagation, recurring-event protections, response-size-cap interactions with conference fields, notification gating, and RSVP preservation.

The branch is based directly on `upstream/main`, and the diff changes only `tests/web/tools/test_google_calendar_mcp.py`.

Validation:

- `pytest -q tests/web/tools/test_google_calendar_mcp.py tests/web/tools/test_mcp_utils.py` — 312 passed
- Ruff check and format — passed
- isort — passed
- codespell — passed
- whitespace and end-of-file hooks — passed
