### PR TITLE
test(kb): prove the KB coordinator stays a router

### DIFF
--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator_external_vector_readiness.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator_external_vector_readiness.py
@@ -1,0 +1,319 @@
+"""#514 - the coordinator reaches collection data only through a handle.
+
+Two complementary guards:
+
+* A structural one over ``coordinator.py``: no method other than context
+  resolution may reach a store, by any of the routes that are reachable from
+  the coordinator -- the shim attribute, its public property, the storage
+  factory, a ``getattr`` by name, or the module-level store accessors.
+* Behavioural ones driving the coordinator with a fake backend handle: one
+  representative method from several operation families, proving each routes
+  through ``KBHandleProvider.open`` and that the resolved capabilities reach
+  the handle. A non-LanceDB backend is not bindable yet, so the fake provider
+  stands in for the external-vector case the split was designed for.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+import xagent.core.tools.core.RAG_tools.kb.coordinator as coordinator_module
+from xagent.core.tools.core.RAG_tools.kb import (
+    KBBackendCapabilities,
+    KBContextRequest,
+    KBCoordinator,
+    KBStorageBackend,
+)
+
+# Every route from a coordinator method to a store: the shim, the public
+# property that returns it, the factory the shim is built from, and the
+# module-level accessors the sibling facades already use.
+SHIM_ATTRIBUTES = frozenset({"_storage_shim", "storage_shim", "_storage_factory"})
+STORE_ACCESSORS = frozenset(
+    {
+        "get_metadata_store",
+        "get_vector_index_store",
+        "get_ingestion_status_store",
+        "get_main_pointer_store",
+    }
+)
+
+# Context resolution owns store lookup; the reset hook and the accessor only
+# forward. Everything else must reach data through a handle.
+SHIM_ALLOWED_METHODS = frozenset(
+    {
+        "__init__",
+        "storage_shim",
+        "get_context",
+        "reset_compatibility_caches",
+    }
+)
+
+
+def _methods_touching_shim(source: str) -> set[str]:
+    tree = ast.parse(source)
+    offenders: set[str] = set()
+    for klass in (n for n in tree.body if isinstance(n, ast.ClassDef)):
+        if klass.name != "KBCoordinator":
+            continue
+        for method in klass.body:
+            if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for node in ast.walk(method):
+                if isinstance(node, ast.Attribute) and node.attr in SHIM_ATTRIBUTES:
+                    offenders.add(method.name)
+                elif isinstance(node, ast.Constant) and node.value in SHIM_ATTRIBUTES:
+                    offenders.add(method.name)
+                elif isinstance(node, ast.Name) and node.id in STORE_ACCESSORS:
+                    offenders.add(method.name)
+    return offenders
+
+
+def test_only_context_resolution_touches_the_storage_shim() -> None:
+    source = Path(coordinator_module.__file__).read_text()
+
+    offenders = _methods_touching_shim(source) - SHIM_ALLOWED_METHODS
+
+    assert offenders == set(), (
+        "KBCoordinator must reach collection data through a handle; these "
+        f"methods touch the storage shim directly: {sorted(offenders)}"
+    )
+
+
+def test_shim_guard_flags_a_method_that_reaches_for_a_store() -> None:
+    """The guard fails on a coordinator that grew its own store access."""
+    source = """
+class KBCoordinator:
+    def get_context(self):
+        return self._storage_shim.get_metadata_store()
+
+    def direct_shim(self):
+        return self._storage_shim.get_metadata_store().scan()
+
+    def via_public_property(self):
+        return self.storage_shim.get_vector_index_store()
+
+    def via_getattr(self):
+        return getattr(self, "_storage_shim").get_vector_index_store()
+
+    def via_factory(self):
+        return self._storage_factory.get_metadata_store()
+
+    def via_module_accessor(self):
+        from ..storage.factory import get_metadata_store
+
+        return get_metadata_store()
+
+    def routed(self, request):
+        handle = self.open_collection(request)
+        return handle.list_documents()
+"""
+
+    offenders = _methods_touching_shim(source) - SHIM_ALLOWED_METHODS
+
+    assert offenders == {
+        "direct_shim",
+        "via_public_property",
+        "via_getattr",
+        "via_factory",
+        "via_module_accessor",
+    }
+
+
+@dataclass
+class _FakeCollectionInfo:
+    extra_metadata: dict[str, Any]
+
+
+class _FakeMetadataStore:
+    def __init__(self, collection_info: Optional[_FakeCollectionInfo] = None) -> None:
+        self._collection_info = collection_info
+        self.calls: list[str] = []
+
+    async def get_collection(self, collection: str) -> Optional[_FakeCollectionInfo]:
+        self.calls.append(collection)
+        return self._collection_info
+
+
+class _FakeStorageShim:
+    """Storage shim that hands out sentinels instead of backend stores."""
+
+    def __init__(self, metadata_store: _FakeMetadataStore) -> None:
+        self.metadata_store = metadata_store
+        self.vector_index_store = object()
+        self.ingestion_status_store = object()
+        self.main_pointer_store = object()
+
+    def get_metadata_store(self) -> _FakeMetadataStore:
+        return self.metadata_store
+
+    def get_vector_index_store(self) -> object:
+        return self.vector_index_store
+
+    def get_ingestion_status_store(self) -> object:
+        return self.ingestion_status_store
+
+    def get_main_pointer_store(self) -> object:
+        return self.main_pointer_store
+
+    def reset_coordinator_caches(self) -> None:
+        return None
+
+
+class _RecordingHandle:
+    """Stands in for an external-vector backend handle."""
+
+    def __init__(self, context: Any) -> None:
+        self.context = context
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def __getattr__(self, name: str) -> Any:
+        def _record(*args: Any, **kwargs: Any) -> str:
+            self.calls.append((name, args, kwargs))
+            return f"{name}-result"
+
+        return _record
+
+
+class _RecordingHandleProvider:
+    def __init__(self) -> None:
+        self.contexts: list[Any] = []
+        self.handles: list[_RecordingHandle] = []
+
+    def open(self, context: Any) -> _RecordingHandle:
+        handle = _RecordingHandle(context)
+        self.contexts.append(context)
+        self.handles.append(handle)
+        return handle
+
+    def reset_for_tests(self) -> None:
+        return None
+
+
+def _coordinator(
+    collection_info: Optional[_FakeCollectionInfo] = None,
+) -> tuple[KBCoordinator, _RecordingHandleProvider, _FakeMetadataStore]:
+    metadata_store = _FakeMetadataStore(collection_info)
+    provider = _RecordingHandleProvider()
+    coordinator = KBCoordinator(
+        handle_provider=provider,  # type: ignore[arg-type]
+        storage_shim=_FakeStorageShim(metadata_store),  # type: ignore[arg-type]
+    )
+    return coordinator, provider, metadata_store
+
+
+# (coordinator method, kwargs, handle method the call must land on)
+ROUTED_OPERATIONS = [
+    (
+        "list_document_records",
+        {"collection": "c"},
+        "list_documents",
+    ),
+    (
+        "delete_document_record",
+        {"collection": "c", "doc_id": "d"},
+        "delete_document_record",
+    ),
+    (
+        "load_ingestion_status",
+        {"collection": "c", "doc_id": "d"},
+        "load_ingestion_status",
+    ),
+    (
+        "get_main_pointer",
+        {"collection": "c", "doc_id": "d", "step_type": "parse"},
+        "get_main_pointer",
+    ),
+    (
+        "list_candidates",
+        {"collection": "c", "doc_id": "d", "step_type": "parse"},
+        "list_candidates",
+    ),
+    (
+        "cleanup_document_cascade",
+        {"collection": "c", "doc_id": "d"},
+        "cleanup_document_cascade",
+    ),
+    (
+        "capture_status_snapshot",
+        {"collection": "c", "doc_id": "d"},
+        "capture_status_snapshot",
+    ),
+    (
+        "cleanup_vectors_for_operation",
+        {"collection": "c", "doc_id": "d"},
+        "cleanup_embeddings_for_operation",
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("coordinator_method", "kwargs", "handle_method"),
+    ROUTED_OPERATIONS,
+    ids=[row[0] for row in ROUTED_OPERATIONS],
+)
+async def test_collection_scoped_operations_route_through_the_handle(
+    coordinator_method: str, kwargs: dict[str, Any], handle_method: str
+) -> None:
+    coordinator, provider, metadata_store = _coordinator()
+
+    result = await getattr(coordinator, coordinator_method)(**kwargs)
+
+    assert result == f"{handle_method}-result"
+    assert len(provider.handles) == 1, (
+        f"{coordinator_method} must open exactly one handle, "
+        f"opened {len(provider.handles)}"
+    )
+    called = [name for name, _args, _kwargs in provider.handles[0].calls]
+    assert called == [handle_method]
+    # The only store the coordinator may touch itself is the metadata store,
+    # and only to resolve the backend binding.
+    assert metadata_store.calls == ["c"]
+
+
+@pytest.mark.asyncio
+async def test_resolved_capabilities_reach_the_handle() -> None:
+    coordinator, provider, _metadata_store = _coordinator()
+
+    await coordinator.list_document_records(collection="c")
+
+    context = provider.contexts[0]
+    assert context.backend is KBStorageBackend.LANCEDB
+    assert context.capabilities == KBBackendCapabilities.lancedb()
+    assert len(provider.contexts) == 1
+
+
+@pytest.mark.asyncio
+async def test_declared_backend_binding_drives_capability_resolution() -> None:
+    """An explicit lancedb binding resolves the same way an absent one does."""
+    collection_info = _FakeCollectionInfo(
+        extra_metadata={coordinator_module.KB_STORAGE_METADATA_KEY: "lancedb"}
+    )
+    coordinator, provider, _metadata_store = _coordinator(collection_info)
+
+    await coordinator.list_document_records(collection="c")
+
+    context = provider.contexts[0]
+    assert context.backend is KBStorageBackend.LANCEDB
+    assert context.capabilities.supports_search is True
+    assert context.collection_info is collection_info
+
+
+@pytest.mark.asyncio
+async def test_unknown_backend_binding_fails_before_a_handle_is_opened() -> None:
+    """An unbindable backend must not reach the handle provider at all."""
+    collection_info = _FakeCollectionInfo(
+        extra_metadata={coordinator_module.KB_STORAGE_METADATA_KEY: "external_vector"}
+    )
+    coordinator, provider, _metadata_store = _coordinator(collection_info)
+
+    with pytest.raises(ValueError, match="external_vector"):
+        await coordinator.open_collection(KBContextRequest(collection="c"))
+
+    assert provider.handles == []

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator_external_vector_readiness.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator_external_vector_readiness.py
@@ -24,6 +24,7 @@ import pytest
 
 import xagent.core.tools.core.RAG_tools.kb.coordinator as coordinator_module
 from xagent.core.tools.core.RAG_tools.kb import (
+    KBAccessMode,
     KBBackendCapabilities,
     KBContextRequest,
     KBCoordinator,
@@ -34,11 +35,16 @@ from xagent.core.tools.core.RAG_tools.kb import (
 # property that returns it, the factory the shim is built from, and the
 # module-level accessors the sibling facades already use.
 SHIM_ATTRIBUTES = frozenset({"_storage_shim", "storage_shim", "_storage_factory"})
+# Every accessor KBStorageShimCompatibilityFacade exposes, not just the four
+# the coordinator happens to use today.
 STORE_ACCESSORS = frozenset(
     {
+        "get_kb_write_coordinator",
         "get_metadata_store",
         "get_vector_index_store",
+        "get_vector_store_raw_connection",
         "get_ingestion_status_store",
+        "get_prompt_template_store",
         "get_main_pointer_store",
     }
 )
@@ -72,6 +78,13 @@ def _methods_touching_shim(source: str) -> set[str]:
                 elif isinstance(node, ast.Constant) and node.value in SHIM_ATTRIBUTES:
                     offenders.add(method.name)
                 elif isinstance(node, ast.Name) and node.id in STORE_ACCESSORS:
+                    offenders.add(method.name)
+                elif (
+                    isinstance(node, ast.ImportFrom)
+                    and (node.module or "").split(".")[0] == "storage"
+                ):
+                    # Catches an accessor renamed on import, which no name
+                    # match can see.
                     offenders.add(method.name)
     return offenders
 
@@ -111,6 +124,14 @@ class KBCoordinator:
 
         return get_metadata_store()
 
+    def via_unlisted_accessor(self):
+        return self._storage_factory.get_vector_store_raw_connection()
+
+    def via_renamed_import(self):
+        from ..storage.factory import get_metadata_store as _grab
+
+        return _grab()
+
     def via_imported_module(self):
         from ..storage import factory
 
@@ -130,6 +151,8 @@ class KBCoordinator:
         "via_factory",
         "via_module_accessor",
         "via_imported_module",
+        "via_unlisted_accessor",
+        "via_renamed_import",
     }
 
 
@@ -300,8 +323,11 @@ async def test_resolved_capabilities_reach_the_handle() -> None:
 @pytest.mark.asyncio
 async def test_declared_backend_binding_drives_capability_resolution() -> None:
     """An explicit lancedb binding resolves the same way an absent one does."""
+    # Production writers persist the nested object (pipeline_compatibility.py:171).
     collection_info = _FakeCollectionInfo(
-        extra_metadata={coordinator_module.KB_STORAGE_METADATA_KEY: "lancedb"}
+        extra_metadata={
+            coordinator_module.KB_STORAGE_METADATA_KEY: {"backend": "lancedb"}
+        }
     )
     coordinator, provider, _metadata_store = _coordinator(collection_info)
 
@@ -325,3 +351,53 @@ async def test_unknown_backend_binding_fails_before_a_handle_is_opened() -> None
         await coordinator.open_collection(KBContextRequest(collection="c"))
 
     assert provider.handles == []
+
+
+@pytest.mark.asyncio
+async def test_a_scoped_read_forwards_caller_identity_and_limit() -> None:
+    """Non-default scope must reach the handle, not be defaulted away."""
+    coordinator, provider, _metadata_store = _coordinator()
+
+    await coordinator.list_document_records(
+        collection="c", user_id=7, is_admin=False, limit=3
+    )
+
+    name, args, kwargs = provider.handles[0].calls[0]
+    assert name == "list_documents"
+    assert kwargs == {"user_id": 7, "is_admin": False, "limit": 3}
+    assert args == ()
+    assert provider.contexts[0].user_scope.user_id == 7
+    assert provider.contexts[0].user_scope.is_admin is False
+
+
+@pytest.mark.asyncio
+async def test_a_scoped_cleanup_forwards_its_target_and_write_access() -> None:
+    """Destructive cleanup must carry its target and open a WRITE context."""
+    coordinator, provider, _metadata_store = _coordinator()
+
+    await coordinator.cleanup_vectors_for_operation(
+        collection="c",
+        doc_id="d",
+        parse_hash="p",
+        chunk_ids=["ch1"],
+        model_tag="m",
+        user_id=7,
+        is_admin=False,
+        preview_only=False,
+        confirm=True,
+    )
+
+    name, args, kwargs = provider.handles[0].calls[0]
+    assert name == "cleanup_embeddings_for_operation"
+    assert args == ()
+    assert kwargs == {
+        "doc_id": "d",
+        "parse_hash": "p",
+        "chunk_ids": ["ch1"],
+        "model_tag": "m",
+        "preview_only": False,
+        "confirm": True,
+    }
+    context = provider.contexts[0]
+    assert context.access_mode is KBAccessMode.WRITE
+    assert context.user_scope.user_id == 7

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator_external_vector_readiness.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator_external_vector_readiness.py
@@ -65,7 +65,9 @@ def _methods_touching_shim(source: str) -> set[str]:
             if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
             for node in ast.walk(method):
-                if isinstance(node, ast.Attribute) and node.attr in SHIM_ATTRIBUTES:
+                if isinstance(node, ast.Attribute) and (
+                    node.attr in SHIM_ATTRIBUTES or node.attr in STORE_ACCESSORS
+                ):
                     offenders.add(method.name)
                 elif isinstance(node, ast.Constant) and node.value in SHIM_ATTRIBUTES:
                     offenders.add(method.name)
@@ -109,6 +111,11 @@ class KBCoordinator:
 
         return get_metadata_store()
 
+    def via_imported_module(self):
+        from ..storage import factory
+
+        return factory.get_metadata_store()
+
     def routed(self, request):
         handle = self.open_collection(request)
         return handle.list_documents()
@@ -122,6 +129,7 @@ class KBCoordinator:
         "via_getattr",
         "via_factory",
         "via_module_accessor",
+        "via_imported_module",
     }
 
 

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
@@ -149,5 +149,7 @@ def test_relative_resolution_clamps_impossible_depth() -> None:
     package = "xagent.core.tools.core.RAG_tools.kb"
 
     assert _resolve_relative("web.api.kb", 6, package) == "xagent.web.api.kb"
-    # Deeper than the package: must not wrap around into a shorter prefix.
-    assert _resolve_relative("web.api.kb", 99, package) == "web.api.kb"
+    # Two past the package depth. Without the clamp this is parts[:-1], which
+    # keeps five segments and resolves to a module no rule matches; level=99
+    # would not show it, since an out-of-range negative slice is already empty.
+    assert _resolve_relative("web.api.kb", 8, package) == "web.api.kb"

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import xagent.core.tools.core.RAG_tools.kb.collection_handle as handle_module
 import xagent.core.tools.core.RAG_tools.kb.coordinator as coordinator_module
 
-# ponytail: hardcoded list with a known ceiling — a NEW backend store impl
-# (e.g. qdrant_stores.py) is NOT auto-detected and must be appended here.
+# A new backend store module (e.g. qdrant_stores.py) is not auto-detected and
+# must be appended here.
 FORBIDDEN_SUBSTRINGS = (
     "lancedb",
     "schema_manager",
@@ -24,14 +25,27 @@ FORBIDDEN_SUBSTRINGS = (
 FORBIDDEN_PREFIXES = ("xagent.web",)
 
 
-def _imported_modules(source: str):
+def _resolve_relative(module: str, level: int, package: str) -> str:
+    """Turn ``from ..x import y`` into the absolute module it names.
+
+    Without this a relative import reaches no prefix rule, so a route module
+    imported as ``from ......web.api.kb import router`` would slip the guard.
+    """
+    if not level:
+        return module
+    parts = package.split(".")
+    base = parts[: len(parts) - (level - 1)]
+    return ".".join([*base, module]) if module else ".".join(base)
+
+
+def _imported_modules(source: str, package: str = ""):
     tree = ast.parse(source)
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
                 yield node.lineno, alias.name
         elif isinstance(node, ast.ImportFrom):
-            module = node.module or ""
+            module = _resolve_relative(node.module or "", node.level, package)
             yield node.lineno, module
             for alias in node.names:
                 yield node.lineno, f"{module}.{alias.name}" if module else alias.name
@@ -50,7 +64,9 @@ def _is_forbidden(module: str) -> bool:
 def test_coordinator_imports_no_backend_or_web_modules() -> None:
     source = Path(coordinator_module.__file__).read_text()
     offenders = [
-        (lineno, mod) for lineno, mod in _imported_modules(source) if _is_forbidden(mod)
+        (lineno, mod)
+        for lineno, mod in _imported_modules(source, coordinator_module.__package__)
+        if _is_forbidden(mod)
     ]
     assert offenders == [], (
         "KBCoordinator must not import backend-store or web/route modules "
@@ -72,3 +88,55 @@ def test_guard_flags_forbidden_imports() -> None:
     assert "lancedb" in flagged
     assert "x.lancedb_stores" in flagged
     assert "xagent.core.tools.core.RAG_tools.storage.lancedb_stores" in flagged
+
+
+# The handle owns backend mechanics, so backend imports are expected there; what
+# it must never need is a web framework or a route module (#514 acceptance:
+# "handle methods do not require FastAPI, HTTP response, or request objects").
+HANDLE_FORBIDDEN_SUBSTRINGS = ("fastapi", "starlette")
+HANDLE_FORBIDDEN_PREFIXES = ("xagent.web",)
+
+
+def _is_forbidden_for_handle(module: str) -> bool:
+    if not module:
+        return False
+    if any(sub in module for sub in HANDLE_FORBIDDEN_SUBSTRINGS):
+        return True
+    return any(
+        module == p or module.startswith(p + ".") for p in HANDLE_FORBIDDEN_PREFIXES
+    )
+
+
+def test_handle_imports_no_web_or_route_modules() -> None:
+    source = Path(handle_module.__file__).read_text()
+    offenders = [
+        (lineno, mod)
+        for lineno, mod in _imported_modules(source, handle_module.__package__)
+        if _is_forbidden_for_handle(mod)
+    ]
+    assert offenders == [], (
+        f"KBCollectionHandle must stay callable without a web framework: {offenders}"
+    )
+
+
+def test_handle_guard_flags_web_imports() -> None:
+    package = "xagent.core.tools.core.RAG_tools.kb"
+    snippet = (
+        "from fastapi import HTTPException\n"
+        "from starlette.responses import JSONResponse\n"
+        "from xagent.web.api.kb import router\n"
+        "from ......web.api.kb import router\n"
+        "from ..storage import lancedb_stores\n"
+    )
+    flagged = [
+        mod
+        for _, mod in _imported_modules(snippet, package)
+        if _is_forbidden_for_handle(mod)
+    ]
+    assert "fastapi" in flagged
+    assert "starlette.responses" in flagged
+    assert "xagent.web.api.kb" in flagged
+    # The relative spelling of the same route module must not slip through.
+    assert flagged.count("xagent.web.api.kb") == 2
+    # Backend imports are legitimate below the boundary.
+    assert "xagent.core.tools.core.RAG_tools.storage.lancedb_stores" not in flagged

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
@@ -34,7 +34,10 @@ def _resolve_relative(module: str, level: int, package: str) -> str:
     if not level:
         return module
     parts = package.split(".")
-    base = parts[: len(parts) - (level - 1)]
+    # More dots than the package is deep is not importable, but the guard reads
+    # source: without the clamp the negative index would slice from the end and
+    # resolve to a plausible-looking module that no rule matches.
+    base = parts[: max(0, len(parts) - (level - 1))]
     return ".".join([*base, module]) if module else ".".join(base)
 
 
@@ -140,3 +143,11 @@ def test_handle_guard_flags_web_imports() -> None:
     assert flagged.count("xagent.web.api.kb") == 2
     # Backend imports are legitimate below the boundary.
     assert "xagent.core.tools.core.RAG_tools.storage.lancedb_stores" not in flagged
+
+
+def test_relative_resolution_clamps_impossible_depth() -> None:
+    package = "xagent.core.tools.core.RAG_tools.kb"
+
+    assert _resolve_relative("web.api.kb", 6, package) == "xagent.web.api.kb"
+    # Deeper than the package: must not wrap around into a shorter prefix.
+    assert _resolve_relative("web.api.kb", 99, package) == "web.api.kb"


### PR DESCRIPTION
**Invariant**: `KBCoordinator` reaches collection data only through a handle. The one exception is the backend-binding lookup in context resolution, which #514 explicitly keeps in the coordinator.

## Audit finding: nothing left to move

#514 asks to shrink the coordinator to a router. Auditing `coordinator.py` (2351 lines, 91 methods, enumerated by AST rather than grep) shows the migration was already completed by H01-H06, #703 and #515. The whole file touches a store in three places, all of them sanctioned:

- `coordinator.py:129` -- `self._storage_factory = storage_factory or StorageFactory.get_factory()`, used only to build the shim on 131-132.
- `coordinator.py:299-302` -- the four store lookups inside `get_context`, plus one `await metadata_store.get_collection(collection)` to resolve the backend binding. "Keep collection backend binding and capability resolution in coordinator" is an acceptance criterion, not a leak.
- `coordinator.py:2297` -- `reset_coordinator_caches()` in the reset hook.

Everything else routes through `open_collection` (35 call sites) to a handle (41 `handle.*` calls). `delete_collection` (201 lines) and `rename_collection` (72 lines), the two largest methods, were read line by line: no backend calls, only policy and orchestration -- the full-delete versus config-only decision and the rollback boundary ordering, both of which the coordinator is supposed to own.

So this PR changes no production code. It delivers the two acceptance items that were never implemented: proof that the coordinator is a router, and proof that the handle needs no web framework.

## What changed

**New `test_coordinator_external_vector_readiness.py`** (13 tests):

- A structural guard: no `KBCoordinator` method other than `__init__`, `get_context`, `reset_compatibility_caches` and the `storage_shim` accessor may reach a store. It covers every route out of the coordinator, not just the obvious one: the shim attribute, the public `storage_shim` property, the `_storage_factory`, a `getattr` by name, and the module-level `get_metadata_store()`-style accessors that the sibling facades already use.
- Routing tests driving the coordinator with a fake handle provider and a fake storage shim, parametrized over one representative method from each of eight operation families (documents, ingestion status, main pointers, version candidates, cascade cleanup, snapshots, vector cleanup). Each asserts exactly one handle was opened, the call landed on the right handle method, the result came back from the handle, and the coordinator itself touched only the metadata store, once.
- Capability resolution: the binding resolves into `context.capabilities`, and an unbindable backend fails before any handle is opened.

**Extended `test_coordinator_router_boundary.py`**:

- A handle-side guard: `collection_handle.py` may import backend modules (that is its job) but never `fastapi`, `starlette`, or `xagent.web` -- the acceptance criterion "handle methods do not require FastAPI, HTTP response, or request objects".
- `_imported_modules` now resolves relative imports to absolute module names. Without it, `from ......web.api.kb import router` reaches no prefix rule and slips both guards. The pre-existing coordinator guard had the same hole; this fixes it for both.

## Mutation matrix

Each mutation was applied to production code, the guards run, then the file restored from a `cp` backup (`git diff` verified clean afterwards).

| Mutation | Caught |
| --- | --- |
| route `cleanup_document_cascade` to the wrong handle method | yes |
| `self._storage_shim.get_metadata_store()` in a routed method | yes |
| `self.storage_shim.get_vector_index_store()` (public property) | yes |
| `getattr(self, "_storage_shim").get_vector_index_store()` | yes |
| `self._storage_factory.get_metadata_store()` | yes |
| module-level `get_metadata_store()` via a deferred import | yes |
| local alias `shim = self._storage_shim` | yes |
| drop the return value of a routed call | yes |
| `from fastapi import HTTPException` in the handle | yes |

The four middle rows were **green** against the first version of the guard; they are the reason it now checks more than one attribute name.

The relative-import case could not be mutation-tested against the real module: adding `from ......web.api.kb import router` to `collection_handle.py` makes it unimportable (circular), so pytest errors during collection instead of failing a test. It is covered instead by the positive-control test, which asserts both the absolute and the relative spelling of the same route module are flagged while a relative backend import is not.

## Verification

- `pytest tests/core/tools/core/RAG_tools/kb`: 0 failures.
- Full `tests/core/tools/core/RAG_tools`: one pre-existing failure, `test_process_document_rejects_absolute_paths_outside_allowed_dir` (local model-hub sqlite missing the `models.managed_by` column), identical on a branch without this change.
- `pre-commit run --files` green: ruff check, ruff format, mypy, isort, codespell.
- Independently reviewed; the review found the guard was bypassable four ways and that one assertion was tautological. Both are fixed here.

## Non-goals

- No production code changes.
- Compatibility facades that reach stores directly (e.g. `kb/api_compatibility.py:409`) are out of scope -- the guard covers the `KBCoordinator` class body only.
- `delete_collection` and `rename_collection` are the only methods that call several handle methods and branch on the results; their call ordering and short-circuit semantics get no behavioural guard here and rely on the structural one.
- No assertions on the argument values or `access_mode` passed to handle methods.

Closes #514
