### PR TITLE
feat: create recurring and all-day Google Calendar events

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
           - types-PyYAML
           - types-beautifulsoup4
           - types-requests
+          - types-python-dateutil
           - httpx
           - fastapi
           - uvicorn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "asyncssh>=2.14.0",  # SSH MCP runner (production runtime, not just tests)
   "requests >= 2.32.0",
   "idna >= 3.7",  # magento.py's non-ASCII MAGENTO_BASE_URL handling; currently only pulled in transitively via requests
+  "python-dateutil >= 2.8.2",  # calendar.py's RRULE validation (utils.parse_rrule); currently only pulled in transitively
   "boto3 >= 1.34.0",  # AWS built-in MCP connector (CloudWatch/DynamoDB/SQS, read-only)
   "celery[redis]>=5.4.0,<6.0.0",
   "redis>=5.0.0",
@@ -248,6 +249,7 @@ static-type-check = [
   "types-openpyxl>=3.1.5",
   "types-setuptools>=69.0.0",
   "types-docker>=7.1.0.20251009",
+  "types-python-dateutil>=2.8.19",
 ]
 
 [project.scripts]

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -413,6 +413,11 @@ def google_calendar_create_events(
     """
     requested_conference = False
     try:
+        # Normalize both accepted input shapes before classifying or validating
+        # them. Google expects exact RFC3339/date values and rejects otherwise
+        # valid values that carry incidental surrounding whitespace.
+        start_time = start_time.strip()
+        end_time = end_time.strip()
         start_is_all_day = is_bare_date(start_time)
         end_is_all_day = is_bare_date(end_time)
         if start_is_all_day != end_is_all_day:
@@ -436,19 +441,12 @@ def google_calendar_create_events(
 
         service = get_calendar_service()
 
-        # Stripped once here so the value written into the payload always
-        # matches what is_bare_date actually validated - is_bare_date
-        # strips internally for the shape check, but a raw start_time with
-        # incidental surrounding whitespace would otherwise still reach
-        # Google verbatim.
-        start_value = start_time.strip() if start_is_all_day else start_time
-        end_value = end_time.strip() if end_is_all_day else end_time
         event: dict[str, Any] = {
             "summary": summary,
             "start": (
-                {"date": start_value} if start_is_all_day else {"dateTime": start_value}
+                {"date": start_time} if start_is_all_day else {"dateTime": start_time}
             ),
-            "end": {"date": end_value} if end_is_all_day else {"dateTime": end_value},
+            "end": {"date": end_time} if end_is_all_day else {"dateTime": end_time},
         }
         if timezone and not start_is_all_day:
             force = recurrence is not None
@@ -468,7 +466,7 @@ def google_calendar_create_events(
             # here for that comparison; it's never written to the event.
             localization_timezone = timezone or ("UTC" if start_is_all_day else None)
             event["recurrence"] = [
-                _normalize_rrule(recurrence, start_value, localization_timezone)
+                _normalize_rrule(recurrence, start_time, localization_timezone)
             ]
         _merge_attendees(event, attendees)
         requested_conference = _apply_conference_request(event, add_google_meet)

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -14,6 +14,7 @@ from .utils import (
     ensure_rrule_prefix,
     is_bare_date,
     parse_rrule,
+    reject_reversed_window,
     resolve_zoneinfo,
     setup_proxy_env,
     success_with_capped_dict,
@@ -27,6 +28,10 @@ setup_proxy_env()
 
 mcp = FastMCP("calendar-mcp")
 
+_GOOGLE_SUPPORTED_RRULE_FREQUENCIES = frozenset(
+    {"DAILY", "WEEKLY", "MONTHLY", "YEARLY"}
+)
+
 
 def _normalize_rrule(recurrence: str, dtstart: str, timezone: str | None = None) -> str:
     """Validate `recurrence` and return it as a single RRULE line, with
@@ -36,7 +41,13 @@ def _normalize_rrule(recurrence: str, dtstart: str, timezone: str | None = None)
     dateTime with no UTC offset) before validation, so it can be compared
     against a "Z"-suffixed UNTIL without dateutil rejecting the mismatch.
     """
-    parse_rrule(recurrence, dtstart, timezone)
+    parts = parse_rrule(recurrence, dtstart, timezone)
+    if parts["FREQ"] not in _GOOGLE_SUPPORTED_RRULE_FREQUENCIES:
+        supported = ", ".join(sorted(_GOOGLE_SUPPORTED_RRULE_FREQUENCIES))
+        raise ValueError(
+            f"Google Calendar does not support FREQ={parts['FREQ']}; "
+            f"use one of {supported}"
+        )
     return ensure_rrule_prefix(recurrence)
 
 
@@ -54,7 +65,7 @@ def _classify_event_time(value: str, field_name: str) -> bool:
         len(value) < 11
         or value[4] != "-"
         or value[7] != "-"
-        or value[10] not in {"T", "t", " "}
+        or value[10] not in {"T", "t"}
     ):
         raise ValueError(
             f"{field_name} must be a valid YYYY-MM-DD date or RFC3339 dateTime"
@@ -401,31 +412,18 @@ def google_calendar_create_events(
     For an all-day event, end_time is exclusive and must be later than
     start_time: use the following date for a one-day event. Both values
     must be the same kind, never a mix.
-    recurrence, if given, is a single RFC 5545 RRULE string describing a
-    repeating series for this event (the "RRULE:" prefix is optional; it
-    must not contain embedded newlines), e.g.
-    'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;UNTIL=20260911T235959Z' for "every
-    weekday until Sep 11, 2026". It's validated before being sent to
-    Google and rejected with a clear error if it can't be parsed, rather
-    than silently landing as inert text with no actual recurrence. There
-    must be a bare-date UNTIL (e.g. UNTIL=20260911) for an all-day event;
-    a timed event with timezone uses a UTC UNTIL ending in Z. There is no
-    way to clear a recurrence back to a single event once set,
-    through this tool or google_calendar_update_events.
-    timezone is an IANA timezone name (e.g. 'America/Los_Angeles'). Google
-    requires it for a non-all-day recurring event specifically - and does
-    so unconditionally, even when start_time/end_time already carry their
-    own UTC offset, since timezone governs how the recurrence itself
-    expands (e.g. across DST transitions) while the offset only fixes
-    this one occurrence's instant - so it's required here whenever
-    recurrence is set on one; an all-day recurring event doesn't need it
-    and it has no effect at all when passed to an all-day event without
-    recurrence either (Google doesn't attach a timeZone to a date-only
-    event). Outside of recurrence, timezone also localizes a naive
-    start_time/end_time (no UTC offset) for the purposes of comparing
-    recurrence's UNTIL against them, and is only written to a side that
-    doesn't already carry its own offset (there it's optional, so it's
-    skipped rather than risk disagreeing with that offset).
+    recurrence, if given, is one RFC 5545 RRULE with DAILY, WEEKLY,
+    MONTHLY, or YEARLY frequency; the "RRULE:" prefix is optional and
+    embedded newlines are rejected. For example,
+    'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;UNTIL=20260911T235959Z'. An all-day
+    event must use a bare-date UNTIL such as UNTIL=20260911; a timed event
+    with timezone must use a UTC UNTIL ending in Z.
+    timezone is an IANA name such as 'America/Los_Angeles' and is required
+    for timed recurring events, including when start_time/end_time carry
+    their own offsets. It is ignored for all-day events.
+    Do not use google_calendar_update_events to reschedule an all-day or
+    recurring event yet; that tool cannot preserve their date/timeZone
+    fields. Metadata-only updates remain safe.
     attendees is a list of email addresses to add to the event. Adding attendees does not, by
     itself, email them; set notify_attendees=True to have Google Calendar send them a native
     invite immediately. Confirm the recipient list with the user before setting notify_attendees=True.
@@ -445,6 +443,8 @@ def google_calendar_create_events(
         # valid values that carry incidental surrounding whitespace.
         start_time = start_time.strip()
         end_time = end_time.strip()
+        if timezone is not None:
+            timezone = timezone.strip() or None
         start_is_all_day = _classify_event_time(start_time, "start_time")
         end_is_all_day = _classify_event_time(end_time, "end_time")
         if start_is_all_day != end_is_all_day:
@@ -460,6 +460,8 @@ def google_calendar_create_events(
                 "end_time is exclusive for an all-day event and must be later "
                 "than start_time; use the following date for a one-day event"
             )
+        if not start_is_all_day:
+            reject_reversed_window(start_time, end_time)
         if recurrence is not None and not start_is_all_day and not timezone:
             raise ValueError(
                 "timezone is required when recurrence is set (Google expands "
@@ -472,6 +474,12 @@ def google_calendar_create_events(
             # leaving an invalid timezone on a non-recurring event to
             # surface as Google's own opaque server-side error instead.
             resolve_zoneinfo(timezone)
+
+        normalized_recurrence = (
+            _normalize_rrule(recurrence, start_time, timezone)
+            if recurrence is not None
+            else None
+        )
 
         service = get_calendar_service()
 
@@ -491,8 +499,8 @@ def google_calendar_create_events(
             event["description"] = description
         if location:
             event["location"] = location
-        if recurrence is not None:
-            event["recurrence"] = [_normalize_rrule(recurrence, start_time, timezone)]
+        if normalized_recurrence is not None:
+            event["recurrence"] = [normalized_recurrence]
         _merge_attendees(event, attendees)
         requested_conference = _apply_conference_request(event, add_google_meet)
 

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -4,11 +4,19 @@ import os
 import uuid
 from typing import Any
 
+from dateutil import parser as _date_parser
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build  # type: ignore
 from mcp.server.fastmcp import FastMCP
 
-from .utils import setup_proxy_env, success_with_capped_dict
+from .utils import (
+    ensure_rrule_prefix,
+    is_bare_date,
+    parse_rrule,
+    resolve_zoneinfo,
+    setup_proxy_env,
+    success_with_capped_dict,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("calendar-mcp")
@@ -17,6 +25,79 @@ logger = logging.getLogger("calendar-mcp")
 setup_proxy_env()
 
 mcp = FastMCP("calendar-mcp")
+
+
+def _normalize_rrule(recurrence: str, dtstart: str, timezone: str | None = None) -> str:
+    """Validate `recurrence` and return it as a single RRULE line, with
+    the "RRULE:" prefix added if the caller omitted it.
+
+    `timezone`, when given, localizes a naive `dtstart` (e.g. an RFC3339
+    dateTime with no UTC offset) before validation, so it can be compared
+    against a "Z"-suffixed UNTIL without dateutil rejecting the mismatch.
+    """
+    parse_rrule(recurrence, dtstart, timezone)
+    return ensure_rrule_prefix(recurrence)
+
+
+def _has_own_utc_offset(dt_string: str) -> bool:
+    """Whether an RFC3339 dateTime string carries its own explicit UTC
+    offset or "Z" suffix, as opposed to a naive local time meant to be
+    paired with a separate timeZone field. Used to avoid stamping a
+    possibly-different reused timeZone onto a value that's already
+    fully self-describing.
+    """
+    try:
+        return _date_parser.isoparse(dt_string).tzinfo is not None
+    except ValueError:
+        return False
+
+
+def _event_side(event: dict[str, Any], side: str) -> dict[str, Any]:
+    """Return `event[side]` as a dict, or {} if it's absent or not
+    actually a dict (a malformed fetched event could carry a truthy
+    non-dict value there, e.g. a list) - `event.get(side) or {}` alone
+    only guards the absent/falsy case, not a truthy non-dict one, and a
+    subsequent `.get(...)` on it would crash with an unhelpful raw
+    AttributeError.
+    """
+    value = event.get(side)
+    return value if isinstance(value, dict) else {}
+
+
+def _stamp_timezone(
+    event: dict[str, Any],
+    side: str,
+    current_value: str | None,
+    timezone: str,
+    *,
+    force: bool,
+) -> None:
+    """Write `timezone` onto ``event[side]["timeZone"]``, skipping only
+    when doing so would be malformed or, for a non-recurring event,
+    redundant.
+
+    Skipped entirely when `current_value` is None: this side has no
+    "dateTime"/"date" value at all (a malformed fetched event), and
+    stamping a bare {"timeZone": ...} would send Google a structurally
+    invalid EventDateTime carrying neither key.
+
+    Otherwise skipped only when `force` is False and `current_value`
+    already carries its own UTC offset, to avoid a possibly-disagreeing
+    zone on a field Google only requires unconditionally for a
+    *recurring* event (`force=True`, passed by the recurrence branch) -
+    Google's own EventDateTime reference states timeZone is required for
+    a recurring event regardless of any offset already in dateTime, since
+    the offset fixes this occurrence's instant while timeZone governs how
+    the recurrence itself expands (e.g. across DST transitions); they are
+    not redundant. For a plain reschedule timeZone is merely optional, so
+    it's skipped there instead when the value is already self-describing.
+    """
+    if current_value is None:
+        return
+    if not force and _has_own_utc_offset(current_value):
+        return
+    event[side] = _event_side(event, side)
+    event[side]["timeZone"] = timezone
 
 
 def get_calendar_service() -> Any:
@@ -287,10 +368,37 @@ def google_calendar_create_events(
     attendees: list[str] | None = None,
     notify_attendees: bool = False,
     add_google_meet: bool = False,
+    timezone: str | None = None,
+    recurrence: str | None = None,
 ) -> str:
     """
     Create a new event in Google Calendar.
-    start_time and end_time must be RFC3339 formatted (e.g., '2024-01-01T10:00:00Z' or '2024-01-01T10:00:00-07:00').
+    start_time and end_time must be RFC3339 formatted (e.g., '2024-01-01T10:00:00Z' or '2024-01-01T10:00:00-07:00'),
+    or both a bare date (e.g. '2024-01-01') to create an all-day event -
+    they must both be the same kind, never a mix.
+    recurrence, if given, is a single RFC 5545 RRULE string describing a
+    repeating series for this event (the "RRULE:" prefix is optional; it
+    must not contain embedded newlines), e.g.
+    'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;UNTIL=20260911T235959Z' for "every
+    weekday until Sep 11, 2026". It's validated before being sent to
+    Google and rejected with a clear error if it can't be parsed, rather
+    than silently landing as inert text with no actual recurrence. There
+    is no way to clear a recurrence back to a single event once set,
+    through this tool or google_calendar_update_events.
+    timezone is an IANA timezone name (e.g. 'America/Los_Angeles'). Google
+    requires it for a non-all-day recurring event specifically - and does
+    so unconditionally, even when start_time/end_time already carry their
+    own UTC offset, since timezone governs how the recurrence itself
+    expands (e.g. across DST transitions) while the offset only fixes
+    this one occurrence's instant - so it's required here whenever
+    recurrence is set on one; an all-day recurring event doesn't need it
+    and it has no effect at all when passed to an all-day event without
+    recurrence either (Google doesn't attach a timeZone to a date-only
+    event). Outside of recurrence, timezone also localizes a naive
+    start_time/end_time (no UTC offset) for the purposes of comparing
+    recurrence's UNTIL against them, and is only written to a side that
+    doesn't already carry its own offset (there it's optional, so it's
+    skipped rather than risk disagreeing with that offset).
     attendees is a list of email addresses to add to the event. Adding attendees does not, by
     itself, email them; set notify_attendees=True to have Google Calendar send them a native
     invite immediately. Confirm the recipient list with the user before setting notify_attendees=True.
@@ -305,22 +413,63 @@ def google_calendar_create_events(
     """
     requested_conference = False
     try:
+        start_is_all_day = is_bare_date(start_time)
+        end_is_all_day = is_bare_date(end_time)
+        if start_is_all_day != end_is_all_day:
+            raise ValueError(
+                "start_time and end_time must both be a bare date or both "
+                "a dateTime, never a mix - a Google Calendar event's start "
+                "and end must be the same kind"
+            )
+        if recurrence is not None and not start_is_all_day and not timezone:
+            raise ValueError(
+                "timezone is required when recurrence is set (Google expands "
+                "a recurring event's occurrences in this timezone)"
+            )
+        if timezone:
+            # Validate eagerly with a clean, actionable message - the only
+            # other path that would otherwise catch a bad IANA name is
+            # parse_rrule, which only runs when recurrence is also set,
+            # leaving an invalid timezone on a non-recurring event to
+            # surface as Google's own opaque server-side error instead.
+            resolve_zoneinfo(timezone)
+
         service = get_calendar_service()
 
+        # Stripped once here so the value written into the payload always
+        # matches what is_bare_date actually validated - is_bare_date
+        # strips internally for the shape check, but a raw start_time with
+        # incidental surrounding whitespace would otherwise still reach
+        # Google verbatim.
+        start_value = start_time.strip() if start_is_all_day else start_time
+        end_value = end_time.strip() if end_is_all_day else end_time
         event: dict[str, Any] = {
             "summary": summary,
-            "start": {
-                "dateTime": start_time,
-            },
-            "end": {
-                "dateTime": end_time,
-            },
+            "start": (
+                {"date": start_value} if start_is_all_day else {"dateTime": start_value}
+            ),
+            "end": {"date": end_value} if end_is_all_day else {"dateTime": end_value},
         }
+        if timezone and not start_is_all_day:
+            force = recurrence is not None
+            _stamp_timezone(event, "start", start_time, timezone, force=force)
+            _stamp_timezone(event, "end", end_time, timezone, force=force)
 
         if description:
             event["description"] = description
         if location:
             event["location"] = location
+        if recurrence is not None:
+            # An all-day event's naive date anchor still needs *some*
+            # timezone to compare against an aware ("Z"-suffixed) UNTIL -
+            # RFC 5545 requires DTSTART and UNTIL to either both be aware
+            # or both floating, regardless of whether Google itself cares
+            # about a timeZone for a date-only event. UTC is only used
+            # here for that comparison; it's never written to the event.
+            localization_timezone = timezone or ("UTC" if start_is_all_day else None)
+            event["recurrence"] = [
+                _normalize_rrule(recurrence, start_value, localization_timezone)
+            ]
         _merge_attendees(event, attendees)
         requested_conference = _apply_conference_request(event, add_google_meet)
 

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import uuid
+from datetime import date
 from typing import Any
 
 from dateutil import parser as _date_parser
@@ -37,6 +38,28 @@ def _normalize_rrule(recurrence: str, dtstart: str, timezone: str | None = None)
     """
     parse_rrule(recurrence, dtstart, timezone)
     return ensure_rrule_prefix(recurrence)
+
+
+def _classify_event_time(value: str, field_name: str) -> bool:
+    """Validate an event time and return whether it is an all-day date."""
+    if is_bare_date(value):
+        return True
+    try:
+        _date_parser.isoparse(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must be a valid YYYY-MM-DD date or RFC3339 dateTime"
+        ) from exc
+    if (
+        len(value) < 11
+        or value[4] != "-"
+        or value[7] != "-"
+        or value[10] not in {"T", "t", " "}
+    ):
+        raise ValueError(
+            f"{field_name} must be a valid YYYY-MM-DD date or RFC3339 dateTime"
+        )
+    return False
 
 
 def _has_own_utc_offset(dt_string: str) -> bool:
@@ -374,8 +397,10 @@ def google_calendar_create_events(
     """
     Create a new event in Google Calendar.
     start_time and end_time must be RFC3339 formatted (e.g., '2024-01-01T10:00:00Z' or '2024-01-01T10:00:00-07:00'),
-    or both a bare date (e.g. '2024-01-01') to create an all-day event -
-    they must both be the same kind, never a mix.
+    or both a bare date (e.g. '2024-01-01') to create an all-day event.
+    For an all-day event, end_time is exclusive and must be later than
+    start_time: use the following date for a one-day event. Both values
+    must be the same kind, never a mix.
     recurrence, if given, is a single RFC 5545 RRULE string describing a
     repeating series for this event (the "RRULE:" prefix is optional; it
     must not contain embedded newlines), e.g.
@@ -383,7 +408,9 @@ def google_calendar_create_events(
     weekday until Sep 11, 2026". It's validated before being sent to
     Google and rejected with a clear error if it can't be parsed, rather
     than silently landing as inert text with no actual recurrence. There
-    is no way to clear a recurrence back to a single event once set,
+    must be a bare-date UNTIL (e.g. UNTIL=20260911) for an all-day event;
+    a timed event with timezone uses a UTC UNTIL ending in Z. There is no
+    way to clear a recurrence back to a single event once set,
     through this tool or google_calendar_update_events.
     timezone is an IANA timezone name (e.g. 'America/Los_Angeles'). Google
     requires it for a non-all-day recurring event specifically - and does
@@ -418,13 +445,20 @@ def google_calendar_create_events(
         # valid values that carry incidental surrounding whitespace.
         start_time = start_time.strip()
         end_time = end_time.strip()
-        start_is_all_day = is_bare_date(start_time)
-        end_is_all_day = is_bare_date(end_time)
+        start_is_all_day = _classify_event_time(start_time, "start_time")
+        end_is_all_day = _classify_event_time(end_time, "end_time")
         if start_is_all_day != end_is_all_day:
             raise ValueError(
                 "start_time and end_time must both be a bare date or both "
                 "a dateTime, never a mix - a Google Calendar event's start "
                 "and end must be the same kind"
+            )
+        if start_is_all_day and date.fromisoformat(end_time) <= date.fromisoformat(
+            start_time
+        ):
+            raise ValueError(
+                "end_time is exclusive for an all-day event and must be later "
+                "than start_time; use the following date for a one-day event"
             )
         if recurrence is not None and not start_is_all_day and not timezone:
             raise ValueError(
@@ -458,16 +492,7 @@ def google_calendar_create_events(
         if location:
             event["location"] = location
         if recurrence is not None:
-            # An all-day event's naive date anchor still needs *some*
-            # timezone to compare against an aware ("Z"-suffixed) UNTIL -
-            # RFC 5545 requires DTSTART and UNTIL to either both be aware
-            # or both floating, regardless of whether Google itself cares
-            # about a timeZone for a date-only event. UTC is only used
-            # here for that comparison; it's never written to the event.
-            localization_timezone = timezone or ("UTC" if start_is_all_day else None)
-            event["recurrence"] = [
-                _normalize_rrule(recurrence, start_time, localization_timezone)
-            ]
+            event["recurrence"] = [_normalize_rrule(recurrence, start_time, timezone)]
         _merge_attendees(event, attendees)
         requested_conference = _apply_conference_request(event, add_google_meet)
 

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -13,6 +13,7 @@ from dateutil.rrule import rrulestr as _rrulestr
 from ....config import get_tool_max_output_length
 
 _DIGITS_ONLY_RE = re.compile(r"[0-9]+")
+_BARE_DATE_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}")
 # RFC 5545 UNTIL is always in "basic" form - no "-"/":" separators, unlike
 # ISO8601's "extended" form that dateutil's isoparse also happily accepts
 # (e.g. "2026-09-11T23:59:59+08:00"). dateutil.rrule.rrulestr's own RFC
@@ -635,20 +636,70 @@ def is_bare_date(value: str) -> bool:
     """Whether a caller-supplied date/time string is a bare "date" (e.g.
     Google's all-day form, "2026-08-26") rather than a "dateTime".
 
-    Checked structurally (exactly three hyphen-separated all-digit parts,
-    after stripping outer whitespace) rather than by the absence of a
+    Checked as an exact, calendar-valid YYYY-MM-DD value (after stripping
+    outer whitespace) rather than only by the absence of a
     "T"/"t" date/time separator: RFC3339 also permits a space in place of
     "T" for readability, so "2026-08-26 07:00:00" contains no "t" either
     and would otherwise be misclassified as a bare date.
 
-    "all-digit" is checked via `_DIGITS_ONLY_RE` (ASCII 0-9 only), not
-    `str.isdigit()`: the latter also accepts non-ASCII digit lookalikes
-    (superscript, Thai, ...) that would misclassify a value as a bare
-    date with no further local validation before it's written straight
-    into a Google Calendar request body.
+    The explicit ASCII shape check rejects abbreviated dates and Unicode
+    digit lookalikes; ``date.fromisoformat`` then rejects impossible dates.
     """
-    parts = value.strip().split("-")
-    return len(parts) == 3 and all(_DIGITS_ONLY_RE.fullmatch(part) for part in parts)
+    normalized = value.strip()
+    if not _BARE_DATE_RE.fullmatch(normalized):
+        return False
+    try:
+        date.fromisoformat(normalized)
+    except ValueError:
+        return False
+    return True
+
+
+def _validate_rrule_constraints(
+    parts: dict[str, str], *, dtstart_is_date: bool
+) -> None:
+    """Enforce RFC 5545 constraints that dateutil accepts leniently."""
+    freq = parts["FREQ"]
+    if dtstart_is_date and any(
+        key in parts for key in ("BYSECOND", "BYMINUTE", "BYHOUR")
+    ):
+        raise ValueError(
+            "invalid recurrence rule: BYSECOND, BYMINUTE, and BYHOUR must "
+            "not be used with an all-day DATE start"
+        )
+
+    byday = parts.get("BYDAY")
+    has_numeric_byday = bool(
+        byday and any(len(value.strip()) > 2 for value in byday.split(","))
+    )
+    if has_numeric_byday and freq not in {"MONTHLY", "YEARLY"}:
+        raise ValueError(
+            "invalid recurrence rule: numeric BYDAY values are only valid "
+            "with MONTHLY or YEARLY frequency"
+        )
+    if has_numeric_byday and freq == "YEARLY" and "BYWEEKNO" in parts:
+        raise ValueError(
+            "invalid recurrence rule: numeric BYDAY must not be combined "
+            "with BYWEEKNO in a YEARLY rule"
+        )
+    if freq == "WEEKLY" and "BYMONTHDAY" in parts:
+        raise ValueError(
+            "invalid recurrence rule: BYMONTHDAY must not be used with WEEKLY frequency"
+        )
+    if freq in {"DAILY", "WEEKLY", "MONTHLY"} and "BYYEARDAY" in parts:
+        raise ValueError(
+            "invalid recurrence rule: BYYEARDAY is only valid with YEARLY frequency"
+        )
+    if freq != "YEARLY" and "BYWEEKNO" in parts:
+        raise ValueError(
+            "invalid recurrence rule: BYWEEKNO is only valid with YEARLY frequency"
+        )
+    if "BYSETPOS" in parts and not any(
+        key.startswith("BY") and key != "BYSETPOS" for key in parts
+    ):
+        raise ValueError(
+            "invalid recurrence rule: BYSETPOS requires another BY rule part"
+        )
 
 
 def _strip_rrule_prefix(rrule_text: str) -> str:
@@ -702,21 +753,15 @@ def parse_rrule(
     Outlook start time) - skipping the format-then-reparse round trip that
     passing `.isoformat()` back in would otherwise cost.
 
-    ``timezone``, if given, localizes a naive ``dtstart``. For a genuine
-    all-day event - ``dtstart`` passed as a bare-date string with no "T",
-    e.g. Google's own all-day "date" field - this only happens when
-    needed to compare against an aware UNTIL; a naive/bare-date UNTIL is
-    correctly left floating to match the still-naive anchor instead,
-    since RFC 5545's DATE value type legitimately pairs a floating DTSTART
-    with a floating UNTIL. For anything else (a full dateTime string,
-    aware or not, or an already-`datetime` object), the
-    anchor is always localized when naive - RFC 5545's DATE-TIME value
-    type requires UNTIL to be aware too, so if it isn't, that's an actual
-    mismatch dateutil's own validation below correctly rejects, the same
-    way it already does for a dtstart string that carries its own offset.
-    Either way, the UNTIL-not-before-dtstart check
-    below still runs - it compares whenever anchor and UNTIL share the
-    same awareness, aware-vs-aware or naive-vs-naive alike.
+    ``timezone``, if given, localizes a naive DATE-TIME ``dtstart``. A
+    genuine all-day event uses a DATE value instead and remains timezone
+    independent. RFC 5545 requires UNTIL to have the same value type as
+    DTSTART: a DATE for an all-day start, a floating DATE-TIME for a
+    floating start, or a UTC DATE-TIME for an aware/timezone-qualified
+    start. These relationships are checked explicitly rather than left to
+    dateutil, which accepts several mismatched combinations. The
+    UNTIL-not-before-dtstart check then compares values with matching types
+    and awareness.
 
     The returned dict (rather than the parsed rrule object) is what
     callers actually build a provider payload from: Google takes the RRULE
@@ -771,6 +816,8 @@ def parse_rrule(
             "recurrence rule must not specify both UNTIL and COUNT - RFC "
             "5545 treats these as mutually exclusive ways to end a series"
         )
+    dtstart_is_bare_date = isinstance(dtstart, str) and is_bare_date(dtstart)
+    _validate_rrule_constraints(parts, dtstart_is_date=dtstart_is_bare_date)
     # RFC 5545 defines INTERVAL/COUNT as `1*DIGIT` - plain unsigned digits,
     # nothing else. Python's int() is more permissive (a leading "+"/"-",
     # PEP 515 "_" digit separators), and `parts` holds the ORIGINAL string,
@@ -817,16 +864,6 @@ def parse_rrule(
                 f"invalid UNTIL value in recurrence rule: {parts['UNTIL']!r}"
             ) from exc
 
-    # A bare-date dtstart string (e.g. Google's own all-day "date" field,
-    # "2026-08-26") is the same signal calendar.py itself already uses to
-    # detect an all-day event - RFC 5545's DATE value type, which
-    # legitimately pairs with an equally bare-date (floating) UNTIL.
-    # Anything else - a full dateTime string (with or without its own
-    # offset) or an already-`datetime` object (as Outlook's caller always
-    # passes, already localized aware) - represents DATE-TIME, which RFC
-    # 5545 requires UNTIL to match: aware, not floating.
-    dtstart_is_bare_date = isinstance(dtstart, str) and is_bare_date(dtstart)
-
     if isinstance(dtstart, datetime):
         anchor = dtstart
     else:
@@ -836,22 +873,35 @@ def parse_rrule(
             raise ValueError(
                 f"invalid start time for recurrence rule: {dtstart}"
             ) from exc
-    if anchor.tzinfo is None and timezone is not None:
-        if dtstart_is_bare_date:
-            # All-day: only localize if needed to compare against an
-            # aware UNTIL - localizing unconditionally would instead
-            # create a mismatch in the opposite direction for a
-            # legitimately floating, bare-date UNTIL.
-            if until_dt is not None and until_dt.tzinfo is not None:
-                anchor = anchor.replace(tzinfo=resolve_zoneinfo(timezone))
-        else:
-            # Timed: always localize. If UNTIL is naive/bare-date here,
-            # that's an actual RFC 5545 value-type mismatch (a DATE-TIME
-            # DTSTART requires an aware UNTIL) - localizing the anchor
-            # anyway makes dateutil's own validation below correctly
-            # reject it, the same way it always has for an
-            # already-aware-string dtstart.
-            anchor = anchor.replace(tzinfo=resolve_zoneinfo(timezone))
+    resolved_timezone = resolve_zoneinfo(timezone) if timezone is not None else None
+    if until_dt is not None:
+        until_is_date = "T" not in parts["UNTIL"]
+        if dtstart_is_bare_date != until_is_date:
+            raise ValueError(
+                "invalid recurrence rule: UNTIL must use the same DATE or "
+                "DATE-TIME value type as the event start"
+            )
+        if not dtstart_is_bare_date:
+            until_is_utc = parts["UNTIL"].endswith("Z")
+            dtstart_has_timezone = (
+                anchor.tzinfo is not None or resolved_timezone is not None
+            )
+            if dtstart_has_timezone != until_is_utc:
+                expected = (
+                    "UTC with a trailing Z"
+                    if dtstart_has_timezone
+                    else "floating local time"
+                )
+                raise ValueError(
+                    f"invalid recurrence rule: UNTIL must be {expected} to match "
+                    "the event start"
+                )
+    if (
+        anchor.tzinfo is None
+        and resolved_timezone is not None
+        and not dtstart_is_bare_date
+    ):
+        anchor = anchor.replace(tzinfo=resolved_timezone)
     try:
         _rrulestr(f"RRULE:{body}", dtstart=anchor)
     except (ValueError, TypeError) as exc:

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -7,7 +7,21 @@ from typing import Any
 from urllib.parse import quote
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from dateutil import parser as _date_parser
+from dateutil.rrule import rrulestr as _rrulestr
+
 from ....config import get_tool_max_output_length
+
+_DIGITS_ONLY_RE = re.compile(r"[0-9]+")
+# RFC 5545 UNTIL is always in "basic" form - no "-"/":" separators, unlike
+# ISO8601's "extended" form that dateutil's isoparse also happily accepts
+# (e.g. "2026-09-11T23:59:59+08:00"). dateutil.rrule.rrulestr's own RFC
+# 5545 line parser expects exactly this basic shape and raises a raw,
+# uninformative "too many values to unpack" if it isn't - see parse_rrule.
+# The trailing "Z" is itself optional: RFC 5545 permits UNTIL as a
+# floating "DATE WITH LOCAL TIME" (no "Z") whenever DTSTART is also
+# floating local time, not just the aware "DATE WITH UTC TIME" form.
+_UNTIL_RE = re.compile(r"[0-9]{8}(T[0-9]{6}Z?)?")
 
 
 class InsufficientScopeError(RuntimeError):
@@ -615,6 +629,251 @@ def window_delta_segments(
         # Real datetimes that still can't be compared (aware vs. naive) -
         # same "can't confirm smaller than the whole window" fallback.
         return [(new_start, new_end)]
+
+
+def is_bare_date(value: str) -> bool:
+    """Whether a caller-supplied date/time string is a bare "date" (e.g.
+    Google's all-day form, "2026-08-26") rather than a "dateTime".
+
+    Checked structurally (exactly three hyphen-separated all-digit parts,
+    after stripping outer whitespace) rather than by the absence of a
+    "T"/"t" date/time separator: RFC3339 also permits a space in place of
+    "T" for readability, so "2026-08-26 07:00:00" contains no "t" either
+    and would otherwise be misclassified as a bare date.
+
+    "all-digit" is checked via `_DIGITS_ONLY_RE` (ASCII 0-9 only), not
+    `str.isdigit()`: the latter also accepts non-ASCII digit lookalikes
+    (superscript, Thai, ...) that would misclassify a value as a bare
+    date with no further local validation before it's written straight
+    into a Google Calendar request body.
+    """
+    parts = value.strip().split("-")
+    return len(parts) == 3 and all(_DIGITS_ONLY_RE.fullmatch(part) for part in parts)
+
+
+def _strip_rrule_prefix(rrule_text: str) -> str:
+    """Return `rrule_text` with any leading "RRULE:" (case-insensitive)
+    removed and outer whitespace trimmed - the one place this stripping
+    happens, so `ensure_rrule_prefix` and `parse_rrule` can't drift apart
+    on what counts as "the prefix"."""
+    body = rrule_text.strip()
+    if body.upper().startswith("RRULE:"):
+        body = body[len("RRULE:") :]
+    return body.strip()
+
+
+def ensure_rrule_prefix(rrule_text: str) -> str:
+    """Return `rrule_text` with a leading "RRULE:" (adding one if it
+    doesn't already have one), with its body canonicalized to uppercase.
+
+    RFC 5545's RRULE grammar has no case-sensitive free-text values - every
+    token (FREQ's value, BYDAY's day codes, the "T"/"Z" markers in UNTIL,
+    ...) is a fixed-case keyword - so uppercasing the whole body is always
+    safe, and it matters here specifically: `parse_rrule`'s validation
+    tolerates lowercase (dateutil is lenient), but a lowercase rule would
+    otherwise reach Google's API as literal text at whatever case the
+    caller happened to use.
+    """
+    return f"RRULE:{_strip_rrule_prefix(rrule_text).upper()}"
+
+
+def parse_rrule(
+    rrule_text: str,
+    dtstart: str | datetime,
+    timezone: str | None = None,
+) -> dict[str, str]:
+    """Validate an RFC 5545 RRULE string and return its components (FREQ,
+    INTERVAL, BYDAY, UNTIL, COUNT, ...) as a plain dict of upper-cased keys
+    to upper-cased string values.
+
+    ``dtstart`` anchors a validation pass through ``dateutil.rrule.rrulestr``
+    so a rule that's syntactically plausible but semantically broken (e.g.
+    a nonsense FREQ) is rejected here rather than being sent to
+    Google/Outlook and either erroring opaquely or - worse - only ever
+    landing as inert description text, which is exactly the failure mode
+    reported against this connector before recurrence support existed.
+    ``dtstart`` also anchors a separate, explicit check this function adds
+    on top of dateutil's: an UNTIL before dtstart parses fine under
+    rrulestr (it just silently produces zero occurrences), so that case is
+    checked here directly rather than trusted to the library. Pass an
+    RFC3339/ISO8601 string (matching what these calendar tools already
+    require for start_time/start_datetime), or a `datetime` directly when
+    the caller already has one on hand (e.g. after localizing a naive
+    Outlook start time) - skipping the format-then-reparse round trip that
+    passing `.isoformat()` back in would otherwise cost.
+
+    ``timezone``, if given, localizes a naive ``dtstart``. For a genuine
+    all-day event - ``dtstart`` passed as a bare-date string with no "T",
+    e.g. Google's own all-day "date" field - this only happens when
+    needed to compare against an aware UNTIL; a naive/bare-date UNTIL is
+    correctly left floating to match the still-naive anchor instead,
+    since RFC 5545's DATE value type legitimately pairs a floating DTSTART
+    with a floating UNTIL. For anything else (a full dateTime string,
+    aware or not, or an already-`datetime` object), the
+    anchor is always localized when naive - RFC 5545's DATE-TIME value
+    type requires UNTIL to be aware too, so if it isn't, that's an actual
+    mismatch dateutil's own validation below correctly rejects, the same
+    way it already does for a dtstart string that carries its own offset.
+    Either way, the UNTIL-not-before-dtstart check
+    below still runs - it compares whenever anchor and UNTIL share the
+    same awareness, aware-vs-aware or naive-vs-naive alike.
+
+    The returned dict (rather than the parsed rrule object) is what
+    callers actually build a provider payload from: Google takes the RRULE
+    text close to verbatim, while Outlook needs these components
+    translated into Graph's own pattern/range structure - neither needs
+    dateutil's internal representation, just confirmation that the text is
+    valid RFC 5545.
+    """
+    if "\n" in rrule_text or "\r" in rrule_text:
+        raise ValueError(
+            "recurrence rule must not contain embedded newlines (this could "
+            "smuggle an extra RRULE/EXDATE/RDATE line into the calendar API "
+            "request)"
+        )
+    body = _strip_rrule_prefix(rrule_text)
+    if not body:
+        raise ValueError("recurrence rule must not be empty")
+
+    parts: dict[str, str] = {}
+    for chunk in body.split(";"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if "=" not in chunk:
+            raise ValueError(f"invalid recurrence rule component: {chunk!r}")
+        key, _, value = chunk.partition("=")
+        key = key.strip().upper()
+        if key in parts:
+            # A duplicate key (e.g. "FREQ=DAILY;FREQ=WEEKLY") would
+            # otherwise just silently overwrite the first occurrence in
+            # `parts` for local validation, while the raw text - still
+            # containing BOTH occurrences - reaches Google's API close to
+            # verbatim, where its behavior is unspecified rather than
+            # matching whatever this function validated.
+            raise ValueError(
+                f"invalid recurrence rule: {key} is specified more than once"
+            )
+        # Uppercased for the same reason ensure_rrule_prefix uppercases the
+        # whole rule text: RFC 5545's RRULE grammar has no case-sensitive
+        # free-text values, and this dict is what a future Outlook
+        # translator (parse_rrule's only other planned caller) would key
+        # lookups against - a caller who wrote "freq=daily" shouldn't get
+        # a dict with "daily" where every other caller gets "DAILY".
+        parts[key] = value.strip().upper()
+    if "FREQ" not in parts:
+        raise ValueError(
+            "recurrence rule must include FREQ, e.g. "
+            "'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;UNTIL=20260911T235959Z'"
+        )
+    if "UNTIL" in parts and "COUNT" in parts:
+        raise ValueError(
+            "recurrence rule must not specify both UNTIL and COUNT - RFC "
+            "5545 treats these as mutually exclusive ways to end a series"
+        )
+    # RFC 5545 defines INTERVAL/COUNT as `1*DIGIT` - plain unsigned digits,
+    # nothing else. Python's int() is more permissive (a leading "+"/"-",
+    # PEP 515 "_" digit separators), and `parts` holds the ORIGINAL string,
+    # which reaches Google's API close to verbatim (only re-cased, not
+    # reconstructed from the parsed int) - so validating only the parsed
+    # value and not the string's own shape would let something like
+    # "INTERVAL=1_0" or "COUNT=+5" slip through to the live API as invalid
+    # RRULE text.
+    for key in ("INTERVAL", "COUNT"):
+        if key not in parts:
+            continue
+        if not _DIGITS_ONLY_RE.fullmatch(parts[key]):
+            raise ValueError(
+                f"invalid recurrence rule: {key} must be an integer, got {parts[key]!r}"
+            )
+        if int(parts[key]) < 1:
+            raise ValueError(
+                f"invalid recurrence rule: {key} must be a positive integer, "
+                f"got {int(parts[key])}"
+            )
+
+    # Parsed before the anchor is localized below, since whether to
+    # localize at all now depends on UNTIL's own value type.
+    until_dt = None
+    if "UNTIL" in parts:
+        # Checked against RFC 5545's actual (basic-form) UNTIL grammar
+        # before handing it to dateutil at all: isoparse below is lenient
+        # enough to accept ISO8601's extended form too (dashes, colons,
+        # e.g. "2026-09-11T23:59:59+08:00"), which RFC 5545 never allows
+        # for UNTIL - and dateutil.rrule.rrulestr's own line parser chokes
+        # on exactly that shape with a raw, uninformative "too many values
+        # to unpack" once this rule reaches the validation pass further
+        # down, instead of the clear error this function exists to give.
+        if not _UNTIL_RE.fullmatch(parts["UNTIL"]):
+            raise ValueError(
+                f"invalid UNTIL value in recurrence rule: {parts['UNTIL']!r} "
+                "- must be RFC 5545's basic form with no '-'/':' separators, "
+                "e.g. '20260911T235959Z' or '20260911'"
+            )
+        try:
+            until_dt = _date_parser.isoparse(parts["UNTIL"])
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid UNTIL value in recurrence rule: {parts['UNTIL']!r}"
+            ) from exc
+
+    # A bare-date dtstart string (e.g. Google's own all-day "date" field,
+    # "2026-08-26") is the same signal calendar.py itself already uses to
+    # detect an all-day event - RFC 5545's DATE value type, which
+    # legitimately pairs with an equally bare-date (floating) UNTIL.
+    # Anything else - a full dateTime string (with or without its own
+    # offset) or an already-`datetime` object (as Outlook's caller always
+    # passes, already localized aware) - represents DATE-TIME, which RFC
+    # 5545 requires UNTIL to match: aware, not floating.
+    dtstart_is_bare_date = isinstance(dtstart, str) and is_bare_date(dtstart)
+
+    if isinstance(dtstart, datetime):
+        anchor = dtstart
+    else:
+        try:
+            anchor = _date_parser.isoparse(dtstart)
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid start time for recurrence rule: {dtstart}"
+            ) from exc
+    if anchor.tzinfo is None and timezone is not None:
+        if dtstart_is_bare_date:
+            # All-day: only localize if needed to compare against an
+            # aware UNTIL - localizing unconditionally would instead
+            # create a mismatch in the opposite direction for a
+            # legitimately floating, bare-date UNTIL.
+            if until_dt is not None and until_dt.tzinfo is not None:
+                anchor = anchor.replace(tzinfo=resolve_zoneinfo(timezone))
+        else:
+            # Timed: always localize. If UNTIL is naive/bare-date here,
+            # that's an actual RFC 5545 value-type mismatch (a DATE-TIME
+            # DTSTART requires an aware UNTIL) - localizing the anchor
+            # anyway makes dateutil's own validation below correctly
+            # reject it, the same way it always has for an
+            # already-aware-string dtstart.
+            anchor = anchor.replace(tzinfo=resolve_zoneinfo(timezone))
+    try:
+        _rrulestr(f"RRULE:{body}", dtstart=anchor)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"invalid recurrence rule {rrule_text!r}: {exc}") from exc
+
+    # dateutil's rrulestr above does NOT catch this: an UNTIL before dtstart
+    # parses fine and just silently yields zero occurrences - a "recurring"
+    # event that never actually recurs, reported as success. Comparable
+    # whenever anchor and until_dt share the same awareness (both aware, or
+    # both naive/floating - a plain datetime comparison works fine either
+    # way); an aware-vs-naive mismatch would raise TypeError rather than
+    # answer the question, so THAT combination is skipped rather than
+    # guessed at (dateutil's rrulestr call above already rejects it before
+    # this point is ever reached, in fact).
+    if until_dt is not None and (until_dt.tzinfo is None) == (anchor.tzinfo is None):
+        if until_dt < anchor:
+            raise ValueError(
+                f"recurrence UNTIL ({parts['UNTIL']}) is before the start "
+                "time; this recurrence would never actually happen"
+            )
+
+    return parts
 
 
 def clamp_limit(limit: int, *, max_limit: int) -> int:

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -14,6 +14,7 @@ from ....config import get_tool_max_output_length
 
 _DIGITS_ONLY_RE = re.compile(r"[0-9]+")
 _BARE_DATE_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}")
+_NUMERIC_BYDAY_RE = re.compile(r"[+-]?[0-9]{1,2}(MO|TU|WE|TH|FR|SA|SU)")
 # RFC 5545 UNTIL is always in "basic" form - no "-"/":" separators, unlike
 # ISO8601's "extended" form that dateutil's isoparse also happily accepts
 # (e.g. "2026-09-11T23:59:59+08:00"). dateutil.rrule.rrulestr's own RFC
@@ -670,7 +671,10 @@ def _validate_rrule_constraints(
 
     byday = parts.get("BYDAY")
     has_numeric_byday = bool(
-        byday and any(len(value.strip()) > 2 for value in byday.split(","))
+        byday
+        and any(
+            _NUMERIC_BYDAY_RE.fullmatch(value.strip()) for value in byday.split(",")
+        )
     )
     if has_numeric_byday and freq not in {"MONTHLY", "YEARLY"}:
         raise ValueError(
@@ -725,6 +729,8 @@ def ensure_rrule_prefix(rrule_text: str) -> str:
     otherwise reach Google's API as literal text at whatever case the
     caller happened to use.
     """
+    if "\n" in rrule_text or "\r" in rrule_text:
+        raise ValueError("recurrence rule must not contain embedded newlines")
     return f"RRULE:{_strip_rrule_prefix(rrule_text).upper()}"
 
 
@@ -770,6 +776,8 @@ def parse_rrule(
     dateutil's internal representation, just confirmation that the text is
     valid RFC 5545.
     """
+    if isinstance(dtstart, str):
+        dtstart = dtstart.strip()
     if "\n" in rrule_text or "\r" in rrule_text:
         raise ValueError(
             "recurrence rule must not contain embedded newlines (this could "

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -3,6 +3,8 @@ import json
 import re
 from unittest.mock import Mock
 
+import pytest
+
 from xagent.web.tools.mcp import calendar
 from xagent.web.tools.mcp import utils as mcp_utils
 
@@ -204,7 +206,7 @@ def test_create_events_rejects_an_invalid_timezone_even_without_recurrence(
     )
 
     assert result["status"] == "error"
-    assert "unknown timezone" in result["message"]
+    assert "recognized IANA zone name" in result["message"]
     service.events.return_value.insert.assert_not_called()
 
 
@@ -330,6 +332,54 @@ def test_create_events_creates_an_all_day_event_from_bare_dates(monkeypatch):
     _, kwargs = service.events.return_value.insert.call_args
     assert kwargs["body"]["start"] == {"date": "2026-09-01"}
     assert kwargs["body"]["end"] == {"date": "2026-09-02"}
+
+
+@pytest.mark.parametrize(
+    ("start_time", "end_time"),
+    [
+        ("2026-02-30", "2026-03-01"),
+        ("2026-2-3", "2026-02-04"),
+        ("2026-13-01", "2026-13-02"),
+    ],
+)
+def test_create_events_rejects_invalid_all_day_dates(monkeypatch, start_time, end_time):
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Invalid all-day event",
+            start_time=start_time,
+            end_time=end_time,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "valid YYYY-MM-DD date or RFC3339 dateTime" in result["message"]
+    service.events.return_value.insert.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("start_time", "end_time"),
+    [("2026-09-01", "2026-09-01"), ("2026-09-02", "2026-09-01")],
+)
+def test_create_events_rejects_nonpositive_all_day_ranges(
+    monkeypatch, start_time, end_time
+):
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Invalid all-day range",
+            start_time=start_time,
+            end_time=end_time,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "end_time is exclusive" in result["message"]
+    service.events.return_value.insert.assert_not_called()
 
 
 def test_create_events_strips_whitespace_from_a_bare_date_before_sending_it(

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -185,6 +185,26 @@ def test_create_events_requires_timezone_when_recurrence_is_set(monkeypatch):
     service.events.return_value.insert.assert_not_called()
 
 
+def test_create_events_treats_empty_timezone_as_not_provided(monkeypatch):
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="All day recurring",
+            start_time="2026-09-01",
+            end_time="2026-09-02",
+            recurrence="FREQ=DAILY;COUNT=3",
+            timezone="  ",
+        )
+    )
+
+    assert result["status"] == "success"
+    _, kwargs = service.events.return_value.insert.call_args
+    assert "timeZone" not in kwargs["body"]["start"]
+    assert "timeZone" not in kwargs["body"]["end"]
+
+
 def test_create_events_rejects_an_invalid_timezone_even_without_recurrence(
     monkeypatch,
 ):
@@ -257,7 +277,8 @@ def test_create_events_rejects_invalid_recurrence_without_calling_the_api(
     originally reported failure mode - silently accepted as inert text
     with no actual recurrence."""
     service = _fake_service({"id": "created"})
-    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+    get_calendar_service = Mock(return_value=service)
+    monkeypatch.setattr(calendar, "get_calendar_service", get_calendar_service)
 
     result = json.loads(
         calendar.google_calendar_create_events(
@@ -271,7 +292,30 @@ def test_create_events_rejects_invalid_recurrence_without_calling_the_api(
 
     assert result["status"] == "error"
     assert "invalid recurrence rule" in result["message"]
+    get_calendar_service.assert_not_called()
     service.events.return_value.insert.assert_not_called()
+
+
+@pytest.mark.parametrize("frequency", ["SECONDLY", "MINUTELY", "HOURLY"])
+def test_create_events_rejects_frequencies_google_does_not_support(
+    monkeypatch, frequency
+):
+    get_calendar_service = Mock()
+    monkeypatch.setattr(calendar, "get_calendar_service", get_calendar_service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Too frequent",
+            start_time="2026-09-01T09:00:00+08:00",
+            end_time="2026-09-01T09:15:00+08:00",
+            recurrence=f"FREQ={frequency};COUNT=3",
+            timezone="Asia/Shanghai",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert f"does not support FREQ={frequency}" in result["message"]
+    get_calendar_service.assert_not_called()
 
 
 def test_create_events_rejects_explicit_empty_recurrence(monkeypatch):
@@ -450,14 +494,12 @@ def test_create_events_accepts_a_whitespace_padded_all_day_recurrence(monkeypatc
     assert result["status"] == "success"
 
 
-def test_create_events_treats_a_space_separated_datetime_as_timed_not_all_day(
+def test_create_events_rejects_a_space_separated_datetime(
     monkeypatch,
 ):
-    """Confirmed bug: RFC3339 permits a space in place of "T" as the
-    date/time separator ("2026-09-01 10:00:00"), so a check that only
-    looked for the absence of "t" misclassified this as a bare date,
-    silently dropping the time-of-day and sending Google a malformed
-    {"date": "2026-09-01 10:00:00"}."""
+    """ISO 8601 permits a space separator, but Google's EventDateTime
+    contract requires RFC3339. Reject it locally instead of forwarding a
+    value the API may reject."""
     service = _fake_service({"id": "created"})
     monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
 
@@ -469,10 +511,53 @@ def test_create_events_treats_a_space_separated_datetime_as_timed_not_all_day(
         )
     )
 
-    assert result["status"] == "success"
-    _, kwargs = service.events.return_value.insert.call_args
-    assert kwargs["body"]["start"] == {"dateTime": "2026-09-01 10:00:00"}
-    assert kwargs["body"]["end"] == {"dateTime": "2026-09-01 11:00:00"}
+    assert result["status"] == "error"
+    assert "RFC3339 dateTime" in result["message"]
+    service.events.return_value.insert.assert_not_called()
+
+
+@pytest.mark.parametrize("value", ["20260826T070000", "2026W011T070000"])
+def test_create_events_rejects_non_rfc3339_datetime_shapes(monkeypatch, value):
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Invalid datetime shape",
+            start_time=value,
+            end_time="2026-09-01T11:00:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "RFC3339 dateTime" in result["message"]
+    service.events.return_value.insert.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("start_time", "end_time"),
+    [
+        ("2026-09-01T10:00:00+08:00", "2026-09-01T10:00:00+08:00"),
+        ("2026-09-01T11:00:00+08:00", "2026-09-01T10:00:00+08:00"),
+    ],
+)
+def test_create_events_rejects_nonpositive_timed_ranges(
+    monkeypatch, start_time, end_time
+):
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Invalid timed range",
+            start_time=start_time,
+            end_time=end_time,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after start" in result["message"]
+    service.events.return_value.insert.assert_not_called()
 
 
 def test_create_events_rejects_mixed_bare_date_and_datetime(monkeypatch):

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -39,6 +39,405 @@ def _fake_service(execute_result: dict, existing_event: dict | None = None):
     return service
 
 
+def test_has_own_utc_offset_true_for_a_z_suffix():
+    assert calendar._has_own_utc_offset("2026-08-26T07:00:00Z")
+
+
+def test_has_own_utc_offset_true_for_an_explicit_offset():
+    assert calendar._has_own_utc_offset("2026-08-26T07:00:00+08:00")
+
+
+def test_has_own_utc_offset_false_for_a_naive_datetime():
+    assert not calendar._has_own_utc_offset("2026-08-26T07:00:00")
+
+
+def test_has_own_utc_offset_false_for_unparseable_input():
+    assert not calendar._has_own_utc_offset("not-a-date")
+
+
+def test_normalize_rrule_returns_a_prefixed_uppercased_string():
+    assert (
+        calendar._normalize_rrule("freq=daily;count=3", "2026-08-26T07:00:00")
+        == "RRULE:FREQ=DAILY;COUNT=3"
+    )
+
+
+def test_create_events_sets_recurrence(monkeypatch):
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Daily Catch up with Bright",
+            start_time="2026-08-26T07:00:00",
+            end_time="2026-08-26T07:15:00",
+            recurrence="FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;UNTIL=20260911T235959Z",
+            timezone="Asia/Shanghai",
+        )
+    )
+
+    assert result["status"] == "success"
+    _, kwargs = service.events.return_value.insert.call_args
+    assert kwargs["body"]["recurrence"] == [
+        "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;UNTIL=20260911T235959Z"
+    ]
+    assert kwargs["body"]["start"]["timeZone"] == "Asia/Shanghai"
+    assert kwargs["body"]["end"]["timeZone"] == "Asia/Shanghai"
+
+
+def test_create_events_stamps_timezone_even_when_recurrence_has_its_own_offset(
+    monkeypatch,
+):
+    """Google's EventDateTime reference requires timeZone unconditionally
+    for a recurring event, regardless of whether start_time/end_time
+    already carry their own UTC offset - the offset only fixes this one
+    occurrence's instant, while timeZone governs how the recurrence
+    itself expands (e.g. across DST transitions). Must NOT be skipped
+    here just because the value is already self-describing."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Weekly sync",
+            start_time="2026-08-26T09:00:00+08:00",
+            end_time="2026-08-26T10:00:00+08:00",
+            timezone="America/Los_Angeles",
+            recurrence="FREQ=WEEKLY;COUNT=5",
+        )
+    )
+
+    assert result["status"] == "success"
+    _, kwargs = service.events.return_value.insert.call_args
+    assert kwargs["body"]["start"]["timeZone"] == "America/Los_Angeles"
+    assert kwargs["body"]["end"]["timeZone"] == "America/Los_Angeles"
+
+
+def test_create_events_skips_timezone_on_its_own_offset_without_recurrence(
+    monkeypatch,
+):
+    """Without recurrence, timeZone is merely optional (per Google's own
+    docs), so a side that already carries its own UTC offset is skipped
+    instead of risking a disagreeing zone on an optional field."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="One-off",
+            start_time="2026-08-26T09:00:00+08:00",
+            end_time="2026-08-26T10:00:00+08:00",
+            timezone="America/Los_Angeles",
+        )
+    )
+
+    assert result["status"] == "success"
+    _, kwargs = service.events.return_value.insert.call_args
+    assert "timeZone" not in kwargs["body"]["start"]
+    assert "timeZone" not in kwargs["body"]["end"]
+
+
+def test_create_events_skips_timezone_independently_per_side_on_asymmetric_offsets(
+    monkeypatch,
+):
+    """start/end are checked independently, not just with a shared
+    offset-or-not assumption - a mock that always gives both sides the
+    same offset shape couldn't catch _stamp_timezone's start/end
+    arguments being accidentally swapped."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="One-off",
+            start_time="2026-08-26T09:00:00+08:00",
+            end_time="2026-08-26T10:00:00",
+            timezone="America/Los_Angeles",
+        )
+    )
+
+    assert result["status"] == "success"
+    _, kwargs = service.events.return_value.insert.call_args
+    assert "timeZone" not in kwargs["body"]["start"]
+    assert kwargs["body"]["end"]["timeZone"] == "America/Los_Angeles"
+
+
+def test_create_events_requires_timezone_when_recurrence_is_set(monkeypatch):
+    """Google documents timeZone as required specifically for recurring
+    events (it's what the recurrence is expanded in) - this must be
+    rejected here rather than silently sent to Google without one."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Standup",
+            start_time="2026-08-26T09:00:00+08:00",
+            end_time="2026-08-26T09:15:00+08:00",
+            recurrence="FREQ=DAILY",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "timezone is required" in result["message"]
+    service.events.return_value.insert.assert_not_called()
+
+
+def test_create_events_rejects_an_invalid_timezone_even_without_recurrence(
+    monkeypatch,
+):
+    """Confirmed bug: an invalid IANA timezone name was only ever caught
+    by resolve_zoneinfo when recurrence was also set (parse_rrule is its
+    only caller) - without recurrence, a bad timezone silently reached
+    Google's API and surfaced as an opaque server-side error instead of
+    this connector's own clean message."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Standup",
+            start_time="2026-08-26T09:00:00",
+            end_time="2026-08-26T09:15:00",
+            timezone="Not/AZone",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "unknown timezone" in result["message"]
+    service.events.return_value.insert.assert_not_called()
+
+
+def test_create_events_accepts_recurrence_with_explicit_prefix(monkeypatch):
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Standup",
+            start_time="2026-08-26T09:00:00+08:00",
+            end_time="2026-08-26T09:15:00+08:00",
+            recurrence="RRULE:FREQ=DAILY;COUNT=10",
+            timezone="Asia/Shanghai",
+        )
+    )
+
+    assert result["status"] == "success"
+    _, kwargs = service.events.return_value.insert.call_args
+    assert kwargs["body"]["recurrence"] == ["RRULE:FREQ=DAILY;COUNT=10"]
+
+
+def test_create_events_normalizes_lowercase_recurrence(monkeypatch):
+    """Regression test: dateutil's validation is lenient about case, so a
+    lowercase RRULE must still be canonicalized to uppercase before
+    reaching Google's API - not sent verbatim in whatever case an LLM
+    happened to produce."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_create_events(
+        summary="Standup",
+        start_time="2026-08-26T09:00:00+08:00",
+        end_time="2026-08-26T09:15:00+08:00",
+        recurrence="freq=daily;count=10",
+        timezone="Asia/Shanghai",
+    )
+
+    _, kwargs = service.events.return_value.insert.call_args
+    assert kwargs["body"]["recurrence"] == ["RRULE:FREQ=DAILY;COUNT=10"]
+
+
+def test_create_events_rejects_invalid_recurrence_without_calling_the_api(
+    monkeypatch,
+):
+    """A rule that can't be parsed must be reported as an error, not sent
+    to Google where it would either be rejected opaquely or - the
+    originally reported failure mode - silently accepted as inert text
+    with no actual recurrence."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Standup",
+            start_time="2026-08-26T09:00:00+08:00",
+            end_time="2026-08-26T09:15:00+08:00",
+            recurrence="FREQ=FORTNIGHTLY",
+            timezone="Asia/Shanghai",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "invalid recurrence rule" in result["message"]
+    service.events.return_value.insert.assert_not_called()
+
+
+def test_create_events_rejects_explicit_empty_recurrence(monkeypatch):
+    """Regression test: every other optional field in this function treats
+    an explicitly-passed value as meaningful; recurrence="" must not be
+    silently treated the same as not mentioning recurrence at all."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Standup",
+            start_time="2026-08-26T09:00:00+08:00",
+            end_time="2026-08-26T09:15:00+08:00",
+            timezone="Asia/Shanghai",
+            recurrence="",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must not be empty" in result["message"]
+    service.events.return_value.insert.assert_not_called()
+
+
+def test_create_events_without_recurrence_has_no_recurrence_key(monkeypatch):
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_create_events(
+        summary="One-off",
+        start_time="2026-08-26T09:00:00+08:00",
+        end_time="2026-08-26T09:15:00+08:00",
+    )
+
+    _, kwargs = service.events.return_value.insert.call_args
+    assert "recurrence" not in kwargs["body"]
+
+
+def test_create_events_creates_an_all_day_event_from_bare_dates(monkeypatch):
+    """Confirmed bug: a bare-date start_time/end_time (e.g. "2026-09-01",
+    no time component) used to be silently written under the "dateTime"
+    key regardless - {"dateTime": "2026-09-01"} is not valid RFC3339 and
+    Google's real API would reject it. Must be written under "date"
+    instead, with no timeZone stamped onto it."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="All day thing",
+            start_time="2026-09-01",
+            end_time="2026-09-02",
+            timezone="Asia/Shanghai",
+        )
+    )
+
+    assert result["status"] == "success"
+    _, kwargs = service.events.return_value.insert.call_args
+    assert kwargs["body"]["start"] == {"date": "2026-09-01"}
+    assert kwargs["body"]["end"] == {"date": "2026-09-02"}
+
+
+def test_create_events_strips_whitespace_from_a_bare_date_before_sending_it(
+    monkeypatch,
+):
+    """is_bare_date strips surrounding whitespace to decide the shape, but
+    the raw start_time/end_time used to be written into the payload as-is
+    - a bare date with incidental whitespace would reach Google as
+    something other than the exact "YYYY-MM-DD" it requires."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="All day thing",
+            start_time="  2026-09-01  ",
+            end_time="  2026-09-02  ",
+        )
+    )
+
+    assert result["status"] == "success"
+    _, kwargs = service.events.return_value.insert.call_args
+    assert kwargs["body"]["start"] == {"date": "2026-09-01"}
+    assert kwargs["body"]["end"] == {"date": "2026-09-02"}
+
+
+def test_create_events_accepts_a_whitespace_padded_all_day_recurrence(monkeypatch):
+    """Confirmed bug: the payload used the stripped bare-date value, but
+    recurrence validation was passed the raw, unstripped start_time - so
+    the exact same all-day start_time that succeeds without recurrence
+    was rejected as an "invalid start time" the moment recurrence was
+    also set."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="All day thing",
+            start_time="  2026-09-01  ",
+            end_time="  2026-09-02  ",
+            recurrence="FREQ=DAILY;COUNT=3",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_create_events_treats_a_space_separated_datetime_as_timed_not_all_day(
+    monkeypatch,
+):
+    """Confirmed bug: RFC3339 permits a space in place of "T" as the
+    date/time separator ("2026-09-01 10:00:00"), so a check that only
+    looked for the absence of "t" misclassified this as a bare date,
+    silently dropping the time-of-day and sending Google a malformed
+    {"date": "2026-09-01 10:00:00"}."""
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Timed with a space separator",
+            start_time="2026-09-01 10:00:00",
+            end_time="2026-09-01 11:00:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    _, kwargs = service.events.return_value.insert.call_args
+    assert kwargs["body"]["start"] == {"dateTime": "2026-09-01 10:00:00"}
+    assert kwargs["body"]["end"] == {"dateTime": "2026-09-01 11:00:00"}
+
+
+def test_create_events_rejects_mixed_bare_date_and_datetime(monkeypatch):
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Mixed",
+            start_time="2026-09-01",
+            end_time="2026-09-02T10:00:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must both be a bare date or both a dateTime" in result["message"]
+    service.events.return_value.insert.assert_not_called()
+
+
+def test_create_events_all_day_recurrence_does_not_require_timezone(monkeypatch):
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="All day recurring",
+            start_time="2026-09-01",
+            end_time="2026-09-02",
+            recurrence="FREQ=DAILY;UNTIL=20260911",
+        )
+    )
+
+    assert result["status"] == "success"
+    _, kwargs = service.events.return_value.insert.call_args
+    assert kwargs["body"]["recurrence"] == ["RRULE:FREQ=DAILY;UNTIL=20260911"]
+    assert "timeZone" not in kwargs["body"]["start"]
+
+
 def test_create_event_without_attendees_or_meet_sends_conference_version_and_no_invites(
     monkeypatch,
 ):

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -356,6 +356,29 @@ def test_create_events_strips_whitespace_from_a_bare_date_before_sending_it(
     assert kwargs["body"]["end"] == {"date": "2026-09-02"}
 
 
+def test_create_events_strips_whitespace_from_timed_values_before_validation_and_send(
+    monkeypatch,
+):
+    service = _fake_service({"id": "created"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Standup",
+            start_time="  2026-09-01T09:00:00+08:00  ",
+            end_time="  2026-09-01T09:15:00+08:00  ",
+            recurrence="FREQ=DAILY;COUNT=3",
+            timezone="Asia/Shanghai",
+        )
+    )
+
+    assert result["status"] == "success"
+    _, kwargs = service.events.return_value.insert.call_args
+    assert kwargs["body"]["start"]["dateTime"] == "2026-09-01T09:00:00+08:00"
+    assert kwargs["body"]["end"]["dateTime"] == "2026-09-01T09:15:00+08:00"
+    assert kwargs["body"]["recurrence"] == ["RRULE:FREQ=DAILY;COUNT=3"]
+
+
 def test_create_events_accepts_a_whitespace_padded_all_day_recurrence(monkeypatch):
     """Confirmed bug: the payload used the stripped bare-date value, but
     recurrence validation was passed the raw, unstripped start_time - so

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -147,6 +147,14 @@ def test_is_bare_date_accepts_surrounding_whitespace():
     assert utils.is_bare_date("  2026-08-26  ")
 
 
+@pytest.mark.parametrize(
+    "value",
+    ["2026-2-3", "2026-02-30", "2026-13-01", "0000-01-01"],
+)
+def test_is_bare_date_rejects_noncanonical_or_impossible_dates(value):
+    assert not utils.is_bare_date(value)
+
+
 def test_is_bare_date_rejects_non_ascii_digit_lookalikes():
     """Confirmed bug: str.isdigit() also accepts non-ASCII digit
     lookalikes (superscript, Thai, fullwidth, ...), unlike the ASCII-only
@@ -324,6 +332,62 @@ def test_parse_rrule_all_day_bare_date_until_before_start_is_still_rejected():
         )
 
 
+@pytest.mark.parametrize(
+    "until",
+    ["20260911T235959", "20260911T235959Z"],
+)
+def test_parse_rrule_rejects_datetime_until_for_all_day_start(until):
+    with pytest.raises(ValueError, match="same DATE or DATE-TIME value type"):
+        utils.parse_rrule(
+            f"FREQ=DAILY;UNTIL={until}",
+            "2026-08-26",
+            timezone="Asia/Shanghai",
+        )
+
+
+def test_parse_rrule_rejects_date_until_for_floating_timed_start():
+    with pytest.raises(ValueError, match="same DATE or DATE-TIME value type"):
+        utils.parse_rrule(
+            "FREQ=DAILY;UNTIL=20260911",
+            "2026-08-26T07:00:00",
+        )
+
+
+@pytest.mark.parametrize("part", ["BYSECOND=10", "BYMINUTE=30", "BYHOUR=9"])
+def test_parse_rrule_rejects_time_parts_for_all_day_start(part):
+    with pytest.raises(ValueError, match="all-day DATE start"):
+        utils.parse_rrule(f"FREQ=DAILY;{part};COUNT=3", "2026-08-26")
+
+
+@pytest.mark.parametrize(
+    ("rule", "message"),
+    [
+        ("FREQ=DAILY;BYDAY=1MO;COUNT=3", "numeric BYDAY"),
+        ("FREQ=YEARLY;BYWEEKNO=1;BYDAY=1MO;COUNT=3", "numeric BYDAY"),
+        ("FREQ=WEEKLY;BYMONTHDAY=1;COUNT=3", "BYMONTHDAY"),
+        ("FREQ=DAILY;BYYEARDAY=1;COUNT=3", "BYYEARDAY"),
+        ("FREQ=MONTHLY;BYWEEKNO=1;COUNT=3", "BYWEEKNO"),
+        ("FREQ=MONTHLY;BYSETPOS=1;COUNT=3", "BYSETPOS"),
+    ],
+)
+def test_parse_rrule_rejects_invalid_frequency_combinations(rule, message):
+    with pytest.raises(ValueError, match=message):
+        utils.parse_rrule(rule, "2026-08-26T07:00:00")
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        "FREQ=MONTHLY;BYDAY=1MO;COUNT=3",
+        "FREQ=YEARLY;BYWEEKNO=1;BYDAY=MO;COUNT=3",
+        "FREQ=YEARLY;BYYEARDAY=1;COUNT=3",
+        "FREQ=MONTHLY;BYMONTHDAY=1;BYSETPOS=1;COUNT=3",
+    ],
+)
+def test_parse_rrule_accepts_valid_frequency_combinations(rule):
+    assert utils.parse_rrule(rule, "2026-08-26T07:00:00")["FREQ"]
+
+
 def test_parse_rrule_rejects_space_separated_dtstart_paired_with_bare_date_until():
     """Confirmed bug: RFC3339 permits a space in place of "T" as the
     date/time separator, so a check that only looked for the absence of
@@ -362,7 +426,7 @@ def test_parse_rrule_timezone_still_rejects_until_before_dtstart():
 
 
 def test_parse_rrule_rejects_unknown_timezone():
-    with pytest.raises(ValueError, match="unknown timezone"):
+    with pytest.raises(ValueError, match="recognized IANA zone name"):
         utils.parse_rrule(
             "FREQ=DAILY;UNTIL=20260911T235959Z",
             "2026-08-26T07:00:00",
@@ -444,7 +508,7 @@ def test_resolve_zoneinfo_returns_zoneinfo_for_valid_iana_name():
 
 
 def test_resolve_zoneinfo_rejects_unknown_timezone():
-    with pytest.raises(ValueError, match="unknown timezone"):
+    with pytest.raises(ValueError, match="recognized IANA zone name"):
         utils.resolve_zoneinfo("Not/ARealZone")
 
 

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -131,6 +131,11 @@ def test_ensure_rrule_prefix_keeps_existing_prefix_and_uppercases():
     )
 
 
+def test_ensure_rrule_prefix_rejects_embedded_newlines():
+    with pytest.raises(ValueError, match="embedded newlines"):
+        utils.ensure_rrule_prefix("FREQ=DAILY\nEXDATE:20260902")
+
+
 def test_is_bare_date_accepts_a_bare_date():
     assert utils.is_bare_date("2026-08-26")
 
@@ -376,16 +381,46 @@ def test_parse_rrule_rejects_invalid_frequency_combinations(rule, message):
 
 
 @pytest.mark.parametrize(
-    "rule",
+    ("rule", "expected"),
     [
-        "FREQ=MONTHLY;BYDAY=1MO;COUNT=3",
-        "FREQ=YEARLY;BYWEEKNO=1;BYDAY=MO;COUNT=3",
-        "FREQ=YEARLY;BYYEARDAY=1;COUNT=3",
-        "FREQ=MONTHLY;BYMONTHDAY=1;BYSETPOS=1;COUNT=3",
+        (
+            "FREQ=MONTHLY;BYDAY=1MO;COUNT=3",
+            {"FREQ": "MONTHLY", "BYDAY": "1MO", "COUNT": "3"},
+        ),
+        (
+            "FREQ=YEARLY;BYWEEKNO=1;BYDAY=MO;COUNT=3",
+            {"FREQ": "YEARLY", "BYWEEKNO": "1", "BYDAY": "MO", "COUNT": "3"},
+        ),
+        (
+            "FREQ=YEARLY;BYYEARDAY=1;COUNT=3",
+            {"FREQ": "YEARLY", "BYYEARDAY": "1", "COUNT": "3"},
+        ),
+        (
+            "FREQ=MONTHLY;BYMONTHDAY=1;BYSETPOS=1;COUNT=3",
+            {
+                "FREQ": "MONTHLY",
+                "BYMONTHDAY": "1",
+                "BYSETPOS": "1",
+                "COUNT": "3",
+            },
+        ),
     ],
 )
-def test_parse_rrule_accepts_valid_frequency_combinations(rule):
-    assert utils.parse_rrule(rule, "2026-08-26T07:00:00")["FREQ"]
+def test_parse_rrule_accepts_valid_frequency_combinations(rule, expected):
+    assert utils.parse_rrule(rule, "2026-08-26T07:00:00") == expected
+
+
+def test_parse_rrule_strips_string_dtstart_before_parsing():
+    assert utils.parse_rrule("FREQ=DAILY;COUNT=3", "  2026-08-26T07:00:00  ") == {
+        "FREQ": "DAILY",
+        "COUNT": "3",
+    }
+
+
+def test_parse_rrule_reports_invalid_byday_without_calling_it_numeric():
+    with pytest.raises(ValueError, match="invalid recurrence rule") as exc_info:
+        utils.parse_rrule("FREQ=FORTNIGHTLY;BYDAY=MOO", "2026-08-26T07:00:00")
+    assert "numeric BYDAY" not in str(exc_info.value)
 
 
 def test_parse_rrule_rejects_space_separated_dtstart_paired_with_bare_date_until():

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -103,6 +103,351 @@ def test_resolve_id_from_url_rejects_non_string():
         utils.resolve_id_from_url(12345, _TEST_URL_ID_PATTERN, "document_id")
 
 
+def test_parse_rrule_extracts_components():
+    parts = utils.parse_rrule(
+        "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;UNTIL=20260911T235959Z",
+        "2026-08-26T07:00:00+08:00",
+    )
+    assert parts == {
+        "FREQ": "WEEKLY",
+        "BYDAY": "MO,TU,WE,TH,FR",
+        "UNTIL": "20260911T235959Z",
+    }
+
+
+def test_parse_rrule_accepts_and_strips_rrule_prefix():
+    parts = utils.parse_rrule("RRULE:FREQ=DAILY;COUNT=5", "2026-08-26T07:00:00+08:00")
+    assert parts == {"FREQ": "DAILY", "COUNT": "5"}
+
+
+def test_ensure_rrule_prefix_adds_prefix_and_uppercases():
+    assert utils.ensure_rrule_prefix("FREQ=DAILY;COUNT=5") == "RRULE:FREQ=DAILY;COUNT=5"
+
+
+def test_ensure_rrule_prefix_keeps_existing_prefix_and_uppercases():
+    assert (
+        utils.ensure_rrule_prefix("rrule:freq=weekly;byday=mo,tu")
+        == "RRULE:FREQ=WEEKLY;BYDAY=MO,TU"
+    )
+
+
+def test_is_bare_date_accepts_a_bare_date():
+    assert utils.is_bare_date("2026-08-26")
+
+
+def test_is_bare_date_rejects_a_datetime():
+    assert not utils.is_bare_date("2026-08-26T07:00:00")
+
+
+def test_is_bare_date_rejects_a_space_separated_datetime():
+    assert not utils.is_bare_date("2026-08-26 07:00:00")
+
+
+def test_is_bare_date_accepts_surrounding_whitespace():
+    assert utils.is_bare_date("  2026-08-26  ")
+
+
+def test_is_bare_date_rejects_non_ascii_digit_lookalikes():
+    """Confirmed bug: str.isdigit() also accepts non-ASCII digit
+    lookalikes (superscript, Thai, fullwidth, ...), unlike the ASCII-only
+    _DIGITS_ONLY_RE this file already uses elsewhere for the identical
+    risk (see parse_rrule's INTERVAL/COUNT validation). A misclassified
+    value here reaches a Google Calendar request body's "date" field with
+    no further local validation, unlike parse_rrule's own path."""
+    assert not utils.is_bare_date("²⁰²⁶-08-26")
+    assert not utils.is_bare_date("๒๐๒๖-08-26")
+
+
+def test_ensure_rrule_prefix_normalizes_lowercase_rrule():
+    """RFC 5545's RRULE grammar has no case-sensitive free-text values, so
+    a fully lowercase rule (which parse_rrule's dateutil-backed validation
+    tolerates) must still reach the calendar API canonicalized to
+    uppercase - not sent verbatim in whatever case an LLM happened to
+    produce."""
+    assert (
+        utils.ensure_rrule_prefix(
+            "freq=weekly;byday=mo,tu,we,th,fr;until=20260911t235959z"
+        )
+        == "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;UNTIL=20260911T235959Z"
+    )
+
+
+def test_parse_rrule_rejects_empty_string():
+    with pytest.raises(ValueError, match="must not be empty"):
+        utils.parse_rrule("", "2026-08-26T07:00:00+08:00")
+    with pytest.raises(ValueError, match="must not be empty"):
+        utils.parse_rrule("RRULE:", "2026-08-26T07:00:00+08:00")
+
+
+def test_parse_rrule_rejects_missing_freq():
+    with pytest.raises(ValueError, match="FREQ"):
+        utils.parse_rrule("BYDAY=MO,TU", "2026-08-26T07:00:00+08:00")
+
+
+def test_parse_rrule_rejects_malformed_component():
+    with pytest.raises(ValueError, match="invalid recurrence rule component"):
+        utils.parse_rrule("FREQ=DAILY;BOGUS", "2026-08-26T07:00:00+08:00")
+
+
+def test_parse_rrule_rejects_duplicate_keys():
+    """A duplicate key (e.g. FREQ specified twice) would otherwise
+    silently keep only the last occurrence in the returned dict for local
+    validation, while the raw text - still containing BOTH occurrences -
+    reaches Google's API close to verbatim, where its behavior is
+    unspecified rather than matching whatever this function validated."""
+    with pytest.raises(ValueError, match="FREQ is specified more than once"):
+        utils.parse_rrule("FREQ=DAILY;FREQ=WEEKLY", "2026-08-26T07:00:00+08:00")
+
+
+def test_parse_rrule_rejects_unparseable_rule():
+    """A syntactically plausible but semantically invalid rule (an unknown
+    FREQ value) must be rejected, not silently accepted as valid RFC 5545
+    - this is exactly the class of bug the connector shipped with before:
+    a recurrence rule that only ever looks valid, never actually works."""
+    with pytest.raises(ValueError, match="invalid recurrence rule"):
+        utils.parse_rrule("FREQ=FORTNIGHTLY", "2026-08-26T07:00:00+08:00")
+
+
+def test_parse_rrule_rejects_bad_dtstart():
+    with pytest.raises(ValueError, match="invalid start time"):
+        utils.parse_rrule("FREQ=DAILY", "not-a-date")
+
+
+def test_parse_rrule_rejects_an_extended_iso8601_until_with_a_clean_message():
+    """Confirmed bug: dateutil's own isoparse is lenient enough to accept
+    ISO8601's extended form for UNTIL (dashes/colons, e.g.
+    "2026-09-11T23:59:59+08:00"), which RFC 5545 never permits - UNTIL
+    must be RFC 5545's basic form. dateutil.rrule.rrulestr's own RFC 5545
+    line parser chokes on the extended form with a raw, uninformative
+    "too many values to unpack" instead of this function's own clean
+    error - must be caught here directly."""
+    with pytest.raises(ValueError, match="must be RFC 5545's basic form"):
+        utils.parse_rrule(
+            "FREQ=DAILY;UNTIL=2026-09-11T23:59:59+08:00",
+            "2026-09-01T07:00:00+08:00",
+        )
+
+
+def test_parse_rrule_accepts_a_floating_local_time_until():
+    """Confirmed bug: the previous fix for the extended-ISO8601 UNTIL
+    problem was too strict - RFC 5545 permits UNTIL as a floating "DATE
+    WITH LOCAL TIME" (no "Z") whenever DTSTART is also floating local
+    time, not only the aware "DATE WITH UTC TIME" form. This combination
+    was wrongly rejected with no test catching the regression."""
+    parts = utils.parse_rrule("FREQ=DAILY;UNTIL=20260911T235959", "2026-08-26T07:00:00")
+    assert parts["UNTIL"] == "20260911T235959"
+
+
+def test_parse_rrule_uppercases_component_values_not_just_keys():
+    """Confirmed bug: only the FREQ/UNTIL/etc. *keys* were uppercased, not
+    their values - a lowercase "freq=daily" produced {"FREQ": "daily"}.
+    RFC 5545's RRULE grammar has no case-sensitive free-text values (the
+    same reasoning ensure_rrule_prefix already applies to the whole rule
+    text), and this returned dict is what a future Outlook translator
+    would key lookups against."""
+    parts = utils.parse_rrule("freq=daily;count=3", "2026-08-26T07:00:00")
+    assert parts == {"FREQ": "DAILY", "COUNT": "3"}
+
+
+def test_parse_rrule_accepts_a_datetime_object_directly():
+    """A caller that already has a datetime (e.g. after localizing a naive
+    Outlook start time) shouldn't need to format it back into a string
+    just to have it reparsed here."""
+    from datetime import datetime, timezone
+
+    parts = utils.parse_rrule(
+        "FREQ=DAILY;UNTIL=20260911T235959Z",
+        datetime(2026, 8, 26, 7, 0, 0, tzinfo=timezone.utc),
+    )
+    assert parts == {"FREQ": "DAILY", "UNTIL": "20260911T235959Z"}
+
+
+def test_parse_rrule_rejects_until_before_dtstart():
+    """dateutil's own rrulestr validation does NOT catch this - an UNTIL
+    before dtstart parses fine and just silently yields zero occurrences,
+    which would otherwise report status=success for a "recurring" event
+    that never actually recurs. This must be checked explicitly."""
+    from datetime import datetime, timezone
+
+    with pytest.raises(ValueError, match="before the start time"):
+        utils.parse_rrule(
+            "FREQ=DAILY;UNTIL=20260101T000000Z",
+            datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+
+
+def test_parse_rrule_allows_until_after_dtstart():
+    from datetime import datetime, timezone
+
+    parts = utils.parse_rrule(
+        "FREQ=DAILY;UNTIL=20260601T000000Z",
+        datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    assert parts["UNTIL"] == "20260601T000000Z"
+
+
+def test_parse_rrule_naive_dtstart_with_utc_until_is_rejected_by_dateutil_itself():
+    """A naive dtstart combined with a "Z"-suffixed (UTC/aware) UNTIL is
+    already rejected by dateutil's own rrulestr validation before this
+    function's explicit UNTIL-vs-dtstart check ever runs - documented here
+    so the anchor.tzinfo guard in that check (added for exactly this kind
+    of aware/naive mismatch) isn't mistaken for dead code: dateutil catches
+    this shape first, with its own message."""
+    from datetime import datetime
+
+    with pytest.raises(ValueError, match="invalid recurrence rule"):
+        utils.parse_rrule(
+            "FREQ=DAILY;UNTIL=20260101T000000Z",
+            datetime(2026, 6, 1),
+        )
+
+
+def test_parse_rrule_all_day_bare_date_until_is_accepted():
+    """Confirmed bug: a bare (no-time) UNTIL is the RFC 5545-correct value
+    type for a DATE (all-day) DTSTART, but localizing a naive anchor
+    whenever `timezone` was given - added to fix the "Z"-suffixed-UNTIL
+    case above - broke this opposite case by forcing the anchor aware
+    while UNTIL stayed naive, a new mismatch. The anchor must only be
+    localized when UNTIL itself is aware."""
+    parts = utils.parse_rrule(
+        "FREQ=DAILY;UNTIL=20260911", "2026-08-26", timezone="Asia/Shanghai"
+    )
+    assert parts["UNTIL"] == "20260911"
+
+
+def test_parse_rrule_all_day_bare_date_until_before_start_is_still_rejected():
+    """The before-start guard must still catch this now-naive-vs-naive
+    comparison, not just the aware-vs-aware case."""
+    with pytest.raises(ValueError, match="before the start time"):
+        utils.parse_rrule(
+            "FREQ=DAILY;UNTIL=20260101", "2026-08-26", timezone="Asia/Shanghai"
+        )
+
+
+def test_parse_rrule_rejects_space_separated_dtstart_paired_with_bare_date_until():
+    """Confirmed bug: RFC3339 permits a space in place of "T" as the
+    date/time separator, so a check that only looked for the absence of
+    "t" misclassified a timed dtstart like "2026-08-26 07:00:00" as an
+    all-day DATE. That let it silently pair with a floating (bare-date)
+    UNTIL instead of being rejected as the DATE-TIME-dtstart/floating-
+    UNTIL mismatch it actually is."""
+    with pytest.raises(ValueError, match="invalid recurrence rule"):
+        utils.parse_rrule(
+            "FREQ=DAILY;UNTIL=20260911",
+            "2026-08-26 07:00:00",
+            timezone="Asia/Shanghai",
+        )
+
+
+def test_parse_rrule_timezone_localizes_naive_dtstart_for_utc_until():
+    """Confirmed bug: unlike the previous test (no timezone given), passing
+    a resolvable IANA timezone must localize a naive dtstart so it can be
+    compared against a "Z"-suffixed UNTIL instead of dateutil rejecting the
+    aware/naive mismatch."""
+    parts = utils.parse_rrule(
+        "FREQ=DAILY;UNTIL=20260911T235959Z",
+        "2026-08-26T07:00:00",
+        timezone="Asia/Shanghai",
+    )
+    assert parts["UNTIL"] == "20260911T235959Z"
+
+
+def test_parse_rrule_timezone_still_rejects_until_before_dtstart():
+    with pytest.raises(ValueError, match="before the start time"):
+        utils.parse_rrule(
+            "FREQ=DAILY;UNTIL=20260101T000000Z",
+            "2026-08-26T07:00:00",
+            timezone="Asia/Shanghai",
+        )
+
+
+def test_parse_rrule_rejects_unknown_timezone():
+    with pytest.raises(ValueError, match="unknown timezone"):
+        utils.parse_rrule(
+            "FREQ=DAILY;UNTIL=20260911T235959Z",
+            "2026-08-26T07:00:00",
+            timezone="Not/ARealZone",
+        )
+
+
+def test_parse_rrule_rejects_non_positive_interval():
+    with pytest.raises(ValueError, match="INTERVAL must be a positive integer"):
+        utils.parse_rrule("FREQ=DAILY;INTERVAL=0", "2026-08-26T07:00:00+08:00")
+
+
+def test_parse_rrule_rejects_non_integer_interval():
+    with pytest.raises(ValueError, match="INTERVAL must be an integer"):
+        utils.parse_rrule("FREQ=DAILY;INTERVAL=abc", "2026-08-26T07:00:00+08:00")
+
+
+def test_parse_rrule_rejects_non_positive_count():
+    with pytest.raises(ValueError, match="COUNT must be a positive integer"):
+        utils.parse_rrule("FREQ=DAILY;COUNT=0", "2026-08-26T07:00:00+08:00")
+
+
+def test_parse_rrule_rejects_non_integer_count():
+    with pytest.raises(ValueError, match="COUNT must be an integer"):
+        utils.parse_rrule("FREQ=DAILY;COUNT=abc", "2026-08-26T07:00:00+08:00")
+
+
+def test_parse_rrule_rejects_signed_interval():
+    """RFC 5545 defines INTERVAL as `1*DIGIT` - plain unsigned digits only.
+    Python's int() is more permissive than that grammar (accepts a leading
+    "+"/"-"), and the raw string (not the parsed int) is what reaches
+    Google's API almost verbatim - so a value int() accepts but RFC 5545
+    doesn't must still be rejected here, not just range-checked once
+    parsed."""
+    with pytest.raises(ValueError, match="INTERVAL must be an integer"):
+        utils.parse_rrule("FREQ=DAILY;INTERVAL=+2", "2026-08-26T07:00:00+08:00")
+
+
+def test_parse_rrule_rejects_underscore_separated_count():
+    """Python's int() accepts PEP 515 "_" digit separators ("1_0" == 10),
+    which isn't valid RFC 5545 RRULE syntax and would reach Google's API as
+    literal, malformed text."""
+    with pytest.raises(ValueError, match="COUNT must be an integer"):
+        utils.parse_rrule("FREQ=DAILY;COUNT=1_0", "2026-08-26T07:00:00+08:00")
+
+
+def test_parse_rrule_accepts_interval_with_leading_zeros():
+    """Unlike a sign or underscore separator, leading zeros ARE valid under
+    RFC 5545's `1*DIGIT` grammar and must still be accepted."""
+    parts = utils.parse_rrule("FREQ=DAILY;INTERVAL=007", "2026-08-26T07:00:00+08:00")
+    assert parts["INTERVAL"] == "007"
+
+
+def test_parse_rrule_rejects_until_and_count_together():
+    """RFC 5545 treats UNTIL and COUNT as mutually exclusive ways to end a
+    series - dateutil's own rrulestr validation does not catch this
+    (COUNT simply wins), so it must be checked explicitly."""
+    with pytest.raises(ValueError, match="must not specify both UNTIL and COUNT"):
+        utils.parse_rrule(
+            "FREQ=DAILY;UNTIL=20260911T235959Z;COUNT=5",
+            "2026-08-26T07:00:00+08:00",
+        )
+
+
+def test_parse_rrule_rejects_embedded_newline():
+    """A newline could smuggle an extra RRULE/EXDATE/RDATE line into the
+    calendar API request past this connector's single-RRULE validation."""
+    with pytest.raises(ValueError, match="embedded newlines"):
+        utils.parse_rrule(
+            "FREQ=DAILY\nEXDATE:20260101T000000Z",
+            "2026-08-26T07:00:00+08:00",
+        )
+
+
+def test_resolve_zoneinfo_returns_zoneinfo_for_valid_iana_name():
+    from zoneinfo import ZoneInfo
+
+    assert utils.resolve_zoneinfo("Asia/Shanghai") == ZoneInfo("Asia/Shanghai")
+
+
+def test_resolve_zoneinfo_rejects_unknown_timezone():
+    with pytest.raises(ValueError, match="unknown timezone"):
+        utils.resolve_zoneinfo("Not/ARealZone")
+
+
 def test_url_path_id_output_survives_requests_url_normalization():
     """Confirms the actual exploit this guards against: a naively
     interpolated ".." collapses the path via requests' own URL

--- a/uv.lock
+++ b/uv.lock
@@ -3,16 +3,16 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12.4' and python_full_version < '3.13' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.12.4' and sys_platform == 'darwin'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.12' and python_full_version < '3.12.4' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12.4' and python_full_version < '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12.4' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12' and python_full_version < '3.12.4' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.12.4' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and python_full_version < '3.12.4' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and python_full_version < '3.12.4' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "python_full_version < '3.12' and sys_platform == 'darwin'",
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
@@ -6920,12 +6920,12 @@ version = "2.12.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.12' and python_full_version < '3.12.4' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12.4' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12' and python_full_version < '3.12.4' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and python_full_version < '3.12.4' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and python_full_version < '3.12.4' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
@@ -7000,12 +7000,12 @@ version = "0.27.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.12' and python_full_version < '3.12.4' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12.4' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12' and python_full_version < '3.12.4' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.12' and python_full_version < '3.12.4' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and python_full_version < '3.12.4' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
@@ -7232,6 +7232,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b7/b8/c6ff3b10c2f7b9897650af746f0dc6c5cddf054db857bc79d621f53c7d22/types_paramiko-4.0.0.20250822.tar.gz", hash = "sha256:1b56b0cbd3eec3d2fd123c9eb2704e612b777e15a17705a804279ea6525e0c53", size = 28730, upload-time = "2025-08-22T03:03:43.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/a1/b3774ed924a66ee2c041224d89c36f0c21f4f6cf75036d6ee7698bf8a4b9/types_paramiko-4.0.0.20250822-py3-none-any.whl", hash = "sha256:55bdb14db75ca89039725ec64ae3fa26b8d57b6991cfb476212fa8f83a59753c", size = 38833, upload-time = "2025-08-22T03:03:42.072Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20260807"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/4e/b3fa538f9cb38dfece0d6ccf6d3d0d925bdedb144fb9c8129dfc007cd003/types_python_dateutil-2.9.0.20260807.tar.gz", hash = "sha256:e0b8a90d464c8684c66b7b8e4556d9074afdddcc56ca45323f0987134f9e7034", size = 17618, upload-time = "2026-08-07T04:17:13.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/5e/3715867caea2f4cea56ccb04c851cde23ed063449c3b004c7a047f20dd48/types_python_dateutil-2.9.0.20260807-py3-none-any.whl", hash = "sha256:54aa3707350ed7a9cc0776fd2f6739679d6967d11b40150985e81edcb86df4db", size = 18486, upload-time = "2026-08-07T04:17:12.504Z" },
 ]
 
 [[package]]
@@ -7817,6 +7826,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pypdf" },
     { name = "pypinyin" },
+    { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "pyyaml" },
@@ -7947,6 +7957,7 @@ dev = [
     { name = "ruff" },
     { name = "types-docker" },
     { name = "types-openpyxl" },
+    { name = "types-python-dateutil" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "types-setuptools" },
@@ -7966,6 +7977,7 @@ sandbox = [
 static-type-check = [
     { name = "types-docker" },
     { name = "types-openpyxl" },
+    { name = "types-python-dateutil" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "types-setuptools" },
@@ -8074,6 +8086,7 @@ requires-dist = [
     { name = "pypdf2", marker = "extra == 'all'", specifier = ">=3.0.1" },
     { name = "pypdf2", marker = "extra == 'document-processing'", specifier = ">=3.0.1" },
     { name = "pypinyin", specifier = ">=0.53.0" },
+    { name = "python-dateutil", specifier = ">=2.8.2" },
     { name = "python-docx", marker = "extra == 'all'", specifier = ">=1.1.0" },
     { name = "python-docx", marker = "extra == 'document-processing'", specifier = ">=1.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -8153,6 +8166,7 @@ dev = [
     { name = "ruff", specifier = ">=0.12.3" },
     { name = "types-docker", specifier = ">=7.1.0.20251009" },
     { name = "types-openpyxl", specifier = ">=3.1.5" },
+    { name = "types-python-dateutil", specifier = ">=2.8.19" },
     { name = "types-pyyaml", specifier = ">=6.0" },
     { name = "types-requests", specifier = ">=2.0.0" },
     { name = "types-setuptools", specifier = ">=69.0.0" },
@@ -8172,6 +8186,7 @@ sandbox = [
 static-type-check = [
     { name = "types-docker", specifier = ">=7.1.0.20251009" },
     { name = "types-openpyxl", specifier = ">=3.1.5" },
+    { name = "types-python-dateutil", specifier = ">=2.8.19" },
     { name = "types-pyyaml", specifier = ">=6.0" },
     { name = "types-requests", specifier = ">=2.0.0" },
     { name = "types-setuptools", specifier = ">=69.0.0" },


### PR DESCRIPTION
Create repeating or all-day Google Calendar events through `google_calendar_create_events`. The tool accepts one RRULE and an IANA timezone, validates the rule before insertion, and writes bare-date start/end values as all-day dates. Existing `update_events` behavior is unchanged.

Includes the recurrence/timezone helpers, explicit dateutil dependency, and creation/validation tests needed by this feature. Extracted from the latest revision of #2311, including its creation fixes. This is the first part of a three-PR split: creation → updates preserving event kind → event-kind conversion.

Validation: 191 Calendar/MCP-utils tests passed; Ruff lint/format, isort, codespell, targeted mypy (with dateutil stubs), and `uv lock --check` passed. GitHub CI runs the full configured checks.
