### PR TITLE
feat: define dormant task start protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,7 +769,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          .github/scripts/docker-pull-retry.sh minio/minio postgres:17-bookworm
+          .github/scripts/docker-pull-retry.sh quay.io/minio/minio postgres:17-bookworm
 
       - name: Run e2e tests
         if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -27,6 +27,8 @@ on:
       - 'tests/web/services/test_runtime_key_transition_postgres.py'
       - 'src/xagent/web/api/auth.py'
       - 'tests/web/services/test_user_preferences_lock_postgres.py'
+      - 'src/xagent/web/services/task_start_protocol.py'
+      - 'tests/web/services/test_task_start_protocol.py'
       - 'src/xagent/web/services/task_command_transport.py'
       - 'tests/web/services/test_task_command_transport.py'
       - 'src/xagent/web/models/task.py'
@@ -133,6 +135,8 @@ jobs:
             tests/web/services/test_runtime_key_transition_postgres.py
             src/xagent/web/api/auth.py
             tests/web/services/test_user_preferences_lock_postgres.py
+            src/xagent/web/services/task_start_protocol.py
+            tests/web/services/test_task_start_protocol.py
             src/xagent/web/services/task_command_transport.py
             tests/web/services/test_task_command_transport.py
             src/xagent/web/models/task.py
@@ -427,7 +431,7 @@ jobs:
       - name: Test task command staging concurrency (Postgres-only)
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
-          pytest tests/web/services/test_task_command_transport.py -m postgresql -q
+          pytest tests/web/services/test_task_command_transport.py tests/web/services/test_task_start_protocol.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/docs/architecture/task-runner-execution-boundary.md
+++ b/docs/architecture/task-runner-execution-boundary.md
@@ -62,3 +62,58 @@ before crossing that boundary.
 Regression coverage includes the existing start/resume, ownership, cancellation,
 output and trace tests, plus a subprocess test rejecting API route imports while
 loading execution services and constructing the persisted-task tracer.
+
+## Dormant START protocol
+
+`services/task_start_protocol.py` defines version 1 of the durable input for
+CREATE and APPEND. This is a protocol-only step: no API produces START, no
+runner consumes it, and existing acceptance/scheduling remains unchanged.
+`TaskCommandKind.START` reuses `task_execution_commands.kind` (a string column),
+so this step needs no schema migration. The current dispatcher excludes START,
+including targeted immediate dispatch. An unfinished START still blocks later
+commands for the same task; it does not block unrelated tasks. Do not enable a
+producer before a consumer is implemented.
+
+The command envelope retains task/actor identity, immutable owner subjects,
+target run/version and the existing `(task_id, command_id)` unique identity.
+The START command ID is the turn ID, also used by the persisted user message.
+Its versioned JSON payload contains:
+
+- accepted `run_id`, `state_version`, `turn_id` and CREATE/APPEND kind;
+- transcript `message` and optional separate `execution_message`;
+- authorized `file_ids`, optional `before_message_id`, timezone and
+  `force_fresh` (APPEND only).
+
+Only these fields are accepted. In particular, version 1 does not encode
+arbitrary execution context, trigger metadata, actor authorization policy,
+connector secrets, live runtime objects or leases. Producers requiring these
+inputs must not silently drop them or use this version until their explicit
+handoff contract is implemented. File IDs are references, not a guarantee that
+the runner can access the file bytes. Stored task/Agent configuration and file
+metadata are loaded at execution time; a serialized Agent or setup snapshot is
+not part of START. Resume retains its separate, currently local contract.
+
+A future producer must perform its existing authorization and business-state
+CAS, reserve the accepted run, persist the transcript, bind files, and stage
+START in **one transaction**, without acquiring an execution lease. It must
+preserve applicable Workforce projections in that transaction as well.
+`stage_task_start_command` verifies the exact accepted RUNNING run/version and
+absence of lease metadata, then delegates to `stage_task_command` as the final
+write. It does not itself accept a turn or commit. The caller must roll back
+all acceptance writes on failure or a conflicting payload. On SQLite the
+caller's acceptance write owns the writer lock; PostgreSQL also locks the task
+row during staging. Calling staging in a later transaction is not this contract.
+
+`read_task_start_command` strictly decodes the JSON and checks its run and turn
+against the immutable command envelope. It does not authorize execution or
+check the current task state. The eventual consumer must acquire the exact run's
+lease and start its heartbeat before executing, and finish START processing
+after the local scheduling handoff rather than waiting for the whole run.
+The accepted public run identity is retained; adding a new client-visible queue
+status is not required by this protocol.
+
+This step adds no effect receipts and no safe replay guarantee for a START whose
+execution outcome is unknown. The existing generic retry behavior must not be
+assumed safe for START when wiring the future consumer. Process roles, producer
+migration, consumer admission, cross-process events and credentials remain
+subsequent work.

--- a/docs/architecture/task-runner-execution-boundary.md
+++ b/docs/architecture/task-runner-execution-boundary.md
@@ -101,8 +101,8 @@ preserve applicable Workforce projections in that transaction as well.
 absence of lease metadata, then delegates to `stage_task_command` as the final
 write. It does not itself accept a turn or commit. The caller must roll back
 all acceptance writes on failure or a conflicting payload. On SQLite the
-caller's acceptance write owns the writer lock; PostgreSQL also locks the task
-row during staging. Calling staging in a later transaction is not this contract.
+caller's acceptance write owns the writer lock; on PostgreSQL the acceptance
+CAS already holds the task row lock, and staging explicitly requests it again. Calling staging in a later transaction is not this contract.
 
 `read_task_start_command` strictly decodes the JSON and checks its run and turn
 against the immutable command envelope. It does not authorize execution or
@@ -110,7 +110,12 @@ check the current task state. The eventual consumer must acquire the exact run's
 lease and start its heartbeat before executing, and finish START processing
 after the local scheduling handoff rather than waiting for the whole run.
 The accepted public run identity is retained; adding a new client-visible queue
-status is not required by this protocol.
+status is not required by this protocol. RUNNING continues to mean an accepted,
+active turn, including the interval before a runner claims it; lease ownership
+distinguishes execution admission. This preserves the existing client-visible
+status contract. A distinct QUEUED status would require coordinated changes to
+status storage, API/client handling, acceptance and the staging precondition,
+and the transition performed when the runner acquires its lease.
 
 This step adds no effect receipts and no safe replay guarantee for a START whose
 execution outcome is unknown. The existing generic retry behavior must not be

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -673,6 +673,8 @@ def _claimable_query(
         .join(Task, Task.id == TaskExecutionCommand.task_id)
         .filter(
             # START remains dormant until runner consumption is implemented.
+            # Keep it in the earlier-command check: later commands must not
+            # overtake START. Without a consumer they remain blocked.
             TaskExecutionCommand.kind != TaskCommandKind.START.value,
             _claim_availability_predicate(now),
             ~_unfinished_earlier_command(),

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -90,6 +90,7 @@ DISPATCHER_CONCURRENCY = 4
 
 
 class TaskCommandKind(str, enum.Enum):
+    START = "start"  # Protocol only; the current dispatcher must not consume it.
     MESSAGE = "message"
     PAUSE = "pause"
     RESUME = "resume"
@@ -671,6 +672,8 @@ def _claimable_query(
         db.query(TaskExecutionCommand)
         .join(Task, Task.id == TaskExecutionCommand.task_id)
         .filter(
+            # START remains dormant until runner consumption is implemented.
+            TaskExecutionCommand.kind != TaskCommandKind.START.value,
             _claim_availability_predicate(now),
             ~_unfinished_earlier_command(),
             _command_routing_predicate(runner_id, now),

--- a/src/xagent/web/services/task_start_protocol.py
+++ b/src/xagent/web/services/task_start_protocol.py
@@ -9,7 +9,6 @@ outside this first version.
 
 from __future__ import annotations
 
-import json
 from typing import Annotated, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -55,7 +54,7 @@ class TaskStartPayload(BaseModel):
     kind: Literal["create", "append"]
     message: str
     execution_message: str | None = None
-    file_ids: tuple[_FileId, ...] = ()
+    file_ids: list[_FileId] = Field(default_factory=list)
     before_message_id: Annotated[int, Field(gt=0)] | None = None
     timezone: str | None = None
     force_fresh: bool = False
@@ -138,7 +137,7 @@ def read_task_start_command(command: ClaimedTaskCommand) -> TaskStartPayload:
     """
     if command.kind != TaskCommandKind.START:
         raise ValueError("Expected a START command")
-    start = TaskStartPayload.model_validate_json(json.dumps(command.payload))
+    start = TaskStartPayload.model_validate(command.payload)
     if start.run_id != command.target_run_id or start.turn_id != command.command_id:
         raise ValueError("START payload does not match its command identity")
     return start

--- a/src/xagent/web/services/task_start_protocol.py
+++ b/src/xagent/web/services/task_start_protocol.py
@@ -45,6 +45,8 @@ class TaskStartPayload(BaseModel):
     arbitrary request context, connector secrets or a transferred lease.
     """
 
+    # Frozen prevents field rebinding, not mutation of nested lists. Producers
+    # must not mutate file_ids after validation.
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
     version: Annotated[int, Field(ge=1, le=1)]
@@ -77,8 +79,10 @@ def stage_task_start_command(
 
     The caller must have reserved the turn through its task-state CAS in THIS
     transaction, including authorization, message persistence and file binding.
-    That write holds SQLite's writer lock; the row lock also protects this
-    check on PostgreSQL. This helper does not replace business acceptance.
+    That write holds SQLite's writer lock and PostgreSQL's task row lock until
+    the transaction ends. FOR UPDATE retains explicit locking at this check;
+    it is not the only lock in a valid acceptance transaction. This helper
+    does not replace business acceptance.
 
     Do not commit a RUNNING turn and call this in a later transaction. On any
     failure the caller must roll back the entire acceptance transaction, as for

--- a/src/xagent/web/services/task_start_protocol.py
+++ b/src/xagent/web/services/task_start_protocol.py
@@ -1,0 +1,144 @@
+"""Dormant wire contract for an accepted CREATE or APPEND turn.
+
+No production producer or consumer uses START yet. Acceptance must persist the
+turn, transcript and file bindings in the same transaction as staging below.
+The future runner acquires its own lease; a request-process lease is never
+transferred through this protocol. Resume and process-local runtime inputs are
+outside this first version.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..models.task import Task, TaskStatus
+from .task_command_transport import (
+    ClaimedTaskCommand,
+    StagedTaskCommand,
+    TaskCommandKind,
+    TaskCommandTaskMissing,
+    stage_task_command,
+)
+
+_Identity = Annotated[
+    str, Field(min_length=1, max_length=64, pattern=r"^[A-Za-z0-9._:-]+$")
+]
+_FileId = Annotated[str, Field(min_length=1)]
+
+
+class TaskStartPayload(BaseModel):
+    """JSON-only inputs not recoverable from the task configuration alone.
+
+    The command envelope supplies task and actor identities. ``turn_id`` is
+    also the command's idempotency key and the persisted transcript identity.
+    ``message`` is the transcript text; ``execution_message`` preserves the
+    separate, possibly file-enriched Agent input. File chips are already in the
+    transcript; only authorized file IDs cross this boundary. The runner must
+    resolve them against its own accessible storage.
+
+    Version is required on the wire. Unknown fields are rejected rather than
+    silently discarding a caller's runtime option or accepting runtime objects,
+    arbitrary request context, connector secrets or a transferred lease.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    version: Annotated[int, Field(ge=1, le=1)]
+    run_id: _Identity
+    state_version: Annotated[int, Field(ge=1)]
+    turn_id: _Identity
+    kind: Literal["create", "append"]
+    message: str
+    execution_message: str | None = None
+    file_ids: tuple[_FileId, ...] = ()
+    before_message_id: Annotated[int, Field(gt=0)] | None = None
+    timezone: str | None = None
+    force_fresh: bool = False
+
+    @model_validator(mode="after")
+    def validate_turn_kind(self) -> Self:
+        if self.kind == "create" and self.force_fresh:
+            raise ValueError("CREATE has no previous execution to discard")
+        return self
+
+
+def stage_task_start_command(
+    db: Session,
+    *,
+    task_id: int,
+    actor_user_id: int,
+    start: TaskStartPayload,
+) -> StagedTaskCommand:
+    """Stage START as the last write of the caller's acceptance transaction.
+
+    The caller must have reserved the turn through its task-state CAS in THIS
+    transaction, including authorization, message persistence and file binding.
+    That write holds SQLite's writer lock; the row lock also protects this
+    check on PostgreSQL. This helper does not replace business acceptance.
+
+    Do not commit a RUNNING turn and call this in a later transaction. On any
+    failure the caller must roll back the entire acceptance transaction, as for
+    ``stage_task_command``. A repeated identity returns its payload comparison;
+    a mismatch must not be committed as a new acceptance.
+    """
+    db.flush()
+    task = db.execute(
+        select(
+            Task.status,
+            Task.run_id,
+            Task.state_version,
+            Task.control_state,
+            Task.runner_id,
+            Task.lease_attempt_id,
+            Task.lease_expires_at,
+            Task.last_heartbeat_at,
+        )
+        .where(Task.id == task_id)
+        .with_for_update()
+    ).one_or_none()
+    if task is None:
+        raise TaskCommandTaskMissing(f"Task {task_id} not found")
+    if (
+        task.status != TaskStatus.RUNNING
+        or task.run_id != start.run_id
+        or task.state_version != start.state_version
+        or task.control_state != "running"
+    ):
+        raise ValueError("START does not match the accepted task turn")
+    if any(
+        value is not None
+        for value in (
+            task.runner_id,
+            task.lease_attempt_id,
+            task.lease_expires_at,
+            task.last_heartbeat_at,
+        )
+    ):
+        raise ValueError("START acceptance must not own an execution lease")
+    return stage_task_command(
+        db,
+        task_id=task_id,
+        actor_user_id=actor_user_id,
+        command_id=start.turn_id,
+        kind=TaskCommandKind.START,
+        payload=start.model_dump(mode="json"),
+    )
+
+
+def read_task_start_command(command: ClaimedTaskCommand) -> TaskStartPayload:
+    """Decode persisted inputs and verify their immutable envelope identity.
+
+    This does not authorize execution, acquire a lease or prove that a prior
+    attempt had no effect. Those are responsibilities of the future consumer.
+    """
+    if command.kind != TaskCommandKind.START:
+        raise ValueError("Expected a START command")
+    start = TaskStartPayload.model_validate_json(json.dumps(command.payload))
+    if start.run_id != command.target_run_id or start.turn_id != command.command_id:
+        raise ValueError("START payload does not match its command identity")
+    return start

--- a/tests/e2e/minio_harness.py
+++ b/tests/e2e/minio_harness.py
@@ -89,7 +89,7 @@ def run_minio_storage(monkeypatch: pytest.MonkeyPatch) -> Iterator[MinioStorage]
     client = _docker_client()
     container, host_ports = run_container_with_dynamic_ports(
         client,
-        "minio/minio",  # Docker Hub — more reliable than quay.io
+        "quay.io/minio/minio",
         "server /data --console-address :9001",
         name=f"xagent-minio-e2e-{uuid4().hex[:12]}",
         container_ports=("9000/tcp", "9001/tcp"),

--- a/tests/e2e/test_minio_harness_ports.py
+++ b/tests/e2e/test_minio_harness_ports.py
@@ -61,7 +61,7 @@ def test_publishes_with_docker_chosen_loopback_ports() -> None:
 
     returned, host_ports = run_container_with_dynamic_ports(
         client,
-        "minio/minio",
+        "quay.io/minio/minio",
         "server /data",
         name="fixture-container",
         container_ports=("9000/tcp", "9001/tcp"),

--- a/tests/web/services/test_task_execution_boundary.py
+++ b/tests/web/services/test_task_execution_boundary.py
@@ -26,7 +26,7 @@ def test_execution_services_and_tracer_load_without_api_routes() -> None:
                             raise AssertionError(f"Execution imported API route: {fullname}")
 
                 sys.meta_path.insert(0, RejectRoutes())
-                from xagent.web.services import agent_service_manager, task_execution, task_orchestrator, task_resume
+                from xagent.web.services import agent_service_manager, task_execution, task_orchestrator, task_resume, task_start_protocol
                 from xagent.web.services.external_task_cancel import _broadcast_external_cancel_terminal_event
                 import asyncio
                 from unittest.mock import AsyncMock, patch
@@ -358,8 +358,9 @@ def test_control_and_reply_commands_execute_without_api_routes() -> None:
                     agent.pause_execution.return_value = True
                     with patch.object(agent_service_manager, "get_agent_manager") as manager:
                         manager.return_value.get_agent_for_task = AsyncMock(return_value=agent)
-                        for index, kind in enumerate(TaskCommandKind):
-                            # Enum includes only the four durable command kinds.
+                        control_kinds = (kind for kind in TaskCommandKind if kind != TaskCommandKind.START)
+                        for index, kind in enumerate(control_kinds):
+                            # Exercise the four wired commands; START is protocol-only.
                             task_index = ["message", "pause", "resume", "cancel"].index(kind.value)
                             payload = (
                                 {"client_message_id": "message-command", "message": "hello"}

--- a/tests/web/services/test_task_start_protocol.py
+++ b/tests/web/services/test_task_start_protocol.py
@@ -336,3 +336,100 @@ def test_append_acceptance_rollback_preserves_previous_turn(db_session):
         assert transcript.turn_id == "previous-turn"
         assert transcript.content == "previous input"
         assert observer.get(TaskExecutionCommand, staged.staged_db_id) is None
+
+
+@pytest.mark.postgresql
+@pytest.mark.parametrize("commit", [True, False], ids=["commit", "rollback"])
+def test_postgres_acceptance_and_start_share_transaction_lock(commit):
+    """The acceptance CAS, transcript and START resolve as one transaction.
+
+    The competing write uses no command identity, so a unique-key conflict
+    cannot masquerade as task-row locking. FOR UPDATE in staging is not the
+    sole lock: the required acceptance CAS already owns this row.
+    """
+    from sqlalchemy import select, text, update
+    from sqlalchemy.exc import OperationalError
+    from sqlalchemy.orm import sessionmaker
+
+    from tests.shared.postgres_disposable import disposable_database_factory
+
+    with disposable_database_factory("start_protocol") as make_database:
+        engine = make_database("acceptance")
+        Base.metadata.create_all(engine)
+        sessions = sessionmaker(bind=engine)
+        with sessions() as setup:
+            user, task = accept_turn(setup, start_payload())
+            setup.commit()
+            task_id, actor_id = task.id, user.id
+
+        start = start_payload(
+            kind="append", run_id="run-2", state_version=2, turn_id="turn-2"
+        )
+        with sessions() as owner, sessions() as competitor:
+            accepted = owner.execute(
+                update(Task)
+                .where(Task.id == task_id, Task.state_version == 1)
+                .values(run_id=start.run_id, state_version=2)
+            )
+            assert accepted.rowcount == 1
+            owner.add(
+                TaskChatMessage(
+                    task_id=task_id,
+                    user_id=actor_id,
+                    role="user",
+                    message_type="user_message",
+                    content=start.message,
+                    turn_id=start.turn_id,
+                )
+            )
+            stage_task_start_command(
+                owner, task_id=task_id, actor_user_id=actor_id, start=start
+            )
+            assert competitor.execute(select(TaskExecutionCommand)).first() is None
+            assert (
+                competitor.execute(
+                    select(TaskChatMessage).where(
+                        TaskChatMessage.turn_id == start.turn_id
+                    )
+                ).first()
+                is None
+            )
+            competitor.execute(text("SET LOCAL lock_timeout = '200ms'"))
+            with pytest.raises(OperationalError) as blocked:
+                competitor.execute(
+                    update(Task)
+                    .where(Task.id == task_id, Task.state_version == 1)
+                    .values(state_version=3)
+                )
+            assert blocked.value.orig.pgcode == "55P03"
+            competitor.rollback()
+
+            if commit:
+                owner.commit()
+            else:
+                owner.rollback()
+            with sessions() as observer:
+                task = observer.get(Task, task_id)
+                assert task.run_id == ("run-2" if commit else "run-1")
+                assert task.state_version == (2 if commit else 1)
+                command = observer.execute(
+                    select(TaskExecutionCommand)
+                ).scalar_one_or_none()
+                message = observer.execute(
+                    select(TaskChatMessage).where(
+                        TaskChatMessage.turn_id == start.turn_id
+                    )
+                ).scalar_one_or_none()
+                assert (command is not None) == commit
+                assert (message is not None) == commit
+                if command is not None:
+                    assert command.payload == start.model_dump(mode="json")
+            # Once the owner resolves, the competing CAS runs rather than waits;
+            # it loses after commit and can reserve the old version after rollback.
+            result = competitor.execute(
+                update(Task)
+                .where(Task.id == task_id, Task.state_version == 1)
+                .values(state_version=3)
+            )
+            assert result.rowcount == (0 if commit else 1)
+            competitor.rollback()

--- a/tests/web/services/test_task_start_protocol.py
+++ b/tests/web/services/test_task_start_protocol.py
@@ -1,0 +1,338 @@
+"""The START wire contract is durable but deliberately not executable yet."""
+
+import json
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from xagent.web.models.chat_message import TaskChatMessage
+from xagent.web.models.database import Base, get_engine, get_session_local, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task_command import TaskExecutionCommand
+from xagent.web.models.user import User
+from xagent.web.services.task_command_transport import (
+    ClaimedTaskCommand,
+    TaskCommandKind,
+    claim_task_command,
+    stage_task_command,
+)
+from xagent.web.services.task_start_protocol import (
+    TaskStartPayload,
+    read_task_start_command,
+    stage_task_start_command,
+)
+
+
+@pytest.fixture
+def db_session(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'start-protocol.db'}")
+    with get_session_local()() as db:
+        yield db
+    Base.metadata.drop_all(bind=get_engine())
+
+
+def start_payload(**overrides):
+    values = {
+        "version": 1,
+        "run_id": "run-1",
+        "state_version": 1,
+        "turn_id": "turn-1",
+        "kind": "create",
+        "message": "Read the attachment",
+        "execution_message": "Read the attachment\n[file_id: uploaded-file-1]",
+        "file_ids": ("uploaded-file-1",),
+        "before_message_id": None,
+        "timezone": "Asia/Taipei",
+    }
+    values.update(overrides)
+    return TaskStartPayload(**values)
+
+
+def accept_turn(db, start):
+    """Stage a new accepted row and transcript without an execution lease."""
+    user = User(username="start-owner", password_hash="unused")
+    db.add(user)
+    db.flush()
+    task = Task(
+        user_id=user.id,
+        title="START protocol",
+        source="sdk",
+        status=TaskStatus.RUNNING,
+        run_id=start.run_id,
+        state_version=start.state_version,
+        control_state="running",
+        input=start.message,
+    )
+    db.add(task)
+    db.flush()
+    db.add(
+        TaskChatMessage(
+            task_id=task.id,
+            user_id=user.id,
+            role="user",
+            message_type="user_message",
+            content=start.message,
+            turn_id=start.turn_id,
+        )
+    )
+    return user, task
+
+
+def claimed_command(payload):
+    return ClaimedTaskCommand(
+        id=1,
+        task_id=1,
+        actor_user_id=1,
+        command_id=payload.turn_id,
+        kind=TaskCommandKind.START,
+        payload=payload.model_dump(mode="json"),
+        target_run_id=payload.run_id,
+        attempt_count=1,
+    )
+
+
+@pytest.mark.parametrize(
+    "kind,force_fresh", [("create", False), ("append", False), ("append", True)]
+)
+def test_json_round_trip_preserves_execution_input_and_turn_identity(kind, force_fresh):
+    start = start_payload(kind=kind, force_fresh=force_fresh, before_message_id=3)
+    command = claimed_command(start)
+    command = replace(command, payload=json.loads(json.dumps(command.payload)))
+    decoded = read_task_start_command(command)
+    assert decoded == start
+    assert decoded.message != decoded.execution_message
+    assert decoded.file_ids == ("uploaded-file-1",)
+    assert decoded.timezone == "Asia/Taipei"
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"version": 2},
+        {"version": True},
+        {"version": 1.0},
+        {"state_version": "1"},
+        {"state_version": 0},
+        {"turn_id": "turn with spaces"},
+        {"kind": "resume"},
+        {"force_fresh": True},
+        {"file_ids": [""]},
+        {"context": {"user": {"id": 1}}},
+        {"secrets": {"token": "synthetic"}},
+        {"task_lease": {"runner_id": "web"}},
+    ],
+)
+def test_decode_rejects_unsupported_or_lossy_payload(changes):
+    command = claimed_command(start_payload())
+    with pytest.raises(ValidationError):
+        read_task_start_command(
+            replace(command, payload={**command.payload, **changes})
+        )
+
+
+def test_decode_requires_version():
+    command = claimed_command(start_payload())
+    del command.payload["version"]
+    with pytest.raises(ValidationError):
+        read_task_start_command(command)
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"kind": TaskCommandKind.MESSAGE},
+        {"target_run_id": "another-run"},
+        {"target_run_id": None},
+        {"command_id": "another-turn"},
+    ],
+)
+def test_decode_rejects_envelope_mismatch(changes):
+    with pytest.raises(ValueError):
+        read_task_start_command(replace(claimed_command(start_payload()), **changes))
+
+
+def test_acceptance_and_command_are_visible_only_after_outer_commit(db_session):
+    start = start_payload()
+    user, task = accept_turn(db_session, start)
+    staged = stage_task_start_command(
+        db_session, task_id=task.id, actor_user_id=user.id, start=start
+    )
+    with get_session_local()() as observer:
+        assert observer.get(Task, task.id) is None
+        assert observer.get(TaskExecutionCommand, staged.staged_db_id) is None
+    db_session.commit()
+    with get_session_local()() as observer:
+        row = observer.get(TaskExecutionCommand, staged.staged_db_id)
+        assert row.kind == "start"
+        assert row.target_run_id == start.run_id
+        assert row.target_state_version == start.state_version
+        assert row.target_runner_id is None
+        assert row.task_owner_user_id == user.id
+        assert row.payload == start.model_dump(mode="json")
+        assert (
+            observer.query(TaskChatMessage)
+            .filter_by(task_id=task.id, turn_id=start.turn_id)
+            .one()
+            .content
+            == start.message
+        )
+        accepted = observer.get(Task, task.id)
+        assert accepted.runner_id is None
+        assert accepted.lease_attempt_id is None
+
+
+def test_outer_rollback_removes_task_message_and_start(db_session):
+    start = start_payload()
+    user, task = accept_turn(db_session, start)
+    task_id = task.id
+    staged = stage_task_start_command(
+        db_session, task_id=task_id, actor_user_id=user.id, start=start
+    )
+    db_session.rollback()
+    with get_session_local()() as observer:
+        assert observer.get(Task, task_id) is None
+        assert observer.get(TaskExecutionCommand, staged.staged_db_id) is None
+        assert observer.query(TaskChatMessage).filter_by(task_id=task_id).count() == 0
+
+
+def test_duplicate_turn_identity_compares_the_full_start_payload(db_session):
+    start = start_payload()
+    user, task = accept_turn(db_session, start)
+    first = stage_task_start_command(
+        db_session, task_id=task.id, actor_user_id=user.id, start=start
+    )
+    same = stage_task_start_command(
+        db_session, task_id=task.id, actor_user_id=user.id, start=start
+    )
+    mismatch = stage_task_start_command(
+        db_session,
+        task_id=task.id,
+        actor_user_id=user.id,
+        start=start_payload(execution_message="different Agent input"),
+    )
+    assert same.staged_db_id == first.staged_db_id == mismatch.staged_db_id
+    assert not same.created and same.payload_matches
+    assert not mismatch.created and not mismatch.payload_matches
+    assert (
+        db_session.query(TaskExecutionCommand).filter_by(task_id=task.id).count() == 1
+    )
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"status": TaskStatus.PENDING},
+        {"run_id": "another-run"},
+        {"state_version": 2},
+        {"control_state": "pause_requested"},
+        {"runner_id": "web-process"},
+        {"lease_attempt_id": "old-attempt"},
+        {"lease_expires_at": datetime.now(timezone.utc)},
+        {"last_heartbeat_at": datetime.now(timezone.utc)},
+    ],
+)
+def test_start_requires_exact_accepted_turn_without_execution_lease(
+    db_session, changes
+):
+    start = start_payload()
+    user, task = accept_turn(db_session, start)
+    for field, value in changes.items():
+        setattr(task, field, value)
+    with pytest.raises(ValueError):
+        stage_task_start_command(
+            db_session, task_id=task.id, actor_user_id=user.id, start=start
+        )
+    assert db_session.query(TaskExecutionCommand).count() == 0
+
+
+def test_existing_dispatcher_cannot_claim_start_or_overtake_it(db_session):
+    start = start_payload()
+    user, task = accept_turn(db_session, start)
+    staged = stage_task_start_command(
+        db_session, task_id=task.id, actor_user_id=user.id, start=start
+    )
+    db_session.commit()
+    # Neither a targeted immediate dispatch nor the background scan may
+    # consume a protocol whose execution semantics have not been wired yet.
+    assert (
+        claim_task_command(
+            db_session, runner_id="runner", command_db_id=staged.staged_db_id
+        )
+        is None
+    )
+    assert claim_task_command(db_session, runner_id="runner") is None
+    stage_task_command(
+        db_session,
+        task_id=task.id,
+        actor_user_id=user.id,
+        command_id="cancel-after-start",
+        kind=TaskCommandKind.CANCEL,
+        payload={},
+    )
+    other = Task(user_id=user.id, title="unrelated", status=TaskStatus.PENDING)
+    db_session.add(other)
+    db_session.flush()
+    independent = stage_task_command(
+        db_session,
+        task_id=other.id,
+        actor_user_id=user.id,
+        command_id="independent-cancel",
+        kind=TaskCommandKind.CANCEL,
+        payload={},
+    )
+    db_session.commit()
+    claimed = claim_task_command(db_session, runner_id="runner")
+    assert claimed is not None and claimed.id == independent.staged_db_id
+    assert db_session.get(TaskExecutionCommand, staged.staged_db_id).attempt_count == 0
+
+
+def test_append_acceptance_rollback_preserves_previous_turn(db_session):
+    start = start_payload(kind="append", force_fresh=True)
+    user, task = accept_turn(db_session, start)
+    task.status = TaskStatus.COMPLETED
+    task.control_state = "completed"
+    task.run_id = "previous-run"
+    task.state_version = 0
+    task.output = "previous output"
+    db_session.flush()
+    db_session.query(TaskChatMessage).filter_by(task_id=task.id).update(
+        {
+            TaskChatMessage.turn_id: "previous-turn",
+            TaskChatMessage.content: "previous input",
+        }
+    )
+    db_session.commit()
+    task_id = task.id
+    task.status = TaskStatus.RUNNING
+    task.control_state = "running"
+    task.run_id = start.run_id
+    task.state_version = start.state_version
+    task.output = None
+    db_session.add(
+        TaskChatMessage(
+            task_id=task_id,
+            user_id=user.id,
+            role="user",
+            message_type="user_message",
+            content=start.message,
+            turn_id=start.turn_id,
+        )
+    )
+    staged = stage_task_start_command(
+        db_session, task_id=task_id, actor_user_id=user.id, start=start
+    )
+    with get_session_local()() as observer:
+        previous = observer.get(Task, task_id)
+        assert previous.run_id == "previous-run"
+        assert previous.status == TaskStatus.COMPLETED
+    db_session.rollback()
+    with get_session_local()() as observer:
+        previous = observer.get(Task, task_id)
+        assert previous.run_id == "previous-run"
+        assert previous.output == "previous output"
+        transcript = observer.query(TaskChatMessage).filter_by(task_id=task_id).one()
+        assert transcript.turn_id == "previous-turn"
+        assert transcript.content == "previous input"
+        assert observer.get(TaskExecutionCommand, staged.staged_db_id) is None

--- a/tests/web/services/test_task_start_protocol.py
+++ b/tests/web/services/test_task_start_protocol.py
@@ -42,7 +42,7 @@ def start_payload(**overrides):
         "kind": "create",
         "message": "Read the attachment",
         "execution_message": "Read the attachment\n[file_id: uploaded-file-1]",
-        "file_ids": ("uploaded-file-1",),
+        "file_ids": ["uploaded-file-1"],
         "before_message_id": None,
         "timezone": "Asia/Taipei",
     }
@@ -103,7 +103,7 @@ def test_json_round_trip_preserves_execution_input_and_turn_identity(kind, force
     decoded = read_task_start_command(command)
     assert decoded == start
     assert decoded.message != decoded.execution_message
-    assert decoded.file_ids == ("uploaded-file-1",)
+    assert decoded.file_ids == ["uploaded-file-1"]
     assert decoded.timezone == "Asia/Taipei"
 
 


### PR DESCRIPTION
Task starts currently rely on an in-process scheduling handoff. Define a versioned, JSON-only START contract for accepted CREATE/APPEND turns, plus transaction-owned staging and envelope decoding, so a later runner integration has an explicit handoff boundary.

The payload preserves run/turn identity, transcript versus execution input, file references, history cutoff, timezone and fresh-append intent. Staging requires the exact accepted RUNNING turn without an execution lease and participates in the caller's acceptance transaction. It reuses the existing command table and idempotency key; no schema migration is needed.

This is deliberately unconnected: no API emits START, and the existing dispatcher excludes it even for targeted dispatch. An unfinished START intentionally blocks every later command for that task, including CANCEL, to preserve FIFO; with no START consumer yet, those commands remain blocked. Other tasks are unaffected. Process roles, execution/lease acquisition, resume, cross-process events, credentials and effect receipts are outside this PR. The architecture document spells out the producer and future-consumer obligations, including inputs that version 1 cannot carry.

Validation: 109 protocol and command-transport tests passed, including real PostgreSQL acceptance commit/rollback locking cases and the existing PostgreSQL concurrent-insert case. The new cases verify that transcript and START visibility follows the acceptance transaction, and that a competing task CAS blocks until that transaction resolves. Both workflow path lists and the PostgreSQL test step include the protocol files. Earlier startup and headless-boundary regression checks also passed. All applicable pre-commit checks passed, including package-wide mypy.

Part of #2306.

