### PR TITLE
ref: share Drive text filename classification

### DIFF
--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -23,6 +23,8 @@ from .utils import (
     clamp_limit,
     require_clean_identifier,
     setup_proxy_env,
+    split_filename_suffix,
+    text_filename_looks_binary,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -684,12 +686,12 @@ def _capped_content_response(
 # accepting them here is always safe, however the caller arrived at
 # declaring one. Thrift/Avro/protobuf are deliberately NOT included here
 # even though their .thrift/.avsc/.proto *extensions* are in
-# _KNOWN_TEXT_EXTENSIONS below (an IDL/schema file is always text) —
+# the shared text-extension allowlist (an IDL/schema file is always text) —
 # unlike graphql, a generic Thrift/Avro/protobuf mime type (e.g.
 # "application/x-protobuf") can legitimately describe an actual
 # binary-encoded message payload in real-world use (Prometheus
 # remote-write, gRPC-Web, ...), the same ambiguity ".bat"/".ts"/".scm" have
-# at the extension level (see _KNOWN_TEXT_EXTENSIONS's own note on those).
+# at the extension level (see utils.KNOWN_TEXT_FILE_EXTENSIONS).
 _TEXT_MIME_TYPES = {
     "application/json",
     "application/xml",
@@ -782,23 +784,6 @@ def _output_dir() -> Path:
     return output_dir
 
 
-def _split_stem_suffix(base: str) -> tuple[str, str]:
-    """Like Path(base).stem/.suffix, except a name that's *entirely* a
-    leading dot plus extension (e.g. ".pdf") is treated as having that
-    extension. pathlib's own split refuses to do this — it follows the
-    Unix dotfile convention where a single leading dot with nothing before
-    it never counts as an extension separator, leaving Path(".pdf").suffix
-    empty — but Drive occasionally hands back names in exactly this shape,
-    and silently losing the extension breaks the downloaded file's type.
-    Only that narrow shape is special-cased; e.g. "..pdf" or "..." already
-    split the way we want via plain pathlib and are left alone.
-    """
-    suffix = Path(base).suffix
-    if not suffix and base.startswith(".") and base.count(".") == 1 and len(base) > 1:
-        return "", base
-    return Path(base).stem, suffix
-
-
 def _safe_output_filename(name: str) -> str:
     """Collapse a Drive file name into a single safe path segment so it
     can't escape the output directory (e.g. via ".." or embedded "/") — the
@@ -811,7 +796,7 @@ def _safe_output_filename(name: str) -> str:
     still come out as "....pdf" (something ending in .pdf), not "pdf".
     """
     base = Path(name).name
-    stem, suffix = _split_stem_suffix(base)
+    stem, suffix = split_filename_suffix(base)
     stem = _UNSAFE_FILENAME_CHARS.sub("_", stem).strip("._") or "file"
     suffix = _UNSAFE_FILENAME_CHARS.sub("_", suffix)[:_MAX_SUFFIX_LENGTH]
     max_stem_length = max(1, _MAX_FILENAME_LENGTH - len(suffix))
@@ -920,98 +905,6 @@ def _resolve_upload_file_path(file_path: str) -> Path:
     if not local_path.is_file():
         raise FileNotFoundError(f"File not found: {file_path}")
     return local_path
-
-
-# Extensions of formats confidently known to be plain UTF-8 text. Default
-# a NAME to "looks binary" unless its extension is in this allowlist (or
-# it has no extension at all — an extensionless name like "Dockerfile" or
-# "README" isn't itself evidence of binary intent) — the opposite of a
-# binary-extension blocklist, which can never enumerate every binary
-# format that exists (three separate review rounds each found more gaps
-# in this module's blocklist attempts: the original hand list, then a
-# mimetypes.guess_type()-based one, then a wider hand list again). A
-# false positive here (a legitimate but unlisted text extension) is a
-# clear, actionable rejection pointing at google_drive_upload_file; a
-# false negative in a blocklist is a silently mislabeled file, a strictly
-# worse outcome, so this list defaults toward rejecting the unfamiliar
-# rather than accepting it.
-#
-# Also NOT delegated to mimetypes.guess_type(): that function's result
-# for anything beyond a small hardcoded core depends on whatever
-# mime.types database happens to be installed on the *host* — verified
-# directly, several of this list's own entries (.sql, .tex, .dart, .tcl,
-# .dtd) came back non-text from an incidental /etc/apache2/mime.types on
-# one development machine, and were silently ABSENT (making them "not
-# text" by the old design's logic) in a minimal CI/production container.
-# A fixed, in-source list is the only way to get identical behavior
-# everywhere this code runs.
-#
-# ".bat", ".ts", and ".scm" are included as text (batch script,
-# TypeScript, Scheme source) even though each also names a real,
-# unrelated binary format elsewhere (a Windows .exe-like executable, an
-# MPEG-2 transport stream, a Lotus ScreenCam recording) -- a judgment
-# call in favor of what an agent generating files is overwhelmingly more
-# likely to mean, resolved per-extension since no mime-type rule can
-# distinguish the two (see _TEXT_MIME_TYPES's matching note on why
-# Thrift/Avro's mime types, unlike protobuf's, are excluded there for
-# the same reason). ".plist" gets the same treatment: real Apple property
-# lists can be either XML text or a binary-encoded format, but an
-# agent-authored one is overwhelmingly more likely to be the XML form.
-_KNOWN_TEXT_EXTENSIONS = {
-    # plain text / docs / dotfiles
-    ".txt", ".md", ".markdown", ".mdx", ".rst", ".adoc", ".rtf", ".log",
-    ".lock", ".gitignore", ".gitattributes", ".editorconfig",
-    ".dockerignore", ".env", ".ini", ".cfg", ".conf", ".properties",
-    ".toml",
-    # structured/data formats
-    ".json", ".json5", ".xml", ".yaml", ".yml", ".csv", ".tsv", ".dtd",
-    ".xsd", ".xsl", ".xslt", ".proto", ".graphql", ".gql", ".thrift",
-    ".avsc", ".ipynb", ".jsonl", ".ndjson", ".geojson", ".plist",
-    # web
-    ".html", ".htm", ".css", ".scss", ".sass", ".less", ".svg",
-    ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx",
-    ".vue", ".svelte", ".astro",
-    # source code
-    ".py", ".rb", ".php", ".java", ".c", ".h", ".cpp", ".hpp", ".cc",
-    ".cxx", ".cs", ".m", ".mm", ".go", ".rs", ".swift", ".kt", ".kts",
-    ".scala", ".groovy", ".lua", ".r", ".jl", ".pl", ".pm", ".hs", ".fs",
-    ".fsx", ".ml", ".mli", ".clj", ".cljs", ".erl", ".ex", ".exs", ".nim",
-    ".zig", ".v", ".d", ".dart", ".elm", ".cr", ".tcl", ".scm", ".rkt",
-    ".lisp", ".el", ".asm", ".s", ".pas", ".f90", ".for", ".vb", ".vbs",
-    ".cabal", ".nix",
-    # shell / scripting / templates
-    ".sh", ".bash", ".zsh", ".csh", ".ksh", ".fish",
-    ".ps1", ".bat", ".cmd", ".awk", ".sed", ".sql", ".j2",
-    # build / infra
-    ".tex", ".latex", ".bib", ".cls", ".sty", ".diff", ".patch",
-    ".hcl", ".tf", ".tfvars", ".gradle", ".dockerfile", ".cmake",
-    # misc
-    ".pem", ".po",
-}  # fmt: skip
-
-
-def _name_looks_binary(name: str) -> bool:
-    """Whether ``name``'s extension is NOT a recognized text format.
-
-    Default-deny: an extension is only accepted if it's in
-    _KNOWN_TEXT_EXTENSIONS. A name with no extension at all (e.g.
-    "Dockerfile", "README") is accepted too — the absence of an
-    extension isn't evidence of binary intent the way an unrecognized
-    one is.
-
-    Uses _split_stem_suffix rather than plain ``Path.suffix`` for the
-    same reason _safe_output_filename does: a name that's *entirely* a
-    leading dot plus extension (e.g. ".pdf") has an empty ``Path(...).suffix``
-    per pathlib's dotfile convention, which would make this function treat
-    it as extensionless (accepted) — exactly the kind of mislabeling this
-    guard exists to catch, just via a name pathlib refuses to split.
-
-    google_drive_create_file's mime_type-based check is the complementary
-    signal that catches an explicitly-declared binary type regardless of
-    what the name looks like.
-    """
-    suffix = _split_stem_suffix(name.strip())[1].lower()
-    return bool(suffix) and suffix not in _KNOWN_TEXT_EXTENSIONS
 
 
 def get_drive_service() -> Any:
@@ -1337,7 +1230,7 @@ def google_drive_upload_file(
     standard mimetypes module, falling back to "application/octet-stream"
     when it can't be guessed. This guess is informational only — Drive's
     displayed file type may be wrong on a host whose mimetypes database
-    doesn't recognize the extension (see the _KNOWN_TEXT_EXTENSIONS
+    doesn't recognize the extension (see the shared text-extension
     comment above for why that's host-dependent), but the uploaded bytes
     are always exactly file_path's real content either way. Pass mime_type
     explicitly for a reliable label, especially for an extension outside
@@ -1450,7 +1343,7 @@ def google_drive_create_file(
     try:
         # Stripped once here so every downstream use agrees: the
         # binary-name guard below and the actual Drive file_metadata["name"]
-        # sent. _name_looks_binary already stripped internally for its own
+        # sent. text_filename_looks_binary already strips internally for its own
         # suffix check, but without also reassigning `name` itself, a
         # trailing-space name like "notes.txt " would pass the guard (the
         # suffix check sees ".txt") yet still land in Drive with the
@@ -1490,13 +1383,13 @@ def google_drive_create_file(
         # A Google Workspace conversion is exempt from both checks below
         # (Docs/Sheets/Slides always take text/HTML source regardless of
         # the target doc's name), so short-circuit here rather than
-        # computing _name_looks_binary and the mime-type check on every
+        # computing text_filename_looks_binary and the mime-type check on every
         # such call for nothing.
         if not is_google_doc_conversion:
             mime_type_is_binary = not _is_text_mime_type(mime_type)
             # Two independent signals catch two different mistakes — but
             # only the name-based one is a heuristic guess, and only when
-            # the caller left mime_type unset. _KNOWN_TEXT_EXTENSIONS is a
+            # the caller left mime_type unset. The shared extension list is a
             # default-deny allowlist, so a name that merely CONTAINS a dot
             # not meant as an extension ("www.example.com",
             # "report-v1.2") or uses a real text extension this list
@@ -1509,7 +1402,9 @@ def google_drive_create_file(
             # mime_type is caught either way, regardless of the name,
             # since content can only ever be UTF-8 text (see the encode()
             # below).
-            name_looks_binary = not explicit_mime_type and _name_looks_binary(name)
+            name_looks_binary = not explicit_mime_type and text_filename_looks_binary(
+                name
+            )
         else:
             name_looks_binary = mime_type_is_binary = False
         if name_looks_binary or mime_type_is_binary:

--- a/src/xagent/web/tools/mcp/onedrive.py
+++ b/src/xagent/web/tools/mcp/onedrive.py
@@ -10,7 +10,12 @@ from urllib.parse import quote
 import requests
 from mcp.server.fastmcp import FastMCP
 
-from .utils import allowed_dirs_from_env, setup_proxy_env, url_path_id
+from .utils import (
+    allowed_dirs_from_env,
+    setup_proxy_env,
+    text_filename_looks_binary,
+    url_path_id,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("onedrive-mcp")
@@ -38,7 +43,7 @@ _UPLOAD_ALLOWED_DIRS_ENV_VAR = "XAGENT_ONEDRIVE_FILE_ALLOWED_DIRS"
 # all. Checked before falling back to mimetypes.guess_type() wherever this
 # module resolves a *real* mime type (i.e. for onedrive_upload_file's
 # Content-Type header, never for the binary/text guard below -- see
-# _name_looks_binary's own docstring for why that guard doesn't use
+# text_filename_looks_binary's own docstring for why that guard doesn't use
 # mimetypes at all), so a real .xlsx/.docx/etc. doesn't get mislabeled
 # "application/octet-stream" just because the host is missing a file this
 # module has no control over.
@@ -82,64 +87,6 @@ def _guess_mime_type(name: str) -> str | None:
             "compress": "application/x-compress",
         }.get(guessed_encoding, "application/octet-stream")
     return guessed_type
-
-
-def _split_stem_suffix(base: str) -> tuple[str, str]:
-    """Like Path(base).stem/.suffix, except a name that's *entirely* a
-    leading dot plus extension (e.g. ".pdf") is treated as having that
-    extension. pathlib's own split refuses to do this -- it follows the
-    Unix dotfile convention where a single leading dot with nothing before
-    it never counts as an extension separator, leaving Path(".pdf").suffix
-    empty -- but silently losing the extension here would let a name like
-    that slip past _name_looks_binary's guard as "extensionless" (accepted)
-    when it's actually naming a real binary format. Only that narrow shape
-    is special-cased; e.g. "..pdf" or "..." already split the way we want
-    via plain pathlib and are left alone.
-    """
-    suffix = Path(base).suffix
-    if not suffix and base.startswith(".") and base.count(".") == 1 and len(base) > 1:
-        return "", base
-    return Path(base).stem, suffix
-
-
-# Stable text-extension allowlist shared in shape with the Google Drive
-# guard. Host MIME databases vary, so they cannot safely decide whether the
-# text-only tool may use a filename. Unknown extensions are rejected; names
-# without an extension remain valid for files such as README and Dockerfile.
-# Ambiguous but commonly textual source extensions such as .ts and .bat are
-# allowed, while formats with common binary variants such as .crt and .plist
-# are not.
-_KNOWN_TEXT_EXTENSIONS = {
-    # plain text / docs / dotfiles
-    ".txt", ".md", ".markdown", ".mdx", ".rst", ".adoc", ".rtf", ".log",
-    ".lock", ".gitignore", ".gitattributes", ".editorconfig",
-    ".dockerignore", ".env", ".ini", ".cfg", ".conf", ".properties",
-    ".toml",
-    # structured/data formats
-    ".json", ".json5", ".xml", ".yaml", ".yml", ".csv", ".tsv", ".dtd",
-    ".xsd", ".xsl", ".xslt", ".proto", ".graphql", ".gql", ".thrift",
-    ".avsc", ".ipynb", ".jsonl", ".ndjson", ".geojson",
-    # web
-    ".html", ".htm", ".css", ".scss", ".sass", ".less", ".svg",
-    ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx",
-    ".vue", ".svelte", ".astro",
-    # source code
-    ".py", ".rb", ".php", ".java", ".c", ".h", ".cpp", ".hpp", ".cc",
-    ".cxx", ".cs", ".m", ".mm", ".go", ".rs", ".swift", ".kt", ".kts",
-    ".scala", ".groovy", ".lua", ".r", ".jl", ".pl", ".pm", ".hs", ".fs",
-    ".fsx", ".ml", ".mli", ".clj", ".cljs", ".erl", ".ex", ".exs", ".nim",
-    ".zig", ".v", ".d", ".dart", ".elm", ".cr", ".tcl", ".scm", ".sc",
-    ".rkt", ".lisp", ".el", ".asm", ".s", ".pas", ".f90", ".for", ".vb",
-    ".vbs", ".cabal", ".nix",
-    # shell / scripting / templates
-    ".sh", ".bash", ".zsh", ".csh", ".ksh", ".fish",
-    ".ps1", ".bat", ".cmd", ".awk", ".sed", ".sql", ".j2", ".tpl", ".srt",
-    # build / infra
-    ".tex", ".latex", ".bib", ".cls", ".sty", ".diff", ".patch",
-    ".hcl", ".tf", ".tfvars", ".gradle", ".dockerfile", ".cmake",
-    # misc
-    ".pem", ".po",
-}  # fmt: skip
 
 
 def _success(**payload: Any) -> str:
@@ -264,25 +211,6 @@ def _decode_bytes(content: bytes) -> tuple[str | None, str | None]:
         return content.decode("utf-8"), None
     except UnicodeDecodeError:
         return None, base64.b64encode(content).decode("ascii")
-
-
-def _name_looks_binary(name: str) -> bool:
-    """Whether ``name``'s extension is NOT a recognized text format.
-
-    Default-deny: an extension is only accepted if it's in
-    _KNOWN_TEXT_EXTENSIONS. A name with no extension at all (e.g.
-    "Dockerfile", "README") is accepted too -- the absence of an extension
-    isn't evidence of binary intent the way an unrecognized one is.
-
-    Uses _split_stem_suffix rather than plain ``Path.suffix`` for the same
-    reason google_drive.py's equivalent does: a name that's *entirely* a
-    leading dot plus extension (e.g. ".pdf") has an empty ``Path(...).suffix``
-    per pathlib's dotfile convention, which would make this function treat
-    it as extensionless (accepted) -- exactly the kind of mislabeling this
-    guard exists to catch, just via a name pathlib refuses to split.
-    """
-    suffix = _split_stem_suffix(Path(name.strip()).name)[1].lower()
-    return bool(suffix) and suffix not in _KNOWN_TEXT_EXTENSIONS
 
 
 def _resolve_upload_file_path(local_file_path: str) -> Path:
@@ -436,7 +364,8 @@ def onedrive_upload_text_file(
     onedrive_upload_file with that file's path instead.
     """
     try:
-        if _name_looks_binary(file_path):
+        content_path = _content_path(file_path)
+        if text_filename_looks_binary(file_path):
             return _error(
                 f"'{file_path}' looks like a binary file, but "
                 "onedrive_upload_text_file only writes text content -- "
@@ -448,7 +377,7 @@ def onedrive_upload_text_file(
             )
         result = _graph_request(
             "PUT",
-            _content_path(file_path),
+            content_path,
             extra_headers={"Content-Type": "text/plain; charset=utf-8"},
             data=content.encode("utf-8"),
         )

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -10,6 +10,67 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ....config import get_tool_max_output_length
 
+# Text-only upload tools must make the same filename decision on every host.
+# ``mimetypes`` cannot provide that guarantee because it reads optional system
+# MIME databases. Unknown extensions and names ending in a period are therefore
+# rejected; extensionless names such as README remain valid. Ambiguous formats
+# with common binary encodings (for example ``.plist``) are deliberately absent.
+KNOWN_TEXT_FILE_EXTENSIONS = frozenset(
+    {
+        # plain text / docs / dotfiles
+        ".txt", ".md", ".markdown", ".mdx", ".rst", ".adoc", ".rtf", ".log",
+        ".lock", ".gitignore", ".gitattributes", ".editorconfig",
+        ".dockerignore", ".env", ".ini", ".cfg", ".conf", ".properties",
+        ".toml",
+        # structured/data formats
+        ".json", ".json5", ".xml", ".yaml", ".yml", ".csv", ".tsv", ".dtd",
+        ".xsd", ".xsl", ".xslt", ".proto", ".graphql", ".gql", ".thrift",
+        ".avsc", ".ipynb", ".jsonl", ".ndjson", ".geojson",
+        # web
+        ".html", ".htm", ".css", ".scss", ".sass", ".less", ".svg",
+        ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx",
+        ".vue", ".svelte", ".astro",
+        # source code
+        ".py", ".rb", ".php", ".java", ".c", ".h", ".cpp", ".hpp", ".cc",
+        ".cxx", ".cs", ".m", ".mm", ".go", ".rs", ".swift", ".kt", ".kts",
+        ".scala", ".groovy", ".lua", ".r", ".jl", ".pl", ".pm", ".hs", ".fs",
+        ".fsx", ".ml", ".mli", ".clj", ".cljs", ".erl", ".ex", ".exs", ".nim",
+        ".zig", ".v", ".d", ".dart", ".elm", ".cr", ".tcl", ".scm", ".sc",
+        ".rkt", ".lisp", ".el", ".asm", ".s", ".pas", ".f90", ".for", ".vb",
+        ".vbs", ".cabal", ".nix",
+        # shell / scripting / templates
+        ".sh", ".bash", ".zsh", ".csh", ".ksh", ".fish",
+        ".ps1", ".bat", ".cmd", ".awk", ".sed", ".sql", ".j2", ".tpl", ".srt",
+        # build / infra
+        ".tex", ".latex", ".bib", ".cls", ".sty", ".diff", ".patch",
+        ".hcl", ".tf", ".tfvars", ".gradle", ".dockerfile", ".cmake",
+        # misc
+        ".pem", ".po",
+    }
+)  # fmt: skip
+
+
+def split_filename_suffix(base: str) -> tuple[str, str]:
+    """Split a filename while treating ``.pdf`` as a suffix-only name."""
+    suffix = Path(base).suffix
+    if not suffix and base.startswith(".") and base.count(".") == 1 and len(base) > 1:
+        return "", base
+    return Path(base).stem, suffix
+
+
+def text_filename_looks_binary(name: str) -> bool:
+    """Return whether a name is unsafe for a tool that writes UTF-8 text.
+
+    Unknown extensions default to binary. A trailing period is also rejected:
+    providers such as OneDrive normalize it away, which could otherwise turn
+    ``report.pdf.`` into a misleading ``report.pdf`` after the check.
+    """
+    base = Path(name.strip()).name
+    if base.endswith("."):
+        return True
+    suffix = split_filename_suffix(base)[1].lower()
+    return bool(suffix) and suffix not in KNOWN_TEXT_FILE_EXTENSIONS
+
 
 def allowed_dirs_from_env(env_var_name: str) -> list[Path]:
     """Parse JSON or legacy comma-separated roots.

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -3061,7 +3061,7 @@ def test_upload_file_returns_error_payload_on_api_failure(
 
 
 @pytest.mark.parametrize(
-    "name", ["report.pdf", "photo.PNG", "deck.pptx", "archive.zip"]
+    "name", ["report.pdf", "photo.PNG", "deck.pptx", "archive.zip", "settings.plist"]
 )
 def test_create_file_rejects_binary_looking_names(monkeypatch, name):
     """Regression guard for the actual production bug: google_drive_create_file
@@ -3127,6 +3127,9 @@ def test_create_file_allows_plain_text_names(monkeypatch):
         "script.tcl",
         "types.dtd",
         "file.scm",
+        "worksheet.sc",
+        "subtitles.srt",
+        "layout.tpl",
         "Program.cs",
         "AppDelegate.m",
         "AppDelegate.mm",
@@ -3357,8 +3360,19 @@ def test_create_file_rejects_dotfile_style_binary_names(monkeypatch, name):
     entirely a leading dot plus extension (pathlib's dotfile convention),
     which would make the old suffix check treat it as extensionless (and
     therefore accepted) -- exactly the mislabeling this guard exists to
-    catch. _name_looks_binary uses _split_stem_suffix instead, which
-    doesn't have this blind spot."""
+    catch. The shared classifier handles this shape explicitly."""
+    files = Mock()
+    _mock_drive_service_with_files(monkeypatch, files)
+
+    result = json.loads(google_drive.google_drive_create_file(name, "some text"))
+
+    assert result["status"] == "error"
+    assert "google_drive_upload_file" in result["message"]
+    files.create.assert_not_called()
+
+
+@pytest.mark.parametrize("name", ["report.pdf.", "archive.zip. "])
+def test_create_file_rejects_trailing_period_names(monkeypatch, name):
     files = Mock()
     _mock_drive_service_with_files(monkeypatch, files)
 
@@ -3378,12 +3392,11 @@ def test_create_file_rejects_dotfile_style_binary_names(monkeypatch, name):
         "cert.pem",
         "CMakeLists.cmake",
         "messages.po",
-        "config.plist",
     ],
 )
 def test_create_file_allows_newly_recognized_text_extensions(monkeypatch, name):
     """These extensions were reported as false-positive rejections in
-    review (real text formats not yet in _KNOWN_TEXT_EXTENSIONS) --
+    review (real text formats not yet in the shared allowlist) --
     confirms they're now accepted without needing an explicit mime_type
     override."""
     files = Mock()

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -9,6 +9,38 @@ import requests
 from xagent.web.tools.mcp import utils
 
 
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("notes.txt", False),
+        ("worksheet.sc", False),
+        ("subtitles.srt", False),
+        ("layout.tpl", False),
+        ("README", False),
+        (".env", False),
+        ("report.pdf", True),
+        (".pdf", True),
+        ("settings.plist", True),
+        ("report.pdf.", True),
+        ("Documents/archive.zip. ", True),
+    ],
+)
+def test_text_filename_looks_binary_shared_policy(name, expected):
+    assert utils.text_filename_looks_binary(name) is expected
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("report.pdf", ("report", ".pdf")),
+        (".pdf", ("", ".pdf")),
+        ("README", ("README", "")),
+    ],
+)
+def test_split_filename_suffix_handles_suffix_only_dotfile(name, expected):
+    assert utils.split_filename_suffix(name) == expected
+
+
 def test_require_clean_identifier_rejects_empty_and_whitespace():
     with pytest.raises(ValueError, match="record_id"):
         utils.require_clean_identifier("", "record_id")


### PR DESCRIPTION
Google Drive and OneDrive had separate filename classifiers for text-only uploads, and their policies had already diverged. This change moves suffix splitting and text-extension classification into `mcp/utils.py`, so both connectors now reject the same misleading binary-looking names.

The shared policy rejects trailing-period names and ambiguous `.plist` files, while consistently allowing `.sc`, `.srt`, and `.tpl` text files. Google Drive keeps its existing explicit text MIME override for intentional false-positive cases, and OneDrive keeps its provider-specific path validation.

Validation:

- Connector and shared utility tests passed (`test_google_drive_mcp.py`, `test_onedrive_mcp.py`, `test_mcp_utils.py`)
- Ruff, mypy, isort, codespell, and Alembic checks passed
- Frontend hooks were not applicable to the changed files

Closes #2358.
