### PR TITLE
fix: stabilize concurrent auth and cancellation tests

### DIFF
--- a/tests/web/api/v1/test_auth.py
+++ b/tests/web/api/v1/test_auth.py
@@ -323,11 +323,11 @@ def test_concurrent_valid_legacy_auth_does_not_wait_for_migration(
         credentials=full_key,
     )
     pool = ThreadPoolExecutor(max_workers=8)
-    futures = [
-        pool.submit(deps._resolve_principal_from_credentials, credentials)
-        for _ in range(8)
-    ]
     try:
+        futures = [
+            pool.submit(deps._resolve_principal_from_credentials, credentials)
+            for _ in range(8)
+        ]
         assert migration_started.wait(timeout=GUARD_TIMEOUT)
         completed = as_completed(futures, timeout=GUARD_TIMEOUT)
         # One request is deliberately parked in migration. Observe the other
@@ -649,7 +649,9 @@ async def test_runtime_key_auth_cancellation_drains_worker_before_propagating(
     finally:
         allow_worker.set()
         auth.cancel()
-        await asyncio.gather(auth, return_exceptions=True)
+        await asyncio.wait_for(
+            asyncio.gather(auth, return_exceptions=True), timeout=GUARD_TIMEOUT
+        )
 
 
 @pytest.mark.asyncio
@@ -809,7 +811,7 @@ async def test_record_key_usage_pool_wait_keeps_event_loop_responsive(
     async def invoke_usage() -> None:
         await record_key_usage(prefix)
 
-    from tests.web.pool_contention_shared import GUARD_TIMEOUT, gated_pool_checkout
+    from tests.web.pool_contention_shared import gated_pool_checkout
 
     try:
         with gated_pool_checkout(engine) as gate:

--- a/tests/web/api/v1/test_auth.py
+++ b/tests/web/api/v1/test_auth.py
@@ -9,7 +9,7 @@ Test plumbing (client, _test_db fixture, auth helpers) is shared via
 
 import asyncio
 import threading
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
@@ -20,6 +20,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy import create_engine, text
 from sqlalchemy.pool import QueuePool
 
+from tests.web.pool_contention_shared import GUARD_TIMEOUT
 from xagent.core.utils.api_key import (
     SHA256_HASH_PREFIX,
     hash_api_key,
@@ -255,7 +256,7 @@ def test_concurrent_wrong_legacy_secrets_verify_without_serializing(
                 active_checks += 1
                 peak_checks = max(peak_checks, active_checks)
             try:
-                verification_barrier.wait(timeout=2)
+                verification_barrier.wait(timeout=GUARD_TIMEOUT)
                 return original_verify(raw, stored_hash)
             finally:
                 with count_lock:
@@ -302,7 +303,7 @@ def test_concurrent_valid_legacy_auth_does_not_wait_for_migration(
     count_lock = threading.Lock()
 
     def synchronized_verify(raw: str, stored_hash: str):  # type: ignore[no-untyped-def]
-        verification_barrier.wait(timeout=2)
+        verification_barrier.wait(timeout=GUARD_TIMEOUT)
         return original_verify(raw, stored_hash)
 
     def blocking_upgrade(*args, **kwargs):  # type: ignore[no-untyped-def]
@@ -310,7 +311,9 @@ def test_concurrent_valid_legacy_auth_does_not_wait_for_migration(
         with count_lock:
             migration_calls += 1
         migration_started.set()
-        assert release_migration.wait(timeout=2)
+        # The test releases this in finally after observing the other requests.
+        # A timed release could let migration finish before that observation.
+        release_migration.wait()
         return original_upgrade(*args, **kwargs)
 
     monkeypatch.setattr(deps, "verify_api_key_with_timing", synchronized_verify)
@@ -325,15 +328,18 @@ def test_concurrent_valid_legacy_auth_does_not_wait_for_migration(
         for _ in range(8)
     ]
     try:
-        assert migration_started.wait(timeout=2)
-        completed, _pending = wait(futures, timeout=1)
-        completed_before_migration = len(completed)
+        assert migration_started.wait(timeout=GUARD_TIMEOUT)
+        completed = as_completed(futures, timeout=GUARD_TIMEOUT)
+        # One request is deliberately parked in migration. Observe the other
+        # seven returning while the gate stays closed, regardless of CPU speed.
+        for _ in range(7):
+            next(completed).result()
+        assert sum(future.done() for future in futures) == 7
     finally:
         release_migration.set()
         pool.shutdown(wait=True)
 
     principals = [future.result() for future in futures]
-    assert completed_before_migration == 7
     assert migration_calls == 1
     assert all(
         principal.agent is not None and principal.agent.id == agent_id
@@ -621,7 +627,7 @@ async def test_runtime_key_auth_cancellation_drains_worker_before_propagating(
 
     def blocking_load(key_prefix: str):  # type: ignore[no-untyped-def]
         worker_started.set()
-        assert allow_worker.wait(timeout=2)
+        assert allow_worker.wait(timeout=GUARD_TIMEOUT)
         try:
             return original_load(key_prefix)
         finally:
@@ -633,13 +639,17 @@ async def test_runtime_key_auth_cancellation_drains_worker_before_propagating(
             HTTPAuthorizationCredentials(scheme="Bearer", credentials=full_key)
         )
     )
-    await asyncio.to_thread(worker_started.wait, 2)
-    auth.cancel()
-    allow_worker.set()
-
-    with pytest.raises(asyncio.CancelledError):
-        await auth
-    assert worker_finished.is_set()
+    try:
+        assert await asyncio.to_thread(worker_started.wait, GUARD_TIMEOUT)
+        auth.cancel()
+        allow_worker.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(auth, timeout=GUARD_TIMEOUT)
+        assert worker_finished.is_set()
+    finally:
+        allow_worker.set()
+        auth.cancel()
+        await asyncio.gather(auth, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -725,7 +725,9 @@ async def test_cancelled_upload_cleans_partial_local_file_and_metadata(
     finally:
         allow_write.set()
         upload_task.cancel()
-        await asyncio.gather(upload_task, return_exceptions=True)
+        await asyncio.wait_for(
+            asyncio.gather(upload_task, return_exceptions=True), timeout=GUARD_TIMEOUT
+        )
 
     assert written_path is not None
     assert not written_path.exists()

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -697,7 +697,7 @@ async def test_cancelled_upload_cleans_partial_local_file_and_metadata(
         with open(target_path, "xb") as buffer:
             buffer.write(b"partial")
         write_started.set()
-        assert allow_write.wait(timeout=2)
+        assert allow_write.wait(timeout=GUARD_TIMEOUT)
         return target_path
 
     monkeypatch.setattr(files_api, "_reserve_and_copy_upload", delayed_copy)
@@ -716,11 +716,16 @@ async def test_cancelled_upload_cleans_partial_local_file_and_metadata(
             user_id=user_id,
         )
     )
-    assert await asyncio.to_thread(write_started.wait, 2)
-    upload_task.cancel()
-    allow_write.set()
-    with pytest.raises(asyncio.CancelledError):
-        await upload_task
+    try:
+        assert await asyncio.to_thread(write_started.wait, GUARD_TIMEOUT)
+        upload_task.cancel()
+        allow_write.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(upload_task, timeout=GUARD_TIMEOUT)
+    finally:
+        allow_write.set()
+        upload_task.cancel()
+        await asyncio.gather(upload_task, return_exceptions=True)
 
     assert written_path is not None
     assert not written_path.exists()

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -1408,7 +1408,7 @@ async def test_channel_durable_upload_does_not_hold_pool_connection_or_upload_tw
         nonlocal put_calls
         put_calls += 1
         put_started.set()
-        assert allow_put.wait(timeout=3)
+        assert allow_put.wait(timeout=GUARD_TIMEOUT)
         return original_put_file(self, source_path, key, content_type)
 
     monkeypatch.setattr(FsspecFileStorage, "put_file", blocking_put_file)
@@ -1421,18 +1421,27 @@ async def test_channel_durable_upload_does_not_hold_pool_connection_or_upload_tw
             files=(downloaded,),
         )
     )
-    assert await asyncio.to_thread(put_started.wait, 2)
 
     def probe_pool() -> int:
         with SessionLocal() as db:
             return int(db.execute(text("SELECT 1")).scalar_one())
 
     try:
-        assert await asyncio.wait_for(asyncio.to_thread(probe_pool), timeout=1) == 1
+        assert await asyncio.to_thread(put_started.wait, GUARD_TIMEOUT)
+        # Upload is still parked at the gate: availability is an invariant,
+        # not a deadline for scheduling the probe thread on a busy CI worker.
+        assert engine.pool.checkedout() == 0
+        assert (
+            await asyncio.wait_for(asyncio.to_thread(probe_pool), timeout=GUARD_TIMEOUT)
+            == 1
+        )
     finally:
         allow_put.set()
+        await asyncio.wait_for(
+            asyncio.gather(registration, return_exceptions=True), timeout=GUARD_TIMEOUT
+        )
 
-    registered = await registration
+    registered = registration.result()
     assert len(registered) == 1
     assert put_calls == 1
     assert workspace.resolve_file_id(registered[0].file_id) == source
@@ -1546,7 +1555,9 @@ async def test_prepare_channel_task_compensates_late_claim_before_cancellation(
     finally:
         allow_worker.set()
         preparation.cancel()
-        await asyncio.gather(preparation, return_exceptions=True)
+        await asyncio.wait_for(
+            asyncio.gather(preparation, return_exceptions=True), timeout=GUARD_TIMEOUT
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -10,6 +10,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.web.pool_contention_shared import GUARD_TIMEOUT
 from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.core.file_storage.storage import FsspecFileStorage
 from xagent.core.workspace import TaskWorkspace
@@ -1510,7 +1511,7 @@ async def test_prepare_channel_task_compensates_late_claim_before_cancellation(
 
     def blocking_prepare(**_kwargs):  # type: ignore[no-untyped-def]
         worker_started.set()
-        assert allow_worker.wait(timeout=2)
+        assert allow_worker.wait(timeout=GUARD_TIMEOUT)
         return claim
 
     def compensate(snapshot: channel_runtime._ChannelTaskClaimSnapshot) -> bool:
@@ -1535,13 +1536,17 @@ async def test_prepare_channel_task_compensates_late_claim_before_cancellation(
             channel_name="Telegram",
         )
     )
-    await asyncio.to_thread(worker_started.wait, 2)
-    preparation.cancel()
-    allow_worker.set()
-
-    with pytest.raises(asyncio.CancelledError):
-        await preparation
-    assert compensated == [claim]
+    try:
+        assert await asyncio.to_thread(worker_started.wait, GUARD_TIMEOUT)
+        preparation.cancel()
+        allow_worker.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(preparation, timeout=GUARD_TIMEOUT)
+        assert compensated == [claim]
+    finally:
+        allow_worker.set()
+        preparation.cancel()
+        await asyncio.gather(preparation, return_exceptions=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The concurrent legacy-key authentication test can fail under CI load because it allows only two seconds for eight workers to reach migration, then counts completed requests after a fixed one-second window. Wait explicitly for seven requests to finish while the migration gate remains closed, and release migration in `finally`. Use the existing generous guard timeout for worker readiness and barrier synchronization.

Also fix the related authentication, channel-task, and upload cancellation tests to check worker readiness and always release gates and settle tasks on failure. This changes five tests across three files; production behavior is unchanged.

Validation:
- All 167 tests in the three affected modules passed both serially and with CI's `-n 4 --dist=loadscope` configuration.
- Pre-commit checks passed, including Ruff and mypy.
- A temporary 2.2-second worker delay reproduced the original CI failure. The fixed test passed with delays in both worker startup and request completion.
- A mutation making migration-lock acquisition blocking still failed the fixed test, confirming that it detects serialized authentication.
