### PR TITLE
fix: pin reply recovery error contracts

### DIFF
--- a/src/xagent/web/services/task_resume.py
+++ b/src/xagent/web/services/task_resume.py
@@ -830,6 +830,11 @@ async def resume_task_reply(ctx: TaskReplyInput) -> TaskReplyResumeResult:
     rejection semantics; the subsequent conditional claim checks current state.
     """
     task_id = ctx.task_id
+    # RUNNING is transient: a turn is in flight, so retrying later can
+    # succeed (task_busy). Other non-waiting states have no interaction to
+    # answer (no_pending_interaction). For PAUSED / COMPLETED / FAILED,
+    # callers should append a new turn. PENDING cannot accept an append
+    # yet; callers must wait for the task to leave that state.
     if ctx.status != TaskStatus.WAITING_FOR_USER:
         if ctx.status == TaskStatus.RUNNING:
             raise TaskResumeBusyError

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -1782,7 +1782,9 @@ def _resume_error_task(agent_id: int, *, context_id: str) -> int:
 
 def test_resume_lease_contention_preserves_the_a2a_error() -> None:
     agent_id, full_key = _create_published_agent_with_key()
+    _resume_error_task(agent_id, context_id="ctx-resume-busy-filler")
     task_id = _resume_error_task(agent_id, context_id="ctx-resume-busy")
+    assert task_id != agent_id
 
     with patch.object(
         task_resume, "_acquire_a2a_resume_prelease_sync", return_value=None
@@ -1821,6 +1823,13 @@ def test_resume_lease_contention_preserves_the_a2a_error() -> None:
             }
         ],
     }
+
+    db = _direct_db_session()
+    try:
+        recovered = db.query(Task).filter(Task.id == task_id).one()
+        assert recovered.status == TaskStatus.WAITING_FOR_USER
+    finally:
+        db.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -1780,6 +1780,49 @@ def _resume_error_task(agent_id: int, *, context_id: str) -> int:
         db.close()
 
 
+def test_resume_lease_contention_preserves_the_a2a_error() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    task_id = _resume_error_task(agent_id, context_id="ctx-resume-busy")
+
+    with patch.object(
+        task_resume, "_acquire_a2a_resume_prelease_sync", return_value=None
+    ) as acquire:
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-resume-busy",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "retry safely"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    acquire.assert_called_once_with(
+        task_id=task_id,
+        agent_id=agent_id,
+        resumable_status=TaskStatus.WAITING_FOR_USER,
+        previous_run_id=None,
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["error"] == {
+        "code": 400,
+        "status": "FAILED_PRECONDITION",
+        "message": "Task is currently running and cannot accept a new message.",
+        "details": [
+            {
+                "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                "reason": "UNSUPPORTED_OPERATION",
+                "domain": "a2a-protocol.org",
+                "metadata": {"taskId": str(task_id)},
+            }
+        ],
+    }
+
+
 @pytest.mark.parametrize(
     ("error", "expected_status"),
     [
@@ -1876,15 +1919,23 @@ def test_checkpoint_access_refused_reuses_existing_running_task_message() -> Non
 
 
 @pytest.mark.parametrize(
-    ("reason", "unexpected_phrase"),
+    ("reason", "expected_message"),
     [
-        ("lease_mismatch", "currently running"),
-        ("superseded_legacy", "currently running"),
+        (
+            "lease_mismatch",
+            "This task is currently owned by a different execution "
+            "and cannot accept a new message.",
+        ),
+        (
+            "superseded_legacy",
+            "This task's checkpoint history has been superseded by "
+            "a newer run and cannot accept a new message.",
+        ),
     ],
 )
 def test_checkpoint_access_refused_reason_gets_a_distinct_message(
     reason: str,
-    unexpected_phrase: str,
+    expected_message: str,
 ) -> None:
     """Only the ``active_run`` reason reuses the pre-existing 'currently
     running' message; the other two refusal reasons are distinct facts
@@ -1918,8 +1969,19 @@ def test_checkpoint_access_refused_reason_gets_a_distinct_message(
         )
 
     assert response.status_code == 400, response.text
-    message = response.json()["error"]["message"]
-    assert unexpected_phrase not in message
+    assert response.json()["error"] == {
+        "code": 400,
+        "status": "FAILED_PRECONDITION",
+        "message": expected_message,
+        "details": [
+            {
+                "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                "reason": "UNSUPPORTED_OPERATION",
+                "domain": "a2a-protocol.org",
+                "metadata": {"taskId": str(task_id)},
+            }
+        ],
+    }
     db = _direct_db_session()
     try:
         recovered = db.query(Task).filter(Task.id == task_id).one()


### PR DESCRIPTION
The reply-recovery move in #2336 dropped the explanation of how SDK callers should handle non-waiting task states. Its A2A tests also allowed changes to the busy error object and checkpoint-refusal wording to pass unnoticed.

Restore the status guidance beside the service check. Add an endpoint test that makes lease acquisition fail and checks the complete A2A error response, and strengthen the existing `lease_mismatch` and `superseded_legacy` cases to assert their exact error objects. Production behavior is unchanged.

Validation:
- 106 tests passed across the A2A and SDK reply modules.
- All applicable pre-commit checks passed, including mypy.
- Post-commit review found no further issues; AST comparison confirmed the production change contains comments only.
- Negative probes that altered the busy error mapping and lease-mismatch message failed the corresponding tests as expected.
