### PR TITLE
feat: add OneDrive large-file upload sessions

### DIFF
--- a/src/xagent/web/tools/mcp/onedrive.py
+++ b/src/xagent/web/tools/mcp/onedrive.py
@@ -263,6 +263,118 @@ def _upload_retry_delay(exc: BaseException, retry_number: int) -> float:
     return min(exponential_delay, _UPLOAD_RETRY_MAX_SECONDS)
 
 
+def _upload_status_code(exc: BaseException) -> int | None:
+    """Return an HTTP status from a credential-safe upload error."""
+    cause = exc.__cause__ if isinstance(exc, _UploadError) else exc
+    status_code = getattr(getattr(cause, "response", None), "status_code", None)
+    return status_code if isinstance(status_code, int) else None
+
+
+def _next_expected_upload_offset(response: Any) -> int:
+    """Parse the first missing offset from an upload-session status response."""
+    try:
+        payload = response.json()
+        ranges = payload["nextExpectedRanges"]
+        offsets = [int(value.split("-", 1)[0]) for value in ranges]
+    except (KeyError, TypeError, ValueError, AttributeError) as exc:
+        raise _UploadError("OneDrive returned invalid upload-session progress") from exc
+    if not offsets or any(offset < 0 for offset in offsets):
+        raise _UploadError("OneDrive returned invalid upload-session progress")
+    return min(offsets)
+
+
+def _upload_item_fingerprint(item: Any) -> tuple[Any, Any, Any, Any] | None:
+    """Return fields that change when an existing destination is replaced."""
+    if not isinstance(item, dict) or not item.get("id"):
+        return None
+    return (item.get("id"), item.get("eTag"), item.get("cTag"), item.get("size"))
+
+
+def _current_upload_item(remote_path: str) -> dict[str, Any] | None:
+    """Read destination metadata, treating an absent item as no baseline."""
+    try:
+        item = _graph_request(
+            "GET",
+            _item_path(remote_path),
+            params={"$select": "id,name,size,eTag,cTag"},
+        )
+    except RuntimeError as exc:
+        cause = exc.__cause__
+        if getattr(getattr(cause, "response", None), "status_code", None) == 404:
+            return None
+        raise _UploadError("Could not inspect the OneDrive upload target") from exc
+    return item if isinstance(item, dict) and item.get("id") else None
+
+
+def _completed_upload_item(
+    remote_path: str,
+    total: int,
+    previous_fingerprint: tuple[Any, Any, Any, Any] | None,
+) -> dict[str, Any]:
+    """Confirm a final fragment whose response was lost via drive metadata."""
+    try:
+        item = _current_upload_item(remote_path)
+    except Exception as exc:
+        raise _UploadError(
+            "OneDrive upload completed ambiguously and could not be confirmed"
+        ) from exc
+    if (
+        not isinstance(item, dict)
+        or not item.get("id")
+        or item.get("size") != total
+        or _upload_item_fingerprint(item) == previous_fingerprint
+    ):
+        raise _UploadError(
+            "OneDrive upload completed ambiguously and could not be confirmed"
+        )
+    return item
+
+
+def _reconcile_upload_progress(
+    http: requests.Session,
+    upload_url: str,
+    remote_path: str,
+    start: int,
+    end: int,
+    total: int,
+    previous_fingerprint: tuple[Any, Any, Any, Any] | None,
+) -> tuple[bool, dict[str, Any] | None]:
+    """Return whether an ambiguous fragment was accepted, plus a final item."""
+    last_error: BaseException | None = None
+    for attempt in range(1, _UPLOAD_CHUNK_MAX_ATTEMPTS + 1):
+        try:
+            response = http.get(upload_url, timeout=DEFAULT_TIMEOUT_SECONDS)
+            if response.status_code == 404:
+                if end == total:
+                    return True, _completed_upload_item(
+                        remote_path, total, previous_fingerprint
+                    )
+                raise _UploadError(
+                    "OneDrive upload session disappeared before completion"
+                )
+            _raise_upload_status(response)
+            next_offset = _next_expected_upload_offset(response)
+            if next_offset == start:
+                return False, None
+            if next_offset >= end:
+                if end == total:
+                    return True, _completed_upload_item(
+                        remote_path, total, previous_fingerprint
+                    )
+                return True, None
+            raise _UploadError("OneDrive returned inconsistent upload-session progress")
+        except Exception as exc:
+            last_error = exc
+            if not _is_retriable_upload_error(exc):
+                raise
+            if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
+                break
+            time.sleep(_upload_retry_delay(exc, attempt))
+    raise _UploadError(
+        "Could not determine OneDrive upload-session progress"
+    ) from last_error
+
+
 def _graph_request(
     method: str,
     path: str,
@@ -453,6 +565,7 @@ def _upload_large_file_content(
         # function initializes below, bypassing the "did OneDrive actually
         # confirm this" check that only runs inside the loop.
         raise ValueError(f"total must be positive, got {total}")
+    previous_fingerprint = _upload_item_fingerprint(_current_upload_item(remote_path))
     session = _graph_request(
         "POST",
         f"{_item_path(remote_path)}/createUploadSession",
@@ -470,8 +583,9 @@ def _upload_large_file_content(
         try:
             for start in range(0, total, _UPLOAD_SESSION_CHUNK_SIZE):
                 end = min(start + _UPLOAD_SESSION_CHUNK_SIZE, total)
-                chunk = fh.read(end - start)
-                if len(chunk) != end - start:
+                expected_size = end - start
+                chunk = fh.read(expected_size)
+                if len(chunk) != expected_size:
                     # A short read here means the local file shrank out from
                     # under this upload (a concurrent rewrite/truncation, or
                     # an unusual filesystem) -- sending Content-Length/
@@ -481,9 +595,16 @@ def _upload_large_file_content(
                     # every later chunk's byte-range accounting. Fail loudly
                     # instead.
                     raise _UploadError(
-                        f"expected to read {end - start} bytes at offset "
+                        f"expected to read {expected_size} bytes at offset "
                         f"{start} but got {len(chunk)} -- the local file "
                         "may have changed size during upload"
+                    )
+                # Detect growth after the caller's fstat snapshot before a
+                # truncated final item is committed. Keeping this as a
+                # separate read preserves the one-chunk memory bound.
+                if end == total and fh.read(1):
+                    raise _UploadError(
+                        "the local file may have changed size during upload"
                     )
                 # The upload session URL is itself pre-authenticated (a
                 # token in its query string) -- Microsoft's own docs for
@@ -513,10 +634,23 @@ def _upload_large_file_content(
                         _raise_upload_status(response)
                         break
                     except Exception as exc:
-                        if (
-                            not _is_retriable_upload_error(exc)
-                            or attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS
-                        ):
+                        status_code = _upload_status_code(exc)
+                        if not (_is_retriable_upload_error(exc) or status_code == 416):
+                            raise
+                        accepted, completed_item = _reconcile_upload_progress(
+                            http,
+                            upload_url,
+                            remote_path,
+                            start,
+                            end,
+                            total,
+                            previous_fingerprint,
+                        )
+                        if accepted:
+                            if completed_item is not None:
+                                result = completed_item
+                            break
+                        if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
                             raise
                         delay = _upload_retry_delay(exc, attempt)
                         logger.warning(
@@ -535,6 +669,8 @@ def _upload_large_file_content(
                 # unrelated intermediate body if Graph's progress responses
                 # ever started including one.
                 if end == total:
+                    if result.get("id"):
+                        continue
                     try:
                         result = response.json() if response.content else {}
                     except ValueError as exc:

--- a/src/xagent/web/tools/mcp/onedrive.py
+++ b/src/xagent/web/tools/mcp/onedrive.py
@@ -5,7 +5,7 @@ import mimetypes
 import os
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -21,12 +21,39 @@ mcp = FastMCP("onedrive-mcp")
 
 GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
 DEFAULT_TIMEOUT_SECONDS = 30
-# Allow more time for binary content than for small Graph JSON requests.
+# Sized for a single binary PUT of up to a few megabytes over a slow link,
+# not just a small JSON Graph call -- DEFAULT_TIMEOUT_SECONDS' 30s is
+# realistic for the API calls elsewhere in this module but can legitimately
+# be too short for a multi-megabyte binary transfer. Used for both the
+# simple-PUT branch (up to _SIMPLE_UPLOAD_MAX_BYTES) and each chunk of the
+# resumable upload-session path.
 _BINARY_UPLOAD_TIMEOUT_SECONDS = 120
-# Deliberate limit for this tool's single-request implementation.
-# Larger files require upload-session support, delivered separately.
+# Microsoft's own docs disagree on the simple content PUT's real limit:
+# the OneDrive API concepts page ("Uploading files") says simple upload is
+# "available for items with less than 4 MB of content", while the Graph
+# v1.0 API reference for the same endpoint (driveitem-put-content) says it
+# "supports files up to 250 MB in size". Rather than trying to resolve
+# which page is authoritative, this deliberately keeps the smaller, more
+# conservative bound -- some Graph deployments enforce it as the decimal
+# 4,000,000 bytes rather than 4 MiB (4,194,304 bytes), so the decimal
+# figure is used here too. This means a file anywhere in the 4MB-250MB gap
+# always takes the resumable upload-session path instead of ever risking a
+# rejection at the simple-PUT boundary; the only cost of guessing wrong
+# this way is an unnecessary chunked upload, never a failed one.
 _SIMPLE_UPLOAD_MAX_BYTES = 4_000_000
-
+# Chunk size for the upload-session path. Must be a multiple of 320 KiB
+# (327,680 bytes) per Graph's requirement for every non-final chunk; 5 MiB
+# is exactly 16 * 320 KiB.
+_UPLOAD_SESSION_CHUNK_SIZE = 5 * 1024 * 1024
+# Not a Graph API limit (OneDrive itself supports files far larger than
+# this via the resumable upload session) -- a guard-rail against a
+# mistargeted file (a generated artifact pointed at the wrong path, an
+# entire log directory, etc.) tying up a chunked upload for a long time
+# with no feedback until it eventually finishes or fails. Unlike gmail.py's
+# _MAX_ATTACHMENT_BYTES (a real derivation of Gmail's documented 25MB
+# message-size limit), this is a deliberately arbitrary product choice, not
+# a limit either this module or Graph actually enforces elsewhere.
+_MAX_UPLOAD_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
 
 _UPLOAD_ALLOWED_DIRS_ENV_VAR = "XAGENT_ONEDRIVE_FILE_ALLOWED_DIRS"
 
@@ -166,6 +193,88 @@ def _graph_headers(extra_headers: dict[str, str] | None = None) -> dict[str, str
     if extra_headers:
         headers.update(extra_headers)
     return headers
+
+
+def _raise_for_status_with_body(response: Any) -> None:
+    """Like response.raise_for_status(), but a non-2xx status raises a
+    RuntimeError with Graph's own error body appended -- a bare HTTPError's
+    default message carries only the status line, not the JSON error detail
+    Graph actually returns. Shared by every call site in this module that
+    talks to Graph directly (both _graph_request and the per-chunk PUTs in
+    _upload_large_file_content, which can't go through _graph_request itself
+    -- see its own Authorization-header note) so a future change to the
+    message format only needs to happen once.
+    """
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        response_text = response.text.strip()
+        message = str(exc)
+        if response_text:
+            message = f"{message} - {response_text}"
+        raise RuntimeError(message) from exc
+
+
+def _redact_upload_url(message: str, upload_url: str) -> str:
+    """Strip ``upload_url`` (a preauthenticated, bearer-token-equivalent
+    Graph upload-session URL) out of ``message`` as thoroughly as possible.
+
+    A plain ``message.replace(upload_url, ...)`` only catches the case
+    where the exception's own message happens to contain the exact,
+    complete "scheme://host/path?query" string. Verified directly against
+    a real failed request: urllib3's own ConnectionError/SSLError messages
+    never do that -- they report the host separately (inside
+    "HTTPSConnectionPool(host=..., port=...)") from the path+query (inside
+    "Max retries exceeded with url: /path?query"), so the whole-string
+    match silently misses them and the query string -- which carries the
+    session's actual bearer-equivalent token -- passes through unredacted.
+    Redacting the host and the path+query independently (in addition to
+    the full URL, for whichever call site does happen to embed it whole)
+    closes that gap without depending on any particular exception's message
+    shape.
+    """
+    redacted = message.replace(upload_url, "<redacted-upload-session-url>")
+    parsed = urlsplit(upload_url)
+    path_and_query = parsed.path + (f"?{parsed.query}" if parsed.query else "")
+    # Excludes a bare "/" with no query: that's indistinguishable from any
+    # other single slash that might appear elsewhere in the message, so
+    # using it as a blanket replace target would mangle the whole string
+    # instead of redacting anything meaningful. Not reachable against a
+    # real Graph upload-session URL (its path is always a specific,
+    # multi-segment session identifier), but nothing stops a test double
+    # or a future API change from producing one this short.
+    if path_and_query and path_and_query != "/":
+        redacted = redacted.replace(path_and_query, "<redacted-upload-session-url>")
+    if parsed.query:
+        redacted = redacted.replace(parsed.query, "<redacted-upload-session-token>")
+    if parsed.netloc:
+        redacted = redacted.replace(parsed.netloc, "<redacted-upload-session-host>")
+    return redacted
+
+
+def _is_retriable_upload_error(exc: BaseException) -> bool:
+    """Whether ``exc`` might succeed on a future attempt against the SAME
+    upload session, so it's worth leaving that session's state (and
+    Graph's ``nextExpectedRanges``) alone rather than actively destroying
+    it via a cancellation DELETE.
+
+    A network-level failure (no response was ever received) and Graph's
+    own documented retriable statuses (429, and any 5xx) are retriable;
+    anything else -- a non-retriable 4xx Graph rejected outright, or a
+    validation failure this module raised itself about the *local* file
+    (a short read, an unparsable/incomplete final response) -- is not:
+    retrying against the same session wouldn't help either of those, so
+    there's no reason to withhold the immediate cleanup. By the time an
+    HTTPError reaches here it's already been converted to a plain
+    RuntimeError by _raise_for_status_with_body, so the original
+    exception (with its .response) is recovered via __cause__ rather than
+    expected on ``exc`` directly.
+    """
+    cause = exc.__cause__ if isinstance(exc, RuntimeError) else exc
+    status_code = getattr(getattr(cause, "response", None), "status_code", None)
+    if isinstance(status_code, int):
+        return status_code == 429 or 500 <= status_code < 600
+    return isinstance(cause, (requests.ConnectionError, requests.Timeout))
 
 
 def _graph_request(
@@ -336,6 +445,197 @@ def _resolve_upload_file_path(local_file_path: str) -> Path:
     return local_path
 
 
+def _upload_large_file_content(
+    remote_path: str, fh: Any, total: int, mime_type: str
+) -> dict[str, Any]:
+    """Upload the next ``total`` bytes readable from ``fh`` (too large for
+    the simple content PUT) via Graph's upload-session API, in 320 KiB-
+    aligned chunks read straight off disk -- never materializing more than
+    one chunk of the file in memory at a time, unlike holding the whole
+    file as a single ``bytes`` object would.
+
+    This uses the session only for chunking, not for actual resumability:
+    failures are not retried from Graph's ``nextExpectedRanges``.
+    Sessions are cancelled only for non-retriable failures, so a transient
+    mid-upload failure means the whole file is re-sent from byte 0 on the
+    next call, not resumed from where it left off.
+    """
+    if total <= 0:
+        # Not reachable through onedrive_upload_file today (it rejects an
+        # empty file before choosing a path, and anything <= 0 bytes would
+        # take the simple-PUT branch regardless) -- guarded directly here
+        # too since `for start in range(0, 0, chunk_size)` would otherwise
+        # silently skip the whole loop and return the empty `result` this
+        # function initializes below, bypassing the "did OneDrive actually
+        # confirm this" check that only runs inside the loop.
+        raise ValueError(f"total must be positive, got {total}")
+    session = _graph_request(
+        "POST",
+        f"{_item_path(remote_path)}/createUploadSession",
+        body={"item": {"@microsoft.graph.conflictBehavior": "replace"}},
+    )
+    upload_url = session.get("uploadUrl")
+    if not upload_url:
+        raise RuntimeError("OneDrive did not return an upload session URL")
+
+    # One Session for every chunk of this upload -- a fresh top-level
+    # requests.put() per chunk would pay a new TCP+TLS handshake each time,
+    # which adds up over the ~100 requests a 500MB upload needs.
+    with requests.Session() as http:
+        result: dict[str, Any] = {}
+        try:
+            for start in range(0, total, _UPLOAD_SESSION_CHUNK_SIZE):
+                end = min(start + _UPLOAD_SESSION_CHUNK_SIZE, total)
+                chunk = fh.read(end - start)
+                if len(chunk) != end - start:
+                    # A short read here means the local file shrank out from
+                    # under this upload (a concurrent rewrite/truncation, or
+                    # an unusual filesystem) -- sending Content-Length/
+                    # Content-Range computed from the size we *expected*
+                    # rather than what we actually read would either hang
+                    # waiting for bytes that never arrive or desynchronize
+                    # every later chunk's byte-range accounting. Fail loudly
+                    # instead.
+                    raise RuntimeError(
+                        f"expected to read {end - start} bytes at offset "
+                        f"{start} but got {len(chunk)} -- the local file "
+                        "may have changed size during upload"
+                    )
+                # The upload session URL is itself pre-authenticated (a
+                # token in its query string) -- Microsoft's own docs for
+                # createUploadSession confirm this explicitly: "If you
+                # include the Authorization header when issuing the PUT
+                # call, it might result in an HTTP 401 Unauthorized
+                # response. ... Don't include it when issuing the PUT
+                # call." So this goes straight through the plain Session
+                # rather than _graph_request (which always attaches one).
+                # Graph's docs don't confirm Content-Type is honored on a
+                # chunk PUT the way it is on the simple-PUT endpoint (only
+                # Content-Length/Content-Range are documented there), but
+                # sending it costs nothing and is the closest available
+                # lever to the simple path's behavior.
+                response = http.put(
+                    upload_url,
+                    data=chunk,
+                    headers={
+                        "Content-Length": str(end - start),
+                        "Content-Range": f"bytes {start}-{end - 1}/{total}",
+                        "Content-Type": mime_type,
+                    },
+                    timeout=_BINARY_UPLOAD_TIMEOUT_SECONDS,
+                )
+                _raise_for_status_with_body(response)
+                # Only the final chunk's response carries the completed
+                # item; Graph's intermediate (202) responses return upload-
+                # progress info, not the item -- checked explicitly
+                # (end == total) rather than "the last response that
+                # happened to have a body", which would silently pick up an
+                # unrelated intermediate body if Graph's progress responses
+                # ever started including one.
+                if end == total:
+                    try:
+                        result = response.json() if response.content else {}
+                    except ValueError as exc:
+                        # The PUT itself succeeded (no HTTPError above) --
+                        # OneDrive has already committed the file at this
+                        # point, so this is "the transfer worked but the
+                        # confirmation can't be read", not a transfer
+                        # failure, even though it's still reported as an
+                        # error here (the caller has no completed item to
+                        # act on either way).
+                        raise RuntimeError(
+                            "OneDrive accepted the final chunk but "
+                            f"returned an unparsable response: {exc}"
+                        ) from exc
+                    if "id" not in result:
+                        # The final chunk's response didn't actually carry
+                        # a completed driveItem (e.g. an unexpected 202 on
+                        # what this loop computed as the last range).
+                        raise RuntimeError(
+                            "OneDrive did not confirm the upload completed "
+                            f"(final response: {result!r})"
+                        )
+        except Exception as exc:
+            # Redact upload_url out of the failure's own message before it
+            # goes anywhere else -- this catches every source uniformly
+            # (an HTTP error response whose body happens to echo the
+            # request URL via an intervening proxy/WAF, and -- the gap a
+            # status-code-keyed sanitize flag on the PUT call alone would
+            # miss -- a transport-level failure before any response
+            # existed at all: requests/urllib3's own ConnectionError/
+            # Timeout/SSLError messages embed the full request URL,
+            # verified directly against a real failed request). A plain
+            # `except requests.HTTPError` (or a flag passed only to the
+            # PUT's own status check) would leave those other paths
+            # unsanitized, so this wraps every exception the chunk loop
+            # can raise instead of trusting each one individually to avoid
+            # the URL. See _redact_upload_url's own docstring for why a
+            # bare whole-string replace isn't enough on its own.
+            redacted_message = _redact_upload_url(str(exc), upload_url)
+            if _is_retriable_upload_error(exc):
+                # A 429/5xx/network failure might still succeed against
+                # this SAME session on a later attempt -- actively
+                # cancelling it here would destroy Graph's
+                # nextExpectedRanges state for no benefit (this module
+                # doesn't currently retry/resume itself, but a future
+                # attempt manually resuming this exact session, or a
+                # resume feature added later, still could). Left alone,
+                # the session and its uploaded ranges simply persist until
+                # Graph's own ~15-minute expiry -- strictly no worse than
+                # cancelling it outright, and possibly better.
+                logger.warning(
+                    "OneDrive upload session left intact after a "
+                    "retriable failure (not cancelled): %s",
+                    redacted_message,
+                )
+            else:
+                # Best-effort: free the abandoned session immediately
+                # instead of leaving it for Graph's own ~15-minute expiry
+                # -- unlike the retriable case above, nothing about this
+                # failure would change on a retry against the same
+                # session, so there's no reason to keep it around. A
+                # failure here must never mask the real error above, and
+                # uses the short, small-request timeout -- this DELETE
+                # carries no body, so it shouldn't compound a slow failure
+                # with another wait as long as a multi-megabyte upload's
+                # own timeout.
+                try:
+                    cancel_response = http.delete(
+                        upload_url, timeout=DEFAULT_TIMEOUT_SECONDS
+                    )
+                except Exception as cleanup_exc:
+                    cleanup_message = _redact_upload_url(str(cleanup_exc), upload_url)
+                    logger.warning(
+                        "Failed to cancel abandoned OneDrive upload session: %s",
+                        cleanup_message,
+                    )
+                else:
+                    # requests does not raise for an HTTP error status on
+                    # its own -- a 429/5xx here would otherwise look like a
+                    # successful cancellation while the session (and its
+                    # partial upload) actually lingers until Graph's own
+                    # expiry. A 404 is also treated as fine (not warned
+                    # on): it means the session is already gone -- expired,
+                    # or completed/cancelled by a previous attempt -- which
+                    # is the outcome this cleanup wants, not a failure of
+                    # it. Status only, no body: nothing about the response
+                    # is expected to carry the upload_url, but there's no
+                    # reason to risk it for a log line that only needs the
+                    # status.
+                    if (
+                        not (200 <= cancel_response.status_code < 300)
+                        and cancel_response.status_code != 404
+                    ):
+                        logger.warning(
+                            "OneDrive upload session cancellation returned "
+                            "HTTP %s instead of success",
+                            cancel_response.status_code,
+                        )
+            raise RuntimeError(redacted_message) from None
+
+    return result
+
+
 @mcp.tool()
 def onedrive_get_profile() -> str:
     """Get the current Microsoft 365 user profile for OneDrive operations."""
@@ -480,10 +780,11 @@ def onedrive_upload_file(
     overwriting any existing file there; defaults to the local file's own
     name at the OneDrive root.
     mime_type: defaults to a guess from the remote filename, then the local
-    filename, falling back to "application/octet-stream".
+    filename, falling back to "application/octet-stream". It is sent on both
+    simple uploads and upload-session chunks.
 
-    Supports non-empty files up to 4,000,000 bytes (4 MB). Larger files
-    are rejected before any upload request is sent.
+    Rejects a file over _MAX_UPLOAD_BYTES (2 GiB) -- a guard-rail against a
+    mistargeted upload, not a OneDrive/Graph limit.
     """
     try:
         local_path = _resolve_upload_file_path(local_file_path)
@@ -495,7 +796,20 @@ def onedrive_upload_file(
                 _guess_mime_type(local_path.name) or "application/octet-stream"
             )
 
-        # Check size and read content through the same open handle.
+        # Read from one open handle throughout -- the size check, the small-
+        # file read, and the large-file chunk reads all use this same fh
+        # rather than each re-opening/re-stat'ing the file. For a file over
+        # _SIMPLE_UPLOAD_MAX_BYTES, _upload_large_file_content reads it
+        # chunk-by-chunk straight off this handle rather than this function
+        # first loading the whole file into memory -- the resumable upload-
+        # session path exists specifically so a large file's memory
+        # footprint stays bounded to one chunk at a time.
+        # A fresh by-path open, not the same descriptor
+        # _resolve_upload_file_path used for its allowlist check -- a
+        # symlink swapped in during that window wouldn't be caught.
+        # Accepted risk: holding a file descriptor open across the whole
+        # allowlist resolution isn't worth it for a local, non-shared task
+        # workspace (same tradeoff google_drive_upload_file makes).
         try:
             fh_ctx = local_path.open("rb")
         except OSError as e:
@@ -509,12 +823,8 @@ def onedrive_upload_file(
             logger.warning("Failed to open upload file %s: %s", local_path, e)
             raise ValueError("Could not read the file at the given path") from e
         with fh_ctx as fh:
-            # A stat-then-unbounded-read sequence can exceed the limit if
-            # another process appends to the file between those operations.
-            # Reading one byte past the cap bounds memory and makes the bytes
-            # actually sent authoritative for both the empty and size checks.
-            content = fh.read(_SIMPLE_UPLOAD_MAX_BYTES + 1)
-            if not content:
+            file_size = os.fstat(fh.fileno()).st_size
+            if file_size == 0:
                 # A deliberate product choice, not an API constraint: Graph
                 # itself accepts a 0-byte file. An agent uploading an empty
                 # file is almost always a symptom of an upstream mistake
@@ -522,20 +832,32 @@ def onedrive_upload_file(
                 # so this is rejected here rather than silently creating a
                 # placeholder-empty item on OneDrive.
                 raise ValueError(f"File is empty: {local_file_path}")
-            if len(content) > _SIMPLE_UPLOAD_MAX_BYTES:
+            if file_size > _MAX_UPLOAD_BYTES:
                 raise ValueError(
-                    f"File is over the {_SIMPLE_UPLOAD_MAX_BYTES:,}-byte "
-                    "(4 MB) limit for "
-                    "onedrive_upload_file. Large-file uploads are not supported yet."
+                    f"File is {file_size} bytes, over the "
+                    f"{_MAX_UPLOAD_BYTES // (1024 * 1024 * 1024)}GB limit for "
+                    "onedrive_upload_file"
                 )
 
-        result = _graph_request(
-            "PUT",
-            content_path,
-            extra_headers={"Content-Type": resolved_mime_type},
-            data=content,
-            timeout=_BINARY_UPLOAD_TIMEOUT_SECONDS,
-        )
+            if file_size <= _SIMPLE_UPLOAD_MAX_BYTES:
+                # Bound the read even if another process appends after fstat.
+                content = fh.read(_SIMPLE_UPLOAD_MAX_BYTES + 1)
+                if not content:
+                    raise ValueError(f"File is empty: {local_file_path}")
+                if len(content) > _SIMPLE_UPLOAD_MAX_BYTES:
+                    raise RuntimeError("the local file grew during upload")
+                result = _graph_request(
+                    "PUT",
+                    content_path,
+                    extra_headers={"Content-Type": resolved_mime_type},
+                    data=content,
+                    timeout=_BINARY_UPLOAD_TIMEOUT_SECONDS,
+                )
+            else:
+                result = _upload_large_file_content(
+                    resolved_remote_path, fh, file_size, resolved_mime_type
+                )
+
         if not isinstance(result, dict) or not result.get("id"):
             raise RuntimeError("OneDrive did not confirm the upload completed")
 

--- a/src/xagent/web/tools/mcp/onedrive.py
+++ b/src/xagent/web/tools/mcp/onedrive.py
@@ -3,9 +3,10 @@ import json
 import logging
 import mimetypes
 import os
+import time
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote, urlsplit
+from urllib.parse import quote
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -45,6 +46,9 @@ _SIMPLE_UPLOAD_MAX_BYTES = 4_000_000
 # (327,680 bytes) per Graph's requirement for every non-final chunk; 5 MiB
 # is exactly 16 * 320 KiB.
 _UPLOAD_SESSION_CHUNK_SIZE = 5 * 1024 * 1024
+_UPLOAD_CHUNK_MAX_ATTEMPTS = 3
+_UPLOAD_RETRY_BASE_SECONDS = 1.0
+_UPLOAD_RETRY_MAX_SECONDS = 10.0
 # Not a Graph API limit (OneDrive itself supports files far larger than
 # this via the resumable upload session) -- a guard-rail against a
 # mistargeted file (a generated artifact pointed at the wrong path, an
@@ -56,6 +60,11 @@ _UPLOAD_SESSION_CHUNK_SIZE = 5 * 1024 * 1024
 _MAX_UPLOAD_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
 
 _UPLOAD_ALLOWED_DIRS_ENV_VAR = "XAGENT_ONEDRIVE_FILE_ALLOWED_DIRS"
+
+
+class _UploadError(RuntimeError):
+    """Upload failure whose message is safe to expose to the caller."""
+
 
 # stdlib mimetypes.guess_type() only recognizes these extensions when a
 # system mime.types file happens to be installed (e.g. Apache's, common on
@@ -195,86 +204,63 @@ def _graph_headers(extra_headers: dict[str, str] | None = None) -> dict[str, str
     return headers
 
 
-def _raise_for_status_with_body(response: Any) -> None:
-    """Like response.raise_for_status(), but a non-2xx status raises a
-    RuntimeError with Graph's own error body appended -- a bare HTTPError's
-    default message carries only the status line, not the JSON error detail
-    Graph actually returns. Shared by every call site in this module that
-    talks to Graph directly (both _graph_request and the per-chunk PUTs in
-    _upload_large_file_content, which can't go through _graph_request itself
-    -- see its own Authorization-header note) so a future change to the
-    message format only needs to happen once.
+def _raise_upload_status(response: Any) -> None:
+    """Raise a credential-safe error for a rejected upload fragment.
+
+    Upload-session URLs are preauthenticated secrets. An intermediary can
+    echo them into an error body with arbitrary escaping, so no part of the
+    response body is forwarded to the caller or logs.
     """
     try:
         response.raise_for_status()
     except requests.HTTPError as exc:
-        response_text = response.text.strip()
-        message = str(exc)
-        if response_text:
-            message = f"{message} - {response_text}"
-        raise RuntimeError(message) from exc
+        status_code = getattr(response, "status_code", "unknown")
+        raise _UploadError(
+            f"OneDrive upload fragment failed with HTTP {status_code}"
+        ) from exc
 
 
-def _redact_upload_url(message: str, upload_url: str) -> str:
-    """Strip ``upload_url`` (a preauthenticated, bearer-token-equivalent
-    Graph upload-session URL) out of ``message`` as thoroughly as possible.
-
-    A plain ``message.replace(upload_url, ...)`` only catches the case
-    where the exception's own message happens to contain the exact,
-    complete "scheme://host/path?query" string. Verified directly against
-    a real failed request: urllib3's own ConnectionError/SSLError messages
-    never do that -- they report the host separately (inside
-    "HTTPSConnectionPool(host=..., port=...)") from the path+query (inside
-    "Max retries exceeded with url: /path?query"), so the whole-string
-    match silently misses them and the query string -- which carries the
-    session's actual bearer-equivalent token -- passes through unredacted.
-    Redacting the host and the path+query independently (in addition to
-    the full URL, for whichever call site does happen to embed it whole)
-    closes that gap without depending on any particular exception's message
-    shape.
-    """
-    redacted = message.replace(upload_url, "<redacted-upload-session-url>")
-    parsed = urlsplit(upload_url)
-    path_and_query = parsed.path + (f"?{parsed.query}" if parsed.query else "")
-    # Excludes a bare "/" with no query: that's indistinguishable from any
-    # other single slash that might appear elsewhere in the message, so
-    # using it as a blanket replace target would mangle the whole string
-    # instead of redacting anything meaningful. Not reachable against a
-    # real Graph upload-session URL (its path is always a specific,
-    # multi-segment session identifier), but nothing stops a test double
-    # or a future API change from producing one this short.
-    if path_and_query and path_and_query != "/":
-        redacted = redacted.replace(path_and_query, "<redacted-upload-session-url>")
-    if parsed.query:
-        redacted = redacted.replace(parsed.query, "<redacted-upload-session-token>")
-    if parsed.netloc:
-        redacted = redacted.replace(parsed.netloc, "<redacted-upload-session-host>")
-    return redacted
+def _safe_upload_error_message(exc: BaseException) -> str:
+    """Describe an upload failure without copying a request URL from it."""
+    if isinstance(exc, _UploadError):
+        return str(exc)
+    cause = exc
+    if isinstance(cause, requests.Timeout):
+        return "OneDrive upload fragment timed out"
+    if isinstance(cause, requests.ConnectionError):
+        return "OneDrive upload fragment connection failed"
+    if isinstance(cause, requests.RequestException):
+        return "OneDrive upload fragment request failed"
+    return f"OneDrive upload failed ({type(exc).__name__})"
 
 
 def _is_retriable_upload_error(exc: BaseException) -> bool:
-    """Whether ``exc`` might succeed on a future attempt against the SAME
-    upload session, so it's worth leaving that session's state (and
-    Graph's ``nextExpectedRanges``) alone rather than actively destroying
-    it via a cancellation DELETE.
+    """Whether ``exc`` might succeed on another bounded fragment attempt.
 
     A network-level failure (no response was ever received) and Graph's
-    own documented retriable statuses (429, and any 5xx) are retriable;
-    anything else -- a non-retriable 4xx Graph rejected outright, or a
-    validation failure this module raised itself about the *local* file
-    (a short read, an unparsable/incomplete final response) -- is not:
-    retrying against the same session wouldn't help either of those, so
-    there's no reason to withhold the immediate cleanup. By the time an
-    HTTPError reaches here it's already been converted to a plain
-    RuntimeError by _raise_for_status_with_body, so the original
-    exception (with its .response) is recovered via __cause__ rather than
-    expected on ``exc`` directly.
+    documented retriable statuses (429 and any 5xx) are retriable. The
+    HTTPError behind an _UploadError is recovered through ``__cause__``.
     """
-    cause = exc.__cause__ if isinstance(exc, RuntimeError) else exc
+    cause = exc.__cause__ if isinstance(exc, _UploadError) else exc
     status_code = getattr(getattr(cause, "response", None), "status_code", None)
     if isinstance(status_code, int):
         return status_code == 429 or 500 <= status_code < 600
     return isinstance(cause, (requests.ConnectionError, requests.Timeout))
+
+
+def _upload_retry_delay(exc: BaseException, retry_number: int) -> float:
+    """Return a bounded Retry-After or exponential-backoff delay."""
+    cause = exc.__cause__ if isinstance(exc, _UploadError) else exc
+    response = getattr(cause, "response", None)
+    headers = getattr(response, "headers", {}) or {}
+    retry_after = headers.get("Retry-After")
+    if retry_after is not None:
+        try:
+            return min(max(float(retry_after), 0.0), _UPLOAD_RETRY_MAX_SECONDS)
+        except (TypeError, ValueError):
+            pass
+    exponential_delay = _UPLOAD_RETRY_BASE_SECONDS * (2.0 ** (retry_number - 1))
+    return min(exponential_delay, _UPLOAD_RETRY_MAX_SECONDS)
 
 
 def _graph_request(
@@ -454,11 +440,9 @@ def _upload_large_file_content(
     one chunk of the file in memory at a time, unlike holding the whole
     file as a single ``bytes`` object would.
 
-    This uses the session only for chunking, not for actual resumability:
-    failures are not retried from Graph's ``nextExpectedRanges``.
-    Sessions are cancelled only for non-retriable failures, so a transient
-    mid-upload failure means the whole file is re-sent from byte 0 on the
-    next call, not resumed from where it left off.
+    Transient fragment failures are retried with bounded backoff on the same
+    session. Cross-call resume state is not persisted, so an exhausted or
+    non-retriable failure cancels the session before returning an error.
     """
     if total <= 0:
         # Not reachable through onedrive_upload_file today (it rejects an
@@ -496,7 +480,7 @@ def _upload_large_file_content(
                     # waiting for bytes that never arrive or desynchronize
                     # every later chunk's byte-range accounting. Fail loudly
                     # instead.
-                    raise RuntimeError(
+                    raise _UploadError(
                         f"expected to read {end - start} bytes at offset "
                         f"{start} but got {len(chunk)} -- the local file "
                         "may have changed size during upload"
@@ -514,17 +498,35 @@ def _upload_large_file_content(
                 # Content-Length/Content-Range are documented there), but
                 # sending it costs nothing and is the closest available
                 # lever to the simple path's behavior.
-                response = http.put(
-                    upload_url,
-                    data=chunk,
-                    headers={
-                        "Content-Length": str(end - start),
-                        "Content-Range": f"bytes {start}-{end - 1}/{total}",
-                        "Content-Type": mime_type,
-                    },
-                    timeout=_BINARY_UPLOAD_TIMEOUT_SECONDS,
-                )
-                _raise_for_status_with_body(response)
+                for attempt in range(1, _UPLOAD_CHUNK_MAX_ATTEMPTS + 1):
+                    try:
+                        response = http.put(
+                            upload_url,
+                            data=chunk,
+                            headers={
+                                "Content-Length": str(end - start),
+                                "Content-Range": f"bytes {start}-{end - 1}/{total}",
+                                "Content-Type": mime_type,
+                            },
+                            timeout=_BINARY_UPLOAD_TIMEOUT_SECONDS,
+                        )
+                        _raise_upload_status(response)
+                        break
+                    except Exception as exc:
+                        if (
+                            not _is_retriable_upload_error(exc)
+                            or attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS
+                        ):
+                            raise
+                        delay = _upload_retry_delay(exc, attempt)
+                        logger.warning(
+                            "Retrying OneDrive upload fragment after a transient "
+                            "failure (attempt %s/%s, delay %.1fs)",
+                            attempt + 1,
+                            _UPLOAD_CHUNK_MAX_ATTEMPTS,
+                            delay,
+                        )
+                        time.sleep(delay)
                 # Only the final chunk's response carries the completed
                 # item; Graph's intermediate (202) responses return upload-
                 # progress info, not the item -- checked explicitly
@@ -543,95 +545,43 @@ def _upload_large_file_content(
                         # failure, even though it's still reported as an
                         # error here (the caller has no completed item to
                         # act on either way).
-                        raise RuntimeError(
+                        raise _UploadError(
                             "OneDrive accepted the final chunk but "
-                            f"returned an unparsable response: {exc}"
+                            "returned an unparsable response"
                         ) from exc
                     if "id" not in result:
                         # The final chunk's response didn't actually carry
                         # a completed driveItem (e.g. an unexpected 202 on
                         # what this loop computed as the last range).
-                        raise RuntimeError(
-                            "OneDrive did not confirm the upload completed "
-                            f"(final response: {result!r})"
+                        raise _UploadError(
+                            "OneDrive did not confirm the upload completed"
                         )
         except Exception as exc:
-            # Redact upload_url out of the failure's own message before it
-            # goes anywhere else -- this catches every source uniformly
-            # (an HTTP error response whose body happens to echo the
-            # request URL via an intervening proxy/WAF, and -- the gap a
-            # status-code-keyed sanitize flag on the PUT call alone would
-            # miss -- a transport-level failure before any response
-            # existed at all: requests/urllib3's own ConnectionError/
-            # Timeout/SSLError messages embed the full request URL,
-            # verified directly against a real failed request). A plain
-            # `except requests.HTTPError` (or a flag passed only to the
-            # PUT's own status check) would leave those other paths
-            # unsanitized, so this wraps every exception the chunk loop
-            # can raise instead of trusting each one individually to avoid
-            # the URL. See _redact_upload_url's own docstring for why a
-            # bare whole-string replace isn't enough on its own.
-            redacted_message = _redact_upload_url(str(exc), upload_url)
-            if _is_retriable_upload_error(exc):
-                # A 429/5xx/network failure might still succeed against
-                # this SAME session on a later attempt -- actively
-                # cancelling it here would destroy Graph's
-                # nextExpectedRanges state for no benefit (this module
-                # doesn't currently retry/resume itself, but a future
-                # attempt manually resuming this exact session, or a
-                # resume feature added later, still could). Left alone,
-                # the session and its uploaded ranges simply persist until
-                # Graph's own ~15-minute expiry -- strictly no worse than
-                # cancelling it outright, and possibly better.
+            # No cross-call resume state is persisted. Once bounded retries
+            # are exhausted, cancel the unusable session instead of leaving
+            # partial data until its provider-defined expiration time.
+            try:
+                cancel_response = http.delete(
+                    upload_url, timeout=DEFAULT_TIMEOUT_SECONDS
+                )
+            except Exception as cleanup_exc:
+                # Never log cleanup exception text: requests exceptions can
+                # contain the preauthenticated upload URL.
                 logger.warning(
-                    "OneDrive upload session left intact after a "
-                    "retriable failure (not cancelled): %s",
-                    redacted_message,
+                    "Failed to cancel abandoned OneDrive upload session (%s)",
+                    type(cleanup_exc).__name__,
                 )
             else:
-                # Best-effort: free the abandoned session immediately
-                # instead of leaving it for Graph's own ~15-minute expiry
-                # -- unlike the retriable case above, nothing about this
-                # failure would change on a retry against the same
-                # session, so there's no reason to keep it around. A
-                # failure here must never mask the real error above, and
-                # uses the short, small-request timeout -- this DELETE
-                # carries no body, so it shouldn't compound a slow failure
-                # with another wait as long as a multi-megabyte upload's
-                # own timeout.
-                try:
-                    cancel_response = http.delete(
-                        upload_url, timeout=DEFAULT_TIMEOUT_SECONDS
-                    )
-                except Exception as cleanup_exc:
-                    cleanup_message = _redact_upload_url(str(cleanup_exc), upload_url)
+                if (
+                    not (200 <= cancel_response.status_code < 300)
+                    and cancel_response.status_code != 404
+                ):
                     logger.warning(
-                        "Failed to cancel abandoned OneDrive upload session: %s",
-                        cleanup_message,
+                        "OneDrive upload session cancellation returned HTTP %s "
+                        "instead of success",
+                        cancel_response.status_code,
                     )
-                else:
-                    # requests does not raise for an HTTP error status on
-                    # its own -- a 429/5xx here would otherwise look like a
-                    # successful cancellation while the session (and its
-                    # partial upload) actually lingers until Graph's own
-                    # expiry. A 404 is also treated as fine (not warned
-                    # on): it means the session is already gone -- expired,
-                    # or completed/cancelled by a previous attempt -- which
-                    # is the outcome this cleanup wants, not a failure of
-                    # it. Status only, no body: nothing about the response
-                    # is expected to carry the upload_url, but there's no
-                    # reason to risk it for a log line that only needs the
-                    # status.
-                    if (
-                        not (200 <= cancel_response.status_code < 300)
-                        and cancel_response.status_code != 404
-                    ):
-                        logger.warning(
-                            "OneDrive upload session cancellation returned "
-                            "HTTP %s instead of success",
-                            cancel_response.status_code,
-                        )
-            raise RuntimeError(redacted_message) from None
+            raise RuntimeError(_safe_upload_error_message(exc)) from None
 
     return result
 

--- a/src/xagent/web/tools/mcp/onedrive.py
+++ b/src/xagent/web/tools/mcp/onedrive.py
@@ -66,6 +66,60 @@ class _UploadError(RuntimeError):
     """Upload failure whose message is safe to expose to the caller."""
 
 
+class _QuickXorHash:
+    """Streaming implementation of OneDrive's 160-bit QuickXorHash."""
+
+    _WIDTH_BITS = 160
+    _WIDTH_BYTES = _WIDTH_BITS // 8
+    _MASK = (1 << _WIDTH_BITS) - 1
+
+    def __init__(self) -> None:
+        self._column_xor = 0
+        self._tail = b""
+        self._length = 0
+
+    def update(self, data: bytes) -> None:
+        """Add bytes while reducing full 160-byte periods in C-sized blocks."""
+        self._length += len(data)
+        if self._tail:
+            needed = self._WIDTH_BYTES - len(self._tail)
+            if len(data) < needed:
+                self._tail += data
+                return
+            self._column_xor ^= int.from_bytes(self._tail + data[:needed], "little")
+            data = data[needed:]
+            self._tail = b""
+
+        full_length = len(data) - (len(data) % self._WIDTH_BYTES)
+        view = memoryview(data)
+        for offset in range(0, full_length, self._WIDTH_BYTES):
+            self._column_xor ^= int.from_bytes(
+                view[offset : offset + self._WIDTH_BYTES], "little"
+            )
+        self._tail = bytes(view[full_length:])
+
+    def base64_digest(self) -> str:
+        """Return the Base64 value exposed as ``file.hashes.quickXorHash``."""
+        columns = self._column_xor
+        if self._tail:
+            columns ^= int.from_bytes(self._tail, "little")
+
+        value = 0
+        for index, byte in enumerate(columns.to_bytes(self._WIDTH_BYTES, "little")):
+            shift = (index * 11) % self._WIDTH_BITS
+            rotated = (
+                byte
+                if shift == 0
+                else ((byte << shift) | (byte >> (self._WIDTH_BITS - shift)))
+            )
+            value ^= rotated & self._MASK
+
+        digest = bytearray(value.to_bytes(self._WIDTH_BYTES, "little"))
+        for index, byte in enumerate(self._length.to_bytes(8, "little")):
+            digest[self._WIDTH_BYTES - 8 + index] ^= byte
+        return base64.b64encode(digest).decode("ascii")
+
+
 # stdlib mimetypes.guess_type() only recognizes these extensions when a
 # system mime.types file happens to be installed (e.g. Apache's, common on
 # a dev laptop) -- on a minimal/slim host with no such file (a stripped-down
@@ -234,6 +288,16 @@ def _safe_upload_error_message(exc: BaseException) -> str:
     return f"OneDrive upload failed ({type(exc).__name__})"
 
 
+def _request_error_cause(exc: BaseException) -> BaseException:
+    """Unwrap nested safe errors to their underlying requests exception."""
+    cause = exc
+    seen: set[int] = set()
+    while cause.__cause__ is not None and id(cause) not in seen:
+        seen.add(id(cause))
+        cause = cause.__cause__
+    return cause
+
+
 def _is_retriable_upload_error(exc: BaseException) -> bool:
     """Whether ``exc`` might succeed on another bounded fragment attempt.
 
@@ -241,7 +305,7 @@ def _is_retriable_upload_error(exc: BaseException) -> bool:
     documented retriable statuses (429 and any 5xx) are retriable. The
     HTTPError behind an _UploadError is recovered through ``__cause__``.
     """
-    cause = exc.__cause__ if isinstance(exc, _UploadError) else exc
+    cause = _request_error_cause(exc)
     status_code = getattr(getattr(cause, "response", None), "status_code", None)
     if isinstance(status_code, int):
         return status_code == 429 or 500 <= status_code < 600
@@ -250,7 +314,7 @@ def _is_retriable_upload_error(exc: BaseException) -> bool:
 
 def _upload_retry_delay(exc: BaseException, retry_number: int) -> float:
     """Return a bounded Retry-After or exponential-backoff delay."""
-    cause = exc.__cause__ if isinstance(exc, _UploadError) else exc
+    cause = _request_error_cause(exc)
     response = getattr(cause, "response", None)
     headers = getattr(response, "headers", {}) or {}
     retry_after = headers.get("Retry-After")
@@ -265,7 +329,7 @@ def _upload_retry_delay(exc: BaseException, retry_number: int) -> float:
 
 def _upload_status_code(exc: BaseException) -> int | None:
     """Return an HTTP status from a credential-safe upload error."""
-    cause = exc.__cause__ if isinstance(exc, _UploadError) else exc
+    cause = _request_error_cause(exc)
     status_code = getattr(getattr(cause, "response", None), "status_code", None)
     return status_code if isinstance(status_code, int) else None
 
@@ -283,20 +347,13 @@ def _next_expected_upload_offset(response: Any) -> int:
     return min(offsets)
 
 
-def _upload_item_fingerprint(item: Any) -> tuple[Any, Any, Any, Any] | None:
-    """Return fields that change when an existing destination is replaced."""
-    if not isinstance(item, dict) or not item.get("id"):
-        return None
-    return (item.get("id"), item.get("eTag"), item.get("cTag"), item.get("size"))
-
-
 def _current_upload_item(remote_path: str) -> dict[str, Any] | None:
     """Read destination metadata, treating an absent item as no baseline."""
     try:
         item = _graph_request(
             "GET",
             _item_path(remote_path),
-            params={"$select": "id,name,size,eTag,cTag"},
+            params={"$select": "id,name,size,file"},
         )
     except RuntimeError as exc:
         cause = exc.__cause__
@@ -309,25 +366,38 @@ def _current_upload_item(remote_path: str) -> dict[str, Any] | None:
 def _completed_upload_item(
     remote_path: str,
     total: int,
-    previous_fingerprint: tuple[Any, Any, Any, Any] | None,
+    expected_quickxor_hash: str,
 ) -> dict[str, Any]:
-    """Confirm a final fragment whose response was lost via drive metadata."""
-    try:
-        item = _current_upload_item(remote_path)
-    except Exception as exc:
-        raise _UploadError(
-            "OneDrive upload completed ambiguously and could not be confirmed"
-        ) from exc
-    if (
-        not isinstance(item, dict)
-        or not item.get("id")
-        or item.get("size") != total
-        or _upload_item_fingerprint(item) == previous_fingerprint
-    ):
-        raise _UploadError(
-            "OneDrive upload completed ambiguously and could not be confirmed"
-        )
-    return item
+    """Bind ambiguous completion to the exact uploaded bytes via QuickXorHash."""
+    last_error: BaseException | None = None
+    for attempt in range(1, _UPLOAD_CHUNK_MAX_ATTEMPTS + 1):
+        try:
+            item = _current_upload_item(remote_path)
+            remote_hash = (
+                item.get("file", {}).get("hashes", {}).get("quickXorHash")
+                if isinstance(item, dict)
+                else None
+            )
+            if (
+                isinstance(item, dict)
+                and item.get("id")
+                and item.get("size") == total
+                and remote_hash == expected_quickxor_hash
+            ):
+                return item
+            last_error = _UploadError(
+                "OneDrive upload completed ambiguously and could not be confirmed"
+            )
+        except Exception as exc:
+            last_error = exc
+            if not _is_retriable_upload_error(exc):
+                break
+        if attempt < _UPLOAD_CHUNK_MAX_ATTEMPTS:
+            delay_source = last_error or _UploadError("confirmation pending")
+            time.sleep(_upload_retry_delay(delay_source, attempt))
+    raise _UploadError(
+        "OneDrive upload completed ambiguously and could not be confirmed"
+    ) from last_error
 
 
 def _reconcile_upload_progress(
@@ -337,18 +407,18 @@ def _reconcile_upload_progress(
     start: int,
     end: int,
     total: int,
-    previous_fingerprint: tuple[Any, Any, Any, Any] | None,
+    expected_quickxor_hash: str,
 ) -> tuple[bool, dict[str, Any] | None]:
     """Return whether an ambiguous fragment was accepted, plus a final item."""
     last_error: BaseException | None = None
+    completed = False
     for attempt in range(1, _UPLOAD_CHUNK_MAX_ATTEMPTS + 1):
         try:
             response = http.get(upload_url, timeout=DEFAULT_TIMEOUT_SECONDS)
             if response.status_code == 404:
                 if end == total:
-                    return True, _completed_upload_item(
-                        remote_path, total, previous_fingerprint
-                    )
+                    completed = True
+                    break
                 raise _UploadError(
                     "OneDrive upload session disappeared before completion"
                 )
@@ -358,9 +428,8 @@ def _reconcile_upload_progress(
                 return False, None
             if next_offset >= end:
                 if end == total:
-                    return True, _completed_upload_item(
-                        remote_path, total, previous_fingerprint
-                    )
+                    completed = True
+                    break
                 return True, None
             raise _UploadError("OneDrive returned inconsistent upload-session progress")
         except Exception as exc:
@@ -370,9 +439,14 @@ def _reconcile_upload_progress(
             if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
                 break
             time.sleep(_upload_retry_delay(exc, attempt))
-    raise _UploadError(
-        "Could not determine OneDrive upload-session progress"
-    ) from last_error
+    else:
+        raise _UploadError(
+            "Could not determine OneDrive upload-session progress"
+        ) from last_error
+
+    if completed:
+        return True, _completed_upload_item(remote_path, total, expected_quickxor_hash)
+    raise _UploadError("Could not determine OneDrive upload-session progress")
 
 
 def _graph_request(
@@ -565,7 +639,6 @@ def _upload_large_file_content(
         # function initializes below, bypassing the "did OneDrive actually
         # confirm this" check that only runs inside the loop.
         raise ValueError(f"total must be positive, got {total}")
-    previous_fingerprint = _upload_item_fingerprint(_current_upload_item(remote_path))
     session = _graph_request(
         "POST",
         f"{_item_path(remote_path)}/createUploadSession",
@@ -580,6 +653,7 @@ def _upload_large_file_content(
     # which adds up over the ~100 requests a 500MB upload needs.
     with requests.Session() as http:
         result: dict[str, Any] = {}
+        quickxor_hash = _QuickXorHash()
         try:
             for start in range(0, total, _UPLOAD_SESSION_CHUNK_SIZE):
                 end = min(start + _UPLOAD_SESSION_CHUNK_SIZE, total)
@@ -599,6 +673,9 @@ def _upload_large_file_content(
                         f"{start} but got {len(chunk)} -- the local file "
                         "may have changed size during upload"
                     )
+                # Hash each byte once when it is first read. Fragment retries
+                # reuse ``chunk`` and therefore cannot double-count it.
+                quickxor_hash.update(chunk)
                 # Detect growth after the caller's fstat snapshot before a
                 # truncated final item is committed. Keeping this as a
                 # separate read preserves the one-chunk memory bound.
@@ -632,6 +709,26 @@ def _upload_large_file_content(
                             timeout=_BINARY_UPLOAD_TIMEOUT_SECONDS,
                         )
                         _raise_upload_status(response)
+                        if end == total and response.status_code not in (200, 201):
+                            accepted, completed_item = _reconcile_upload_progress(
+                                http,
+                                upload_url,
+                                remote_path,
+                                start,
+                                end,
+                                total,
+                                quickxor_hash.base64_digest(),
+                            )
+                            if accepted:
+                                if completed_item is not None:
+                                    result = completed_item
+                                break
+                            if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
+                                raise _UploadError(
+                                    "OneDrive did not confirm the upload completed"
+                                )
+                            time.sleep(_UPLOAD_RETRY_BASE_SECONDS)
+                            continue
                         break
                     except Exception as exc:
                         status_code = _upload_status_code(exc)
@@ -644,7 +741,7 @@ def _upload_large_file_content(
                             start,
                             end,
                             total,
-                            previous_fingerprint,
+                            quickxor_hash.base64_digest(),
                         )
                         if accepted:
                             if completed_item is not None:
@@ -672,26 +769,21 @@ def _upload_large_file_content(
                     if result.get("id"):
                         continue
                     try:
-                        result = response.json() if response.content else {}
-                    except ValueError as exc:
-                        # The PUT itself succeeded (no HTTPError above) --
-                        # OneDrive has already committed the file at this
-                        # point, so this is "the transfer worked but the
-                        # confirmation can't be read", not a transfer
-                        # failure, even though it's still reported as an
-                        # error here (the caller has no completed item to
-                        # act on either way).
-                        raise _UploadError(
-                            "OneDrive accepted the final chunk but "
-                            "returned an unparsable response"
-                        ) from exc
-                    if "id" not in result:
-                        # The final chunk's response didn't actually carry
-                        # a completed driveItem (e.g. an unexpected 202 on
-                        # what this loop computed as the last range).
-                        raise _UploadError(
-                            "OneDrive did not confirm the upload completed"
-                        )
+                        final_item = response.json() if response.content else {}
+                    except ValueError:
+                        final_item = {}
+                    if isinstance(final_item, dict) and final_item.get("id"):
+                        result = final_item
+                        continue
+
+                    # A 200/201 final PUT can still lose or omit its JSON
+                    # driveItem response. Bind destination metadata to the
+                    # exact local bytes before reporting success.
+                    result = _completed_upload_item(
+                        remote_path,
+                        total,
+                        quickxor_hash.base64_digest(),
+                    )
         except Exception as exc:
             # No cross-call resume state is persisted. Once bounded retries
             # are exhausted, cancel the unusable session instead of leaving

--- a/src/xagent/web/tools/mcp/onedrive.py
+++ b/src/xagent/web/tools/mcp/onedrive.py
@@ -4,6 +4,7 @@ import logging
 import mimetypes
 import os
 import time
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -70,7 +71,10 @@ class _QuickXorHash:
     """Streaming implementation of OneDrive's 160-bit QuickXorHash."""
 
     _WIDTH_BITS = 160
-    _WIDTH_BYTES = _WIDTH_BITS // 8
+    _DIGEST_BYTES = _WIDTH_BITS // 8
+    # rotate(byte, index * 11) repeats after 160 input bytes because 11
+    # and 160 are coprime. This is distinct from the 20-byte digest width.
+    _INPUT_PERIOD_BYTES = _WIDTH_BITS
     _MASK = (1 << _WIDTH_BITS) - 1
 
     def __init__(self) -> None:
@@ -82,7 +86,7 @@ class _QuickXorHash:
         """Add bytes while reducing full 160-byte periods in C-sized blocks."""
         self._length += len(data)
         if self._tail:
-            needed = self._WIDTH_BYTES - len(self._tail)
+            needed = self._INPUT_PERIOD_BYTES - len(self._tail)
             if len(data) < needed:
                 self._tail += data
                 return
@@ -90,11 +94,11 @@ class _QuickXorHash:
             data = data[needed:]
             self._tail = b""
 
-        full_length = len(data) - (len(data) % self._WIDTH_BYTES)
+        full_length = len(data) - (len(data) % self._INPUT_PERIOD_BYTES)
         view = memoryview(data)
-        for offset in range(0, full_length, self._WIDTH_BYTES):
+        for offset in range(0, full_length, self._INPUT_PERIOD_BYTES):
             self._column_xor ^= int.from_bytes(
-                view[offset : offset + self._WIDTH_BYTES], "little"
+                view[offset : offset + self._INPUT_PERIOD_BYTES], "little"
             )
         self._tail = bytes(view[full_length:])
 
@@ -105,7 +109,9 @@ class _QuickXorHash:
             columns ^= int.from_bytes(self._tail, "little")
 
         value = 0
-        for index, byte in enumerate(columns.to_bytes(self._WIDTH_BYTES, "little")):
+        for index, byte in enumerate(
+            columns.to_bytes(self._INPUT_PERIOD_BYTES, "little")
+        ):
             shift = (index * 11) % self._WIDTH_BITS
             rotated = (
                 byte
@@ -114,9 +120,9 @@ class _QuickXorHash:
             )
             value ^= rotated & self._MASK
 
-        digest = bytearray(value.to_bytes(self._WIDTH_BYTES, "little"))
+        digest = bytearray(value.to_bytes(self._DIGEST_BYTES, "little"))
         for index, byte in enumerate(self._length.to_bytes(8, "little")):
-            digest[self._WIDTH_BYTES - 8 + index] ^= byte
+            digest[self._DIGEST_BYTES - 8 + index] ^= byte
         return base64.b64encode(digest).decode("ascii")
 
 
@@ -305,26 +311,35 @@ def _is_retriable_upload_error(exc: BaseException) -> bool:
     documented retriable statuses (429 and any 5xx) are retriable. The
     HTTPError behind an _UploadError is recovered through ``__cause__``.
     """
-    cause = _request_error_cause(exc)
-    status_code = getattr(getattr(cause, "response", None), "status_code", None)
-    if isinstance(status_code, int):
+    status_code = _upload_status_code(exc)
+    if status_code is not None:
         return status_code == 429 or 500 <= status_code < 600
+    cause = _request_error_cause(exc)
     return isinstance(cause, (requests.ConnectionError, requests.Timeout))
 
 
-def _upload_retry_delay(exc: BaseException, retry_number: int) -> float:
-    """Return a bounded Retry-After or exponential-backoff delay."""
-    cause = _request_error_cause(exc)
-    response = getattr(cause, "response", None)
-    headers = getattr(response, "headers", {}) or {}
+def _retry_delay(headers: Any, retry_number: int) -> float:
+    """Return a bounded seconds/HTTP-date Retry-After or exponential delay."""
+    headers = headers or {}
     retry_after = headers.get("Retry-After")
     if retry_after is not None:
         try:
             return min(max(float(retry_after), 0.0), _UPLOAD_RETRY_MAX_SECONDS)
         except (TypeError, ValueError):
-            pass
+            try:
+                retry_at = parsedate_to_datetime(str(retry_after)).timestamp()
+                return min(max(retry_at - time.time(), 0.0), _UPLOAD_RETRY_MAX_SECONDS)
+            except (TypeError, ValueError, OverflowError):
+                pass
     exponential_delay = _UPLOAD_RETRY_BASE_SECONDS * (2.0 ** (retry_number - 1))
     return min(exponential_delay, _UPLOAD_RETRY_MAX_SECONDS)
+
+
+def _upload_retry_delay(exc: BaseException, retry_number: int) -> float:
+    """Return a retry delay from an upload exception."""
+    cause = _request_error_cause(exc)
+    response = getattr(cause, "response", None)
+    return _retry_delay(getattr(response, "headers", None), retry_number)
 
 
 def _upload_status_code(exc: BaseException) -> int | None:
@@ -334,15 +349,19 @@ def _upload_status_code(exc: BaseException) -> int | None:
     return status_code if isinstance(status_code, int) else None
 
 
-def _next_expected_upload_offset(response: Any) -> int:
+def _next_expected_upload_offset(response: Any, total: int) -> int:
     """Parse the first missing offset from an upload-session status response."""
     try:
         payload = response.json()
         ranges = payload["nextExpectedRanges"]
+        if not isinstance(ranges, list):
+            raise TypeError("nextExpectedRanges must be a list")
         offsets = [int(value.split("-", 1)[0]) for value in ranges]
     except (KeyError, TypeError, ValueError, AttributeError) as exc:
         raise _UploadError("OneDrive returned invalid upload-session progress") from exc
-    if not offsets or any(offset < 0 for offset in offsets):
+    if not offsets:
+        return total
+    if any(offset < 0 or offset > total for offset in offsets):
         raise _UploadError("OneDrive returned invalid upload-session progress")
     return min(offsets)
 
@@ -373,10 +392,10 @@ def _completed_upload_item(
     for attempt in range(1, _UPLOAD_CHUNK_MAX_ATTEMPTS + 1):
         try:
             item = _current_upload_item(remote_path)
+            file_facet = item.get("file") if isinstance(item, dict) else None
+            hashes = file_facet.get("hashes") if isinstance(file_facet, dict) else None
             remote_hash = (
-                item.get("file", {}).get("hashes", {}).get("quickXorHash")
-                if isinstance(item, dict)
-                else None
+                hashes.get("quickXorHash") if isinstance(hashes, dict) else None
             )
             if (
                 isinstance(item, dict)
@@ -393,8 +412,7 @@ def _completed_upload_item(
             if not _is_retriable_upload_error(exc):
                 break
         if attempt < _UPLOAD_CHUNK_MAX_ATTEMPTS:
-            delay_source = last_error or _UploadError("confirmation pending")
-            time.sleep(_upload_retry_delay(delay_source, attempt))
+            time.sleep(_upload_retry_delay(last_error, attempt))
     raise _UploadError(
         "OneDrive upload completed ambiguously and could not be confirmed"
     ) from last_error
@@ -408,8 +426,8 @@ def _reconcile_upload_progress(
     end: int,
     total: int,
     expected_quickxor_hash: str,
-) -> tuple[bool, dict[str, Any] | None]:
-    """Return whether an ambiguous fragment was accepted, plus a final item."""
+) -> tuple[int, dict[str, Any] | None]:
+    """Return the first missing byte offset, plus a confirmed final item."""
     last_error: BaseException | None = None
     completed = False
     for attempt in range(1, _UPLOAD_CHUNK_MAX_ATTEMPTS + 1):
@@ -423,15 +441,22 @@ def _reconcile_upload_progress(
                     "OneDrive upload session disappeared before completion"
                 )
             _raise_upload_status(response)
-            next_offset = _next_expected_upload_offset(response)
-            if next_offset == start:
-                return False, None
+            next_offset = _next_expected_upload_offset(response, total)
+            if next_offset < start:
+                raise _UploadError(
+                    "OneDrive returned inconsistent upload-session progress"
+                )
+            if next_offset == total and end < total:
+                raise _UploadError(
+                    "OneDrive reported completion before the local final fragment"
+                )
+            if next_offset < end:
+                return next_offset, None
             if next_offset >= end:
                 if end == total:
                     completed = True
                     break
-                return True, None
-            raise _UploadError("OneDrive returned inconsistent upload-session progress")
+                return next_offset, None
         except Exception as exc:
             last_error = exc
             if not _is_retriable_upload_error(exc):
@@ -439,14 +464,11 @@ def _reconcile_upload_progress(
             if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
                 break
             time.sleep(_upload_retry_delay(exc, attempt))
-    else:
-        raise _UploadError(
-            "Could not determine OneDrive upload-session progress"
-        ) from last_error
-
     if completed:
-        return True, _completed_upload_item(remote_path, total, expected_quickxor_hash)
-    raise _UploadError("Could not determine OneDrive upload-session progress")
+        return total, _completed_upload_item(remote_path, total, expected_quickxor_hash)
+    raise _UploadError(
+        "Could not determine OneDrive upload-session progress"
+    ) from last_error
 
 
 def _graph_request(
@@ -639,11 +661,14 @@ def _upload_large_file_content(
         # function initializes below, bypassing the "did OneDrive actually
         # confirm this" check that only runs inside the loop.
         raise ValueError(f"total must be positive, got {total}")
-    session = _graph_request(
-        "POST",
-        f"{_item_path(remote_path)}/createUploadSession",
-        body={"item": {"@microsoft.graph.conflictBehavior": "replace"}},
-    )
+    try:
+        session = _graph_request(
+            "POST",
+            f"{_item_path(remote_path)}/createUploadSession",
+            body={"item": {"@microsoft.graph.conflictBehavior": "replace"}},
+        )
+    except (RuntimeError, requests.RequestException) as exc:
+        raise _UploadError("Could not create OneDrive upload session") from exc
     upload_url = session.get("uploadUrl")
     if not upload_url:
         raise RuntimeError("OneDrive did not return an upload session URL")
@@ -683,6 +708,7 @@ def _upload_large_file_content(
                     raise _UploadError(
                         "the local file may have changed size during upload"
                     )
+                fragment_start = start
                 # The upload session URL is itself pre-authenticated (a
                 # token in its query string) -- Microsoft's own docs for
                 # createUploadSession confirm this explicitly: "If you
@@ -700,53 +726,63 @@ def _upload_large_file_content(
                     try:
                         response = http.put(
                             upload_url,
-                            data=chunk,
+                            data=(
+                                chunk
+                                if fragment_start == start
+                                else memoryview(chunk)[fragment_start - start :]
+                            ),
                             headers={
-                                "Content-Length": str(end - start),
-                                "Content-Range": f"bytes {start}-{end - 1}/{total}",
+                                "Content-Length": str(end - fragment_start),
+                                "Content-Range": (
+                                    f"bytes {fragment_start}-{end - 1}/{total}"
+                                ),
                                 "Content-Type": mime_type,
                             },
                             timeout=_BINARY_UPLOAD_TIMEOUT_SECONDS,
                         )
                         _raise_upload_status(response)
                         if end == total and response.status_code not in (200, 201):
-                            accepted, completed_item = _reconcile_upload_progress(
+                            next_offset, completed_item = _reconcile_upload_progress(
                                 http,
                                 upload_url,
                                 remote_path,
-                                start,
+                                fragment_start,
                                 end,
                                 total,
                                 quickxor_hash.base64_digest(),
                             )
-                            if accepted:
-                                if completed_item is not None:
-                                    result = completed_item
+                            if completed_item is not None:
+                                result = completed_item
                                 break
+                            if next_offset >= end:
+                                break
+                            fragment_start = next_offset
                             if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
                                 raise _UploadError(
                                     "OneDrive did not confirm the upload completed"
                                 )
-                            time.sleep(_UPLOAD_RETRY_BASE_SECONDS)
+                            time.sleep(_retry_delay(response.headers, attempt))
                             continue
                         break
                     except Exception as exc:
                         status_code = _upload_status_code(exc)
                         if not (_is_retriable_upload_error(exc) or status_code == 416):
                             raise
-                        accepted, completed_item = _reconcile_upload_progress(
+                        next_offset, completed_item = _reconcile_upload_progress(
                             http,
                             upload_url,
                             remote_path,
-                            start,
+                            fragment_start,
                             end,
                             total,
                             quickxor_hash.base64_digest(),
                         )
-                        if accepted:
-                            if completed_item is not None:
-                                result = completed_item
+                        if completed_item is not None:
+                            result = completed_item
                             break
+                        if next_offset >= end:
+                            break
+                        fragment_start = next_offset
                         if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
                             raise
                         delay = _upload_retry_delay(exc, attempt)

--- a/src/xagent/web/tools/mcp/onedrive.py
+++ b/src/xagent/web/tools/mcp/onedrive.py
@@ -807,7 +807,14 @@ def _upload_large_file_content(
                             timeout=_BINARY_UPLOAD_TIMEOUT_SECONDS,
                         )
                         _raise_upload_status(response)
-                        if end < total or response.status_code in (200, 201):
+                        if response.status_code in (200, 201):
+                            if end < total:
+                                raise _UploadError(
+                                    "OneDrive reported completion before the local "
+                                    "final fragment"
+                                )
+                            break
+                        if end < total and response.status_code == 202:
                             break
                     except Exception as exc:
                         status_code = _upload_status_code(exc)

--- a/src/xagent/web/tools/mcp/onedrive.py
+++ b/src/xagent/web/tools/mcp/onedrive.py
@@ -1,9 +1,11 @@
 import base64
 import json
 import logging
+import math
 import mimetypes
 import os
 import time
+from datetime import timezone
 from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any
@@ -48,6 +50,10 @@ _SIMPLE_UPLOAD_MAX_BYTES = 4_000_000
 # is exactly 16 * 320 KiB.
 _UPLOAD_SESSION_CHUNK_SIZE = 5 * 1024 * 1024
 _UPLOAD_CHUNK_MAX_ATTEMPTS = 3
+# Forward progress resets the consecutive-failure counter, so keep a separate
+# cap on recovery cycles within one buffered fragment to prevent a server that
+# advances by tiny ranges from extending a synchronous call without bound.
+_UPLOAD_CHUNK_MAX_RECOVERY_CYCLES = 12
 _UPLOAD_RETRY_BASE_SECONDS = 1.0
 _UPLOAD_RETRY_MAX_SECONDS = 10.0
 # Not a Graph API limit (OneDrive itself supports files far larger than
@@ -286,7 +292,7 @@ def _safe_upload_error_message(exc: BaseException) -> str:
     """Describe an upload failure without copying a request URL from it."""
     if isinstance(exc, _UploadError):
         return str(exc)
-    cause = exc
+    cause = _request_error_cause(exc)
     if isinstance(cause, requests.Timeout):
         return "OneDrive upload fragment timed out"
     if isinstance(cause, requests.ConnectionError):
@@ -326,13 +332,20 @@ def _retry_delay(headers: Any, retry_number: int) -> float:
     retry_after = headers.get("Retry-After")
     if retry_after is not None:
         try:
-            return min(max(float(retry_after), 0.0), _UPLOAD_RETRY_MAX_SECONDS)
+            retry_seconds = float(retry_after)
+            if math.isfinite(retry_seconds):
+                return min(max(retry_seconds, 0.0), _UPLOAD_RETRY_MAX_SECONDS)
         except (TypeError, ValueError):
-            try:
-                retry_at = parsedate_to_datetime(str(retry_after)).timestamp()
-                return min(max(retry_at - time.time(), 0.0), _UPLOAD_RETRY_MAX_SECONDS)
-            except (TypeError, ValueError, OverflowError):
-                pass
+            pass
+        try:
+            retry_at = parsedate_to_datetime(str(retry_after))
+            if retry_at.tzinfo is None:
+                retry_at = retry_at.replace(tzinfo=timezone.utc)
+            retry_seconds = retry_at.timestamp() - time.time()
+            if math.isfinite(retry_seconds):
+                return min(max(retry_seconds, 0.0), _UPLOAD_RETRY_MAX_SECONDS)
+        except (TypeError, ValueError, OverflowError):
+            pass
     exponential_delay = _UPLOAD_RETRY_BASE_SECONDS * (2.0 ** (retry_number - 1))
     return min(exponential_delay, _UPLOAD_RETRY_MAX_SECONDS)
 
@@ -377,8 +390,7 @@ def _current_upload_item(remote_path: str) -> dict[str, Any] | None:
             params={"$select": "id,name,size,file"},
         )
     except RuntimeError as exc:
-        cause = exc.__cause__
-        if getattr(getattr(cause, "response", None), "status_code", None) == 404:
+        if _upload_status_code(exc) == 404:
             return None
         raise _UploadError("Could not inspect the OneDrive upload target") from exc
     return item if isinstance(item, dict) and item.get("id") else None
@@ -443,6 +455,23 @@ def _reconcile_upload_progress(
                     "OneDrive upload session disappeared before completion"
                 )
             _raise_upload_status(response)
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise _UploadError(
+                    "OneDrive returned invalid upload-session progress"
+                ) from exc
+            if (
+                isinstance(payload, dict)
+                and payload.get("id")
+                and "nextExpectedRanges" not in payload
+            ):
+                if end < total:
+                    raise _UploadError(
+                        "OneDrive reported completion before the local final fragment"
+                    )
+                completed = True
+                break
             next_offset = _next_expected_upload_offset(response, total)
             if next_offset < start:
                 raise _UploadError(
@@ -458,11 +487,10 @@ def _reconcile_upload_progress(
                 )
             if next_offset < end:
                 return next_offset, None
-            if next_offset >= end:
-                if end == total:
-                    completed = True
-                    break
-                return next_offset, None
+            if end == total:
+                completed = True
+                break
+            return next_offset, None
         except Exception as exc:
             last_error = exc
             if not _is_retriable_upload_error(exc):
@@ -760,7 +788,11 @@ def _upload_large_file_content(
                 # Content-Length/Content-Range are documented there), but
                 # sending it costs nothing and is the closest available
                 # lever to the simple path's behavior.
-                for attempt in range(1, _UPLOAD_CHUNK_MAX_ATTEMPTS + 1):
+                consecutive_failures = 0
+                recovery_cycles = 0
+                response: Any | None = None
+                while True:
+                    upload_error: BaseException | None = None
                     try:
                         response = http.put(
                             upload_url,
@@ -775,34 +807,19 @@ def _upload_large_file_content(
                             timeout=_BINARY_UPLOAD_TIMEOUT_SECONDS,
                         )
                         _raise_upload_status(response)
-                        if end == total and response.status_code not in (200, 201):
-                            next_offset, completed_item = _reconcile_upload_progress(
-                                http,
-                                upload_url,
-                                remote_path,
-                                fragment_start,
-                                end,
-                                total,
-                                quickxor_hash.base64_digest(),
-                            )
-                            if completed_item is not None:
-                                result = completed_item
-                                break
-                            if next_offset == end:
-                                break
-                            end = refill_fragment(chunk, fragment_start, next_offset)
-                            fragment_start = next_offset
-                            if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
-                                raise _UploadError(
-                                    "OneDrive did not confirm the upload completed"
-                                )
-                            time.sleep(_retry_delay(response.headers, attempt))
-                            continue
-                        break
+                        if end < total or response.status_code in (200, 201):
+                            break
                     except Exception as exc:
                         status_code = _upload_status_code(exc)
-                        if not (_is_retriable_upload_error(exc) or status_code == 416):
+                        if not (
+                            _is_retriable_upload_error(exc)
+                            or status_code in (404, 409, 416)
+                        ):
                             raise
+                        upload_error = exc
+
+                    recovery_cycles += 1
+                    try:
                         next_offset, completed_item = _reconcile_upload_progress(
                             http,
                             upload_url,
@@ -812,24 +829,54 @@ def _upload_large_file_content(
                             total,
                             quickxor_hash.base64_digest(),
                         )
+                    except Exception as reconcile_error:
+                        if not _is_retriable_upload_error(reconcile_error):
+                            raise
+                        consecutive_failures += 1
+                        if consecutive_failures >= _UPLOAD_CHUNK_MAX_ATTEMPTS:
+                            raise _UploadError(
+                                "Could not determine OneDrive upload-session progress"
+                            ) from reconcile_error
+                        delay = _upload_retry_delay(
+                            reconcile_error, consecutive_failures
+                        )
+                    else:
                         if completed_item is not None:
                             result = completed_item
                             break
                         if next_offset == end:
                             break
-                        end = refill_fragment(chunk, fragment_start, next_offset)
-                        fragment_start = next_offset
-                        if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
-                            raise
-                        delay = _upload_retry_delay(exc, attempt)
-                        logger.warning(
-                            "Retrying OneDrive upload fragment after a transient "
-                            "failure (attempt %s/%s, delay %.1fs)",
-                            attempt + 1,
-                            _UPLOAD_CHUNK_MAX_ATTEMPTS,
-                            delay,
+                        if next_offset > fragment_start:
+                            end = refill_fragment(chunk, fragment_start, next_offset)
+                            fragment_start = next_offset
+                            consecutive_failures = 0
+                        else:
+                            consecutive_failures += 1
+                            if consecutive_failures >= _UPLOAD_CHUNK_MAX_ATTEMPTS:
+                                raise _UploadError(
+                                    "OneDrive upload fragment made no forward progress"
+                                ) from upload_error
+                        retry_number = max(consecutive_failures, 1)
+                        delay = (
+                            _upload_retry_delay(upload_error, retry_number)
+                            if upload_error is not None
+                            else _retry_delay(
+                                getattr(response, "headers", None), retry_number
+                            )
                         )
-                        time.sleep(delay)
+
+                    if recovery_cycles >= _UPLOAD_CHUNK_MAX_RECOVERY_CYCLES:
+                        raise _UploadError(
+                            "OneDrive upload fragment exceeded its recovery budget"
+                        ) from upload_error
+                    logger.warning(
+                        "Retrying OneDrive upload fragment after reconciliation "
+                        "(recovery cycle %s/%s, delay %.1fs)",
+                        recovery_cycles + 1,
+                        _UPLOAD_CHUNK_MAX_RECOVERY_CYCLES,
+                        delay,
+                    )
+                    time.sleep(delay)
                 # Only the final chunk's response carries the completed
                 # item; Graph's intermediate (202) responses return upload-
                 # progress info, not the item -- checked explicitly
@@ -840,6 +887,10 @@ def _upload_large_file_content(
                 if end == total:
                     if result.get("id"):
                         break
+                    if response is None:
+                        raise _UploadError(
+                            "OneDrive did not return a final upload response"
+                        )
                     try:
                         final_item = response.json() if response.content else {}
                     except ValueError:
@@ -1035,8 +1086,8 @@ def onedrive_upload_file(
     filename, falling back to "application/octet-stream". It is sent on both
     simple uploads and upload-session chunks.
 
-    Rejects a file over _MAX_UPLOAD_BYTES (2 GiB) -- a guard-rail against a
-    mistargeted upload, not a OneDrive/Graph limit.
+    Empty files are rejected. Files over 2 GiB are also rejected as a
+    guard-rail against a mistargeted upload, not as a OneDrive/Graph limit.
     """
     try:
         local_path = _resolve_upload_file_path(local_file_path)
@@ -1087,7 +1138,7 @@ def onedrive_upload_file(
             if file_size > _MAX_UPLOAD_BYTES:
                 raise ValueError(
                     f"File is {file_size} bytes, over the "
-                    f"{_MAX_UPLOAD_BYTES // (1024 * 1024 * 1024)}GB limit for "
+                    f"{_MAX_UPLOAD_BYTES // (1024 * 1024 * 1024)} GiB limit for "
                     "onedrive_upload_file"
                 )
 

--- a/src/xagent/web/tools/mcp/onedrive.py
+++ b/src/xagent/web/tools/mcp/onedrive.py
@@ -49,7 +49,13 @@ _SIMPLE_UPLOAD_MAX_BYTES = 4_000_000
 # (327,680 bytes) per Graph's requirement for every non-final chunk; 5 MiB
 # is exactly 16 * 320 KiB.
 _UPLOAD_SESSION_CHUNK_SIZE = 5 * 1024 * 1024
-_UPLOAD_CHUNK_MAX_ATTEMPTS = 3
+_UPLOAD_FRAGMENT_MAX_ATTEMPTS = 3
+_UPLOAD_RECONCILE_MAX_ATTEMPTS = 3
+# Destination metadata can lag behind a committed final fragment. Keep this
+# confirmation budget separate from fragment/status retries so an ambiguous
+# completion can wait up to 45 seconds (1+2+4+8+10+10+10) for QuickXorHash
+# without weakening the exact-content check or making ordinary chunks slower.
+_UPLOAD_COMPLETION_MAX_ATTEMPTS = 8
 # Forward progress resets the consecutive-failure counter, so keep a separate
 # cap on recovery cycles within one buffered fragment to prevent a server that
 # advances by tiny ranges from extending a synchronous call without bound.
@@ -71,6 +77,14 @@ _UPLOAD_ALLOWED_DIRS_ENV_VAR = "XAGENT_ONEDRIVE_FILE_ALLOWED_DIRS"
 
 class _UploadError(RuntimeError):
     """Upload failure whose message is safe to expose to the caller."""
+
+
+class _GraphRequestError(RuntimeError):
+    """Graph HTTP failure that retains its status without response parsing."""
+
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class _QuickXorHash:
@@ -250,6 +264,13 @@ def _success(**payload: Any) -> str:
     return json.dumps({"status": "success", **payload}, ensure_ascii=False)
 
 
+def _caller_safe_drive_item(item: dict[str, Any]) -> dict[str, Any]:
+    """Copy a driveItem without Graph's short-lived preauthenticated URL."""
+    safe_item = dict(item)
+    safe_item.pop("@microsoft.graph.downloadUrl", None)
+    return safe_item
+
+
 def _error(message: str, *, details: Any = None) -> str:
     payload: dict[str, Any] = {"status": "error", "message": message}
     if details is not None:
@@ -291,7 +312,11 @@ def _raise_upload_status(response: Any) -> None:
 def _safe_upload_error_message(exc: BaseException) -> str:
     """Describe an upload failure without copying a request URL from it."""
     if isinstance(exc, _UploadError):
-        return str(exc)
+        status_code = _upload_status_code(exc)
+        message = str(exc)
+        if status_code is not None and "HTTP" not in message:
+            return f"{message} (last HTTP status {status_code})"
+        return message
     cause = _request_error_cause(exc)
     if isinstance(cause, requests.Timeout):
         return "OneDrive upload fragment timed out"
@@ -359,15 +384,22 @@ def _upload_retry_delay(exc: BaseException, retry_number: int) -> float:
 
 def _upload_status_code(exc: BaseException) -> int | None:
     """Return an HTTP status from a credential-safe upload error."""
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        status_code = getattr(current, "status_code", None)
+        if isinstance(status_code, int):
+            return status_code
+        current = current.__cause__
     cause = _request_error_cause(exc)
     status_code = getattr(getattr(cause, "response", None), "status_code", None)
     return status_code if isinstance(status_code, int) else None
 
 
-def _next_expected_upload_offset(response: Any, total: int) -> int:
-    """Parse the first missing offset from an upload-session status response."""
+def _next_expected_upload_offset(payload: Any, total: int) -> int:
+    """Parse the first missing offset from an upload-session status payload."""
     try:
-        payload = response.json()
         ranges = payload["nextExpectedRanges"]
         if not isinstance(ranges, list):
             raise TypeError("nextExpectedRanges must be a list")
@@ -389,7 +421,7 @@ def _current_upload_item(remote_path: str) -> dict[str, Any] | None:
             _item_path(remote_path),
             params={"$select": "id,name,size,file"},
         )
-    except RuntimeError as exc:
+    except (RuntimeError, ValueError, requests.RequestException) as exc:
         if _upload_status_code(exc) == 404:
             return None
         raise _UploadError("Could not inspect the OneDrive upload target") from exc
@@ -399,11 +431,11 @@ def _current_upload_item(remote_path: str) -> dict[str, Any] | None:
 def _completed_upload_item(
     remote_path: str,
     total: int,
-    expected_quickxor_hash: str,
+    expected_final_quickxor_hash: str,
 ) -> dict[str, Any]:
     """Bind ambiguous completion to the exact uploaded bytes via QuickXorHash."""
     last_error: BaseException | None = None
-    for attempt in range(1, _UPLOAD_CHUNK_MAX_ATTEMPTS + 1):
+    for attempt in range(1, _UPLOAD_COMPLETION_MAX_ATTEMPTS + 1):
         try:
             item = _current_upload_item(remote_path)
             file_facet = item.get("file") if isinstance(item, dict) else None
@@ -415,7 +447,7 @@ def _completed_upload_item(
                 isinstance(item, dict)
                 and item.get("id")
                 and item.get("size") == total
-                and remote_hash == expected_quickxor_hash
+                and remote_hash == expected_final_quickxor_hash
             ):
                 return item
             last_error = _UploadError(
@@ -425,7 +457,7 @@ def _completed_upload_item(
             last_error = exc
             if not _is_retriable_upload_error(exc):
                 break
-        if attempt < _UPLOAD_CHUNK_MAX_ATTEMPTS:
+        if attempt < _UPLOAD_COMPLETION_MAX_ATTEMPTS:
             time.sleep(_upload_retry_delay(last_error, attempt))
     raise _UploadError(
         "OneDrive upload completed ambiguously and could not be confirmed"
@@ -439,12 +471,12 @@ def _reconcile_upload_progress(
     start: int,
     end: int,
     total: int,
-    expected_quickxor_hash: str,
+    expected_final_quickxor_hash: str,
 ) -> tuple[int, dict[str, Any] | None]:
     """Return the first missing byte offset, plus a confirmed final item."""
     last_error: BaseException | None = None
     completed = False
-    for attempt in range(1, _UPLOAD_CHUNK_MAX_ATTEMPTS + 1):
+    for attempt in range(1, _UPLOAD_RECONCILE_MAX_ATTEMPTS + 1):
         try:
             response = http.get(upload_url, timeout=DEFAULT_TIMEOUT_SECONDS)
             if response.status_code == 404:
@@ -472,7 +504,7 @@ def _reconcile_upload_progress(
                     )
                 completed = True
                 break
-            next_offset = _next_expected_upload_offset(response, total)
+            next_offset = _next_expected_upload_offset(payload, total)
             if next_offset < start:
                 raise _UploadError(
                     "OneDrive returned inconsistent upload-session progress"
@@ -495,11 +527,13 @@ def _reconcile_upload_progress(
             last_error = exc
             if not _is_retriable_upload_error(exc):
                 raise
-            if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
+            if attempt == _UPLOAD_RECONCILE_MAX_ATTEMPTS:
                 break
             time.sleep(_upload_retry_delay(exc, attempt))
     if completed:
-        return total, _completed_upload_item(remote_path, total, expected_quickxor_hash)
+        return total, _completed_upload_item(
+            remote_path, total, expected_final_quickxor_hash
+        )
     raise _UploadError(
         "Could not determine OneDrive upload-session progress"
     ) from last_error
@@ -532,7 +566,7 @@ def _graph_request(
         message = str(exc)
         if response_text:
             message = f"{message} - {response_text}"
-        raise RuntimeError(message) from exc
+        raise _GraphRequestError(message, response.status_code) from exc
 
     if raw:
         return response.content
@@ -798,7 +832,6 @@ def _upload_large_file_content(
                             upload_url,
                             data=chunk,
                             headers={
-                                "Content-Length": str(end - fragment_start),
                                 "Content-Range": (
                                     f"bytes {fragment_start}-{end - 1}/{total}"
                                 ),
@@ -840,7 +873,7 @@ def _upload_large_file_content(
                         if not _is_retriable_upload_error(reconcile_error):
                             raise
                         consecutive_failures += 1
-                        if consecutive_failures >= _UPLOAD_CHUNK_MAX_ATTEMPTS:
+                        if consecutive_failures >= _UPLOAD_FRAGMENT_MAX_ATTEMPTS:
                             raise _UploadError(
                                 "Could not determine OneDrive upload-session progress"
                             ) from reconcile_error
@@ -859,7 +892,7 @@ def _upload_large_file_content(
                             consecutive_failures = 0
                         else:
                             consecutive_failures += 1
-                            if consecutive_failures >= _UPLOAD_CHUNK_MAX_ATTEMPTS:
+                            if consecutive_failures >= _UPLOAD_FRAGMENT_MAX_ATTEMPTS:
                                 raise _UploadError(
                                     "OneDrive upload fragment made no forward progress"
                                 ) from upload_error
@@ -879,7 +912,7 @@ def _upload_large_file_content(
                     logger.warning(
                         "Retrying OneDrive upload fragment after reconciliation "
                         "(recovery cycle %s/%s, delay %.1fs)",
-                        recovery_cycles + 1,
+                        recovery_cycles,
                         _UPLOAD_CHUNK_MAX_RECOVERY_CYCLES,
                         delay,
                     )
@@ -917,6 +950,19 @@ def _upload_large_file_content(
                     break
                 start = end
         except Exception as exc:
+            cause = _request_error_cause(exc)
+            if isinstance(exc, _UploadError) or isinstance(
+                cause, requests.RequestException
+            ):
+                logger.error(
+                    "OneDrive large-file upload failed: %s",
+                    _safe_upload_error_message(exc),
+                )
+            else:
+                logger.exception(
+                    "Unexpected OneDrive large-file upload failure (%s)",
+                    type(exc).__name__,
+                )
             # No cross-call resume state is persisted. Once bounded retries
             # are exhausted, cancel the unusable session instead of leaving
             # partial data until its provider-defined expiration time.
@@ -1007,7 +1053,7 @@ def onedrive_get_item(path: str | None = None, item_id: str | None = None) -> st
             result = _graph_request("GET", _item_path(path))
         else:
             raise ValueError("either path or item_id is required")
-        return _success(item=result)
+        return _success(item=_caller_safe_drive_item(result))
     except Exception as e:
         logger.error("Error getting OneDrive item: %s", e)
         return _error(str(e))
@@ -1064,7 +1110,7 @@ def onedrive_upload_text_file(
         )
         if not isinstance(result, dict) or not result.get("id"):
             raise RuntimeError("OneDrive did not confirm the upload completed")
-        return _success(item=result)
+        return _success(item=_caller_safe_drive_item(result))
     except Exception as e:
         logger.error("Error uploading OneDrive text file %s: %s", file_path, e)
         return _error(str(e))
@@ -1171,9 +1217,14 @@ def onedrive_upload_file(
         if not isinstance(result, dict) or not result.get("id"):
             raise RuntimeError("OneDrive did not confirm the upload completed")
 
-        return _success(item=result)
+        return _success(item=_caller_safe_drive_item(result))
     except Exception as e:
-        logger.error("Error uploading OneDrive file %s: %s", local_file_path, e)
+        if isinstance(e, (OSError, ValueError, RuntimeError)):
+            logger.error("Error uploading OneDrive file %s: %s", local_file_path, e)
+        else:
+            logger.exception(
+                "Unexpected error uploading OneDrive file %s", local_file_path
+            )
         return _error(str(e))
 
 

--- a/src/xagent/web/tools/mcp/onedrive.py
+++ b/src/xagent/web/tools/mcp/onedrive.py
@@ -82,15 +82,17 @@ class _QuickXorHash:
         self._tail = b""
         self._length = 0
 
-    def update(self, data: bytes) -> None:
+    def update(self, data: bytes | bytearray) -> None:
         """Add bytes while reducing full 160-byte periods in C-sized blocks."""
         self._length += len(data)
         if self._tail:
             needed = self._INPUT_PERIOD_BYTES - len(self._tail)
             if len(data) < needed:
-                self._tail += data
+                self._tail += bytes(data)
                 return
-            self._column_xor ^= int.from_bytes(self._tail + data[:needed], "little")
+            self._column_xor ^= int.from_bytes(
+                self._tail + bytes(data[:needed]), "little"
+            )
             data = data[needed:]
             self._tail = b""
 
@@ -446,6 +448,10 @@ def _reconcile_upload_progress(
                 raise _UploadError(
                     "OneDrive returned inconsistent upload-session progress"
                 )
+            if next_offset > end:
+                raise _UploadError(
+                    "OneDrive returned progress beyond the submitted fragment"
+                )
             if next_offset == total and end < total:
                 raise _UploadError(
                     "OneDrive reported completion before the local final fragment"
@@ -679,11 +685,43 @@ def _upload_large_file_content(
     with requests.Session() as http:
         result: dict[str, Any] = {}
         quickxor_hash = _QuickXorHash()
+
+        def refill_fragment(
+            chunk: bytearray, fragment_start: int, next_offset: int
+        ) -> int:
+            """Drop an accepted prefix and refill a non-final fragment.
+
+            Graph can report an arbitrary missing-byte offset. Sending only
+            the old fragment's suffix could make a non-final PUT shorter than
+            the required 320 KiB multiple, so extend it back to the configured
+            chunk size while keeping only one fragment buffer resident.
+            """
+            accepted_size = next_offset - fragment_start
+            del chunk[:accepted_size]
+            new_end = min(next_offset + _UPLOAD_SESSION_CHUNK_SIZE, total)
+            extra_size = new_end - next_offset - len(chunk)
+            if extra_size:
+                extra = fh.read(extra_size)
+                if len(extra) != extra_size:
+                    raise _UploadError(
+                        f"expected to read {extra_size} bytes at offset "
+                        f"{next_offset + len(chunk)} but got {len(extra)} -- the "
+                        "local file may have changed size during upload"
+                    )
+                quickxor_hash.update(extra)
+                chunk.extend(extra)
+                if new_end == total and fh.read(1):
+                    raise _UploadError(
+                        "the local file may have changed size during upload"
+                    )
+            return new_end
+
         try:
-            for start in range(0, total, _UPLOAD_SESSION_CHUNK_SIZE):
+            start = 0
+            while start < total:
                 end = min(start + _UPLOAD_SESSION_CHUNK_SIZE, total)
                 expected_size = end - start
-                chunk = fh.read(expected_size)
+                chunk = bytearray(fh.read(expected_size))
                 if len(chunk) != expected_size:
                     # A short read here means the local file shrank out from
                     # under this upload (a concurrent rewrite/truncation, or
@@ -726,11 +764,7 @@ def _upload_large_file_content(
                     try:
                         response = http.put(
                             upload_url,
-                            data=(
-                                chunk
-                                if fragment_start == start
-                                else memoryview(chunk)[fragment_start - start :]
-                            ),
+                            data=chunk,
                             headers={
                                 "Content-Length": str(end - fragment_start),
                                 "Content-Range": (
@@ -754,8 +788,9 @@ def _upload_large_file_content(
                             if completed_item is not None:
                                 result = completed_item
                                 break
-                            if next_offset >= end:
+                            if next_offset == end:
                                 break
+                            end = refill_fragment(chunk, fragment_start, next_offset)
                             fragment_start = next_offset
                             if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
                                 raise _UploadError(
@@ -780,8 +815,9 @@ def _upload_large_file_content(
                         if completed_item is not None:
                             result = completed_item
                             break
-                        if next_offset >= end:
+                        if next_offset == end:
                             break
+                        end = refill_fragment(chunk, fragment_start, next_offset)
                         fragment_start = next_offset
                         if attempt == _UPLOAD_CHUNK_MAX_ATTEMPTS:
                             raise
@@ -803,14 +839,14 @@ def _upload_large_file_content(
                 # ever started including one.
                 if end == total:
                     if result.get("id"):
-                        continue
+                        break
                     try:
                         final_item = response.json() if response.content else {}
                     except ValueError:
                         final_item = {}
                     if isinstance(final_item, dict) and final_item.get("id"):
                         result = final_item
-                        continue
+                        break
 
                     # A 200/201 final PUT can still lose or omit its JSON
                     # driveItem response. Bind destination metadata to the
@@ -820,6 +856,8 @@ def _upload_large_file_content(
                         total,
                         quickxor_hash.base64_digest(),
                     )
+                    break
+                start = end
         except Exception as exc:
             # No cross-call resume state is persisted. Once bounded retries
             # are exhausted, cancel the unusable session instead of leaving

--- a/src/xagent/web/tools/mcp/onedrive.py
+++ b/src/xagent/web/tools/mcp/onedrive.py
@@ -737,8 +737,8 @@ def _upload_large_file_content(
         )
     except (RuntimeError, requests.RequestException) as exc:
         raise _UploadError("Could not create OneDrive upload session") from exc
-    upload_url = session.get("uploadUrl")
-    if not upload_url:
+    upload_url = session.get("uploadUrl") if isinstance(session, dict) else None
+    if not isinstance(upload_url, str) or not upload_url:
         raise RuntimeError("OneDrive did not return an upload session URL")
 
     # One Session for every chunk of this upload -- a fresh top-level

--- a/tests/web/tools/test_onedrive_mcp.py
+++ b/tests/web/tools/test_onedrive_mcp.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import json
 import os
@@ -74,6 +75,26 @@ def _quickxor_hash(data: bytes, *split_points: int) -> str:
     return digest.base64_digest()
 
 
+def _microsoft_quickxor_reference(data: bytes) -> str:
+    """Direct oracle from Microsoft's published rotate/XOR pseudocode.
+
+    This intentionally uses one 160-bit rotation per input byte instead of
+    production's optimized 160-byte period folding:
+    https://learn.microsoft.com/onedrive/developer/code-snippets/quickxorhash
+    """
+    width = 160
+    mask = (1 << width) - 1
+    value = 0
+    for index, byte in enumerate(data):
+        shift = (index * 11) % width
+        rotated = byte if shift == 0 else ((byte << shift) | (byte >> (width - shift)))
+        value ^= rotated & mask
+    digest = bytearray(value.to_bytes(20, "little"))
+    for index, byte in enumerate(len(data).to_bytes(8, "little")):
+        digest[12 + index] ^= byte
+    return base64.b64encode(digest).decode("ascii")
+
+
 @pytest.fixture(autouse=True)
 def _credentials(monkeypatch):
     monkeypatch.setenv("AUTH_TOKEN", "test-graph-token")
@@ -97,11 +118,23 @@ def _upload_allowed_dirs_env(tmp_path, monkeypatch):
 
 
 def test_quickxor_hash_matches_microsoft_reference_vector_across_updates():
+    # Values generated from Microsoft's published per-byte 160-bit rotate/XOR
+    # reference algorithm, rather than from the implementation under test.
     assert _quickxor_hash(b"hello world", 1, 5, 9) == ("aCgDG9jwBhDc4Q1yawMZAAAAAAA=")
+    assert _quickxor_hash(bytes(range(21)), 7, 19, 20) == (
+        "4AmQiIZEpkIZ4AAIXYACFsCABjg="
+    )
     periodic_data = bytes(range(256)) * 2
     assert _quickxor_hash(periodic_data, 7, 159, 160, 161, 333) == (
-        "t7kynSnMaX7wgx9UoAAVqMCMZjg="
+        "edJlP68QDhntUYpkxf/vpP5uDuY="
     )
+
+
+@pytest.mark.parametrize("size", [21, 159, 160, 161, 512, 4097])
+def test_quickxor_hash_matches_independent_microsoft_algorithm(size):
+    data = bytes((index * 37 + 11) % 256 for index in range(size))
+    split_points = tuple(point for point in (13, 157, 401) if point < size)
+    assert _quickxor_hash(data, *split_points) == _microsoft_quickxor_reference(data)
 
 
 @pytest.mark.asyncio
@@ -1064,6 +1097,77 @@ def test_upload_large_file_content_advances_when_server_has_fragment(
     mock_delete.assert_not_called()
 
 
+def test_upload_large_file_content_resumes_inside_ambiguous_fragment(monkeypatch):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    partial_offset = 320 * 1024
+    total_size = chunk_size + 10
+    content = b"a" * partial_offset + b"b" * (total_size - partial_offset)
+    fh = io.BytesIO(content)
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_put = Mock(
+        side_effect=[
+            requests.ConnectionError("response lost"),
+            MockResponse({}, status_code=202),
+            MockResponse({"id": "item-1"}, status_code=201),
+        ]
+    )
+    mock_get = Mock(
+        return_value=MockResponse({"nextExpectedRanges": [f"{partial_offset}-"]})
+    )
+    _patch_session(monkeypatch, _FakeSession(put=mock_put, get=mock_get))
+
+    result = onedrive._upload_large_file_content(
+        "big.bin", fh, total_size, "application/octet-stream"
+    )
+
+    assert result == {"id": "item-1"}
+    resumed = mock_put.call_args_list[1].kwargs
+    assert resumed["headers"]["Content-Range"] == (
+        f"bytes {partial_offset}-{chunk_size - 1}/{total_size}"
+    )
+    assert resumed["headers"]["Content-Length"] == str(chunk_size - partial_offset)
+    assert bytes(resumed["data"]) == content[partial_offset:chunk_size]
+
+
+def test_upload_large_file_content_retries_transient_reconciliation_get(monkeypatch):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 10
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_put = Mock(
+        side_effect=[
+            requests.ConnectionError("response lost"),
+            MockResponse({}, status_code=202),
+            MockResponse({"id": "item-1"}, status_code=201),
+        ]
+    )
+    mock_get = Mock(
+        side_effect=[
+            MockResponse({}, status_code=503),
+            MockResponse({"nextExpectedRanges": ["0-"]}),
+        ]
+    )
+    _patch_session(monkeypatch, _FakeSession(put=mock_put, get=mock_get))
+
+    result = onedrive._upload_large_file_content(
+        "big.bin",
+        io.BytesIO(b"\x00" * total_size),
+        total_size,
+        "application/octet-stream",
+    )
+
+    assert result == {"id": "item-1"}
+    assert mock_get.call_count == 2
+    assert mock_put.call_count == 3
+
+
 def test_upload_large_file_content_confirms_lost_final_response(monkeypatch):
     chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
     total_size = chunk_size + 10
@@ -1110,6 +1214,48 @@ def test_upload_large_file_content_confirms_lost_final_response(monkeypatch):
     }
     assert graph_request.call_count == 2
     mock_delete.assert_not_called()
+
+
+def test_upload_large_file_content_treats_empty_ranges_as_final_completion(
+    monkeypatch,
+):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 10
+    content = b"\x00" * total_size
+    expected_hash = _quickxor_hash(content)
+    graph_request = Mock(
+        side_effect=[
+            MockResponse({"uploadUrl": "https://upload.example/s"}),
+            MockResponse(
+                {
+                    "id": "item-1",
+                    "size": total_size,
+                    "file": {"hashes": {"quickXorHash": expected_hash}},
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(onedrive.requests, "request", graph_request)
+    mock_get = Mock(return_value=MockResponse({"nextExpectedRanges": []}))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(
+            put=Mock(
+                side_effect=[
+                    MockResponse({}, status_code=202),
+                    requests.ConnectionError("final response lost"),
+                ]
+            ),
+            get=mock_get,
+        ),
+    )
+
+    result = onedrive._upload_large_file_content(
+        "big.bin", io.BytesIO(content), total_size, "application/octet-stream"
+    )
+
+    assert result["id"] == "item-1"
+    mock_get.assert_called_once()
 
 
 def test_upload_large_file_content_rejects_same_size_concurrent_item(
@@ -1160,6 +1306,17 @@ def test_upload_large_file_content_rejects_same_size_concurrent_item(
     mock_delete.assert_called_once()
 
 
+def test_completed_upload_item_handles_null_file_facet(monkeypatch):
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"id": "item-1", "size": 123, "file": None})),
+    )
+
+    with pytest.raises(onedrive._UploadError, match="could not be confirmed"):
+        onedrive._completed_upload_item("big.bin", 123, "expected-hash")
+
+
 def test_upload_large_file_content_honors_bounded_retry_after(monkeypatch):
     total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
     fh = io.BytesIO(b"\x00" * total_size)
@@ -1181,6 +1338,14 @@ def test_upload_large_file_content_honors_bounded_retry_after(monkeypatch):
     )
 
     onedrive.time.sleep.assert_called_once_with(onedrive._UPLOAD_RETRY_MAX_SECONDS)
+
+
+def test_upload_retry_delay_accepts_http_date(monkeypatch):
+    monkeypatch.setattr(onedrive.time, "time", Mock(return_value=0.0))
+
+    assert onedrive._retry_delay(
+        {"Retry-After": "Thu, 01 Jan 1970 00:00:07 GMT"}, 1
+    ) == pytest.approx(7.0)
 
 
 def test_upload_large_file_content_still_cancels_on_a_non_retriable_failure(
@@ -1376,6 +1541,24 @@ def test_upload_large_file_content_retries_nested_metadata_failure(monkeypatch):
     onedrive.time.sleep.assert_called_once()
 
 
+def test_reconcile_exhaustion_preserves_retriable_cause(monkeypatch):
+    response = MockResponse({}, status_code=503)
+    http = _FakeSession(get=Mock(return_value=response))
+
+    with pytest.raises(onedrive._UploadError) as exc_info:
+        onedrive._reconcile_upload_progress(
+            http,
+            "https://upload.example/s",
+            "big.bin",
+            0,
+            onedrive._UPLOAD_SESSION_CHUNK_SIZE,
+            onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10,
+            "unused-hash",
+        )
+
+    assert onedrive._is_retriable_upload_error(exc_info.value)
+
+
 def test_upload_large_file_content_retries_unaccepted_final_202(monkeypatch):
     chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
     total_size = chunk_size + 10
@@ -1388,7 +1571,7 @@ def test_upload_large_file_content_retries_unaccepted_final_202(monkeypatch):
     mock_put = Mock(
         side_effect=[
             MockResponse({}, status_code=202),
-            MockResponse({}, status_code=202),
+            MockResponse({}, status_code=202, headers={"Retry-After": "999"}),
             MockResponse({"id": "item-1"}, status_code=201),
         ]
     )
@@ -1404,6 +1587,7 @@ def test_upload_large_file_content_retries_unaccepted_final_202(monkeypatch):
     assert result == {"id": "item-1"}
     assert mock_put.call_count == 3
     mock_get.assert_called_once()
+    onedrive.time.sleep.assert_called_once_with(onedrive._UPLOAD_RETRY_MAX_SECONDS)
 
 
 def test_upload_large_file_content_rejects_short_chunk_read(monkeypatch):
@@ -1794,6 +1978,34 @@ def test_upload_file_raises_when_upload_session_has_no_url(
 
     assert result["status"] == "error"
     assert "upload session" in result["message"]
+
+
+def test_upload_file_sanitizes_upload_session_creation_failure(
+    monkeypatch, _upload_allowed_dirs_env, caplog
+):
+    local_file = _upload_allowed_dirs_env / "big.bin"
+    local_file.write_bytes(b"\x01" * (onedrive._UPLOAD_SESSION_CHUNK_SIZE + 1))
+    secret = "provider-internal-secret"
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                {"error": {"message": secret}},
+                status_code=500,
+                content=f'{{"error":{{"message":"{secret}"}}}}'.encode(),
+            )
+        ),
+    )
+
+    with caplog.at_level("ERROR"):
+        result = json.loads(onedrive.onedrive_upload_file(str(local_file)))
+
+    assert result == {
+        "status": "error",
+        "message": "Could not create OneDrive upload session",
+    }
+    assert secret not in caplog.text
 
 
 def test_upload_file_rejects_path_outside_allowed_directories(

--- a/tests/web/tools/test_onedrive_mcp.py
+++ b/tests/web/tools/test_onedrive_mcp.py
@@ -12,12 +12,14 @@ from xagent.web.tools.mcp import onedrive
 
 class MockResponse:
     def __init__(
-        self, json_data=None, status_code=200, content=b"{}", url=None, headers=None
+        self, json_data=None, status_code=200, content=None, url=None, headers=None
     ):
         self._json_data = json_data if json_data is not None else {}
         self.status_code = status_code
-        self.content = content
-        self.text = content.decode("utf-8", errors="replace")
+        self.content = (
+            json.dumps(self._json_data).encode("utf-8") if content is None else content
+        )
+        self.text = self.content.decode("utf-8", errors="replace")
         # Real requests.HTTPError messages embed the request URL (e.g.
         # "500 Server Error: ... for url: https://...") -- defaulting this
         # to a URL-shaped string rather than leaving it out entirely means
@@ -190,6 +192,32 @@ def test_upload_file_sends_real_binary_content(monkeypatch, _upload_allowed_dirs
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     )
     assert kwargs["timeout"] == onedrive._BINARY_UPLOAD_TIMEOUT_SECONDS
+
+
+def test_upload_file_does_not_return_preauthenticated_download_url(
+    monkeypatch, _upload_allowed_dirs_env
+):
+    local_file = _upload_allowed_dirs_env / "report.txt"
+    local_file.write_bytes(b"content")
+    download_url = "https://download.example/file?tempauth=secret"
+    drive_item = {
+        "id": "item-1",
+        "name": "report.txt",
+        "@microsoft.graph.downloadUrl": download_url,
+    }
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse(drive_item)),
+    )
+
+    result = json.loads(onedrive.onedrive_upload_file(str(local_file)))
+
+    assert result == {
+        "status": "success",
+        "item": {"id": "item-1", "name": "report.txt"},
+    }
+    assert drive_item["@microsoft.graph.downloadUrl"] == download_url
 
 
 def test_upload_file_accepts_explicit_remote_path_and_mime_type(
@@ -1037,13 +1065,14 @@ def test_upload_large_file_content_retries_then_cancels_transient_http_failure(
     )
 
     with caplog.at_level("WARNING"):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as exc_info:
             onedrive._upload_large_file_content(
                 "big.bin", fh, total_size, "application/octet-stream"
             )
 
-    assert mock_put.call_count == onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS
-    assert onedrive.time.sleep.call_count == onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS - 1
+    assert f"last HTTP status {status_code}" in str(exc_info.value)
+    assert mock_put.call_count == onedrive._UPLOAD_FRAGMENT_MAX_ATTEMPTS
+    assert onedrive.time.sleep.call_count == onedrive._UPLOAD_FRAGMENT_MAX_ATTEMPTS - 1
     mock_delete.assert_called_once()
     assert "Retrying OneDrive upload fragment" in caplog.text
 
@@ -1073,7 +1102,7 @@ def test_upload_large_file_content_retries_then_cancels_network_failure(
                 "big.bin", fh, total_size, "application/octet-stream"
             )
 
-    assert mock_put.call_count == onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS
+    assert mock_put.call_count == onedrive._UPLOAD_FRAGMENT_MAX_ATTEMPTS
     mock_delete.assert_called_once()
 
 
@@ -1193,7 +1222,7 @@ def test_upload_large_file_content_resumes_inside_ambiguous_fragment(monkeypatch
     assert resumed["headers"]["Content-Range"] == (
         f"bytes {partial_offset}-{partial_offset + chunk_size - 1}/{total_size}"
     )
-    assert resumed["headers"]["Content-Length"] == str(chunk_size)
+    assert "Content-Length" not in resumed["headers"]
     assert (
         bytes(resumed["data"]) == content[partial_offset : partial_offset + chunk_size]
     )
@@ -1256,7 +1285,7 @@ def test_upload_large_file_content_retries_put_after_reconcile_exhaustion(monkey
     mock_get = Mock(
         side_effect=[
             MockResponse({}, status_code=503)
-            for _ in range(onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS)
+            for _ in range(onedrive._UPLOAD_RECONCILE_MAX_ATTEMPTS)
         ]
     )
     _patch_session(monkeypatch, _FakeSession(put=mock_put, get=mock_get))
@@ -1270,7 +1299,7 @@ def test_upload_large_file_content_retries_put_after_reconcile_exhaustion(monkey
 
     assert result == {"id": "item-1"}
     assert mock_put.call_count == 3
-    assert mock_get.call_count == onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS
+    assert mock_get.call_count == onedrive._UPLOAD_RECONCILE_MAX_ATTEMPTS
 
 
 def test_upload_large_file_content_resets_failures_after_forward_progress(monkeypatch):
@@ -1313,6 +1342,40 @@ def test_upload_large_file_content_resets_failures_after_forward_progress(monkey
     assert mock_get.call_count == len(partial_offsets)
     assert mock_put.call_count == 6
     mock_delete.assert_not_called()
+
+
+def test_upload_large_file_content_bounds_repeated_dribbling_progress(monkeypatch):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = 2 * chunk_size
+    offsets = list(range(1, onedrive._UPLOAD_CHUNK_MAX_RECOVERY_CYCLES + 1))
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_put = Mock(side_effect=requests.ConnectionError("response lost"))
+    mock_get = Mock(
+        side_effect=[
+            MockResponse({"nextExpectedRanges": [f"{offset}-"]}) for offset in offsets
+        ]
+    )
+    mock_delete = Mock(return_value=MockResponse({}, status_code=204))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(put=mock_put, get=mock_get, delete=mock_delete),
+    )
+
+    with pytest.raises(RuntimeError, match="exceeded its recovery budget"):
+        onedrive._upload_large_file_content(
+            "big.bin",
+            io.BytesIO(b"\x00" * total_size),
+            total_size,
+            "application/octet-stream",
+        )
+
+    assert mock_put.call_count == onedrive._UPLOAD_CHUNK_MAX_RECOVERY_CYCLES
+    assert mock_get.call_count == onedrive._UPLOAD_CHUNK_MAX_RECOVERY_CYCLES
+    mock_delete.assert_called_once()
 
 
 def test_upload_large_file_content_confirms_lost_final_response(monkeypatch):
@@ -1405,7 +1468,9 @@ def test_upload_large_file_content_treats_empty_ranges_as_final_completion(
     mock_get.assert_called_once()
 
 
-def test_upload_large_file_content_accepts_completed_item_from_status_get(monkeypatch):
+def test_upload_large_file_content_recognizes_completed_status_then_verifies_destination(
+    monkeypatch,
+):
     chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
     total_size = chunk_size + 10
     content = b"\x00" * total_size
@@ -1425,7 +1490,8 @@ def test_upload_large_file_content_accepts_completed_item_from_status_get(monkey
             ]
         ),
     )
-    mock_get = Mock(return_value=MockResponse(completed_item, status_code=200))
+    status_item = {"id": "status-item-proves-session-complete"}
+    mock_get = Mock(return_value=MockResponse(status_item, status_code=200))
     _patch_session(
         monkeypatch,
         _FakeSession(
@@ -1512,7 +1578,7 @@ def test_upload_large_file_content_rejects_same_size_concurrent_item(
                 MockResponse({"uploadUrl": "https://upload.example/s"}),
                 *[
                     MockResponse(concurrent_item)
-                    for _ in range(onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS)
+                    for _ in range(onedrive._UPLOAD_COMPLETION_MAX_ATTEMPTS)
                 ],
             ]
         ),
@@ -1549,6 +1615,27 @@ def test_completed_upload_item_handles_null_file_facet(monkeypatch):
 
     with pytest.raises(onedrive._UploadError, match="could not be confirmed"):
         onedrive._completed_upload_item("big.bin", 123, "expected-hash")
+
+
+def test_completed_upload_item_waits_for_delayed_quickxor_hash(monkeypatch):
+    expected_hash = "expected-hash"
+    item_without_hash = {"id": "item-1", "size": 123, "file": {"hashes": {}}}
+    completed_item = {
+        "id": "item-1",
+        "size": 123,
+        "file": {"hashes": {"quickXorHash": expected_hash}},
+    }
+    mock_request = Mock(
+        side_effect=[MockResponse(item_without_hash) for _ in range(3)]
+        + [MockResponse(completed_item)]
+    )
+    monkeypatch.setattr(onedrive.requests, "request", mock_request)
+
+    assert (
+        onedrive._completed_upload_item("big.bin", 123, expected_hash) == completed_item
+    )
+    assert mock_request.call_count == 4
+    assert onedrive.time.sleep.call_count == 3
 
 
 def test_upload_large_file_content_honors_bounded_retry_after(monkeypatch):
@@ -1833,6 +1920,76 @@ def test_reconcile_rejects_progress_beyond_submitted_fragment():
             2 * chunk_size,
             "unused-hash",
         )
+
+
+def test_reconcile_rejects_disappeared_non_final_session():
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    http = _FakeSession(get=Mock(return_value=MockResponse({}, status_code=404)))
+
+    with pytest.raises(onedrive._UploadError, match="disappeared before completion"):
+        onedrive._reconcile_upload_progress(
+            http,
+            "https://upload.example/s",
+            "big.bin",
+            0,
+            chunk_size,
+            2 * chunk_size,
+            "unused-hash",
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"nextExpectedRanges": "0-"},
+        {"nextExpectedRanges": ["not-a-range"]},
+        {"nextExpectedRanges": ["999-"]},
+    ],
+)
+def test_reconcile_rejects_invalid_progress(payload):
+    http = _FakeSession(get=Mock(return_value=MockResponse(payload)))
+
+    with pytest.raises(onedrive._UploadError, match="invalid upload-session progress"):
+        onedrive._reconcile_upload_progress(
+            http,
+            "https://upload.example/s",
+            "big.bin",
+            0,
+            100,
+            200,
+            "unused-hash",
+        )
+
+
+def test_reconcile_rejects_progress_behind_submitted_fragment():
+    http = _FakeSession(
+        get=Mock(return_value=MockResponse({"nextExpectedRanges": ["50-"]}))
+    )
+
+    with pytest.raises(onedrive._UploadError, match="inconsistent.*progress"):
+        onedrive._reconcile_upload_progress(
+            http,
+            "https://upload.example/s",
+            "big.bin",
+            100,
+            200,
+            300,
+            "unused-hash",
+        )
+
+
+def test_current_upload_item_wraps_request_failure(monkeypatch):
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(side_effect=requests.ConnectionError("network unavailable")),
+    )
+
+    with pytest.raises(onedrive._UploadError, match="Could not inspect") as exc_info:
+        onedrive._current_upload_item("big.bin")
+
+    assert isinstance(exc_info.value.__cause__, requests.ConnectionError)
 
 
 def test_upload_large_file_content_retries_unaccepted_final_202(monkeypatch):

--- a/tests/web/tools/test_onedrive_mcp.py
+++ b/tests/web/tools/test_onedrive_mcp.py
@@ -1099,8 +1099,11 @@ def test_upload_large_file_content_advances_when_server_has_fragment(
 
 def test_upload_large_file_content_resumes_inside_ambiguous_fragment(monkeypatch):
     chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
-    partial_offset = 320 * 1024
-    total_size = chunk_size + 10
+    # Graph explicitly says nextExpectedRanges need not use the client's
+    # fragment boundaries. Choose an unaligned offset so this test catches a
+    # retry that sends only the old suffix (an invalid non-final fragment).
+    partial_offset = 12_345
+    total_size = 2 * chunk_size + 10
     content = b"a" * partial_offset + b"b" * (total_size - partial_offset)
     fh = io.BytesIO(content)
     monkeypatch.setattr(
@@ -1127,10 +1130,16 @@ def test_upload_large_file_content_resumes_inside_ambiguous_fragment(monkeypatch
     assert result == {"id": "item-1"}
     resumed = mock_put.call_args_list[1].kwargs
     assert resumed["headers"]["Content-Range"] == (
-        f"bytes {partial_offset}-{chunk_size - 1}/{total_size}"
+        f"bytes {partial_offset}-{partial_offset + chunk_size - 1}/{total_size}"
     )
-    assert resumed["headers"]["Content-Length"] == str(chunk_size - partial_offset)
-    assert bytes(resumed["data"]) == content[partial_offset:chunk_size]
+    assert resumed["headers"]["Content-Length"] == str(chunk_size)
+    assert (
+        bytes(resumed["data"]) == content[partial_offset : partial_offset + chunk_size]
+    )
+    final = mock_put.call_args_list[2].kwargs
+    assert final["headers"]["Content-Range"] == (
+        f"bytes {partial_offset + chunk_size}-{total_size - 1}/{total_size}"
+    )
 
 
 def test_upload_large_file_content_retries_transient_reconciliation_get(monkeypatch):
@@ -1557,6 +1566,28 @@ def test_reconcile_exhaustion_preserves_retriable_cause(monkeypatch):
         )
 
     assert onedrive._is_retriable_upload_error(exc_info.value)
+
+
+def test_reconcile_rejects_progress_beyond_submitted_fragment():
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    http = _FakeSession(
+        get=Mock(
+            return_value=MockResponse({"nextExpectedRanges": [f"{chunk_size + 1}-"]})
+        )
+    )
+
+    with pytest.raises(
+        onedrive._UploadError, match="progress beyond the submitted fragment"
+    ):
+        onedrive._reconcile_upload_progress(
+            http,
+            "https://upload.example/s",
+            "big.bin",
+            0,
+            chunk_size,
+            2 * chunk_size,
+            "unused-hash",
+        )
 
 
 def test_upload_large_file_content_retries_unaccepted_final_202(monkeypatch):

--- a/tests/web/tools/test_onedrive_mcp.py
+++ b/tests/web/tools/test_onedrive_mcp.py
@@ -43,8 +43,13 @@ class _FakeSession:
     on its own, and mocking Session.put/.delete at the class level would
     leak between tests since the module only ever creates one Session."""
 
-    def __init__(self, put=None, delete=None):
+    def __init__(self, put=None, get=None, delete=None):
         self.put = put if put is not None else Mock(return_value=MockResponse({}))
+        self.get = (
+            get
+            if get is not None
+            else Mock(return_value=MockResponse({"nextExpectedRanges": ["0-"]}))
+        )
         self.delete = (
             delete if delete is not None else Mock(return_value=MockResponse({}))
         )
@@ -986,6 +991,154 @@ def test_upload_large_file_content_recovers_from_transient_failure(monkeypatch):
     mock_delete.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "ambiguous_result",
+    [
+        requests.ConnectionError("response lost"),
+        MockResponse({}, status_code=416),
+    ],
+)
+def test_upload_large_file_content_advances_when_server_has_fragment(
+    monkeypatch, ambiguous_result
+):
+    """A lost response or 416 is reconciled before resending the range."""
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_put = Mock(
+        side_effect=[
+            ambiguous_result,
+            MockResponse({"id": "item-1", "size": total_size}),
+        ]
+    )
+    mock_get = Mock(
+        return_value=MockResponse({"nextExpectedRanges": [f"{chunk_size}-"]})
+    )
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(put=mock_put, get=mock_get, delete=mock_delete),
+    )
+
+    result = onedrive._upload_large_file_content(
+        "big.bin", fh, total_size, "application/octet-stream"
+    )
+
+    assert result["id"] == "item-1"
+    assert mock_put.call_count == 2
+    assert (
+        mock_put.call_args_list[0]
+        .kwargs["headers"]["Content-Range"]
+        .startswith("bytes 0-")
+    )
+    assert (
+        mock_put.call_args_list[1]
+        .kwargs["headers"]["Content-Range"]
+        .startswith(f"bytes {chunk_size}-")
+    )
+    mock_get.assert_called_once_with(
+        "https://upload.example/s", timeout=onedrive.DEFAULT_TIMEOUT_SECONDS
+    )
+    mock_delete.assert_not_called()
+
+
+def test_upload_large_file_content_confirms_lost_final_response(monkeypatch):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+    graph_request = Mock(
+        side_effect=[
+            MockResponse({}),
+            MockResponse({"uploadUrl": "https://upload.example/s"}),
+            MockResponse(
+                {
+                    "id": "item-1",
+                    "name": "big.bin",
+                    "size": total_size,
+                    "eTag": "new-version",
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(onedrive.requests, "request", graph_request)
+    mock_put = Mock(
+        side_effect=[
+            MockResponse({}, status_code=202, content=b""),
+            requests.ConnectionError("final response lost"),
+        ]
+    )
+    mock_get = Mock(return_value=MockResponse({}, status_code=404))
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(put=mock_put, get=mock_get, delete=mock_delete),
+    )
+
+    result = onedrive._upload_large_file_content(
+        "big.bin", fh, total_size, "application/octet-stream"
+    )
+
+    assert result == {
+        "id": "item-1",
+        "name": "big.bin",
+        "size": total_size,
+        "eTag": "new-version",
+    }
+    assert graph_request.call_count == 3
+    mock_delete.assert_not_called()
+
+
+def test_upload_large_file_content_does_not_mistake_old_item_for_completion(
+    monkeypatch,
+):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+    old_item = {
+        "id": "existing-item",
+        "name": "big.bin",
+        "size": total_size,
+        "eTag": "unchanged-version",
+    }
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(
+            side_effect=[
+                MockResponse(old_item),
+                MockResponse({"uploadUrl": "https://upload.example/s"}),
+                MockResponse(old_item),
+            ]
+        ),
+    )
+    mock_delete = Mock(return_value=MockResponse({}, status_code=404))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(
+            put=Mock(
+                side_effect=[
+                    MockResponse({}, status_code=202, content=b""),
+                    requests.ConnectionError("final response lost"),
+                ]
+            ),
+            get=Mock(return_value=MockResponse({}, status_code=404)),
+            delete=mock_delete,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="could not be confirmed"):
+        onedrive._upload_large_file_content(
+            "big.bin", fh, total_size, "application/octet-stream"
+        )
+
+    mock_delete.assert_called_once()
+
+
 def test_upload_large_file_content_honors_bounded_retry_after(monkeypatch):
     total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
     fh = io.BytesIO(b"\x00" * total_size)
@@ -1059,21 +1212,22 @@ def test_upload_large_file_content_fails_on_a_non_first_chunk(monkeypatch):
         status_code=416,
         content=b'{"error": {"message": "range conflict"}}',
     )
-    mock_put = Mock(
-        side_effect=[
-            MockResponse({}, content=b""),  # chunk 1 succeeds
-            error_response,  # chunk 2 fails
-        ]
+    mock_put = Mock(side_effect=[MockResponse({}, content=b"")] + [error_response] * 3)
+    mock_get = Mock(
+        return_value=MockResponse({"nextExpectedRanges": [f"{chunk_size}-"]})
     )
     mock_delete = Mock(return_value=MockResponse({}))
-    _patch_session(monkeypatch, _FakeSession(put=mock_put, delete=mock_delete))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(put=mock_put, get=mock_get, delete=mock_delete),
+    )
 
     with pytest.raises(RuntimeError, match="HTTP 416"):
         onedrive._upload_large_file_content(
             "big.bin", fh, total_size, "application/octet-stream"
         )
 
-    assert mock_put.call_count == 2
+    assert mock_put.call_count == 4
     mock_delete.assert_called_once()
 
 
@@ -1181,6 +1335,29 @@ def test_upload_large_file_content_rejects_short_chunk_read(monkeypatch):
 
     # Must fail before ever sending the short chunk to Graph.
     mock_put.assert_not_called()
+
+
+def test_upload_large_file_content_rejects_growth_before_final_chunk(monkeypatch):
+    """The final over-read catches bytes appended after the size snapshot."""
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    snapshotted_size = chunk_size + 100
+    fh = io.BytesIO(b"\x00" * (snapshotted_size + 1))
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_put = Mock(return_value=MockResponse({}, status_code=202, content=b""))
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(monkeypatch, _FakeSession(put=mock_put, delete=mock_delete))
+
+    with pytest.raises(RuntimeError, match="changed size during upload"):
+        onedrive._upload_large_file_content(
+            "big.bin", fh, snapshotted_size, "application/octet-stream"
+        )
+
+    assert mock_put.call_count == 1
+    mock_delete.assert_called_once()
 
 
 def test_simple_upload_max_bytes_is_at_or_below_graphs_4mb_limit():

--- a/tests/web/tools/test_onedrive_mcp.py
+++ b/tests/web/tools/test_onedrive_mcp.py
@@ -65,6 +65,15 @@ def _patch_session(monkeypatch, fake_session):
     monkeypatch.setattr(onedrive.requests, "Session", Mock(return_value=fake_session))
 
 
+def _quickxor_hash(data: bytes, *split_points: int) -> str:
+    digest = onedrive._QuickXorHash()
+    start = 0
+    for end in (*split_points, len(data)):
+        digest.update(data[start:end])
+        start = end
+    return digest.base64_digest()
+
+
 @pytest.fixture(autouse=True)
 def _credentials(monkeypatch):
     monkeypatch.setenv("AUTH_TOKEN", "test-graph-token")
@@ -85,6 +94,14 @@ def _upload_allowed_dirs_env(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 # onedrive_upload_file
 # ---------------------------------------------------------------------------
+
+
+def test_quickxor_hash_matches_microsoft_reference_vector_across_updates():
+    assert _quickxor_hash(b"hello world", 1, 5, 9) == ("aCgDG9jwBhDc4Q1yawMZAAAAAAA=")
+    periodic_data = bytes(range(256)) * 2
+    assert _quickxor_hash(periodic_data, 7, 159, 160, 161, 333) == (
+        "t7kynSnMaX7wgx9UoAAVqMCMZjg="
+    )
 
 
 @pytest.mark.asyncio
@@ -1051,9 +1068,9 @@ def test_upload_large_file_content_confirms_lost_final_response(monkeypatch):
     chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
     total_size = chunk_size + 10
     fh = io.BytesIO(b"\x00" * total_size)
+    expected_hash = _quickxor_hash(b"\x00" * total_size)
     graph_request = Mock(
         side_effect=[
-            MockResponse({}),
             MockResponse({"uploadUrl": "https://upload.example/s"}),
             MockResponse(
                 {
@@ -1061,6 +1078,7 @@ def test_upload_large_file_content_confirms_lost_final_response(monkeypatch):
                     "name": "big.bin",
                     "size": total_size,
                     "eTag": "new-version",
+                    "file": {"hashes": {"quickXorHash": expected_hash}},
                 }
             ),
         ]
@@ -1088,31 +1106,34 @@ def test_upload_large_file_content_confirms_lost_final_response(monkeypatch):
         "name": "big.bin",
         "size": total_size,
         "eTag": "new-version",
+        "file": {"hashes": {"quickXorHash": expected_hash}},
     }
-    assert graph_request.call_count == 3
+    assert graph_request.call_count == 2
     mock_delete.assert_not_called()
 
 
-def test_upload_large_file_content_does_not_mistake_old_item_for_completion(
+def test_upload_large_file_content_rejects_same_size_concurrent_item(
     monkeypatch,
 ):
     chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
     total_size = chunk_size + 10
     fh = io.BytesIO(b"\x00" * total_size)
-    old_item = {
-        "id": "existing-item",
+    concurrent_item = {
+        "id": "concurrent-item",
         "name": "big.bin",
         "size": total_size,
-        "eTag": "unchanged-version",
+        "file": {"hashes": {"quickXorHash": _quickxor_hash(b"x" * total_size)}},
     }
     monkeypatch.setattr(
         onedrive.requests,
         "request",
         Mock(
             side_effect=[
-                MockResponse(old_item),
                 MockResponse({"uploadUrl": "https://upload.example/s"}),
-                MockResponse(old_item),
+                *[
+                    MockResponse(concurrent_item)
+                    for _ in range(onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS)
+                ],
             ]
         ),
     )
@@ -1231,16 +1252,134 @@ def test_upload_large_file_content_fails_on_a_non_first_chunk(monkeypatch):
     mock_delete.assert_called_once()
 
 
-def test_upload_large_file_content_raises_when_final_response_has_no_item(
+def test_upload_large_file_content_recovers_when_final_response_is_202(
     monkeypatch,
 ):
-    """Regression guard: the final chunk's response must actually carry a
-    completed driveItem before this reports success -- an unexpected 202 (or
-    any body without an "id") on what this loop computed as the last range
-    must surface as an error, not a hollow {"status": "success", "item": {}}."""
     total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
     fh = io.BytesIO(b"\x00" * total_size)
+    expected_hash = _quickxor_hash(b"\x00" * total_size)
 
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(
+            side_effect=[
+                MockResponse({"uploadUrl": "https://upload.example/s"}),
+                MockResponse(
+                    {
+                        "id": "item-1",
+                        "size": total_size,
+                        "file": {"hashes": {"quickXorHash": expected_hash}},
+                    }
+                ),
+            ]
+        ),
+    )
+    mock_put = Mock(
+        side_effect=[
+            MockResponse({}, content=b""),
+            MockResponse(
+                {"expirationDateTime": "2099-01-01T00:00:00Z"}, status_code=202
+            ),
+        ]
+    )
+    mock_get = Mock(return_value=MockResponse({}, status_code=404))
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(put=mock_put, get=mock_get, delete=mock_delete),
+    )
+
+    result = onedrive._upload_large_file_content(
+        "big.bin", fh, total_size, "application/octet-stream"
+    )
+
+    assert result["id"] == "item-1"
+    mock_get.assert_called_once()
+    mock_delete.assert_not_called()
+
+
+@pytest.mark.parametrize("final_content", [b"", b"not valid json"])
+def test_upload_large_file_content_recovers_from_missing_or_unparsable_final_response(
+    monkeypatch, final_content
+):
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+    expected_hash = _quickxor_hash(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(
+            side_effect=[
+                MockResponse({"uploadUrl": "https://upload.example/s"}),
+                MockResponse(
+                    {
+                        "id": "item-1",
+                        "size": total_size,
+                        "file": {"hashes": {"quickXorHash": expected_hash}},
+                    }
+                ),
+            ]
+        ),
+    )
+    final_response = MockResponse({}, status_code=201, content=final_content)
+    if final_content:
+        final_response.json = Mock(side_effect=ValueError("Expecting value"))
+    mock_put = Mock(side_effect=[MockResponse({}, content=b""), final_response])
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(monkeypatch, _FakeSession(put=mock_put, delete=mock_delete))
+
+    result = onedrive._upload_large_file_content(
+        "big.bin", fh, total_size, "application/octet-stream"
+    )
+
+    assert result["id"] == "item-1"
+    mock_delete.assert_not_called()
+
+
+def test_upload_large_file_content_retries_nested_metadata_failure(monkeypatch):
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    content = b"\x00" * total_size
+    fh = io.BytesIO(content)
+    expected_hash = _quickxor_hash(content)
+    transient = MockResponse({}, status_code=503)
+    graph_request = Mock(
+        side_effect=[
+            MockResponse({"uploadUrl": "https://upload.example/s"}),
+            transient,
+            MockResponse(
+                {
+                    "id": "item-1",
+                    "size": total_size,
+                    "file": {"hashes": {"quickXorHash": expected_hash}},
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(onedrive.requests, "request", graph_request)
+    malformed_final = MockResponse({}, status_code=201, content=b"not valid json")
+    malformed_final.json = Mock(side_effect=ValueError("Expecting value"))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(
+            put=Mock(side_effect=[MockResponse({}, status_code=202), malformed_final])
+        ),
+    )
+
+    result = onedrive._upload_large_file_content(
+        "big.bin", fh, total_size, "application/octet-stream"
+    )
+
+    assert result["id"] == "item-1"
+    assert graph_request.call_count == 3
+    onedrive.time.sleep.assert_called_once()
+
+
+def test_upload_large_file_content_retries_unaccepted_final_202(monkeypatch):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 10
+    fh = io.BytesIO(b"\x00" * total_size)
     monkeypatch.setattr(
         onedrive.requests,
         "request",
@@ -1248,52 +1387,23 @@ def test_upload_large_file_content_raises_when_final_response_has_no_item(
     )
     mock_put = Mock(
         side_effect=[
-            MockResponse({}, content=b""),
-            MockResponse({"expirationDateTime": "2099-01-01T00:00:00Z"}),
+            MockResponse({}, status_code=202),
+            MockResponse({}, status_code=202),
+            MockResponse({"id": "item-1"}, status_code=201),
         ]
     )
-    mock_delete = Mock(return_value=MockResponse({}))
-    _patch_session(monkeypatch, _FakeSession(put=mock_put, delete=mock_delete))
-
-    with pytest.raises(RuntimeError, match="did not confirm"):
-        onedrive._upload_large_file_content(
-            "big.bin", fh, total_size, "application/octet-stream"
-        )
-
-    # Regression guard: this validation error must go through the same
-    # cleanup path as a genuine transfer failure, not just the try/except
-    # around the HTTP call itself -- an earlier version of this check ran
-    # after the `with requests.Session()` block had already exited
-    # normally, so it never attempted to cancel the (still-incomplete, by
-    # this check's own logic) upload session.
-    mock_delete.assert_called_once()
-
-
-def test_upload_large_file_content_reports_unparsable_final_response_distinctly(
-    monkeypatch,
-):
-    """Regression guard: when every chunk PUT succeeds (no HTTPError) but the
-    final response body can't be parsed as JSON, the error must say the
-    upload itself was accepted -- distinguishing "transfer succeeded, can't
-    confirm the result" from a genuine transfer failure, since OneDrive has
-    already committed the file by this point."""
-    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
-    fh = io.BytesIO(b"\x00" * total_size)
-
-    monkeypatch.setattr(
-        onedrive.requests,
-        "request",
-        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    mock_get = Mock(
+        return_value=MockResponse({"nextExpectedRanges": [f"{chunk_size}-"]})
     )
-    malformed_final = MockResponse({}, content=b"not valid json")
-    malformed_final.json = Mock(side_effect=ValueError("Expecting value"))
-    mock_put = Mock(side_effect=[MockResponse({}, content=b""), malformed_final])
-    _patch_session(monkeypatch, _FakeSession(put=mock_put))
+    _patch_session(monkeypatch, _FakeSession(put=mock_put, get=mock_get))
 
-    with pytest.raises(RuntimeError, match="accepted the final chunk"):
-        onedrive._upload_large_file_content(
-            "big.bin", fh, total_size, "application/octet-stream"
-        )
+    result = onedrive._upload_large_file_content(
+        "big.bin", fh, total_size, "application/octet-stream"
+    )
+
+    assert result == {"id": "item-1"}
+    assert mock_put.call_count == 3
+    mock_get.assert_called_once()
 
 
 def test_upload_large_file_content_rejects_short_chunk_read(monkeypatch):

--- a/tests/web/tools/test_onedrive_mcp.py
+++ b/tests/web/tools/test_onedrive_mcp.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 from unittest.mock import Mock
@@ -14,7 +15,12 @@ class MockResponse:
         self.status_code = status_code
         self.content = content
         self.text = content.decode("utf-8", errors="replace")
-        # Match the URL-bearing shape of real requests errors.
+        # Real requests.HTTPError messages embed the request URL (e.g.
+        # "500 Server Error: ... for url: https://...") -- defaulting this
+        # to a URL-shaped string rather than leaving it out entirely means
+        # every test that triggers raise_for_status() exercises the real
+        # message shape the redaction code (_redact_upload_url) was written
+        # to handle, not a synthetic one with no URL to redact at all.
         self.url = url or "https://upload.example/session-default"
 
     def json(self):
@@ -26,6 +32,29 @@ class MockResponse:
                 f"{self.status_code} Client Error: Error for url: {self.url}",
                 response=self,
             )
+
+
+class _FakeSession:
+    """Stand-in for requests.Session() used by _upload_large_file_content --
+    a plain Mock doesn't support the `with ... as` context-manager protocol
+    on its own, and mocking Session.put/.delete at the class level would
+    leak between tests since the module only ever creates one Session."""
+
+    def __init__(self, put=None, delete=None):
+        self.put = put if put is not None else Mock(return_value=MockResponse({}))
+        self.delete = (
+            delete if delete is not None else Mock(return_value=MockResponse({}))
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def _patch_session(monkeypatch, fake_session):
+    monkeypatch.setattr(onedrive.requests, "Session", Mock(return_value=fake_session))
 
 
 @pytest.fixture(autouse=True)
@@ -424,10 +453,697 @@ def test_path_based_tools_reject_dot_segments_end_to_end(monkeypatch, call):
     mock_request.assert_not_called()
 
 
+def test_upload_file_uses_upload_session_for_large_files(
+    monkeypatch, _upload_allowed_dirs_env
+):
+    """Files over Graph's ~4MB simple-PUT cap must go through
+    createUploadSession + chunked PUTs instead of a single content PUT."""
+    local_file = _upload_allowed_dirs_env / "big.bin"
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 10
+    # Distinguishable per-region content (not a single repeated byte) so the
+    # assertions below can catch a chunk-boundary regression in the read-
+    # from-disk path (e.g. an off-by-one that shifts bytes between chunks)
+    # that a uniform b"\x01" * total_size body would silently pass.
+    first_chunk_bytes = bytes([1]) * chunk_size
+    second_chunk_bytes = bytes([2]) * (total_size - chunk_size)
+    local_file.write_bytes(first_chunk_bytes + second_chunk_bytes)
+
+    mock_request = Mock(
+        return_value=MockResponse({"uploadUrl": "https://upload.example/session-1"})
+    )
+    monkeypatch.setattr(onedrive.requests, "request", mock_request)
+
+    mock_put = Mock(
+        side_effect=[
+            MockResponse({}, content=b""),
+            MockResponse({"id": "item-1", "name": "big.bin"}),
+        ]
+    )
+    _patch_session(monkeypatch, _FakeSession(put=mock_put))
+
+    result = json.loads(
+        onedrive.onedrive_upload_file(str(local_file), mime_type="application/x-custom")
+    )
+
+    assert result["status"] == "success"
+    assert result["item"]["id"] == "item-1"
+
+    session_call = mock_request.call_args
+    assert session_call.kwargs["method"] == "POST"
+    assert session_call.kwargs["url"].endswith(
+        "/me/drive/root:/big.bin:/createUploadSession"
+    )
+    assert session_call.kwargs["json"] == {
+        "item": {"@microsoft.graph.conflictBehavior": "replace"}
+    }
+
+    assert mock_put.call_count == 2
+    first_call, second_call = mock_put.call_args_list
+    assert first_call.args[0] == "https://upload.example/session-1"
+    assert first_call.kwargs["data"] == first_chunk_bytes
+    assert second_call.kwargs["data"] == second_chunk_bytes
+    assert first_call.kwargs["headers"]["Content-Range"] == (
+        f"bytes 0-{chunk_size - 1}/{total_size}"
+    )
+    assert second_call.kwargs["headers"]["Content-Range"] == (
+        f"bytes {chunk_size}-{total_size - 1}/{total_size}"
+    )
+    # The explicit mime_type must reach every chunk, not just the simple-PUT
+    # branch — Graph doesn't document Content-Type as authoritative for the
+    # resumable path, but there's no other client-controllable lever, and
+    # sending it costs nothing.
+    assert first_call.kwargs["headers"]["Content-Type"] == "application/x-custom"
+    assert second_call.kwargs["headers"]["Content-Type"] == "application/x-custom"
+    # Chunk uploads use a longer timeout than the small-JSON-call default —
+    # a multi-megabyte PUT over a slow link can legitimately take longer
+    # than DEFAULT_TIMEOUT_SECONDS.
+    assert first_call.kwargs["timeout"] == onedrive._BINARY_UPLOAD_TIMEOUT_SECONDS
+    # The pre-authenticated upload session URL must never carry our own
+    # Authorization header alongside its own query-string token.
+    assert "Authorization" not in first_call.kwargs["headers"]
+    assert "Authorization" not in second_call.kwargs["headers"]
+
+
+def test_upload_large_file_content_reads_bounded_chunks_from_disk(monkeypatch):
+    """Regression guard for the actual production bug's efficiency half:
+    _upload_large_file_content must pull each chunk straight off the file
+    handle rather than the caller loading the whole file into memory first
+    — verified directly against the function (not through the mimetypes/
+    allowlist plumbing of onedrive_upload_file) by tracking the largest
+    single read() request it issues against a fake file object."""
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = 2 * chunk_size + 10
+    content = bytes(range(256)) * (total_size // 256 + 1)
+    content = content[:total_size]
+
+    class _TrackingBuffer(io.BytesIO):
+        max_read_size = 0
+
+        def read(self, size=-1, *a, **kw):
+            if isinstance(size, int) and size > 0:
+                type(self).max_read_size = max(type(self).max_read_size, size)
+            return super().read(size, *a, **kw)
+
+    fh = _TrackingBuffer(content)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    put_calls = []
+
+    def _fake_put(url, data, headers, timeout):
+        put_calls.append(data)
+        is_last = sum(len(d) for d in put_calls) >= total_size
+        return MockResponse(
+            {"id": "item-1"} if is_last else {}, content=b"{}" if is_last else b""
+        )
+
+    _patch_session(monkeypatch, _FakeSession(put=Mock(side_effect=_fake_put)))
+
+    result = onedrive._upload_large_file_content(
+        "big.bin", fh, total_size, "application/octet-stream"
+    )
+
+    assert result == {"id": "item-1"}
+    assert b"".join(put_calls) == content
+    assert _TrackingBuffer.max_read_size <= chunk_size
+
+
+def test_upload_large_file_content_enriches_chunk_error_with_response_body(
+    monkeypatch,
+):
+    """Regression guard: a rejected chunk must surface Graph's actual error
+    body, not a bare HTTPError with no detail — every other error path in
+    this module (via _graph_request) already does this."""
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    error_response = MockResponse(
+        {"error": {"message": "Invalid upload session"}},
+        status_code=400,
+        content=b'{"error": {"message": "Invalid upload session"}}',
+    )
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(put=Mock(return_value=error_response), delete=mock_delete),
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid upload session"):
+        onedrive._upload_large_file_content(
+            "big.bin", fh, total_size, "application/octet-stream"
+        )
+
+    # A failed upload must cancel its now-abandoned session immediately
+    # rather than leaving it for Graph's own ~15-minute expiry. The
+    # cancellation itself carries no body, so it uses the short default
+    # timeout rather than the long one sized for a multi-megabyte PUT --
+    # otherwise a stalled cleanup call would needlessly delay surfacing the
+    # real failure by up to another _BINARY_UPLOAD_TIMEOUT_SECONDS.
+    mock_delete.assert_called_once_with(
+        "https://upload.example/s", timeout=onedrive.DEFAULT_TIMEOUT_SECONDS
+    )
+
+
+def test_upload_large_file_content_never_leaks_upload_url_on_chunk_failure(
+    monkeypatch, caplog
+):
+    """Regression guard: Graph's preauthenticated upload-session URL is
+    itself usable for PUT/GET/DELETE without the OAuth bearer token, so a
+    rejected chunk must never format requests' own HTTPError (whose default
+    message embeds the full request URL) into the error the caller/LLM
+    sees or into a log line."""
+    sentinel_url = "https://upload.example/session-with-a-secret-token-abc123"
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": sentinel_url})),
+    )
+    error_response = MockResponse(
+        {"error": {"message": "range conflict"}},
+        status_code=416,
+        content=b'{"error": {"message": "range conflict"}}',
+    )
+    _patch_session(monkeypatch, _FakeSession(put=Mock(return_value=error_response)))
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError) as exc_info:
+            onedrive._upload_large_file_content(
+                "big.bin", fh, total_size, "application/octet-stream"
+            )
+
+    assert sentinel_url not in str(exc_info.value)
+    assert "range conflict" in str(exc_info.value)
+    for record in caplog.records:
+        assert sentinel_url not in record.getMessage()
+
+
+def test_upload_large_file_content_redacts_url_even_if_echoed_in_response_body(
+    monkeypatch, caplog
+):
+    """Regression guard: the redaction must not rely on the URL only ever
+    appearing in requests' own HTTPError message -- an intervening proxy
+    or WAF error page that happens to echo the request URL into the
+    response *body* must be scrubbed too, since the body is appended
+    verbatim to the raised error."""
+    sentinel_url = "https://upload.example/session-with-a-secret-token-abc123"
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": sentinel_url})),
+    )
+    waf_body = f"Blocked: request to {sentinel_url} was denied".encode()
+    error_response = MockResponse({}, status_code=403, content=waf_body)
+    _patch_session(monkeypatch, _FakeSession(put=Mock(return_value=error_response)))
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError) as exc_info:
+            onedrive._upload_large_file_content(
+                "big.bin", fh, total_size, "application/octet-stream"
+            )
+
+    assert sentinel_url not in str(exc_info.value)
+    assert "Blocked" in str(exc_info.value)
+
+
+def test_upload_large_file_content_never_leaks_upload_url_on_transport_failure(
+    monkeypatch, caplog
+):
+    """Regression guard: a chunk PUT that fails at the transport layer
+    (connection error, timeout, TLS failure) before any HTTP response
+    exists at all raises a requests exception whose own default message
+    embeds the full request URL (verified directly against a real failed
+    request) -- a sanitize step that only covers the "got a non-2xx
+    response" path would miss this entirely. Every exception the chunk
+    loop can raise must have the URL scrubbed, not just HTTPError."""
+    sentinel_url = "https://upload.example/session-with-a-secret-token-abc123"
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": sentinel_url})),
+    )
+    transport_error = requests.ConnectionError(
+        f"HTTPSConnectionPool(...): Max retries exceeded with url: "
+        f"{sentinel_url} (Caused by ...)"
+    )
+    _patch_session(monkeypatch, _FakeSession(put=Mock(side_effect=transport_error)))
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError) as exc_info:
+            onedrive._upload_large_file_content(
+                "big.bin", fh, total_size, "application/octet-stream"
+            )
+
+    assert sentinel_url not in str(exc_info.value)
+    for record in caplog.records:
+        assert sentinel_url not in record.getMessage()
+
+
+def test_upload_large_file_content_never_leaks_token_when_host_and_path_are_reported_separately(
+    monkeypatch, caplog
+):
+    """Regression guard for the real urllib3 message shape, not just a
+    synthetic one: verified directly against an actual failed request that
+    a genuine ConnectionError/SSLError never embeds "scheme://host/path?
+    query" as one contiguous string the way the test above's synthetic
+    message does -- it reports the host separately (inside
+    "HTTPSConnectionPool(host=..., port=...)") from the path+query (inside
+    "Max retries exceeded with url: /path?query"). A sanitize step built
+    around a single `message.replace(upload_url, ...)` passes the
+    synthetic-message test above while still leaking the token-bearing
+    query string here."""
+    sentinel_host = "upload.example.invalid"
+    sentinel_token = "SECRETTOKEN123"
+    sentinel_url = f"https://{sentinel_host}/session-1?token={sentinel_token}"
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": sentinel_url})),
+    )
+    transport_error = requests.ConnectionError(
+        f"HTTPSConnectionPool(host='{sentinel_host}', port=443): Max "
+        f"retries exceeded with url: /session-1?token={sentinel_token} "
+        "(Caused by SSLError(...))"
+    )
+    _patch_session(monkeypatch, _FakeSession(put=Mock(side_effect=transport_error)))
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError) as exc_info:
+            onedrive._upload_large_file_content(
+                "big.bin", fh, total_size, "application/octet-stream"
+            )
+
+    assert sentinel_token not in str(exc_info.value)
+    assert sentinel_host not in str(exc_info.value)
+    for record in caplog.records:
+        assert sentinel_token not in record.getMessage()
+        assert sentinel_host not in record.getMessage()
+
+
+def test_upload_large_file_content_treats_cleanup_404_as_fine(monkeypatch, caplog):
+    """Regression guard: a 404 on the cancellation DELETE means the session
+    is already gone (expired, or already completed/cancelled) -- exactly
+    the outcome cleanup wants, not a failure of it, so it must not warn."""
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    error_response = MockResponse(
+        {"error": {"message": "boom"}}, status_code=500, content=b'{"error": "boom"}'
+    )
+    delete_404_response = MockResponse({}, status_code=404)
+    _patch_session(
+        monkeypatch,
+        _FakeSession(
+            put=Mock(return_value=error_response),
+            delete=Mock(return_value=delete_404_response),
+        ),
+    )
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError, match="boom"):
+            onedrive._upload_large_file_content(
+                "big.bin", fh, total_size, "application/octet-stream"
+            )
+
+    assert not any(
+        "cancellation returned" in record.getMessage() for record in caplog.records
+    )
+
+
+def test_upload_large_file_content_rejects_non_positive_total(monkeypatch):
+    """Regression guard: total=0 would make `range(0, 0, chunk_size)` skip
+    the loop entirely, silently returning the empty `result` this function
+    initializes before ever running the "did OneDrive confirm this"
+    check -- not reachable through onedrive_upload_file today, but this
+    function should refuse to silently no-op if called directly."""
+    monkeypatch.setattr(onedrive.requests, "request", Mock())
+
+    with pytest.raises(ValueError, match="must be positive"):
+        onedrive._upload_large_file_content(
+            "big.bin", io.BytesIO(b""), 0, "application/octet-stream"
+        )
+
+
+def test_upload_large_file_content_warns_without_leaking_url_when_cleanup_fails(
+    monkeypatch, caplog
+):
+    """Regression guard: if the best-effort cancellation DELETE itself
+    raises (e.g. a network-level requests exception, whose own message
+    commonly embeds the request URL), the warning log must have that URL
+    scrubbed out of the logged message rather than leaking it verbatim."""
+    sentinel_url = "https://upload.example/session-with-a-secret-token-abc123"
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": sentinel_url})),
+    )
+    error_response = MockResponse({}, status_code=500, content=b"{}")
+    cleanup_error = requests.ConnectionError(f"Failed to reach {sentinel_url}")
+    _patch_session(
+        monkeypatch,
+        _FakeSession(
+            put=Mock(return_value=error_response),
+            delete=Mock(side_effect=cleanup_error),
+        ),
+    )
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError):
+            onedrive._upload_large_file_content(
+                "big.bin", fh, total_size, "application/octet-stream"
+            )
+
+    for record in caplog.records:
+        assert sentinel_url not in record.getMessage()
+        assert sentinel_url not in caplog.text
+
+
+def test_upload_large_file_content_warns_on_failed_cleanup_status(monkeypatch, caplog):
+    """Regression guard: requests doesn't raise on its own for an HTTP
+    error status -- a 429/5xx response to the cancellation DELETE must not
+    be silently treated as a successful cancellation.
+
+    Uses a 400 (non-retriable) chunk failure, not a 429/5xx -- those are
+    now treated as retriable and deliberately skip the cancellation DELETE
+    entirely (see test_upload_large_file_content_never_cancels_on_a_
+    retriable_failure), so they'd never reach the cleanup-status-check code
+    this test targets."""
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    error_response = MockResponse(
+        {"error": {"message": "boom"}}, status_code=400, content=b'{"error": "boom"}'
+    )
+    delete_failure_response = MockResponse({}, status_code=429)
+    _patch_session(
+        monkeypatch,
+        _FakeSession(
+            put=Mock(return_value=error_response),
+            delete=Mock(return_value=delete_failure_response),
+        ),
+    )
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError, match="boom"):
+            onedrive._upload_large_file_content(
+                "big.bin", fh, total_size, "application/octet-stream"
+            )
+
+    assert any("429" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.parametrize("status_code", [429, 500, 503])
+def test_upload_large_file_content_never_cancels_on_a_retriable_failure(
+    monkeypatch, caplog, status_code
+):
+    """Regression guard: a 429/5xx chunk failure might still succeed
+    against the SAME upload session on a later attempt -- actively
+    cancelling it (as every failure used to, unconditionally) destroys
+    Graph's nextExpectedRanges state for no benefit. The session should be
+    left alone (not DELETEd) for Graph's own ~15-minute expiry to handle."""
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    error_response = MockResponse({}, status_code=status_code)
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(put=Mock(return_value=error_response), delete=mock_delete),
+    )
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError):
+            onedrive._upload_large_file_content(
+                "big.bin", fh, total_size, "application/octet-stream"
+            )
+
+    mock_delete.assert_not_called()
+    assert any("not cancelled" in record.getMessage() for record in caplog.records)
+
+
+def test_upload_large_file_content_never_cancels_on_a_network_failure(
+    monkeypatch, caplog
+):
+    """Same as the HTTP-status case above, but for a transport-level
+    failure (no response was ever received at all)."""
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(
+            put=Mock(side_effect=requests.ConnectionError("boom")), delete=mock_delete
+        ),
+    )
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError):
+            onedrive._upload_large_file_content(
+                "big.bin", fh, total_size, "application/octet-stream"
+            )
+
+    mock_delete.assert_not_called()
+
+
+def test_upload_large_file_content_still_cancels_on_a_non_retriable_failure(
+    monkeypatch,
+):
+    """Complementary case: a genuine client-side rejection (not a 429/5xx,
+    not a network failure) still gets the session cancelled immediately,
+    exactly like before -- nothing about a retry against the same session
+    would fix a 400, so there's no reason to withhold the cleanup."""
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    error_response = MockResponse({}, status_code=400)
+    mock_delete = Mock(return_value=MockResponse({}, status_code=204))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(put=Mock(return_value=error_response), delete=mock_delete),
+    )
+
+    with pytest.raises(RuntimeError):
+        onedrive._upload_large_file_content(
+            "big.bin", fh, total_size, "application/octet-stream"
+        )
+
+    mock_delete.assert_called_once()
+
+
+def test_upload_large_file_content_fails_on_a_non_first_chunk(monkeypatch):
+    """Regression guard: earlier test coverage only ever failed the first
+    chunk of a session — verifying a mid-sequence failure also propagates
+    (and still triggers cleanup) catches a bug that only manifests once the
+    loop has state to lose (e.g. an exception handler scoped to the first
+    iteration only)."""
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = 3 * chunk_size
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    error_response = MockResponse(
+        {"error": {"message": "range conflict"}},
+        status_code=416,
+        content=b'{"error": {"message": "range conflict"}}',
+    )
+    mock_put = Mock(
+        side_effect=[
+            MockResponse({}, content=b""),  # chunk 1 succeeds
+            error_response,  # chunk 2 fails
+        ]
+    )
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(monkeypatch, _FakeSession(put=mock_put, delete=mock_delete))
+
+    with pytest.raises(RuntimeError, match="range conflict"):
+        onedrive._upload_large_file_content(
+            "big.bin", fh, total_size, "application/octet-stream"
+        )
+
+    assert mock_put.call_count == 2
+    mock_delete.assert_called_once()
+
+
+def test_upload_large_file_content_raises_when_final_response_has_no_item(
+    monkeypatch,
+):
+    """Regression guard: the final chunk's response must actually carry a
+    completed driveItem before this reports success -- an unexpected 202 (or
+    any body without an "id") on what this loop computed as the last range
+    must surface as an error, not a hollow {"status": "success", "item": {}}."""
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_put = Mock(
+        side_effect=[
+            MockResponse({}, content=b""),
+            MockResponse({"expirationDateTime": "2099-01-01T00:00:00Z"}),
+        ]
+    )
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(monkeypatch, _FakeSession(put=mock_put, delete=mock_delete))
+
+    with pytest.raises(RuntimeError, match="did not confirm"):
+        onedrive._upload_large_file_content(
+            "big.bin", fh, total_size, "application/octet-stream"
+        )
+
+    # Regression guard: this validation error must go through the same
+    # cleanup path as a genuine transfer failure, not just the try/except
+    # around the HTTP call itself -- an earlier version of this check ran
+    # after the `with requests.Session()` block had already exited
+    # normally, so it never attempted to cancel the (still-incomplete, by
+    # this check's own logic) upload session.
+    mock_delete.assert_called_once()
+
+
+def test_upload_large_file_content_reports_unparsable_final_response_distinctly(
+    monkeypatch,
+):
+    """Regression guard: when every chunk PUT succeeds (no HTTPError) but the
+    final response body can't be parsed as JSON, the error must say the
+    upload itself was accepted -- distinguishing "transfer succeeded, can't
+    confirm the result" from a genuine transfer failure, since OneDrive has
+    already committed the file by this point."""
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    malformed_final = MockResponse({}, content=b"not valid json")
+    malformed_final.json = Mock(side_effect=ValueError("Expecting value"))
+    mock_put = Mock(side_effect=[MockResponse({}, content=b""), malformed_final])
+    _patch_session(monkeypatch, _FakeSession(put=mock_put))
+
+    with pytest.raises(RuntimeError, match="accepted the final chunk"):
+        onedrive._upload_large_file_content(
+            "big.bin", fh, total_size, "application/octet-stream"
+        )
+
+
+def test_upload_large_file_content_rejects_short_chunk_read(monkeypatch):
+    """Regression guard: if the local file shrinks mid-upload (a concurrent
+    rewrite/truncation), a short fh.read() must fail loudly instead of
+    silently sending a Content-Length/Content-Range that doesn't match the
+    actual bytes transmitted -- which would desynchronize every later
+    chunk's byte-range accounting."""
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 100
+
+    class _ShortReadBuffer:
+        def __init__(self, data):
+            self._data = data
+            self._pos = 0
+
+        def read(self, size=-1):
+            # Always return at most half of what was asked for (but never
+            # zero, so this isn't just simulating ordinary EOF).
+            actual = max(1, size // 2) if size and size > 1 else size
+            chunk = self._data[self._pos : self._pos + actual]
+            self._pos += len(chunk)
+            return chunk
+
+    fh = _ShortReadBuffer(b"\x00" * total_size)
+
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_put = Mock(return_value=MockResponse({}, content=b""))
+    _patch_session(monkeypatch, _FakeSession(put=mock_put))
+
+    with pytest.raises(RuntimeError, match="changed size during upload"):
+        onedrive._upload_large_file_content(
+            "big.bin", fh, total_size, "application/octet-stream"
+        )
+
+    # Must fail before ever sending the short chunk to Graph.
+    mock_put.assert_not_called()
+
+
+def test_simple_upload_max_bytes_is_at_or_below_graphs_4mb_limit():
+    """Regression guard for the actual production boundary bug: Microsoft's
+    own docs disagree on the simple content PUT's real limit (the OneDrive
+    API concepts page says "4 MB", the Graph v1.0 API reference for the
+    same endpoint says "250 MB" -- see _SIMPLE_UPLOAD_MAX_BYTES's own
+    comment), and some deployments enforce the smaller figure as the
+    decimal 4,000,000 bytes rather than the binary 4 MiB (4,194,304 bytes).
+    The cutoff must stay at or below the smaller, decimal figure so a file
+    anywhere in the ambiguous gap always takes the resumable upload-session
+    path instead of ever risking rejection at the simple-PUT boundary."""
+    assert onedrive._SIMPLE_UPLOAD_MAX_BYTES <= 4_000_000
+
+
 def test_upload_file_at_exact_boundary_uses_simple_put(
     monkeypatch, _upload_allowed_dirs_env
 ):
-    """A file exactly at the size limit still uploads successfully."""
+    """Regression guard: a purely static assertion on the constant (see
+    above) can't catch a routing-condition regression like `<=` silently
+    flipped to `<` -- this exercises onedrive_upload_file itself with a
+    file sized exactly at the boundary and confirms it takes the simple-PUT
+    branch, not the upload-session one."""
     local_file = _upload_allowed_dirs_env / "at_boundary.bin"
     local_file.write_bytes(b"\x00" * onedrive._SIMPLE_UPLOAD_MAX_BYTES)
 
@@ -454,6 +1170,9 @@ def test_upload_file_bounds_the_actual_read_before_upload(
             real_file.close()
             return False
 
+        def fileno(self):
+            return real_file.fileno()
+
         def read(self, size):
             with open(local_file, "ab") as append_fh:
                 append_fh.write(b"x" * (onedrive._SIMPLE_UPLOAD_MAX_BYTES + 1))
@@ -466,9 +1185,31 @@ def test_upload_file_bounds_the_actual_read_before_upload(
     result = json.loads(onedrive.onedrive_upload_file(str(local_file)))
 
     assert result["status"] == "error"
-    assert "4 MB" in result["message"]
+    assert "grew during upload" in result["message"]
     assert local_file.stat().st_size > onedrive._SIMPLE_UPLOAD_MAX_BYTES
     mock_request.assert_not_called()
+
+
+def test_upload_file_one_byte_over_boundary_uses_upload_session(
+    monkeypatch, _upload_allowed_dirs_env
+):
+    """The complementary case to the exact-boundary test above: one byte
+    over the cutoff must take the resumable upload-session path."""
+    local_file = _upload_allowed_dirs_env / "over_boundary.bin"
+    local_file.write_bytes(b"\x00" * (onedrive._SIMPLE_UPLOAD_MAX_BYTES + 1))
+
+    mock_request = Mock(
+        return_value=MockResponse({"uploadUrl": "https://upload.example/s"})
+    )
+    monkeypatch.setattr(onedrive.requests, "request", mock_request)
+    mock_put = Mock(return_value=MockResponse({"id": "item-1"}))
+    _patch_session(monkeypatch, _FakeSession(put=mock_put))
+
+    result = json.loads(onedrive.onedrive_upload_file(str(local_file)))
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["url"].endswith("createUploadSession")
+    mock_put.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -690,6 +1431,22 @@ def test_upload_file_resolves_real_mime_type_for_ambiguous_extensions(
     assert result["status"] == "success"
     sent_headers = mock_request.call_args.kwargs["headers"]
     assert sent_headers["Content-Type"] == "video/mp2t"
+
+
+def test_upload_file_raises_when_upload_session_has_no_url(
+    monkeypatch, _upload_allowed_dirs_env
+):
+    local_file = _upload_allowed_dirs_env / "big.bin"
+    local_file.write_bytes(b"\x01" * (onedrive._UPLOAD_SESSION_CHUNK_SIZE + 1))
+
+    monkeypatch.setattr(
+        onedrive.requests, "request", Mock(return_value=MockResponse({}))
+    )
+
+    result = json.loads(onedrive.onedrive_upload_file(str(local_file)))
+
+    assert result["status"] == "error"
+    assert "upload session" in result["message"]
 
 
 def test_upload_file_rejects_path_outside_allowed_directories(
@@ -952,6 +1709,47 @@ def test_upload_file_rejects_empty_file(monkeypatch, _upload_allowed_dirs_env):
     mock_request.assert_not_called()
 
 
+def test_upload_file_rejects_file_over_max_upload_bytes(
+    monkeypatch, _upload_allowed_dirs_env
+):
+    """Regression guard: onedrive_upload_file previously had no upper size
+    bound at all (only rejected 0 bytes), so a mistargeted large file (an
+    unrelated log directory, the wrong generated artifact) would trigger
+    an unbounded chunked upload with no early feedback."""
+    local_file = _upload_allowed_dirs_env / "huge.bin"
+    local_file.write_bytes(b"x")
+
+    mock_request = Mock()
+    monkeypatch.setattr(onedrive.requests, "request", mock_request)
+    real_fstat = onedrive.os.fstat
+    fake_size = onedrive._MAX_UPLOAD_BYTES + 1
+
+    def _fake_fstat(fd):
+        real = real_fstat(fd)
+        return type(real)(
+            (
+                real.st_mode,
+                real.st_ino,
+                real.st_dev,
+                real.st_nlink,
+                real.st_uid,
+                real.st_gid,
+                fake_size,
+                real.st_atime,
+                real.st_mtime,
+                real.st_ctime,
+            )
+        )
+
+    monkeypatch.setattr(onedrive.os, "fstat", _fake_fstat)
+
+    result = json.loads(onedrive.onedrive_upload_file(str(local_file)))
+
+    assert result["status"] == "error"
+    assert "limit" in result["message"].lower()
+    mock_request.assert_not_called()
+
+
 def test_upload_file_returns_error_payload_on_api_failure(
     monkeypatch, _upload_allowed_dirs_env
 ):
@@ -1128,18 +1926,3 @@ def test_get_item_by_item_id_still_works_for_a_normal_id(monkeypatch):
 
     assert result["status"] == "success"
     assert result["item"]["id"] == "abc123"
-
-
-def test_upload_file_one_byte_over_limit_rejected_before_network(
-    monkeypatch, _upload_allowed_dirs_env
-):
-    local_file = _upload_allowed_dirs_env / "over_limit.bin"
-    local_file.write_bytes(b"x" * (onedrive._SIMPLE_UPLOAD_MAX_BYTES + 1))
-    request = Mock()
-    monkeypatch.setattr(onedrive.requests, "request", request)
-
-    result = json.loads(onedrive.onedrive_upload_file(str(local_file)))
-
-    assert result["status"] == "error"
-    assert "4,000,000-byte (4 MB) limit" in result["message"]
-    request.assert_not_called()

--- a/tests/web/tools/test_onedrive_mcp.py
+++ b/tests/web/tools/test_onedrive_mcp.py
@@ -10,7 +10,9 @@ from xagent.web.tools.mcp import onedrive
 
 
 class MockResponse:
-    def __init__(self, json_data=None, status_code=200, content=b"{}", url=None):
+    def __init__(
+        self, json_data=None, status_code=200, content=b"{}", url=None, headers=None
+    ):
         self._json_data = json_data if json_data is not None else {}
         self.status_code = status_code
         self.content = content
@@ -19,9 +21,10 @@ class MockResponse:
         # "500 Server Error: ... for url: https://...") -- defaulting this
         # to a URL-shaped string rather than leaving it out entirely means
         # every test that triggers raise_for_status() exercises the real
-        # message shape the redaction code (_redact_upload_url) was written
-        # to handle, not a synthetic one with no URL to redact at all.
+        # message shape the production code must keep out of caller-visible
+        # errors, not a synthetic one with no URL to protect at all.
         self.url = url or "https://upload.example/session-default"
+        self.headers = headers or {}
 
     def json(self):
         return self._json_data
@@ -60,6 +63,7 @@ def _patch_session(monkeypatch, fake_session):
 @pytest.fixture(autouse=True)
 def _credentials(monkeypatch):
     monkeypatch.setenv("AUTH_TOKEN", "test-graph-token")
+    monkeypatch.setattr(onedrive.time, "sleep", Mock())
 
 
 @pytest.fixture(autouse=True)
@@ -572,12 +576,11 @@ def test_upload_large_file_content_reads_bounded_chunks_from_disk(monkeypatch):
     assert _TrackingBuffer.max_read_size <= chunk_size
 
 
-def test_upload_large_file_content_enriches_chunk_error_with_response_body(
+def test_upload_large_file_content_does_not_forward_chunk_error_body(
     monkeypatch,
 ):
-    """Regression guard: a rejected chunk must surface Graph's actual error
-    body, not a bare HTTPError with no detail — every other error path in
-    this module (via _graph_request) already does this."""
+    """Upload responses can echo a preauthenticated URL in arbitrary
+    encodings, so their body must never be exposed to the caller."""
     total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
     fh = io.BytesIO(b"\x00" * total_size)
 
@@ -597,10 +600,12 @@ def test_upload_large_file_content_enriches_chunk_error_with_response_body(
         _FakeSession(put=Mock(return_value=error_response), delete=mock_delete),
     )
 
-    with pytest.raises(RuntimeError, match="Invalid upload session"):
+    with pytest.raises(RuntimeError, match="HTTP 400") as exc_info:
         onedrive._upload_large_file_content(
             "big.bin", fh, total_size, "application/octet-stream"
         )
+
+    assert "Invalid upload session" not in str(exc_info.value)
 
     # A failed upload must cancel its now-abandoned session immediately
     # rather than leaving it for Graph's own ~15-minute expiry. The
@@ -644,20 +649,25 @@ def test_upload_large_file_content_never_leaks_upload_url_on_chunk_failure(
             )
 
     assert sentinel_url not in str(exc_info.value)
-    assert "range conflict" in str(exc_info.value)
+    assert "HTTP 416" in str(exc_info.value)
     for record in caplog.records:
         assert sentinel_url not in record.getMessage()
 
 
-def test_upload_large_file_content_redacts_url_even_if_echoed_in_response_body(
-    monkeypatch, caplog
+@pytest.mark.parametrize(
+    "echoed_url",
+    [
+        "https://upload.example/session?tempauth=SECRETVALUE&foo=bar",
+        "https://upload.example/session?tempauth=SECRETVALUE&amp;foo=bar",
+        "/session?tempauth%3DSECRETVALUE%26foo%3Dbar",
+    ],
+)
+def test_upload_large_file_content_never_forwards_encoded_url_from_response_body(
+    monkeypatch, caplog, echoed_url
 ):
-    """Regression guard: the redaction must not rely on the URL only ever
-    appearing in requests' own HTTPError message -- an intervening proxy
-    or WAF error page that happens to echo the request URL into the
-    response *body* must be scrubbed too, since the body is appended
-    verbatim to the raised error."""
-    sentinel_url = "https://upload.example/session-with-a-secret-token-abc123"
+    """A proxy/WAF can echo the upload URL using encodings that defeat
+    string-replacement redaction, so the response body is discarded."""
+    sentinel_url = "https://upload.example/session?tempauth=SECRETVALUE&foo=bar"
     total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
     fh = io.BytesIO(b"\x00" * total_size)
 
@@ -666,7 +676,7 @@ def test_upload_large_file_content_redacts_url_even_if_echoed_in_response_body(
         "request",
         Mock(return_value=MockResponse({"uploadUrl": sentinel_url})),
     )
-    waf_body = f"Blocked: request to {sentinel_url} was denied".encode()
+    waf_body = f"Blocked: request to {echoed_url} was denied".encode()
     error_response = MockResponse({}, status_code=403, content=waf_body)
     _patch_session(monkeypatch, _FakeSession(put=Mock(return_value=error_response)))
 
@@ -676,8 +686,10 @@ def test_upload_large_file_content_redacts_url_even_if_echoed_in_response_body(
                 "big.bin", fh, total_size, "application/octet-stream"
             )
 
-    assert sentinel_url not in str(exc_info.value)
-    assert "Blocked" in str(exc_info.value)
+    assert "SECRETVALUE" not in str(exc_info.value)
+    assert "Blocked" not in str(exc_info.value)
+    assert "HTTP 403" in str(exc_info.value)
+    assert "SECRETVALUE" not in caplog.text
 
 
 def test_upload_large_file_content_never_leaks_upload_url_on_transport_failure(
@@ -773,23 +785,25 @@ def test_upload_large_file_content_treats_cleanup_404_as_fine(monkeypatch, caplo
         Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
     )
     error_response = MockResponse(
-        {"error": {"message": "boom"}}, status_code=500, content=b'{"error": "boom"}'
+        {"error": {"message": "boom"}}, status_code=400, content=b'{"error": "boom"}'
     )
     delete_404_response = MockResponse({}, status_code=404)
+    mock_delete = Mock(return_value=delete_404_response)
     _patch_session(
         monkeypatch,
         _FakeSession(
             put=Mock(return_value=error_response),
-            delete=Mock(return_value=delete_404_response),
+            delete=mock_delete,
         ),
     )
 
     with caplog.at_level("WARNING"):
-        with pytest.raises(RuntimeError, match="boom"):
+        with pytest.raises(RuntimeError, match="HTTP 400"):
             onedrive._upload_large_file_content(
                 "big.bin", fh, total_size, "application/octet-stream"
             )
 
+    mock_delete.assert_called_once()
     assert not any(
         "cancellation returned" in record.getMessage() for record in caplog.records
     )
@@ -825,13 +839,14 @@ def test_upload_large_file_content_warns_without_leaking_url_when_cleanup_fails(
         "request",
         Mock(return_value=MockResponse({"uploadUrl": sentinel_url})),
     )
-    error_response = MockResponse({}, status_code=500, content=b"{}")
+    error_response = MockResponse({}, status_code=400, content=b"{}")
     cleanup_error = requests.ConnectionError(f"Failed to reach {sentinel_url}")
+    mock_delete = Mock(side_effect=cleanup_error)
     _patch_session(
         monkeypatch,
         _FakeSession(
             put=Mock(return_value=error_response),
-            delete=Mock(side_effect=cleanup_error),
+            delete=mock_delete,
         ),
     )
 
@@ -844,6 +859,8 @@ def test_upload_large_file_content_warns_without_leaking_url_when_cleanup_fails(
     for record in caplog.records:
         assert sentinel_url not in record.getMessage()
         assert sentinel_url not in caplog.text
+    mock_delete.assert_called_once()
+    assert "Failed to cancel abandoned" in caplog.text
 
 
 def test_upload_large_file_content_warns_on_failed_cleanup_status(monkeypatch, caplog):
@@ -851,11 +868,7 @@ def test_upload_large_file_content_warns_on_failed_cleanup_status(monkeypatch, c
     error status -- a 429/5xx response to the cancellation DELETE must not
     be silently treated as a successful cancellation.
 
-    Uses a 400 (non-retriable) chunk failure, not a 429/5xx -- those are
-    now treated as retriable and deliberately skip the cancellation DELETE
-    entirely (see test_upload_large_file_content_never_cancels_on_a_
-    retriable_failure), so they'd never reach the cleanup-status-check code
-    this test targets."""
+    Uses a 400 chunk failure so the test reaches cleanup immediately."""
     total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
     fh = io.BytesIO(b"\x00" * total_size)
 
@@ -877,7 +890,7 @@ def test_upload_large_file_content_warns_on_failed_cleanup_status(monkeypatch, c
     )
 
     with caplog.at_level("WARNING"):
-        with pytest.raises(RuntimeError, match="boom"):
+        with pytest.raises(RuntimeError, match="HTTP 400"):
             onedrive._upload_large_file_content(
                 "big.bin", fh, total_size, "application/octet-stream"
             )
@@ -886,14 +899,11 @@ def test_upload_large_file_content_warns_on_failed_cleanup_status(monkeypatch, c
 
 
 @pytest.mark.parametrize("status_code", [429, 500, 503])
-def test_upload_large_file_content_never_cancels_on_a_retriable_failure(
+def test_upload_large_file_content_retries_then_cancels_transient_http_failure(
     monkeypatch, caplog, status_code
 ):
-    """Regression guard: a 429/5xx chunk failure might still succeed
-    against the SAME upload session on a later attempt -- actively
-    cancelling it (as every failure used to, unconditionally) destroys
-    Graph's nextExpectedRanges state for no benefit. The session should be
-    left alone (not DELETEd) for Graph's own ~15-minute expiry to handle."""
+    """Transient failures retry on the same session; an exhausted session
+    is cancelled because no cross-call resume state is persisted."""
     total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
     fh = io.BytesIO(b"\x00" * total_size)
 
@@ -903,10 +913,11 @@ def test_upload_large_file_content_never_cancels_on_a_retriable_failure(
         Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
     )
     error_response = MockResponse({}, status_code=status_code)
+    mock_put = Mock(return_value=error_response)
     mock_delete = Mock(return_value=MockResponse({}))
     _patch_session(
         monkeypatch,
-        _FakeSession(put=Mock(return_value=error_response), delete=mock_delete),
+        _FakeSession(put=mock_put, delete=mock_delete),
     )
 
     with caplog.at_level("WARNING"):
@@ -915,15 +926,16 @@ def test_upload_large_file_content_never_cancels_on_a_retriable_failure(
                 "big.bin", fh, total_size, "application/octet-stream"
             )
 
-    mock_delete.assert_not_called()
-    assert any("not cancelled" in record.getMessage() for record in caplog.records)
+    assert mock_put.call_count == onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS
+    assert onedrive.time.sleep.call_count == onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS - 1
+    mock_delete.assert_called_once()
+    assert "Retrying OneDrive upload fragment" in caplog.text
 
 
-def test_upload_large_file_content_never_cancels_on_a_network_failure(
+def test_upload_large_file_content_retries_then_cancels_network_failure(
     monkeypatch, caplog
 ):
-    """Same as the HTTP-status case above, but for a transport-level
-    failure (no response was ever received at all)."""
+    """Transport failures use the same bounded retry and cleanup path."""
     total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
     fh = io.BytesIO(b"\x00" * total_size)
 
@@ -932,12 +944,11 @@ def test_upload_large_file_content_never_cancels_on_a_network_failure(
         "request",
         Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
     )
+    mock_put = Mock(side_effect=requests.ConnectionError("boom"))
     mock_delete = Mock(return_value=MockResponse({}))
     _patch_session(
         monkeypatch,
-        _FakeSession(
-            put=Mock(side_effect=requests.ConnectionError("boom")), delete=mock_delete
-        ),
+        _FakeSession(put=mock_put, delete=mock_delete),
     )
 
     with caplog.at_level("WARNING"):
@@ -946,7 +957,56 @@ def test_upload_large_file_content_never_cancels_on_a_network_failure(
                 "big.bin", fh, total_size, "application/octet-stream"
             )
 
+    assert mock_put.call_count == onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS
+    mock_delete.assert_called_once()
+
+
+def test_upload_large_file_content_recovers_from_transient_failure(monkeypatch):
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    transient = MockResponse({}, status_code=503)
+    intermediate = MockResponse({}, status_code=202, content=b"")
+    completed = MockResponse({"id": "item-1"})
+    mock_put = Mock(side_effect=[transient, intermediate, completed])
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(monkeypatch, _FakeSession(put=mock_put, delete=mock_delete))
+
+    result = onedrive._upload_large_file_content(
+        "big.bin", fh, total_size, "application/octet-stream"
+    )
+
+    assert result == {"id": "item-1"}
+    assert mock_put.call_count == 3
+    onedrive.time.sleep.assert_called_once()
     mock_delete.assert_not_called()
+
+
+def test_upload_large_file_content_honors_bounded_retry_after(monkeypatch):
+    total_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE + 10
+    fh = io.BytesIO(b"\x00" * total_size)
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    throttled = MockResponse({}, status_code=429, headers={"Retry-After": "999"})
+    intermediate = MockResponse({}, status_code=202, content=b"")
+    completed = MockResponse({"id": "item-1"})
+    _patch_session(
+        monkeypatch,
+        _FakeSession(put=Mock(side_effect=[throttled, intermediate, completed])),
+    )
+
+    onedrive._upload_large_file_content(
+        "big.bin", fh, total_size, "application/octet-stream"
+    )
+
+    onedrive.time.sleep.assert_called_once_with(onedrive._UPLOAD_RETRY_MAX_SECONDS)
 
 
 def test_upload_large_file_content_still_cancels_on_a_non_retriable_failure(
@@ -1008,7 +1068,7 @@ def test_upload_large_file_content_fails_on_a_non_first_chunk(monkeypatch):
     mock_delete = Mock(return_value=MockResponse({}))
     _patch_session(monkeypatch, _FakeSession(put=mock_put, delete=mock_delete))
 
-    with pytest.raises(RuntimeError, match="range conflict"):
+    with pytest.raises(RuntimeError, match="HTTP 416"):
         onedrive._upload_large_file_content(
             "big.bin", fh, total_size, "application/octet-stream"
         )

--- a/tests/web/tools/test_onedrive_mcp.py
+++ b/tests/web/tools/test_onedrive_mcp.py
@@ -535,7 +535,7 @@ def test_upload_file_uses_upload_session_for_large_files(
 
     mock_put = Mock(
         side_effect=[
-            MockResponse({}, content=b""),
+            MockResponse({}, status_code=202, content=b""),
             MockResponse({"id": "item-1", "name": "big.bin"}),
         ]
     )
@@ -617,7 +617,9 @@ def test_upload_large_file_content_reads_bounded_chunks_from_disk(monkeypatch):
         put_calls.append(data)
         is_last = sum(len(d) for d in put_calls) >= total_size
         return MockResponse(
-            {"id": "item-1"} if is_last else {}, content=b"{}" if is_last else b""
+            {"id": "item-1"} if is_last else {},
+            status_code=201 if is_last else 202,
+            content=b"{}" if is_last else b"",
         )
 
     _patch_session(monkeypatch, _FakeSession(put=Mock(side_effect=_fake_put)))
@@ -659,6 +661,35 @@ def test_upload_large_file_content_handles_exact_chunk_multiple(monkeypatch):
     assert mock_put.call_args_list[-1].kwargs["headers"]["Content-Range"] == (
         f"bytes {chunk_size}-{total_size - 1}/{total_size}"
     )
+
+
+def test_upload_large_file_content_rejects_completion_before_final_fragment(
+    monkeypatch,
+):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 10
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_put = Mock(return_value=MockResponse({"id": "premature"}, status_code=201))
+    mock_delete = Mock(return_value=MockResponse({}, status_code=204))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(put=mock_put, delete=mock_delete),
+    )
+
+    with pytest.raises(RuntimeError, match="completion before the local final"):
+        onedrive._upload_large_file_content(
+            "big.bin",
+            io.BytesIO(b"\x00" * total_size),
+            total_size,
+            "application/octet-stream",
+        )
+
+    mock_put.assert_called_once()
+    mock_delete.assert_called_once()
 
 
 def test_upload_large_file_content_does_not_forward_chunk_error_body(
@@ -1616,7 +1647,10 @@ def test_upload_large_file_content_fails_on_a_non_first_chunk(monkeypatch):
         status_code=416,
         content=b'{"error": {"message": "range conflict"}}',
     )
-    mock_put = Mock(side_effect=[MockResponse({}, content=b"")] + [error_response] * 3)
+    mock_put = Mock(
+        side_effect=[MockResponse({}, status_code=202, content=b"")]
+        + [error_response] * 3
+    )
     mock_get = Mock(
         return_value=MockResponse({"nextExpectedRanges": [f"{chunk_size}-"]})
     )
@@ -1660,7 +1694,7 @@ def test_upload_large_file_content_recovers_when_final_response_is_202(
     )
     mock_put = Mock(
         side_effect=[
-            MockResponse({}, content=b""),
+            MockResponse({}, status_code=202, content=b""),
             MockResponse(
                 {"expirationDateTime": "2099-01-01T00:00:00Z"}, status_code=202
             ),
@@ -1709,7 +1743,9 @@ def test_upload_large_file_content_recovers_from_missing_or_unparsable_final_res
     final_response = MockResponse({}, status_code=201, content=final_content)
     if final_content:
         final_response.json = Mock(side_effect=ValueError("Expecting value"))
-    mock_put = Mock(side_effect=[MockResponse({}, content=b""), final_response])
+    mock_put = Mock(
+        side_effect=[MockResponse({}, status_code=202, content=b""), final_response]
+    )
     mock_delete = Mock(return_value=MockResponse({}))
     _patch_session(monkeypatch, _FakeSession(put=mock_put, delete=mock_delete))
 
@@ -1859,7 +1895,7 @@ def test_upload_large_file_content_rejects_short_chunk_read(monkeypatch):
         "request",
         Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
     )
-    mock_put = Mock(return_value=MockResponse({}, content=b""))
+    mock_put = Mock(return_value=MockResponse({}, status_code=202, content=b""))
     _patch_session(monkeypatch, _FakeSession(put=mock_put))
 
     with pytest.raises(RuntimeError, match="changed size during upload"):

--- a/tests/web/tools/test_onedrive_mcp.py
+++ b/tests/web/tools/test_onedrive_mcp.py
@@ -631,6 +631,36 @@ def test_upload_large_file_content_reads_bounded_chunks_from_disk(monkeypatch):
     assert _TrackingBuffer.max_read_size <= chunk_size
 
 
+def test_upload_large_file_content_handles_exact_chunk_multiple(monkeypatch):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = 2 * chunk_size
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_put = Mock(
+        side_effect=[
+            MockResponse({}, status_code=202),
+            MockResponse({"id": "item-1"}, status_code=201),
+        ]
+    )
+    _patch_session(monkeypatch, _FakeSession(put=mock_put))
+
+    result = onedrive._upload_large_file_content(
+        "big.bin",
+        io.BytesIO(b"\x00" * total_size),
+        total_size,
+        "application/octet-stream",
+    )
+
+    assert result == {"id": "item-1"}
+    assert mock_put.call_count == 2
+    assert mock_put.call_args_list[-1].kwargs["headers"]["Content-Range"] == (
+        f"bytes {chunk_size}-{total_size - 1}/{total_size}"
+    )
+
+
 def test_upload_large_file_content_does_not_forward_chunk_error_body(
     monkeypatch,
 ):
@@ -704,7 +734,7 @@ def test_upload_large_file_content_never_leaks_upload_url_on_chunk_failure(
             )
 
     assert sentinel_url not in str(exc_info.value)
-    assert "HTTP 416" in str(exc_info.value)
+    assert "made no forward progress" in str(exc_info.value)
     for record in caplog.records:
         assert sentinel_url not in record.getMessage()
 
@@ -1177,6 +1207,83 @@ def test_upload_large_file_content_retries_transient_reconciliation_get(monkeypa
     assert mock_put.call_count == 3
 
 
+def test_upload_large_file_content_retries_put_after_reconcile_exhaustion(monkeypatch):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 10
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_put = Mock(
+        side_effect=[
+            requests.ConnectionError("response lost"),
+            MockResponse({}, status_code=202),
+            MockResponse({"id": "item-1"}, status_code=201),
+        ]
+    )
+    mock_get = Mock(
+        side_effect=[
+            MockResponse({}, status_code=503)
+            for _ in range(onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS)
+        ]
+    )
+    _patch_session(monkeypatch, _FakeSession(put=mock_put, get=mock_get))
+
+    result = onedrive._upload_large_file_content(
+        "big.bin",
+        io.BytesIO(b"\x00" * total_size),
+        total_size,
+        "application/octet-stream",
+    )
+
+    assert result == {"id": "item-1"}
+    assert mock_put.call_count == 3
+    assert mock_get.call_count == onedrive._UPLOAD_CHUNK_MAX_ATTEMPTS
+
+
+def test_upload_large_file_content_resets_failures_after_forward_progress(monkeypatch):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = 3 * chunk_size
+    partial_offsets = [1 * 1024 * 1024, 2 * 1024 * 1024, 3 * 1024 * 1024]
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse({"uploadUrl": "https://upload.example/s"})),
+    )
+    mock_put = Mock(
+        side_effect=[requests.ConnectionError("response lost") for _ in partial_offsets]
+        + [
+            MockResponse({}, status_code=202),
+            MockResponse({}, status_code=202),
+            MockResponse({"id": "item-1"}, status_code=201),
+        ]
+    )
+    mock_get = Mock(
+        side_effect=[
+            MockResponse({"nextExpectedRanges": [f"{offset}-"]})
+            for offset in partial_offsets
+        ]
+    )
+    mock_delete = Mock(return_value=MockResponse({}))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(put=mock_put, get=mock_get, delete=mock_delete),
+    )
+
+    result = onedrive._upload_large_file_content(
+        "big.bin",
+        io.BytesIO(b"\x00" * total_size),
+        total_size,
+        "application/octet-stream",
+    )
+
+    assert result == {"id": "item-1"}
+    assert mock_get.call_count == len(partial_offsets)
+    assert mock_put.call_count == 6
+    mock_delete.assert_not_called()
+
+
 def test_upload_large_file_content_confirms_lost_final_response(monkeypatch):
     chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
     total_size = chunk_size + 10
@@ -1264,6 +1371,93 @@ def test_upload_large_file_content_treats_empty_ranges_as_final_completion(
     )
 
     assert result["id"] == "item-1"
+    mock_get.assert_called_once()
+
+
+def test_upload_large_file_content_accepts_completed_item_from_status_get(monkeypatch):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 10
+    content = b"\x00" * total_size
+    expected_hash = _quickxor_hash(content)
+    completed_item = {
+        "id": "item-1",
+        "size": total_size,
+        "file": {"hashes": {"quickXorHash": expected_hash}},
+    }
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(
+            side_effect=[
+                MockResponse({"uploadUrl": "https://upload.example/s"}),
+                MockResponse(completed_item),
+            ]
+        ),
+    )
+    mock_get = Mock(return_value=MockResponse(completed_item, status_code=200))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(
+            put=Mock(
+                side_effect=[
+                    MockResponse({}, status_code=202),
+                    requests.ConnectionError("final response lost"),
+                ]
+            ),
+            get=mock_get,
+        ),
+    )
+
+    result = onedrive._upload_large_file_content(
+        "big.bin", io.BytesIO(content), total_size, "application/octet-stream"
+    )
+
+    assert result == completed_item
+    mock_get.assert_called_once()
+
+
+@pytest.mark.parametrize("fragment_status", [404, 409])
+def test_upload_large_file_content_reconciles_final_fragment_status(
+    monkeypatch, fragment_status
+):
+    chunk_size = onedrive._UPLOAD_SESSION_CHUNK_SIZE
+    total_size = chunk_size + 10
+    content = b"\x00" * total_size
+    expected_hash = _quickxor_hash(content)
+    completed_item = {
+        "id": "item-1",
+        "size": total_size,
+        "file": {"hashes": {"quickXorHash": expected_hash}},
+    }
+    monkeypatch.setattr(
+        onedrive.requests,
+        "request",
+        Mock(
+            side_effect=[
+                MockResponse({"uploadUrl": "https://upload.example/s"}),
+                MockResponse(completed_item),
+            ]
+        ),
+    )
+    mock_get = Mock(return_value=MockResponse({}, status_code=404))
+    _patch_session(
+        monkeypatch,
+        _FakeSession(
+            put=Mock(
+                side_effect=[
+                    MockResponse({}, status_code=202),
+                    MockResponse({}, status_code=fragment_status),
+                ]
+            ),
+            get=mock_get,
+        ),
+    )
+
+    result = onedrive._upload_large_file_content(
+        "big.bin", io.BytesIO(content), total_size, "application/octet-stream"
+    )
+
+    assert result == completed_item
     mock_get.assert_called_once()
 
 
@@ -1357,6 +1551,21 @@ def test_upload_retry_delay_accepts_http_date(monkeypatch):
     ) == pytest.approx(7.0)
 
 
+@pytest.mark.parametrize("invalid_delay", ["nan", "inf", "-inf"])
+def test_upload_retry_delay_rejects_non_finite_seconds(invalid_delay):
+    assert onedrive._retry_delay({"Retry-After": invalid_delay}, 2) == pytest.approx(
+        2.0
+    )
+
+
+def test_upload_retry_delay_treats_naive_http_date_as_utc(monkeypatch):
+    monkeypatch.setattr(onedrive.time, "time", Mock(return_value=0.0))
+
+    assert onedrive._retry_delay(
+        {"Retry-After": "Thu, 01 Jan 1970 00:00:07"}, 1
+    ) == pytest.approx(7.0)
+
+
 def test_upload_large_file_content_still_cancels_on_a_non_retriable_failure(
     monkeypatch,
 ):
@@ -1417,7 +1626,7 @@ def test_upload_large_file_content_fails_on_a_non_first_chunk(monkeypatch):
         _FakeSession(put=mock_put, get=mock_get, delete=mock_delete),
     )
 
-    with pytest.raises(RuntimeError, match="HTTP 416"):
+    with pytest.raises(RuntimeError, match="made no forward progress"):
         onedrive._upload_large_file_content(
             "big.bin", fh, total_size, "application/octet-stream"
         )

--- a/tests/web/tools/test_onedrive_mcp.py
+++ b/tests/web/tools/test_onedrive_mcp.py
@@ -2397,14 +2397,17 @@ def test_upload_file_resolves_real_mime_type_for_ambiguous_extensions(
     assert sent_headers["Content-Type"] == "video/mp2t"
 
 
-def test_upload_file_raises_when_upload_session_has_no_url(
-    monkeypatch, _upload_allowed_dirs_env
+@pytest.mark.parametrize("session_payload", [{}, [], {"uploadUrl": 123}])
+def test_upload_file_raises_when_upload_session_has_no_valid_url(
+    monkeypatch, _upload_allowed_dirs_env, session_payload
 ):
     local_file = _upload_allowed_dirs_env / "big.bin"
     local_file.write_bytes(b"\x01" * (onedrive._UPLOAD_SESSION_CHUNK_SIZE + 1))
 
     monkeypatch.setattr(
-        onedrive.requests, "request", Mock(return_value=MockResponse({}))
+        onedrive.requests,
+        "request",
+        Mock(return_value=MockResponse(session_payload)),
     )
 
     result = json.loads(onedrive.onedrive_upload_file(str(local_file)))
@@ -2740,6 +2743,25 @@ def test_upload_file_rejects_file_over_max_upload_bytes(
     assert result["status"] == "error"
     assert "limit" in result["message"].lower()
     mock_request.assert_not_called()
+
+
+def test_upload_file_accepts_exact_max_upload_bytes(
+    monkeypatch, _upload_allowed_dirs_env
+):
+    local_file = _upload_allowed_dirs_env / "max-size.bin"
+    local_file.write_bytes(b"x")
+    monkeypatch.setattr(
+        onedrive.os,
+        "fstat",
+        Mock(return_value=Mock(st_size=onedrive._MAX_UPLOAD_BYTES)),
+    )
+    upload_large = Mock(return_value={"id": "item-1"})
+    monkeypatch.setattr(onedrive, "_upload_large_file_content", upload_large)
+
+    result = json.loads(onedrive.onedrive_upload_file(str(local_file)))
+
+    assert result["status"] == "success"
+    assert upload_large.call_args.args[2] == onedrive._MAX_UPLOAD_BYTES
 
 
 def test_upload_file_returns_error_payload_on_api_failure(


### PR DESCRIPTION
PR #2294 added bounded single-request uploads for files up to 4,000,000 bytes. This follow-up adds the upload-session path needed for larger files while retaining the simple upload path at and below that boundary.

Large uploads use 320 KiB-aligned chunks with bounded reads, connection reuse, and exact completion validation. Transient 429/5xx and transport failures, unusual final 202 responses, and ambiguous 404/409/416 outcomes all enter one reconciliation path. The client queries `nextExpectedRanges`, rebuilds a full aligned fragment from any partial offset, resets the consecutive-failure budget when the server makes forward progress, and retains a separate per-fragment recovery-cycle cap. Status checks and fragment retries use bounded backoff with numeric or HTTP-date `Retry-After` support.

A lost final response, an empty `nextExpectedRanges`, a disappeared final session, or a status response containing a completed driveItem is verified against the destination's exact size and QuickXorHash before success is reported. Exhausted and non-retriable failures cancel the abandoned upload session.

Upload-session URLs are preauthenticated secrets. Fragment failures expose only fixed status/category messages: response bodies, request URLs, and transport exception text never reach caller-visible errors or logs. Tests cover exact, HTML-encoded, and percent-encoded URL echoes, transport failures, cleanup failures, retry recovery, partial forward progress, status-query exhaustion, and retry exhaustion.

The final chunk performs a one-byte EOF check before sending, so growth after the initial size snapshot cannot silently create a truncated remote item. The tool rejects empty files and files larger than 2 GiB as product guardrails. Cross-call resume state is not persisted; after retry exhaustion, a later tool call starts a new upload session. Explicit MIME overrides are sent on each chunk, though Microsoft Graph does not document whether the upload-session path honors them.

The branch is based on `main` after #2294 merged, and the PR diff contains only the OneDrive implementation and tests.

Latest local validation: 220 OneDrive and migration tests passed. Ruff, formatting, mypy, isort, codespell, and Alembic checks passed through pre-commit. The PR contains no frontend changes and GitHub CI runs the frontend checks.

Follow-up: #2364 tracks cancellation-aware cleanup and runtime ownership when the MCP/stdio process is externally terminated while a synchronous upload request is blocked.
