### PR TITLE
fix: tighten task control boundary regressions

### DIFF
--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -127,11 +127,6 @@ async def _load_published_agent_card_isolated(
     )
 
 
-def _task_run_id(task: Task) -> str | None:
-    run_id = getattr(task, "run_id", None)
-    return str(run_id) if run_id is not None else None
-
-
 def _require_bound_agent(path_agent_id: int, agent: AgentPrincipalSnapshot) -> None:
     if int(agent.id) != int(path_agent_id) or not is_published_agent(agent):
         raise a2a_error("agent_not_found", "Agent not found.", status_code=404)

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -220,16 +220,6 @@ async def _handle_chat_message_unserialized(
 CHECKPOINT_EVENT_TYPE_NAME = str(CHECKPOINT_EVENT_TYPE)
 
 
-# Non-transient turn rejections must not fall back to retryable busy guidance.
-_TURN_REJECTION_CODES = {
-    "actor_task_reuse_unsupported": (ClientErrorCode.MESSAGE_CONTINUATION_UNSUPPORTED),
-    "workforce_archived": ClientErrorCode.WORKFORCE_ARCHIVED,
-    "workforce_config_changed": ClientErrorCode.WORKFORCE_UNAVAILABLE,
-    "workforce_run_not_found": ClientErrorCode.WORKFORCE_UNAVAILABLE,
-    "workforce_run_not_active": ClientErrorCode.WORKFORCE_UNAVAILABLE,
-}
-
-
 # Exception text can carry file paths, SQL fragments, provider payloads and
 # other internals. It reaches anonymous widget/share visitors through both the
 # error bubble and the message_rejected ack, so an *incidental* validation

--- a/src/xagent/web/services/task_command_execution.py
+++ b/src/xagent/web/services/task_command_execution.py
@@ -165,6 +165,7 @@ from .task_runtime import (
 
 logger = logging.getLogger(__name__)
 
+# Non-transient turn rejections must not fall back to retryable busy guidance.
 _TURN_REJECTION_CODES = {
     "actor_task_reuse_unsupported": (ClientErrorCode.MESSAGE_CONTINUATION_UNSUPPORTED),
     "workforce_archived": ClientErrorCode.WORKFORCE_ARCHIVED,
@@ -1983,7 +1984,7 @@ async def handle_task_message(
                         # reports the distinction explicitly and this guard
                         # reads that report. See task_interaction_close's
                         # module docstring for the rule, the other sites,
-                        # and why the v1 websocket resume-input path needs no
+                        # and why the v1 reply resume-input path needs no
                         # guard at all.
                         #
                         # The run fence
@@ -3159,7 +3160,7 @@ async def resume_task(
                     # ``acquire_task_lease_no_commit`` keeps the existing run
                     # (``candidate_run_id = expected_run_id or uuid4()``)
                     # while bumping ``state_version``. Without this fence a
-                    # v1 websocket and a WebSocket Resume landing together both
+                    # v1 reply and a WebSocket Resume landing together both
                     # transition the row and schedule two coordinators
                     # against one lease.
                     #

--- a/src/xagent/web/services/task_events.py
+++ b/src/xagent/web/services/task_events.py
@@ -59,7 +59,11 @@ CommandReply = Callable[[dict[str, Any]], Awaitable[None]]
 
 
 class TaskCommandDelivery(Protocol):
-    """Host-owned personal replies and their command-scoped lifetime."""
+    """Host-owned personal replies and their command-scoped lifetime.
+
+    Replies must raise ConnectionError when delivery fails because the
+    recipient disconnected. Hosts translate transport-specific exceptions.
+    """
 
     def reply_for(self, command_id: str, task_id: int) -> CommandReply: ...
 

--- a/src/xagent/web/services/task_events.py
+++ b/src/xagent/web/services/task_events.py
@@ -63,6 +63,8 @@ class TaskCommandDelivery(Protocol):
 
     Replies must raise ConnectionError when delivery fails because the
     recipient disconnected. Hosts translate transport-specific exceptions.
+    Commands without a local recipient intentionally use discard_command_reply,
+    which neither delivers nor raises; command_reply also uses it without a host.
     """
 
     def reply_for(self, command_id: str, task_id: int) -> CommandReply: ...

--- a/tests/web/api/test_durable_message_resume_contention.py
+++ b/tests/web/api/test_durable_message_resume_contention.py
@@ -14,7 +14,6 @@ from tests.web.services.task_lease_shared import (
     live_task_lease as live_task_lease_fixture,
 )
 from xagent.core.agent.runner import UserMessageInjectionOutcome
-from xagent.web.api import websocket as websocket_api
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
@@ -243,7 +242,7 @@ async def test_dispatcher_reclaims_and_applies_message_after_contention_clears(
     db_session,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    caplog.set_level("INFO", logger=websocket_api.__name__)
+    caplog.set_level("INFO", logger=command_execution_service.__name__)
     owner = _user(db_session, "eventual-delivery-owner")
     task = _live_task(db_session, int(owner.id))
     task.runner_id = get_runner_id()

--- a/tests/web/api/test_execute_task_background_snapshot_passthrough.py
+++ b/tests/web/api/test_execute_task_background_snapshot_passthrough.py
@@ -392,7 +392,7 @@ async def test_cancellation_after_uncommitted_finalization_always_propagates(
     with_task_lease: bool,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    caplog.set_level(logging.WARNING, logger="xagent.web.api.websocket")
+    caplog.set_level(logging.WARNING, logger="xagent.web.services.task_execution")
     snapshot = _make_snapshot()
     agent_service = _build_fake_agent_service()
     agent_manager = MagicMock(

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -1084,7 +1084,7 @@ async def test_resume_pool_timeout_does_not_start_secondary_db_cleanup(caplog) -
         return_value={"status": "completed", "success": True, "output": "ok"}
     )
     ws_manager = MagicMock(broadcast_to_task=AsyncMock())
-    caplog.set_level(logging.ERROR, logger="xagent.web.api.websocket")
+    caplog.set_level(logging.ERROR, logger="xagent.web.services.task_execution")
 
     with _Patches(
         [

--- a/tests/web/api/test_resume_interaction_seam.py
+++ b/tests/web/api/test_resume_interaction_seam.py
@@ -946,7 +946,7 @@ async def test_legacy_resume_is_not_refused_when_the_active_interaction_read_is_
             )
         )
         stack.enter_context(
-            caplog.at_level(logging.INFO, logger="xagent.web.api.websocket")
+            caplog.at_level(logging.INFO, logger=command_execution_service.__name__)
         )
 
         result = await command_execution_service.resume_task(

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -2185,7 +2185,7 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
             "xagent.web.services.task_command_execution.close_legacy_resume_interaction_sync",
             return_value=1,
         ) as close_mock,
-        caplog.at_level(logging.INFO, logger="xagent.web.api.websocket"),
+        caplog.at_level(logging.INFO, logger=command_execution_service.__name__),
     ):
         await handle_task_message(
             _make_command_reply(MagicMock()),

--- a/tests/web/services/test_task_execution_boundary.py
+++ b/tests/web/services/test_task_execution_boundary.py
@@ -157,7 +157,7 @@ def test_control_and_reply_commands_execute_without_api_routes() -> None:
             from xagent.web.models.agent import Agent
             from xagent.web.models.task import Task, TaskStatus
             from xagent.web.models.chat_message import TaskChatMessage
-            from xagent.web.services.task_command_execution import execute_durable_task_command
+            from xagent.web.services.task_command_execution import execute_durable_task_command, handle_task_message
             from xagent.web.services.task_command_transport import (
                 ClaimedTaskCommand,
                 TaskCommandKind,
@@ -165,6 +165,7 @@ def test_control_and_reply_commands_execute_without_api_routes() -> None:
             from xagent.web.services import agent_service_manager
             from xagent.core.agent.runner import UserMessageInjectionOutcome
             from xagent.web.services import task_execution, task_resume
+            from xagent.web.services.task_orchestrator import TaskTurnOrchestrator, TurnKind
             from xagent.web.services.task_lease_service import (
                 stop_task_lease_heartbeat, release_task_lease_no_commit,
             )
@@ -252,6 +253,45 @@ def test_control_and_reply_commands_execute_without_api_routes() -> None:
                         assert canceled.agent_config["a2a_state"] == "TASK_STATE_CANCELED"
                         assert canceled.state_version == 1
                         assert db.query(TaskChatMessage).filter_by(task_id=ids[0]).count() == 1
+                    # Durable ingress already acknowledged the message. Exercise
+                    # replay directly too, so a no-op handler cannot pass merely
+                    # because the completed transcript row was seeded above.
+                    with get_session_local()() as db:
+                        actor = db.get(User, uid)
+                        db.expunge(actor)
+                    reply = AsyncMock()
+                    await handle_task_message(reply, ids[0], {
+                        "client_message_id": "message-command", "message": "hello", "user": actor,
+                    })
+                    reply.assert_awaited_once()
+                    ack = reply.await_args.args[0]
+                    assert ack["type"] == "message_accepted", ack
+                    assert ack["client_message_id"] == "message-command", ack
+                    assert ack["turn_id"] == "message-command", ack
+                    # Exercise a fresh MESSAGE through preparation and dispatch,
+                    # with only the orchestrator's turn-start boundary replaced.
+                    with get_session_local()() as db:
+                        task = db.get(Task, ids[0])
+                        task.status = TaskStatus.COMPLETED
+                        task.control_state = "completed"
+                        db.commit()
+                    fresh = ClaimedTaskCommand(
+                        id=5, task_id=ids[0], actor_user_id=uid,
+                        command_id="fresh-message-command", kind=TaskCommandKind.MESSAGE,
+                        payload={"client_message_id": "fresh-message-command", "message": "new turn"},
+                        target_run_id="message", attempt_count=1,
+                    )
+                    with patch.object(TaskTurnOrchestrator, "begin_turn", new_callable=AsyncMock) as begin:
+                        result = await execute_durable_task_command(fresh)
+                        assert result["kind"] == "message", result
+                        begin.assert_awaited_once()
+                        kwargs = begin.await_args.kwargs
+                        assert kwargs["task_id"] == ids[0]
+                        assert kwargs["task_owner_user_id"] == uid
+                        assert kwargs["actor_user_id"] == uid
+                        assert kwargs["kind"] == TurnKind.APPEND
+                        assert kwargs["payload"].turn_id == "fresh-message-command"
+                        assert kwargs["payload"].transcript_message == "new turn"
                     # Both reply paths run their real claims, writes and scheduling
                     # without loading HTTP routes. Only the Agent and execution
                     # leaf are replaced, so no model or external tools are needed.

--- a/tests/web/services/test_task_execution_boundary.py
+++ b/tests/web/services/test_task_execution_boundary.py
@@ -180,6 +180,10 @@ def test_control_and_reply_commands_execute_without_api_routes() -> None:
                         db.add(user)
                         db.flush()
                         uid = user.id
+                        admin = User(username="runner-admin", password_hash="unused", is_admin=True)
+                        db.add(admin)
+                        db.flush()
+                        admin_id = admin.id
                         db.add(Agent(id=1, user_id=uid, name="cancel-agent"))
                         db.flush()
                         tasks = [
@@ -253,16 +257,18 @@ def test_control_and_reply_commands_execute_without_api_routes() -> None:
                         assert canceled.agent_config["a2a_state"] == "TASK_STATE_CANCELED"
                         assert canceled.state_version == 1
                         assert db.query(TaskChatMessage).filter_by(task_id=ids[0]).count() == 1
-                    # Durable ingress already acknowledged the message. Exercise
-                    # replay directly too, so a no-op handler cannot pass merely
-                    # because the completed transcript row was seeded above.
+                    # The durable commands above suppress duplicate acknowledgements.
+                    # This direct replay sends its own acknowledgement and must
+                    # short-circuit before acquiring an agent for live execution.
                     with get_session_local()() as db:
                         actor = db.get(User, uid)
                         db.expunge(actor)
                     reply = AsyncMock()
-                    await handle_task_message(reply, ids[0], {
-                        "client_message_id": "message-command", "message": "hello", "user": actor,
-                    })
+                    with patch.object(agent_service_manager, "get_agent_manager") as replay_manager:
+                        await handle_task_message(reply, ids[0], {
+                            "client_message_id": "message-command", "message": "hello", "user": actor,
+                        })
+                        replay_manager.return_value.get_agent_for_task.assert_not_called()
                     reply.assert_awaited_once()
                     ack = reply.await_args.args[0]
                     assert ack["type"] == "message_accepted", ack
@@ -276,7 +282,7 @@ def test_control_and_reply_commands_execute_without_api_routes() -> None:
                         task.control_state = "completed"
                         db.commit()
                     fresh = ClaimedTaskCommand(
-                        id=5, task_id=ids[0], actor_user_id=uid,
+                        id=5, task_id=ids[0], actor_user_id=admin_id,
                         command_id="fresh-message-command", kind=TaskCommandKind.MESSAGE,
                         payload={"client_message_id": "fresh-message-command", "message": "new turn"},
                         target_run_id="message", attempt_count=1,
@@ -288,7 +294,7 @@ def test_control_and_reply_commands_execute_without_api_routes() -> None:
                         kwargs = begin.await_args.kwargs
                         assert kwargs["task_id"] == ids[0]
                         assert kwargs["task_owner_user_id"] == uid
-                        assert kwargs["actor_user_id"] == uid
+                        assert kwargs["actor_user_id"] == admin_id
                         assert kwargs["kind"] == TurnKind.APPEND
                         assert kwargs["payload"].turn_id == "fresh-message-command"
                         assert kwargs["payload"].transcript_message == "new turn"


### PR DESCRIPTION
After the task-control extraction in #2327, three INFO log captures still targeted the WebSocket logger, causing five cases to fail when run independently. The MESSAGE boundary test also passed when the handler did nothing because it only checked a seeded completed delivery.

This follow-up points log captures at their owning services, verifies the replay acknowledgement and short-circuit before agent lookup, and exercises a fresh durable MESSAGE through preparation and dispatch to the orchestrator's turn-start boundary with distinct owner and admin actor identities under the API import guard. It also removes two unused definitions from the route modules, corrects the SDK reply comments, and documents the host's disconnect exception contract.

Validation:
- 233 related tests passed, 1 skipped with `-n 4 --dist loadscope`.
- All 7 cases across the three INFO capture tests passed in isolated runs.
- Negative probes confirmed that a no-op MESSAGE handler, an API import in the fresh-message path, bypassing the replay short-circuit, and swapping owner/actor arguments all fail the boundary test.
- After the assertion and documentation follow-up, all 6 focused boundary and admin-owner tests passed.
- All applicable pre-commit checks passed, including mypy.

Missing-delivery-host diagnostics remain deferred to the process-split work; the current WebSocket host registers the delivery adapter.

