### PR TITLE
feat(outlook): check conflicts before creating events

### DIFF
--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from datetime import datetime
 from typing import Any
 from urllib.parse import quote
 
@@ -164,10 +165,40 @@ def _has_own_utc_offset(value: str) -> bool:
 
 def _is_midnight_in_timezone(value: str, timezone: str) -> bool:
     """Whether ``value`` represents midnight in the event timezone."""
-    parsed = _date_parser.isoparse(value)
+    parsed: datetime = _date_parser.isoparse(value)
     if parsed.tzinfo is not None:
         parsed = parsed.astimezone(_resolve_zoneinfo(timezone))
     return not (parsed.hour or parsed.minute or parsed.second or parsed.microsecond)
+
+
+def _naive_datetime_in_timezone(value: str, timezone: str) -> str:
+    """Return an Outlook dateTimeTimeZone clock value in ``timezone``.
+
+    Graph represents these values as a naive local datetime plus a separate
+    timeZone field. Preserve already-naive wall-clock input, but convert an
+    offset-bearing instant into the requested zone before removing its offset.
+    """
+    parsed: datetime = _date_parser.isoparse(value)
+    if parsed.tzinfo is None:
+        return value
+    return (
+        parsed.astimezone(_resolve_zoneinfo(timezone)).replace(tzinfo=None).isoformat()
+    )
+
+
+def _reject_invalid_create_window(
+    start_datetime: str, end_datetime: str, *, is_all_day: bool
+) -> None:
+    try:
+        _reject_reversed_window(start_datetime, end_datetime)
+    except ValueError as exc:
+        if is_all_day:
+            raise ValueError(
+                "end_datetime is exclusive for an all-day event and must "
+                "be after start_datetime; use the following day's midnight "
+                "as the end of a one-day event."
+            ) from exc
+        raise
 
 
 # Defensive cap on calendarView pages followed for one organizer-side
@@ -607,30 +638,38 @@ def outlook_create_event(
     following day's midnight as the end of a one-day event.
     """
     try:
-        # Both sides share the same `timezone`, so comparing them as naive
-        # values (no offset attached) is already a valid relative
-        # comparison - it doesn't matter which real zone that is.
-        try:
-            _reject_reversed_window(start_datetime, end_datetime)
-        except ValueError as exc:
-            if is_all_day:
-                raise ValueError(
-                    "end_datetime is exclusive for an all-day event and must "
-                    "be after start_datetime; use the following day's midnight "
-                    "as the end of a one-day event."
-                ) from exc
-            raise
         normalized_attendees = _normalize_addresses(attendees) if attendees else []
 
-        # Graph requires all-day event boundaries to be midnight in the
-        # same timezone. Normalize both the availability query and the
-        # eventual write, including when ignore_conflicts bypasses the query.
-        effective_start, effective_end = start_datetime, end_datetime
+        # Retain the caller-level ordering check before all-day normalization:
+        # two reversed times on the same date must not become a valid full-day
+        # window merely because both are widened to date boundaries.
+        _reject_invalid_create_window(
+            start_datetime, end_datetime, is_all_day=is_all_day
+        )
+
+        # Graph's dateTimeTimeZone shape carries a naive wall-clock value and
+        # its timezone separately. Convert offset-bearing inputs to that shape
+        # before comparing, querying, or writing them. This also makes a mixed
+        # aware/naive pair comparable instead of letting it bypass the ordering
+        # check when Python refuses to compare the two datetime kinds.
+        effective_start = _naive_datetime_in_timezone(start_datetime, timezone)
+        effective_end = _naive_datetime_in_timezone(end_datetime, timezone)
+
+        # Graph additionally requires all-day boundaries to be midnight in the
+        # same timezone. Normalize both the availability query and the eventual
+        # write, including when ignore_conflicts bypasses the query.
         if is_all_day:
             effective_start, _ = _naive_day_bounds(start_datetime, timezone)
             end_of_its_day, next_day_start = _naive_day_bounds(end_datetime, timezone)
             end_is_midnight = _is_midnight_in_timezone(end_datetime, timezone)
             effective_end = end_of_its_day if end_is_midnight else next_day_start
+
+        # The raw comparison is deliberately unable to compare a mixed
+        # aware/naive pair. Recheck after normalization so that case cannot
+        # bypass the invariant.
+        _reject_invalid_create_window(
+            effective_start, effective_end, is_all_day=is_all_day
+        )
 
         unchecked_attendees: list[str] = []
         check_error: str | None = None

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -248,6 +248,12 @@ def _find_conflicts(
             if not next_link:
                 break
             next_path = _next_link_path(next_link)
+        else:
+            raise RuntimeError(
+                "Outlook calendar conflict check exceeded the pagination limit; "
+                "the event was not created because availability could not be "
+                "verified completely."
+            )
 
     # getSchedule accepts at most _MAX_ATTENDEES_PER_SCHEDULE_QUERY
     # schedules per call - chunk rather than giving up on the whole batch,
@@ -537,36 +543,27 @@ def outlook_create_event(
         _reject_reversed_window(start_datetime, end_datetime)
         normalized_attendees = _normalize_addresses(attendees) if attendees else []
 
+        # Graph requires all-day event boundaries to be midnight in the
+        # same timezone. Normalize both the availability query and the
+        # eventual write, including when ignore_conflicts bypasses the query.
+        effective_start, effective_end = start_datetime, end_datetime
+        if is_all_day:
+            effective_start, _ = _naive_day_bounds(start_datetime)
+            end_of_its_day, next_day_start = _naive_day_bounds(end_datetime)
+            parsed_end = _date_parser.isoparse(end_datetime)
+            end_is_midnight = (
+                parsed_end.hour == 0
+                and parsed_end.minute == 0
+                and parsed_end.second == 0
+                and parsed_end.microsecond == 0
+            )
+            effective_end = end_of_its_day if end_is_midnight else next_day_start
+
         unchecked_attendees: list[str] = []
         if not ignore_conflicts:
-            # An all-day event occupies the *whole* calendar day(s) it
-            # lands on, not just the literal clock-time slot given -
-            # widen the query window to that before checking, or a
-            # conflict elsewhere that day would be missed. Graph itself
-            # doesn't require start/end to already be day-aligned for
-            # isAllDay=True, so a caller passing e.g. business hours with
-            # is_all_day=True must still get the whole day checked.
-            query_start, query_end = start_datetime, end_datetime
-            if is_all_day:
-                query_start, _ = _naive_day_bounds(start_datetime)
-                end_of_its_day, next_day_start = _naive_day_bounds(end_datetime)
-                # end_datetime may already BE a well-formed exclusive day
-                # boundary (exactly midnight) - naive_day_bounds always
-                # treats its input as a day that needs widening to [that
-                # midnight, next midnight), so applying it unconditionally
-                # would push an already-correct boundary one whole day
-                # too far.
-                parsed_end = _date_parser.isoparse(end_datetime)
-                end_is_midnight = (
-                    parsed_end.hour == 0
-                    and parsed_end.minute == 0
-                    and parsed_end.second == 0
-                    and parsed_end.microsecond == 0
-                )
-                query_end = end_of_its_day if end_is_midnight else next_day_start
             try:
                 conflicts, unchecked_attendees = _find_conflicts(
-                    query_start, query_end, timezone, normalized_attendees
+                    effective_start, effective_end, timezone, normalized_attendees
                 )
             except InsufficientScopeError as exc:
                 conflicts, unchecked_attendees = _merge_scope_error(exc, [], [])
@@ -574,14 +571,14 @@ def outlook_create_event(
                 return _conflict_response(
                     conflicts,
                     unchecked_attendees,
-                    query_start,
-                    query_end,
+                    effective_start,
+                    effective_end,
                 )
 
         payload: dict[str, Any] = {
             "subject": subject,
-            "start": {"dateTime": start_datetime, "timeZone": timezone},
-            "end": {"dateTime": end_datetime, "timeZone": timezone},
+            "start": {"dateTime": effective_start, "timeZone": timezone},
+            "end": {"dateTime": effective_end, "timeZone": timezone},
             "isAllDay": is_all_day,
         }
         if body:

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -10,13 +10,14 @@ from mcp.server.fastmcp import FastMCP
 
 from .utils import InsufficientScopeError
 from .utils import conflict_response as _conflict_response
+from .utils import incomplete_check_response as _incomplete_check_response
 from .utils import merge_scope_error as _merge_scope_error
 from .utils import naive_day_bounds as _naive_day_bounds
 from .utils import normalize_addresses as _normalize_addresses
 from .utils import offset_datetime_string as _offset_datetime_string
 from .utils import reject_reversed_window as _reject_reversed_window
+from .utils import resolve_zoneinfo as _resolve_zoneinfo
 from .utils import setup_proxy_env
-from .utils import unchecked_extra as _unchecked_extra
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("outlook-mcp")
@@ -46,6 +47,20 @@ class _GraphRequestError(RuntimeError):
     def __init__(self, message: str, *, status_code: int) -> None:
         super().__init__(message)
         self.status_code = status_code
+
+
+class _ConflictCheckIncompleteError(RuntimeError):
+    """An availability scan that stopped after finding partial results."""
+
+    def __init__(
+        self,
+        message: str,
+        conflicts: list[dict[str, Any]],
+        unchecked_attendees: list[str],
+    ) -> None:
+        super().__init__(message)
+        self.conflicts = conflicts
+        self.unchecked_attendees = unchecked_attendees
 
 
 def _success(**payload: Any) -> str:
@@ -128,15 +143,31 @@ def _message_body(content: str, content_type: str) -> dict[str, str]:
     return {"contentType": normalized, "content": content}
 
 
-def _next_link_path(next_link: str) -> str:
+def _next_link_path(next_link: Any) -> str:
     """Strip GRAPH_BASE_URL from an @odata.nextLink so it can be re-issued
     through `_graph_request` as a plain path+query (the link is always an
     absolute URL; `_graph_request` builds its own URL as
     ``f"{GRAPH_BASE_URL}{path}"``, so passing the absolute link verbatim as
     `path` would double up the host instead of following it)."""
-    if next_link.startswith(GRAPH_BASE_URL):
-        return next_link[len(GRAPH_BASE_URL) :]
-    return next_link
+    if not isinstance(next_link, str) or not next_link.startswith(f"{GRAPH_BASE_URL}/"):
+        raise ValueError("Outlook returned an invalid calendarView next link.")
+    return next_link[len(GRAPH_BASE_URL) :]
+
+
+def _has_own_utc_offset(value: str) -> bool:
+    """Whether an ISO datetime already identifies an absolute instant."""
+    try:
+        return _date_parser.isoparse(value).tzinfo is not None
+    except (TypeError, ValueError):
+        return False
+
+
+def _is_midnight_in_timezone(value: str, timezone: str) -> bool:
+    """Whether ``value`` represents midnight in the event timezone."""
+    parsed = _date_parser.isoparse(value)
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(_resolve_zoneinfo(timezone))
+    return not (parsed.hour or parsed.minute or parsed.second or parsed.microsecond)
 
 
 # Defensive cap on calendarView pages followed for one organizer-side
@@ -169,6 +200,12 @@ def _find_conflicts(
     - a naive value there is silently read as UTC. So only the calendarView
     call needs an explicit offset attached before it's sent.
 
+    The organizer results are accepted as Graph's own overlap decision for
+    this half-open window; this connector does not apply a second local
+    overlap calculation at the exact start/end edges. Each returned
+    boundary retains its response timezone below so organizer-local and
+    getSchedule UTC values cannot be mistaken for the same clock basis.
+
     getSchedule has no concept of "exclude this event": it only returns raw
     busy blocks, so a query against a window an attendee is *already* busy
     for (because that's the very event being updated) can't be told apart
@@ -192,8 +229,16 @@ def _find_conflicts(
     unchecked_attendees: list[str] = []
 
     if check_organizer:
-        offset_start = _offset_datetime_string(start_datetime, timezone)
-        offset_end = _offset_datetime_string(end_datetime, timezone)
+        offset_start = (
+            start_datetime
+            if _has_own_utc_offset(start_datetime)
+            else _offset_datetime_string(start_datetime, timezone)
+        )
+        offset_end = (
+            end_datetime
+            if _has_own_utc_offset(end_datetime)
+            else _offset_datetime_string(end_datetime, timezone)
+        )
         params: dict[str, Any] | None = {
             "startDateTime": offset_start,
             "endDateTime": offset_end,
@@ -202,12 +247,24 @@ def _find_conflicts(
         }
         next_path: str | None = None
         for _ in range(_MAX_CALENDAR_VIEW_PAGES):
-            calendar_view = _graph_request(
-                "GET",
-                next_path if next_path is not None else "/me/calendarView",
-                params=params if next_path is None else None,
-                extra_headers={"Prefer": f'outlook.timezone="{timezone}"'},
-            )
+            try:
+                calendar_view = _graph_request(
+                    "GET",
+                    next_path if next_path is not None else "/me/calendarView",
+                    params=params if next_path is None else None,
+                    extra_headers={"Prefer": f'outlook.timezone="{timezone}"'},
+                )
+            except _GraphRequestError as exc:
+                if exc.status_code == 403:
+                    raise InsufficientScopeError(
+                        "Missing the calendars.read permission needed to check "
+                        "organizer availability - reconnecting the Outlook "
+                        "connector may grant it. This is a missing permission "
+                        "on our own credential, not a scheduling conflict.",
+                        conflicts,
+                        unchecked_attendees + attendees,
+                    ) from exc
+                raise
             for item in calendar_view.get("value") or []:
                 if item.get("isCancelled"):
                     continue
@@ -242,17 +299,25 @@ def _find_conflicts(
                         "summary": item.get("subject") or "(no subject)",
                         "start": start.get("dateTime"),
                         "end": end.get("dateTime"),
+                        "start_timezone": start.get("timeZone") or timezone,
+                        "end_timezone": end.get("timeZone") or timezone,
                     }
                 )
             next_link = calendar_view.get("@odata.nextLink")
-            if not next_link:
+            if next_link is None:
                 break
-            next_path = _next_link_path(next_link)
+            try:
+                next_path = _next_link_path(next_link)
+            except ValueError as exc:
+                raise _ConflictCheckIncompleteError(
+                    str(exc), conflicts, unchecked_attendees + attendees
+                ) from exc
         else:
-            raise RuntimeError(
+            raise _ConflictCheckIncompleteError(
                 "Outlook calendar conflict check exceeded the pagination limit; "
-                "the event was not created because availability could not be "
-                "verified completely."
+                "availability could not be verified completely.",
+                conflicts,
+                unchecked_attendees + attendees,
             )
 
     # getSchedule accepts at most _MAX_ATTENDEES_PER_SCHEDULE_QUERY
@@ -272,6 +337,7 @@ def _find_conflicts(
                     "endTime": {"dateTime": end_datetime, "timeZone": timezone},
                     "availabilityViewInterval": 30,
                 },
+                extra_headers={"Prefer": f'outlook.timezone="{timezone}"'},
             )
         except _GraphRequestError as exc:
             if exc.status_code == 403:
@@ -345,6 +411,8 @@ def _find_conflicts(
                             "summary": None,
                             "start": start.get("dateTime"),
                             "end": end.get("dateTime"),
+                            "start_timezone": start.get("timeZone") or timezone,
+                            "end_timezone": end.get("timeZone") or timezone,
                         }
                     )
 
@@ -535,12 +603,23 @@ def outlook_create_event(
     own calendar; a conflict returns status="conflict" instead of creating
     the event. Pass ignore_conflicts=True to create it anyway once the user
     has explicitly confirmed a conflict is fine.
+    For an all-day event, end_datetime is an exclusive boundary: use the
+    following day's midnight as the end of a one-day event.
     """
     try:
         # Both sides share the same `timezone`, so comparing them as naive
         # values (no offset attached) is already a valid relative
         # comparison - it doesn't matter which real zone that is.
-        _reject_reversed_window(start_datetime, end_datetime)
+        try:
+            _reject_reversed_window(start_datetime, end_datetime)
+        except ValueError as exc:
+            if is_all_day:
+                raise ValueError(
+                    "end_datetime is exclusive for an all-day event and must "
+                    "be after start_datetime; use the following day's midnight "
+                    "as the end of a one-day event."
+                ) from exc
+            raise
         normalized_attendees = _normalize_addresses(attendees) if attendees else []
 
         # Graph requires all-day event boundaries to be midnight in the
@@ -548,31 +627,39 @@ def outlook_create_event(
         # eventual write, including when ignore_conflicts bypasses the query.
         effective_start, effective_end = start_datetime, end_datetime
         if is_all_day:
-            effective_start, _ = _naive_day_bounds(start_datetime)
-            end_of_its_day, next_day_start = _naive_day_bounds(end_datetime)
-            parsed_end = _date_parser.isoparse(end_datetime)
-            end_is_midnight = (
-                parsed_end.hour == 0
-                and parsed_end.minute == 0
-                and parsed_end.second == 0
-                and parsed_end.microsecond == 0
-            )
+            effective_start, _ = _naive_day_bounds(start_datetime, timezone)
+            end_of_its_day, next_day_start = _naive_day_bounds(end_datetime, timezone)
+            end_is_midnight = _is_midnight_in_timezone(end_datetime, timezone)
             effective_end = end_of_its_day if end_is_midnight else next_day_start
 
         unchecked_attendees: list[str] = []
+        check_error: str | None = None
         if not ignore_conflicts:
             try:
                 conflicts, unchecked_attendees = _find_conflicts(
                     effective_start, effective_end, timezone, normalized_attendees
                 )
             except InsufficientScopeError as exc:
+                check_error = str(exc)
                 conflicts, unchecked_attendees = _merge_scope_error(exc, [], [])
+            except _ConflictCheckIncompleteError as exc:
+                check_error = str(exc)
+                conflicts = exc.conflicts
+                unchecked_attendees = exc.unchecked_attendees
             if conflicts:
                 return _conflict_response(
                     conflicts,
                     unchecked_attendees,
                     effective_start,
                     effective_end,
+                    check_error=check_error,
+                )
+            if check_error or unchecked_attendees:
+                return _incomplete_check_response(
+                    unchecked_attendees,
+                    effective_start,
+                    effective_end,
+                    message=check_error,
                 )
 
         payload: dict[str, Any] = {
@@ -589,7 +676,7 @@ def outlook_create_event(
             payload["attendees"] = _attendee_list(normalized_attendees)
 
         result = _graph_request("POST", "/me/events", body=payload)
-        return _success(event=result, **_unchecked_extra(unchecked_attendees))
+        return _success(event=result)
     except Exception as e:
         logger.error("Error creating Outlook event: %s", e)
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -3,7 +3,7 @@ import logging
 import os
 from datetime import datetime
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, unquote, urlsplit
 
 import requests
 from dateutil import parser as _date_parser
@@ -152,15 +152,12 @@ def _next_link_path(next_link: Any) -> str:
     `path` would double up the host instead of following it)."""
     if not isinstance(next_link, str) or not next_link.startswith(f"{GRAPH_BASE_URL}/"):
         raise ValueError("Outlook returned an invalid calendarView next link.")
+    if any(
+        unquote(segment) in {".", ".."}
+        for segment in urlsplit(next_link).path.split("/")
+    ):
+        raise ValueError("Outlook returned an invalid calendarView next link.")
     return next_link[len(GRAPH_BASE_URL) :]
-
-
-def _has_own_utc_offset(value: str) -> bool:
-    """Whether an ISO datetime already identifies an absolute instant."""
-    try:
-        return _date_parser.isoparse(value).tzinfo is not None
-    except (TypeError, ValueError):
-        return False
 
 
 def _is_midnight_in_timezone(value: str, timezone: str) -> bool:
@@ -178,9 +175,30 @@ def _naive_datetime_in_timezone(value: str, timezone: str) -> str:
     timeZone field. Preserve already-naive wall-clock input, but convert an
     offset-bearing instant into the requested zone before removing its offset.
     """
-    parsed: datetime = _date_parser.isoparse(value)
+    normalized = value.strip()
+    if (
+        len(normalized) < 19
+        or normalized[4] != "-"
+        or normalized[7] != "-"
+        or normalized[10] not in {"T", "t"}
+        or normalized[13] != ":"
+        or normalized[16] != ":"
+    ):
+        raise ValueError(
+            "Outlook event datetimes must use the extended ISO format "
+            "YYYY-MM-DDTHH:MM:SS, optionally followed by fractional seconds "
+            "and a UTC offset or Z suffix."
+        )
+    try:
+        parsed: datetime = _date_parser.isoparse(normalized)
+    except ValueError as exc:
+        raise ValueError(
+            "Outlook event datetimes must use the extended ISO format "
+            "YYYY-MM-DDTHH:MM:SS, optionally followed by fractional seconds "
+            "and a UTC offset or Z suffix."
+        ) from exc
     if parsed.tzinfo is None:
-        return value
+        return normalized
     return (
         parsed.astimezone(_resolve_zoneinfo(timezone)).replace(tzinfo=None).isoformat()
     )
@@ -260,16 +278,8 @@ def _find_conflicts(
     unchecked_attendees: list[str] = []
 
     if check_organizer:
-        offset_start = (
-            start_datetime
-            if _has_own_utc_offset(start_datetime)
-            else _offset_datetime_string(start_datetime, timezone)
-        )
-        offset_end = (
-            end_datetime
-            if _has_own_utc_offset(end_datetime)
-            else _offset_datetime_string(end_datetime, timezone)
-        )
+        offset_start = _offset_datetime_string(start_datetime, timezone)
+        offset_end = _offset_datetime_string(end_datetime, timezone)
         params: dict[str, Any] | None = {
             "startDateTime": offset_start,
             "endDateTime": offset_end,
@@ -290,8 +300,10 @@ def _find_conflicts(
                     raise InsufficientScopeError(
                         "Missing the calendars.read permission needed to check "
                         "organizer availability - reconnecting the Outlook "
-                        "connector may grant it. This is a missing permission "
-                        "on our own credential, not a scheduling conflict.",
+                        "connector may grant it; if it already has calendar "
+                        "access, an org-level policy may be blocking the call. "
+                        "This is a credential or policy error, not a scheduling "
+                        "conflict.",
                         conflicts,
                         unchecked_attendees + attendees,
                     ) from exc
@@ -426,7 +438,9 @@ def _find_conflicts(
             if entry.get("error"):
                 unchecked_attendees.append(email)
                 continue
-            for item in entry.get("scheduleItems") or []:
+            schedule_items = entry.get("scheduleItems") or []
+            found_busy_item = False
+            for item in schedule_items:
                 # See the matching comment on the organizer-side loop
                 # above: "unknown" is unclassified, not confirmed-free,
                 # so it's treated the same way here for consistency -
@@ -434,6 +448,7 @@ def _find_conflicts(
                 # over-flagging one the caller can dismiss with
                 # ignore_conflicts.
                 if item.get("status") in ("busy", "tentative", "oof", "unknown"):
+                    found_busy_item = True
                     start = item.get("start") or {}
                     end = item.get("end") or {}
                     conflicts.append(
@@ -446,6 +461,17 @@ def _find_conflicts(
                             "end_timezone": end.get("timeZone") or timezone,
                         }
                     )
+            availability_view = entry.get("availabilityView")
+            if not found_busy_item and (
+                not isinstance(availability_view, str)
+                or not availability_view
+                or any(slot != "0" for slot in availability_view)
+            ):
+                # scheduleItems can be withheld even though availabilityView
+                # still reports a busy slot. Without item boundaries there is
+                # not enough detail to construct a normal conflict entry, but
+                # treating the attendee as free would permit a double booking.
+                unchecked_attendees.append(email)
 
     return conflicts, unchecked_attendees
 
@@ -629,15 +655,18 @@ def outlook_create_event(
     ignore_conflicts: bool = False,
 ) -> str:
     """Create an Outlook calendar event.
+    The organizer's calendar is always checked for scheduling conflicts.
     attendees, if given, are invited by email (Graph emails them the invite)
-    and are checked for scheduling conflicts together with the organizer's
-    own calendar; a conflict returns status="conflict" instead of creating
-    the event. Pass ignore_conflicts=True to create it anyway once the user
-    has explicitly confirmed a conflict is fine.
+    and their schedules are checked too; a conflict returns status="conflict"
+    instead of creating the event. Pass ignore_conflicts=True to create it
+    anyway once the user has explicitly confirmed a conflict is fine.
     For an all-day event, end_datetime is an exclusive boundary: use the
     following day's midnight as the end of a one-day event.
     """
     try:
+        # Timezone validity is part of the write contract, independent of
+        # whether the caller explicitly bypasses availability checks.
+        _resolve_zoneinfo(timezone)
         normalized_attendees = _normalize_addresses(attendees) if attendees else []
 
         # Retain the caller-level ordering check before all-day normalization:
@@ -662,7 +691,14 @@ def outlook_create_event(
             effective_start, _ = _naive_day_bounds(start_datetime, timezone)
             end_of_its_day, next_day_start = _naive_day_bounds(end_datetime, timezone)
             end_is_midnight = _is_midnight_in_timezone(end_datetime, timezone)
-            effective_end = end_of_its_day if end_is_midnight else next_day_start
+            # end_datetime is an exclusive date boundary. A same-day time
+            # range still denotes one all-day event, while a later date is
+            # already the exclusive boundary even if its clock is non-midnight.
+            effective_end = (
+                end_of_its_day
+                if end_is_midnight or end_of_its_day != effective_start
+                else next_day_start
+            )
 
         # The raw comparison is deliberately unable to compare a mixed
         # aware/naive pair. Recheck after normalization so that case cannot

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -152,9 +152,11 @@ def _next_link_path(next_link: Any) -> str:
     `path` would double up the host instead of following it)."""
     if not isinstance(next_link, str) or not next_link.startswith(f"{GRAPH_BASE_URL}/"):
         raise ValueError("Outlook returned an invalid calendarView next link.")
+    # Decode before splitting so an encoded slash cannot hide a dot segment
+    # inside one raw segment (for example ``%2e%2e%2fusers``).
     if any(
-        unquote(segment) in {".", ".."}
-        for segment in urlsplit(next_link).path.split("/")
+        segment in {".", ".."}
+        for segment in unquote(urlsplit(next_link).path).split("/")
     ):
         raise ValueError("Outlook returned an invalid calendarView next link.")
     return next_link[len(GRAPH_BASE_URL) :]
@@ -465,10 +467,13 @@ def _find_conflicts(
             if not found_busy_item and (
                 not isinstance(availability_view, str)
                 or not availability_view
-                or any(slot != "0" for slot in availability_view)
+                or any(slot not in {"0", "4"} for slot in availability_view)
             ):
                 # scheduleItems can be withheld even though availabilityView
-                # still reports a busy slot. Without item boundaries there is
+                # still reports a busy slot. Graph uses "4" for
+                # workingElsewhere, which follows the same non-blocking policy
+                # as detailed schedule items above. Without item boundaries for
+                # any other non-free state there is
                 # not enough detail to construct a normal conflict entry, but
                 # treating the attendee as free would permit a double booking.
                 unchecked_attendees.append(email)

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -1,13 +1,22 @@
 import json
 import logging
 import os
+from datetime import datetime
 from typing import Any
 from urllib.parse import quote
 
 import requests
 from mcp.server.fastmcp import FastMCP
 
+from .utils import InsufficientScopeError
+from .utils import conflict_response as _conflict_response
+from .utils import merge_scope_error as _merge_scope_error
+from .utils import naive_day_bounds as _naive_day_bounds
+from .utils import normalize_addresses as _normalize_addresses
+from .utils import offset_datetime_string as _offset_datetime_string
+from .utils import reject_reversed_window as _reject_reversed_window
 from .utils import setup_proxy_env
+from .utils import unchecked_extra as _unchecked_extra
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("outlook-mcp")
@@ -18,6 +27,25 @@ mcp = FastMCP("outlook-mcp")
 
 GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
 DEFAULT_TIMEOUT_SECONDS = 30
+
+# getSchedule accepts at most this many schedules (users/resources) per call.
+_MAX_ATTENDEES_PER_SCHEDULE_QUERY = 20
+
+
+class _GraphRequestError(RuntimeError):
+    """Raised by _graph_request on any HTTP error response.
+
+    Carries status_code so a caller that needs to distinguish e.g. a 403
+    (likely a missing-scope/permission issue on a /me/... call) from other
+    failures doesn't have to string-match the rendered message - Graph has
+    no single canonical error code for "missing scope" the way Slack does.
+    Still a RuntimeError, so every existing bare `except Exception` call
+    site keeps working unchanged.
+    """
+
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 def _success(**payload: Any) -> str:
@@ -69,17 +97,11 @@ def _graph_request(
         message = str(exc)
         if response_text:
             message = f"{message} - {response_text}"
-        raise RuntimeError(message) from exc
+        raise _GraphRequestError(message, status_code=response.status_code) from exc
 
     if response.status_code == 204 or not response.content:
         return {}
     return response.json()
-
-
-def _normalize_addresses(addresses: list[str] | str) -> list[str]:
-    if isinstance(addresses, str):
-        return [address.strip() for address in addresses.split(",") if address.strip()]
-    return [address.strip() for address in addresses if address and address.strip()]
 
 
 def _recipient_list(addresses: list[str] | str) -> list[dict[str, Any]]:
@@ -104,6 +126,223 @@ def _message_body(content: str, content_type: str) -> dict[str, str]:
     if normalized not in {"text", "html"}:
         raise ValueError("content_type must be either 'text' or 'html'")
     return {"contentType": normalized, "content": content}
+
+
+def _next_link_path(next_link: str) -> str:
+    """Strip GRAPH_BASE_URL from an @odata.nextLink so it can be re-issued
+    through `_graph_request` as a plain path+query (the link is always an
+    absolute URL; `_graph_request` builds its own URL as
+    ``f"{GRAPH_BASE_URL}{path}"``, so passing the absolute link verbatim as
+    `path` would double up the host instead of following it)."""
+    if next_link.startswith(GRAPH_BASE_URL):
+        return next_link[len(GRAPH_BASE_URL) :]
+    return next_link
+
+
+# Defensive cap on calendarView pages followed for one organizer-side
+# conflict check - comfortably more than any single-window query should
+# ever need, just bounding the loop against an unexpected/pathological
+# amount of paging rather than looping forever.
+_MAX_CALENDAR_VIEW_PAGES = 20
+
+
+def _find_conflicts(
+    start_datetime: str,
+    end_datetime: str,
+    timezone: str,
+    attendees: list[str],
+    *,
+    exclude_event_id: str | None = None,
+    check_organizer: bool = True,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Check the organizer's own calendar (when check_organizer) plus each
+    attendee's schedule for anything overlapping [start_datetime,
+    end_datetime) in the given timezone.
+
+    `start_datetime`/`end_datetime` are naive (no embedded offset) clock
+    values paired with `timezone` - the same shape Outlook's own
+    dateTimeTimeZone resource uses, and getSchedule's structured
+    startTime/endTime fields accept directly. calendarView's
+    startDateTime/endDateTime query parameters are different: Graph's own
+    docs say they're "interpreted using the timezone offset specified in
+    the value" and "aren't impacted by the value of the Prefer ... header"
+    - a naive value there is silently read as UTC. So only the calendarView
+    call needs an explicit offset attached before it's sent.
+
+    getSchedule has no concept of "exclude this event": it only returns raw
+    busy blocks, so a query against a window an attendee is *already* busy
+    for (because that's the very event being updated) can't be told apart
+    from a genuine conflict here. Callers that aren't moving the event to a
+    new window must restrict `attendees` to only the newly-added ones (see
+    outlook_update_event) rather than relying on this function to exclude
+    the event's own footprint on attendee schedules.
+
+    Returns (conflicts, unchecked_attendees). A missing-scope 403 covering
+    the whole call raises `InsufficientScopeError` (carrying whatever was
+    already confirmed in `conflicts`/`unchecked_attendees` before the
+    error) instead of degrading to unchecked and returning normally -
+    that's OUR OWN credential/policy problem, not a per-attendee
+    visibility gap, and writing an event whose availability was never
+    actually checked would defeat the point of this feature. Every entry
+    that does end up in `unchecked_attendees` on a normal return is the
+    self-explanatory kind (absent from the response, or its own
+    per-attendee error).
+    """
+    conflicts: list[dict[str, Any]] = []
+    unchecked_attendees: list[str] = []
+
+    if check_organizer:
+        offset_start = _offset_datetime_string(start_datetime, timezone)
+        offset_end = _offset_datetime_string(end_datetime, timezone)
+        params: dict[str, Any] | None = {
+            "startDateTime": offset_start,
+            "endDateTime": offset_end,
+            "$top": 250,
+            "$select": "id,subject,start,end,isCancelled,showAs,responseStatus",
+        }
+        next_path: str | None = None
+        for _ in range(_MAX_CALENDAR_VIEW_PAGES):
+            calendar_view = _graph_request(
+                "GET",
+                next_path if next_path is not None else "/me/calendarView",
+                params=params if next_path is None else None,
+                extra_headers={"Prefer": f'outlook.timezone="{timezone}"'},
+            )
+            for item in calendar_view.get("value") or []:
+                if item.get("isCancelled"):
+                    continue
+                # Graph's own showAs enum documents "unknown" as an
+                # unclassified value (e.g. an event synced from a
+                # third-party calendar that never set it), not
+                # specifically a permission gap - it can represent a
+                # genuinely busy block. Missing a real conflict is worse
+                # than occasionally over-flagging one the caller can
+                # dismiss with ignore_conflicts, so only skip the values
+                # that are unambiguously not-busy - matching the policy
+                # used for attendees' schedules below.
+                if item.get("showAs") in ("free", "workingElsewhere"):
+                    continue
+                if exclude_event_id and item.get("id") == exclude_event_id:
+                    continue
+                # NOTE: declining an invite (responseStatus.response ==
+                # "declined") is NOT used as a busy/free signal here -
+                # Microsoft's event resource documents responseStatus and
+                # showAs as independent fields, with no documented
+                # guarantee that declining clears showAs to "free". An
+                # earlier version of this check skipped declined events
+                # outright, which silently treated a still-busy declined
+                # event as free and permitted a real double booking.
+                # `showAs` above is the one field Graph actually
+                # documents as the busy/free predicate.
+                start = item.get("start") or {}
+                end = item.get("end") or {}
+                conflicts.append(
+                    {
+                        "calendar": "organizer",
+                        "summary": item.get("subject") or "(no subject)",
+                        "start": start.get("dateTime"),
+                        "end": end.get("dateTime"),
+                    }
+                )
+            next_link = calendar_view.get("@odata.nextLink")
+            if not next_link:
+                break
+            next_path = _next_link_path(next_link)
+
+    # getSchedule accepts at most _MAX_ATTENDEES_PER_SCHEDULE_QUERY
+    # schedules per call - chunk rather than giving up on the whole batch,
+    # so a large invite list still gets everyone it can check checked.
+    # `range(0, 0, N)` is empty, so this is also just a no-op loop when
+    # `attendees` is empty.
+    for offset in range(0, len(attendees), _MAX_ATTENDEES_PER_SCHEDULE_QUERY):
+        batch = attendees[offset : offset + _MAX_ATTENDEES_PER_SCHEDULE_QUERY]
+        try:
+            schedule = _graph_request(
+                "POST",
+                "/me/calendar/getSchedule",
+                body={
+                    "schedules": batch,
+                    "startTime": {"dateTime": start_datetime, "timeZone": timezone},
+                    "endTime": {"dateTime": end_datetime, "timeZone": timezone},
+                    "availabilityViewInterval": 30,
+                },
+            )
+        except _GraphRequestError as exc:
+            if exc.status_code == 403:
+                # Graph gives no single reliable code for "this is a
+                # missing-scope/permission issue" (unlike Google's
+                # PERMISSION_DENIED/insufficientPermissions pairing) -
+                # but a 403 on this /me/... call for the signed-in
+                # user's own mailbox is not expected to have another
+                # cause here. This is OUR OWN credential/policy problem,
+                # not a per-attendee visibility gap (which genuinely
+                # can't be fixed and still degrades to unchecked below) -
+                # proceeding to write an event whose availability was
+                # never actually checked would defeat the entire point
+                # of this feature, so reject instead of silently booking
+                # over a possible conflict. Carrying `conflicts` (e.g. an
+                # organizer conflict already found above, before this
+                # batch ever ran) lets a caller still report it rather
+                # than silently discarding a known problem just because
+                # this later, unrelated check also failed.
+                raise InsufficientScopeError(
+                    "Missing the calendars.read/schedule permission "
+                    "needed to check attendee availability - "
+                    "reconnecting the Outlook connector may grant it; if "
+                    "the connector already has calendar access, this is "
+                    "more likely an org-level policy blocking this call, "
+                    "which a reconnect won't fix. Pass "
+                    "ignore_conflicts=true if the user has confirmed "
+                    "they want to proceed without this check.",
+                    conflicts,
+                    # Every attendee from this failed batch onward is
+                    # unchecked - every remaining batch would hit this
+                    # same scope error too, so there's nothing left to
+                    # gain by attempting them.
+                    unchecked_attendees + attendees[offset:],
+                ) from exc
+            raise
+
+        # Keyed by Graph's own scheduleId casing for lookup, but every
+        # value reported back below (conflicts and unchecked_attendees)
+        # uses the caller's original attendees casing - matching
+        # google_calendar's _find_conflicts, which iterates `attendees`
+        # for the same reason.
+        by_schedule_id = {
+            (entry.get("scheduleId") or "").lower(): entry
+            for entry in (schedule.get("value") or [])
+        }
+        for email in batch:
+            entry = by_schedule_id.get(email.lower())
+            if entry is None:
+                # Not even present in the response - can't tell
+                # whether they're free, so don't silently report them
+                # as clear.
+                unchecked_attendees.append(email)
+                continue
+            if entry.get("error"):
+                unchecked_attendees.append(email)
+                continue
+            for item in entry.get("scheduleItems") or []:
+                # See the matching comment on the organizer-side loop
+                # above: "unknown" is unclassified, not confirmed-free,
+                # so it's treated the same way here for consistency -
+                # missing a real conflict is worse than occasionally
+                # over-flagging one the caller can dismiss with
+                # ignore_conflicts.
+                if item.get("status") in ("busy", "tentative", "oof", "unknown"):
+                    start = item.get("start") or {}
+                    end = item.get("end") or {}
+                    conflicts.append(
+                        {
+                            "calendar": email,
+                            "summary": None,
+                            "start": start.get("dateTime"),
+                            "end": end.get("dateTime"),
+                        }
+                    )
+
+    return conflicts, unchecked_attendees
 
 
 @mcp.tool()
@@ -282,9 +521,61 @@ def outlook_create_event(
     location: str | None = None,
     attendees: list[str] | str | None = None,
     is_all_day: bool = False,
+    ignore_conflicts: bool = False,
 ) -> str:
-    """Create an Outlook calendar event."""
+    """Create an Outlook calendar event.
+    attendees, if given, are invited by email (Graph emails them the invite)
+    and are checked for scheduling conflicts together with the organizer's
+    own calendar; a conflict returns status="conflict" instead of creating
+    the event. Pass ignore_conflicts=True to create it anyway once the user
+    has explicitly confirmed a conflict is fine.
+    """
     try:
+        # Both sides share the same `timezone`, so comparing them as naive
+        # values (no offset attached) is already a valid relative
+        # comparison - it doesn't matter which real zone that is.
+        _reject_reversed_window(start_datetime, end_datetime)
+        normalized_attendees = _normalize_addresses(attendees) if attendees else []
+
+        unchecked_attendees: list[str] = []
+        if not ignore_conflicts:
+            # An all-day event occupies the *whole* calendar day(s) it
+            # lands on, not just the literal clock-time slot given -
+            # widen the query window to that before checking, or a
+            # conflict elsewhere that day would be missed. Graph itself
+            # doesn't require start/end to already be day-aligned for
+            # isAllDay=True, so a caller passing e.g. business hours with
+            # is_all_day=True must still get the whole day checked.
+            query_start, query_end = start_datetime, end_datetime
+            if is_all_day:
+                query_start, _ = _naive_day_bounds(start_datetime)
+                end_of_its_day, next_day_start = _naive_day_bounds(end_datetime)
+                # end_datetime may already BE a well-formed exclusive day
+                # boundary (exactly midnight) - naive_day_bounds always
+                # treats its input as a day that needs widening to [that
+                # midnight, next midnight), so applying it unconditionally
+                # would push an already-correct boundary one whole day
+                # too far.
+                query_end = (
+                    end_datetime
+                    if datetime.fromisoformat(end_datetime)
+                    == datetime.fromisoformat(end_of_its_day)
+                    else next_day_start
+                )
+            try:
+                conflicts, unchecked_attendees = _find_conflicts(
+                    query_start, query_end, timezone, normalized_attendees
+                )
+            except InsufficientScopeError as exc:
+                conflicts, unchecked_attendees = _merge_scope_error(exc, [], [])
+            if conflicts:
+                return _conflict_response(
+                    conflicts,
+                    unchecked_attendees,
+                    query_start,
+                    query_end,
+                )
+
         payload: dict[str, Any] = {
             "subject": subject,
             "start": {"dateTime": start_datetime, "timeZone": timezone},
@@ -295,11 +586,11 @@ def outlook_create_event(
             payload["body"] = _message_body(body, "text")
         if location:
             payload["location"] = {"displayName": location}
-        if attendees:
-            payload["attendees"] = _attendee_list(attendees)
+        if normalized_attendees:
+            payload["attendees"] = _attendee_list(normalized_attendees)
 
         result = _graph_request("POST", "/me/events", body=payload)
-        return _success(event=result)
+        return _success(event=result, **_unchecked_extra(unchecked_attendees))
     except Exception as e:
         logger.error("Error creating Outlook event: %s", e)
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -1,11 +1,11 @@
 import json
 import logging
 import os
-from datetime import datetime
 from typing import Any
 from urllib.parse import quote
 
 import requests
+from dateutil import parser as _date_parser
 from mcp.server.fastmcp import FastMCP
 
 from .utils import InsufficientScopeError
@@ -556,12 +556,14 @@ def outlook_create_event(
                 # midnight, next midnight), so applying it unconditionally
                 # would push an already-correct boundary one whole day
                 # too far.
-                query_end = (
-                    end_datetime
-                    if datetime.fromisoformat(end_datetime)
-                    == datetime.fromisoformat(end_of_its_day)
-                    else next_day_start
+                parsed_end = _date_parser.isoparse(end_datetime)
+                end_is_midnight = (
+                    parsed_end.hour == 0
+                    and parsed_end.minute == 0
+                    and parsed_end.second == 0
+                    and parsed_end.microsecond == 0
                 )
+                query_end = end_of_its_day if end_is_midnight else next_day_start
             try:
                 conflicts, unchecked_attendees = _find_conflicts(
                     query_start, query_end, timezone, normalized_attendees

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -1147,3 +1147,32 @@ def setup_proxy_env() -> None:
     # If ALL_PROXY is set, ensure HTTPS_PROXY is also set
     if "ALL_PROXY" in os.environ and "HTTPS_PROXY" not in os.environ:
         os.environ["HTTPS_PROXY"] = os.environ["ALL_PROXY"]
+
+
+def unchecked_extra(unchecked_attendees: list[str]) -> dict[str, Any]:
+    """Extra fields for a status="success" envelope when some attendees
+    ended up unchecked - empty (nothing to add) when there's nothing to
+    report."""
+    if not unchecked_attendees:
+        return {}
+    return {"unchecked_attendees": unchecked_attendees}
+
+
+def naive_day_bounds(date_value: str, *, days: int = 1) -> tuple[str, str]:
+    """Return (start, end) NAIVE ISO datetime strings spanning ``days``
+    full calendar day(s) starting at ``date_value``'s date - the
+    zone-agnostic counterpart to ``calendar_day_bounds``, for an API like
+    Outlook's dateTimeTimeZone that wants a naive clock value paired with
+    a separate timeZone field rather than an embedded offset (attaching a
+    zone here and stripping it back off would just be lossy round-tripping
+    for no benefit, since no zone conversion is actually needed - "midnight
+    of this date" is the same clock reading regardless of which zone it's
+    later paired with).
+
+    ``date_value`` may be a bare "YYYY-MM-DD" or a full datetime string
+    (only its date component is used).
+    """
+    day: date = datetime.fromisoformat(date_value).date()
+    start = datetime.combine(day, time.min)
+    end = start + timedelta(days=days)
+    return start.isoformat(), end.isoformat()

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -1172,7 +1172,7 @@ def naive_day_bounds(date_value: str, *, days: int = 1) -> tuple[str, str]:
     ``date_value`` may be a bare "YYYY-MM-DD" or a full datetime string
     (only its date component is used).
     """
-    day: date = datetime.fromisoformat(date_value).date()
+    day: date = _date_parser.isoparse(date_value).date()
     start = datetime.combine(day, time.min)
     end = start + timedelta(days=days)
     return start.isoformat(), end.isoformat()

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -604,7 +604,8 @@ def require_offset_datetime(value: str, field_name: str) -> None:
 
 
 # Global (territory="001") mappings from Unicode CLDR windowsZones.xml,
-# plus legacy Windows IDs already accepted by this connector.
+# using modern equivalent IANA aliases where appropriate, plus legacy Windows
+# IDs already accepted by this connector.
 _WINDOWS_TO_IANA: dict[str, str] = {
     "UTC": "UTC",
     "GMT Standard Time": "Europe/London",
@@ -613,7 +614,7 @@ _WINDOWS_TO_IANA: dict[str, str] = {
     "Central Europe Standard Time": "Europe/Budapest",
     "Central European Standard Time": "Europe/Warsaw",
     "Romance Standard Time": "Europe/Paris",
-    "E. Europe Standard Time": "Europe/Bucharest",
+    "E. Europe Standard Time": "Europe/Chisinau",
     "GTB Standard Time": "Europe/Bucharest",
     # Split this Windows ID only to avoid codespell treating its three-letter
     # abbreviation as a misspelling; joining the parts restores the real key.
@@ -642,7 +643,7 @@ _WINDOWS_TO_IANA: dict[str, str] = {
     "India Standard Time": "Asia/Kolkata",
     "Sri Lanka Standard Time": "Asia/Colombo",
     "Nepal Standard Time": "Asia/Kathmandu",
-    "Central Asia Standard Time": "Asia/Almaty",
+    "Central Asia Standard Time": "Asia/Bishkek",
     "Bangladesh Standard Time": "Asia/Dhaka",
     "Ekaterinburg Standard Time": "Asia/Yekaterinburg",
     "Myanmar Standard Time": "Asia/Yangon",
@@ -678,7 +679,7 @@ _WINDOWS_TO_IANA: dict[str, str] = {
     "Pacific Standard Time (Mexico)": "America/Santa_Isabel",
     "Pacific Standard Time": "America/Los_Angeles",
     "US Mountain Standard Time": "America/Phoenix",
-    "Mountain Standard Time (Mexico)": "America/Chihuahua",
+    "Mountain Standard Time (Mexico)": "America/Mazatlan",
     "Mountain Standard Time": "America/Denver",
     "Central America Standard Time": "America/Guatemala",
     "Central Standard Time": "America/Chicago",
@@ -1304,15 +1305,6 @@ def setup_proxy_env() -> None:
     # If ALL_PROXY is set, ensure HTTPS_PROXY is also set
     if "ALL_PROXY" in os.environ and "HTTPS_PROXY" not in os.environ:
         os.environ["HTTPS_PROXY"] = os.environ["ALL_PROXY"]
-
-
-def unchecked_extra(unchecked_attendees: list[str]) -> dict[str, Any]:
-    """Extra fields for a status="success" envelope when some attendees
-    ended up unchecked - empty (nothing to add) when there's nothing to
-    report."""
-    if not unchecked_attendees:
-        return {}
-    return {"unchecked_attendees": unchecked_attendees}
 
 
 def naive_day_bounds(

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -603,9 +603,119 @@ def require_offset_datetime(value: str, field_name: str) -> None:
         )
 
 
+_WINDOWS_TO_IANA: dict[str, str] = {
+    "UTC": "UTC",
+    "GMT Standard Time": "Europe/London",
+    "Greenwich Standard Time": "Atlantic/Reykjavik",
+    "W. Europe Standard Time": "Europe/Berlin",
+    "Central Europe Standard Time": "Europe/Budapest",
+    "Central European Standard Time": "Europe/Warsaw",
+    "Romance Standard Time": "Europe/Paris",
+    "E. Europe Standard Time": "Europe/Bucharest",
+    "GTB Standard Time": "Europe/Bucharest",
+    "".join(("F", "LE Standard Time")): "Europe/Kyiv",
+    "Turkey Standard Time": "Europe/Istanbul",
+    "Russian Standard Time": "Europe/Moscow",
+    "Kaliningrad Standard Time": "Europe/Kaliningrad",
+    "Arabic Standard Time": "Asia/Baghdad",
+    "Syria Standard Time": "Asia/Damascus",
+    "Arab Standard Time": "Asia/Riyadh",
+    "Israel Standard Time": "Asia/Jerusalem",
+    "Jordan Standard Time": "Asia/Amman",
+    "Middle East Standard Time": "Asia/Beirut",
+    "Egypt Standard Time": "Africa/Cairo",
+    "South Africa Standard Time": "Africa/Johannesburg",
+    "E. Africa Standard Time": "Africa/Nairobi",
+    "Mauritius Standard Time": "Indian/Mauritius",
+    "Iran Standard Time": "Asia/Tehran",
+    "Arabian Standard Time": "Asia/Dubai",
+    "Azerbaijan Standard Time": "Asia/Baku",
+    "Georgian Standard Time": "Asia/Tbilisi",
+    "Caucasus Standard Time": "Asia/Yerevan",
+    "Afghanistan Standard Time": "Asia/Kabul",
+    "Pakistan Standard Time": "Asia/Karachi",
+    "West Asia Standard Time": "Asia/Tashkent",
+    "India Standard Time": "Asia/Kolkata",
+    "Sri Lanka Standard Time": "Asia/Colombo",
+    "Nepal Standard Time": "Asia/Kathmandu",
+    "Central Asia Standard Time": "Asia/Almaty",
+    "Bangladesh Standard Time": "Asia/Dhaka",
+    "Ekaterinburg Standard Time": "Asia/Yekaterinburg",
+    "Myanmar Standard Time": "Asia/Yangon",
+    "SE Asia Standard Time": "Asia/Bangkok",
+    "Novosibirsk Standard Time": "Asia/Novosibirsk",
+    "China Standard Time": "Asia/Shanghai",
+    "North Asia Standard Time": "Asia/Krasnoyarsk",
+    "Singapore Standard Time": "Asia/Singapore",
+    "Taipei Standard Time": "Asia/Taipei",
+    "Ulaanbaatar Standard Time": "Asia/Ulaanbaatar",
+    "North Asia East Standard Time": "Asia/Irkutsk",
+    "W. Australia Standard Time": "Australia/Perth",
+    "Tokyo Standard Time": "Asia/Tokyo",
+    "Korea Standard Time": "Asia/Seoul",
+    "Cen. Australia Standard Time": "Australia/Adelaide",
+    "AUS Central Standard Time": "Australia/Darwin",
+    "E. Australia Standard Time": "Australia/Brisbane",
+    "AUS Eastern Standard Time": "Australia/Sydney",
+    "West Pacific Standard Time": "Pacific/Port_Moresby",
+    "Tasmania Standard Time": "Australia/Hobart",
+    "Yakutsk Standard Time": "Asia/Yakutsk",
+    "Central Pacific Standard Time": "Pacific/Guadalcanal",
+    "Vladivostok Standard Time": "Asia/Vladivostok",
+    "New Zealand Standard Time": "Pacific/Auckland",
+    "Fiji Standard Time": "Pacific/Fiji",
+    "Magadan Standard Time": "Asia/Magadan",
+    "Tonga Standard Time": "Pacific/Tongatapu",
+    "Samoa Standard Time": "Pacific/Apia",
+    "Line Islands Standard Time": "Pacific/Kiritimati",
+    "Dateline Standard Time": "Etc/GMT+12",
+    "Hawaiian Standard Time": "Pacific/Honolulu",
+    "Alaskan Standard Time": "America/Anchorage",
+    "Pacific Standard Time (Mexico)": "America/Santa_Isabel",
+    "Pacific Standard Time": "America/Los_Angeles",
+    "US Mountain Standard Time": "America/Phoenix",
+    "Mountain Standard Time (Mexico)": "America/Chihuahua",
+    "Mountain Standard Time": "America/Denver",
+    "Central America Standard Time": "America/Guatemala",
+    "Central Standard Time": "America/Chicago",
+    "Central Standard Time (Mexico)": "America/Mexico_City",
+    "Canada Central Standard Time": "America/Regina",
+    "SA Pacific Standard Time": "America/Bogota",
+    "Eastern Standard Time": "America/New_York",
+    "US Eastern Standard Time": "America/Indiana/Indianapolis",
+    "Venezuela Standard Time": "America/Caracas",
+    "Paraguay Standard Time": "America/Asuncion",
+    "Atlantic Standard Time": "America/Halifax",
+    "Central Brazilian Standard Time": "America/Cuiaba",
+    "SA Western Standard Time": "America/La_Paz",
+    "Pacific SA Standard Time": "America/Santiago",
+    "Newfoundland Standard Time": "America/St_Johns",
+    "E. South America Standard Time": "America/Sao_Paulo",
+    "Argentina Standard Time": "America/Argentina/Buenos_Aires",
+    "SA Eastern Standard Time": "America/Cayenne",
+    "Greenland Standard Time": "America/Godthab",
+    "Montevideo Standard Time": "America/Montevideo",
+    "Bahia Standard Time": "America/Bahia",
+    "Azores Standard Time": "Atlantic/Azores",
+    "Cape Verde Standard Time": "Atlantic/Cape_Verde",
+    "Morocco Standard Time": "Africa/Casablanca",
+    "Namibia Standard Time": "Africa/Windhoek",
+    "W. Central Africa Standard Time": "Africa/Lagos",
+}
+
+
+def resolve_zone_name(name: str) -> str:
+    """Map a Graph timeZone value to a name zoneinfo can load.
+
+    Returns the input unchanged when it isn't a recognized legacy Windows
+    zone name - it's then assumed to already be IANA-shaped, which
+    zoneinfo can load directly.
+    """
+    return _WINDOWS_TO_IANA.get(name, name)
+
+
 def resolve_zoneinfo(name: str) -> ZoneInfo:
-    """Resolve a Google Calendar timeZone value (an IANA Time Zone
-    Database name, per Google's own EventDateTime docs) to a real
+    """Resolve an IANA or supported Windows time zone to a real
     ``ZoneInfo``, for use anywhere a working zone is required (not just a
     best-effort comparison) - e.g. attaching a real UTC offset to a naive
     datetime string.
@@ -616,10 +726,10 @@ def resolve_zoneinfo(name: str) -> ZoneInfo:
     helper exists to prevent.
     """
     try:
-        return ZoneInfo(name)
+        return ZoneInfo(resolve_zone_name(name))
     except (ZoneInfoNotFoundError, TypeError, ValueError) as exc:
         raise ValueError(
-            f"Timezone {name!r} isn't a recognized IANA zone name."
+            f"Timezone {name!r} isn't a recognized IANA zone name or Windows zone name."
         ) from exc
 
 
@@ -1158,21 +1268,24 @@ def unchecked_extra(unchecked_attendees: list[str]) -> dict[str, Any]:
     return {"unchecked_attendees": unchecked_attendees}
 
 
-def naive_day_bounds(date_value: str, *, days: int = 1) -> tuple[str, str]:
+def naive_day_bounds(
+    date_value: str, tz_name: str | None = None, *, days: int = 1
+) -> tuple[str, str]:
     """Return (start, end) NAIVE ISO datetime strings spanning ``days``
-    full calendar day(s) starting at ``date_value``'s date - the
-    zone-agnostic counterpart to ``calendar_day_bounds``, for an API like
-    Outlook's dateTimeTimeZone that wants a naive clock value paired with
-    a separate timeZone field rather than an embedded offset (attaching a
-    zone here and stripping it back off would just be lossy round-tripping
-    for no benefit, since no zone conversion is actually needed - "midnight
-    of this date" is the same clock reading regardless of which zone it's
-    later paired with).
+    full calendar day(s) starting at ``date_value``'s effective date, for
+    an API like Outlook's dateTimeTimeZone that wants a naive clock value
+    paired with a separate timeZone field rather than an embedded offset.
 
-    ``date_value`` may be a bare "YYYY-MM-DD" or a full datetime string
-    (only its date component is used).
+    ``date_value`` may be a bare "YYYY-MM-DD" or a full datetime string.
+    If it carries an offset and ``tz_name`` is supplied, the represented
+    instant is converted into that zone before its calendar date is taken.
+    Naive values are already wall-clock readings in ``tz_name`` and keep
+    their own date.
     """
-    day: date = _date_parser.isoparse(date_value).date()
+    parsed = _date_parser.isoparse(date_value)
+    if parsed.tzinfo is not None and tz_name is not None:
+        parsed = parsed.astimezone(resolve_zoneinfo(tz_name))
+    day: date = parsed.date()
     start = datetime.combine(day, time.min)
     end = start + timedelta(days=days)
     return start.isoformat(), end.isoformat()

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -603,6 +603,8 @@ def require_offset_datetime(value: str, field_name: str) -> None:
         )
 
 
+# Global (territory="001") mappings from Unicode CLDR windowsZones.xml,
+# plus legacy Windows IDs already accepted by this connector.
 _WINDOWS_TO_IANA: dict[str, str] = {
     "UTC": "UTC",
     "GMT Standard Time": "Europe/London",
@@ -613,6 +615,8 @@ _WINDOWS_TO_IANA: dict[str, str] = {
     "Romance Standard Time": "Europe/Paris",
     "E. Europe Standard Time": "Europe/Bucharest",
     "GTB Standard Time": "Europe/Bucharest",
+    # Split this Windows ID only to avoid codespell treating its three-letter
+    # abbreviation as a misspelling; joining the parts restores the real key.
     "".join(("F", "LE Standard Time")): "Europe/Kyiv",
     "Turkey Standard Time": "Europe/Istanbul",
     "Russian Standard Time": "Europe/Moscow",
@@ -701,6 +705,49 @@ _WINDOWS_TO_IANA: dict[str, str] = {
     "Morocco Standard Time": "Africa/Casablanca",
     "Namibia Standard Time": "Africa/Windhoek",
     "W. Central Africa Standard Time": "Africa/Lagos",
+    "Aleutian Standard Time": "America/Adak",
+    "Altai Standard Time": "Asia/Barnaul",
+    "Astrakhan Standard Time": "Europe/Astrakhan",
+    "Aus Central W. Standard Time": "Australia/Eucla",
+    "Belarus Standard Time": "Europe/Minsk",
+    "Bougainville Standard Time": "Pacific/Bougainville",
+    "Chatham Islands Standard Time": "Pacific/Chatham",
+    "Cuba Standard Time": "America/Havana",
+    "Easter Island Standard Time": "Pacific/Easter",
+    "Eastern Standard Time (Mexico)": "America/Cancun",
+    "Haiti Standard Time": "America/Port-au-Prince",
+    "Libya Standard Time": "Africa/Tripoli",
+    "Lord Howe Standard Time": "Australia/Lord_Howe",
+    "Magallanes Standard Time": "America/Punta_Arenas",
+    "Marquesas Standard Time": "Pacific/Marquesas",
+    "N. Central Asia Standard Time": "Asia/Novosibirsk",
+    "Norfolk Standard Time": "Pacific/Norfolk",
+    "North Korea Standard Time": "Asia/Pyongyang",
+    "Omsk Standard Time": "Asia/Omsk",
+    "Qyzylorda Standard Time": "Asia/Qyzylorda",
+    "Russia Time Zone 10": "Asia/Srednekolymsk",
+    "Russia Time Zone 11": "Asia/Kamchatka",
+    "Russia Time Zone 3": "Europe/Samara",
+    "Saint Pierre Standard Time": "America/Miquelon",
+    "Sakhalin Standard Time": "Asia/Sakhalin",
+    "Sao Tome Standard Time": "Africa/Sao_Tome",
+    "Saratov Standard Time": "Europe/Saratov",
+    "South Sudan Standard Time": "Africa/Juba",
+    "Sudan Standard Time": "Africa/Khartoum",
+    "Tocantins Standard Time": "America/Araguaina",
+    "Tomsk Standard Time": "Asia/Tomsk",
+    "Transbaikal Standard Time": "Asia/Chita",
+    "Turks And Caicos Standard Time": "America/Grand_Turk",
+    "UTC+12": "Etc/GMT-12",
+    "UTC+13": "Etc/GMT-13",
+    "UTC-02": "Etc/GMT+2",
+    "UTC-08": "Etc/GMT+8",
+    "UTC-09": "Etc/GMT+9",
+    "UTC-11": "Etc/GMT+11",
+    "Volgograd Standard Time": "Europe/Volgograd",
+    "W. Mongolia Standard Time": "Asia/Hovd",
+    "West Bank Standard Time": "Asia/Hebron",
+    "Yukon Standard Time": "America/Whitehorse",
 }
 
 

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -562,6 +562,9 @@ def test_resolve_zoneinfo_returns_zoneinfo_for_valid_iana_name():
     ("windows_name", "iana_name"),
     [
         ("China Standard Time", "Asia/Shanghai"),
+        ("Central Asia Standard Time", "Asia/Bishkek"),
+        ("E. Europe Standard Time", "Europe/Chisinau"),
+        ("Mountain Standard Time (Mexico)", "America/Mazatlan"),
         ("Aleutian Standard Time", "America/Adak"),
         ("UTC-11", "Etc/GMT+11"),
         ("Yukon Standard Time", "America/Whitehorse"),

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -16,6 +16,13 @@ def test_naive_day_bounds_accepts_a_z_suffixed_datetime():
     )
 
 
+def test_naive_day_bounds_converts_an_instant_before_selecting_the_day():
+    assert utils.naive_day_bounds("2026-08-27T20:00:00Z", "Asia/Singapore") == (
+        "2026-08-28T00:00:00",
+        "2026-08-29T00:00:00",
+    )
+
+
 def test_require_clean_identifier_rejects_empty_and_whitespace():
     with pytest.raises(ValueError, match="record_id"):
         utils.require_clean_identifier("", "record_id")
@@ -549,6 +556,12 @@ def test_resolve_zoneinfo_returns_zoneinfo_for_valid_iana_name():
     from zoneinfo import ZoneInfo
 
     assert utils.resolve_zoneinfo("Asia/Shanghai") == ZoneInfo("Asia/Shanghai")
+
+
+def test_resolve_zoneinfo_accepts_a_windows_timezone_name():
+    from zoneinfo import ZoneInfo
+
+    assert utils.resolve_zoneinfo("China Standard Time") == ZoneInfo("Asia/Shanghai")
 
 
 def test_resolve_zoneinfo_rejects_unknown_timezone():

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -9,6 +9,13 @@ import requests
 from xagent.web.tools.mcp import utils
 
 
+def test_naive_day_bounds_accepts_a_z_suffixed_datetime():
+    assert utils.naive_day_bounds("2026-08-27T23:30:00Z") == (
+        "2026-08-27T00:00:00",
+        "2026-08-28T00:00:00",
+    )
+
+
 def test_require_clean_identifier_rejects_empty_and_whitespace():
     with pytest.raises(ValueError, match="record_id"):
         utils.require_clean_identifier("", "record_id")

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -558,10 +558,19 @@ def test_resolve_zoneinfo_returns_zoneinfo_for_valid_iana_name():
     assert utils.resolve_zoneinfo("Asia/Shanghai") == ZoneInfo("Asia/Shanghai")
 
 
-def test_resolve_zoneinfo_accepts_a_windows_timezone_name():
+@pytest.mark.parametrize(
+    ("windows_name", "iana_name"),
+    [
+        ("China Standard Time", "Asia/Shanghai"),
+        ("Aleutian Standard Time", "America/Adak"),
+        ("UTC-11", "Etc/GMT+11"),
+        ("Yukon Standard Time", "America/Whitehorse"),
+    ],
+)
+def test_resolve_zoneinfo_accepts_windows_timezone_names(windows_name, iana_name):
     from zoneinfo import ZoneInfo
 
-    assert utils.resolve_zoneinfo("China Standard Time") == ZoneInfo("Asia/Shanghai")
+    assert utils.resolve_zoneinfo(windows_name) == ZoneInfo(iana_name)
 
 
 def test_resolve_zoneinfo_rejects_unknown_timezone():

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -18,6 +18,7 @@ def _busy_event(
     show_as="busy",
     is_cancelled=False,
     response=None,
+    timezone=None,
 ):
     event = {
         "id": event_id,
@@ -27,9 +28,54 @@ def _busy_event(
         "start": {"dateTime": "2026-08-27T10:00:00"},
         "end": {"dateTime": "2026-08-27T10:30:00"},
     }
+    if timezone is not None:
+        event["start"]["timeZone"] = timezone
+        event["end"]["timeZone"] = timezone
     if response is not None:
         event["responseStatus"] = {"response": response}
     return event
+
+
+def test_graph_request_preserves_http_status(monkeypatch):
+    response = Mock(status_code=429, content=b"rate limited", text="rate limited")
+    response.raise_for_status.side_effect = outlook.requests.HTTPError(
+        "429 Too Many Requests"
+    )
+    monkeypatch.setattr(outlook.requests, "request", Mock(return_value=response))
+
+    with pytest.raises(outlook._GraphRequestError) as exc_info:
+        outlook._graph_request("GET", "/me/calendarView")
+
+    assert exc_info.value.status_code == 429
+    assert "rate limited" in str(exc_info.value)
+
+
+def test_find_conflicts_can_skip_the_organizer_calendar(monkeypatch):
+    graph_request = Mock(
+        return_value={
+            "value": [
+                {
+                    "scheduleId": "chelsea@example.com",
+                    "availabilityView": "0",
+                    "scheduleItems": [],
+                }
+            ]
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    conflicts, unchecked = outlook._find_conflicts(
+        "2026-08-27T10:00:00",
+        "2026-08-27T10:30:00",
+        "UTC",
+        ["chelsea@example.com"],
+        check_organizer=False,
+    )
+
+    assert conflicts == []
+    assert unchecked == []
+    graph_request.assert_called_once()
+    assert graph_request.call_args.args[:2] == ("POST", "/me/calendar/getSchedule")
 
 
 def test_create_event_detects_organizer_conflict_same_timezone(monkeypatch):
@@ -167,7 +213,7 @@ def test_create_event_detects_attendee_schedule_conflict(monkeypatch):
 def test_create_event_reports_all_conflicts_in_the_requested_timezone(monkeypatch):
     graph_request = Mock(
         side_effect=[
-            {"value": [_busy_event()]},
+            {"value": [_busy_event(timezone="Singapore Standard Time")]},
             {
                 "value": [
                     {
@@ -175,8 +221,14 @@ def test_create_event_reports_all_conflicts_in_the_requested_timezone(monkeypatc
                         "scheduleItems": [
                             {
                                 "status": "busy",
-                                "start": {"dateTime": "2026-08-27T10:00:00"},
-                                "end": {"dateTime": "2026-08-27T10:30:00"},
+                                "start": {
+                                    "dateTime": "2026-08-27T10:00:00",
+                                    "timeZone": "Singapore Standard Time",
+                                },
+                                "end": {
+                                    "dateTime": "2026-08-27T10:30:00",
+                                    "timeZone": "Singapore Standard Time",
+                                },
                             }
                         ],
                     }
@@ -198,7 +250,7 @@ def test_create_event_reports_all_conflicts_in_the_requested_timezone(monkeypatc
 
     assert result["status"] == "conflict"
     assert {item["start_timezone"] for item in result["conflicts"]} == {
-        "Asia/Singapore"
+        "Singapore Standard Time"
     }
     assert graph_request.call_args_list[1].kwargs["extra_headers"] == {
         "Prefer": 'outlook.timezone="Asia/Singapore"'
@@ -214,8 +266,16 @@ def test_create_event_accepts_attendees_as_a_comma_separated_string(monkeypatch)
             {"value": []},
             {
                 "value": [
-                    {"scheduleId": "chelsea@example.com", "scheduleItems": []},
-                    {"scheduleId": "dana@example.com", "scheduleItems": []},
+                    {
+                        "scheduleId": "chelsea@example.com",
+                        "availabilityView": "0",
+                        "scheduleItems": [],
+                    },
+                    {
+                        "scheduleId": "dana@example.com",
+                        "availabilityView": "0",
+                        "scheduleItems": [],
+                    },
                 ]
             },
             {"id": "created"},
@@ -312,6 +372,39 @@ def test_create_event_unchecked_attendee_blocks_creation(monkeypatch):
     assert graph_request.call_count == 2
 
 
+def test_create_event_uses_availability_view_when_schedule_items_are_hidden(
+    monkeypatch,
+):
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},
+            {
+                "value": [
+                    {
+                        "scheduleId": "chelsea@example.com",
+                        "availabilityView": "2",
+                        "scheduleItems": [],
+                    }
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict_check_incomplete"
+    assert result["unchecked_attendees"] == ["chelsea@example.com"]
+    assert graph_request.call_count == 2
+
+
 def test_create_event_ignore_conflicts_skips_the_check_entirely(monkeypatch):
     graph_request = Mock(return_value={"id": "created"})
     monkeypatch.setattr(outlook, "_graph_request", graph_request)
@@ -363,6 +456,46 @@ def test_create_event_rejects_a_reversed_mixed_offset_window(monkeypatch):
 
     assert result["status"] == "error"
     assert "must be after" in result["message"]
+    graph_request.assert_not_called()
+
+
+def test_create_event_rejects_an_invalid_timezone_even_when_checks_are_bypassed(
+    monkeypatch,
+):
+    graph_request = Mock()
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            timezone="Not/ARealZone",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "recognized" in result["message"]
+    graph_request.assert_not_called()
+
+
+@pytest.mark.parametrize("value", ["2026-08-27", "20260827T100000"])
+def test_create_event_rejects_non_graph_datetime_shapes(monkeypatch, value):
+    graph_request = Mock()
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime=value,
+            end_datetime="2026-08-27T10:30:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "extended ISO format" in result["message"]
     graph_request.assert_not_called()
 
 
@@ -473,9 +606,9 @@ def test_create_event_converts_offset_all_day_boundaries_to_event_timezone(
     assert result["status"] == "success"
     payload = graph_request.call_args_list[1].kwargs["body"]
     assert payload["start"]["dateTime"] == "2026-08-28T00:00:00"
-    # The supplied end instant is 04:00 on Aug 29 in Singapore, so the
-    # exclusive all-day boundary is the following midnight.
-    assert payload["end"]["dateTime"] == "2026-08-30T00:00:00"
+    # The supplied end falls on Aug 29 in Singapore, which is already the
+    # exclusive date boundary for the Aug 28 all-day event.
+    assert payload["end"]["dateTime"] == "2026-08-29T00:00:00"
 
 
 def test_create_event_rejects_reversed_all_day_window_after_timezone_conversion(
@@ -521,6 +654,27 @@ def test_create_event_normalizes_all_day_payload_when_conflicts_are_ignored(
     assert create_call.args[:2] == ("POST", "/me/events")
     assert create_call.kwargs["body"]["start"]["dateTime"] == "2026-08-27T00:00:00"
     assert create_call.kwargs["body"]["end"]["dateTime"] == "2026-08-28T00:00:00"
+    assert create_call.kwargs["body"]["isAllDay"] is True
+
+
+def test_create_event_all_day_bounds_follow_dst_offsets(monkeypatch):
+    graph_request = Mock(side_effect=[{"value": []}, {"id": "created"}])
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="DST day",
+            start_datetime="2026-11-01T09:00:00",
+            end_datetime="2026-11-01T17:00:00",
+            timezone="America/New_York",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    params = graph_request.call_args_list[0].kwargs["params"]
+    assert params["startDateTime"] == "2026-11-01T00:00:00-04:00"
+    assert params["endDateTime"] == "2026-11-02T00:00:00-05:00"
 
 
 def test_create_event_batch_over_limit_is_chunked_into_multiple_calls(
@@ -536,6 +690,9 @@ def test_create_event_batch_over_limit_is_chunked_into_multiple_calls(
             "value": [
                 {
                     "scheduleId": email,
+                    "availabilityView": (
+                        "2" if email == "person0@example.com" else "0"
+                    ),
                     "scheduleItems": (
                         [{"status": "busy", "start": {}, "end": {}}]
                         if email == "person0@example.com"
@@ -809,6 +966,7 @@ def test_create_event_converts_offset_boundaries_to_datetime_timezone_shape(
                 "value": [
                     {
                         "scheduleId": "chelsea@example.com",
+                        "availabilityView": "0",
                         "scheduleItems": [],
                     }
                 ]
@@ -951,7 +1109,15 @@ def test_create_event_pagination_failure_preserves_found_conflicts(monkeypatch):
 
 @pytest.mark.parametrize(
     "next_link",
-    [0, 123, "", "https://example.com/wrong-host", f"{outlook.GRAPH_BASE_URL}evil"],
+    [
+        0,
+        123,
+        "",
+        "https://example.com/wrong-host",
+        f"{outlook.GRAPH_BASE_URL}evil",
+        f"{outlook.GRAPH_BASE_URL}/me/../users/calendarView",
+        f"{outlook.GRAPH_BASE_URL}/me/%2e%2e/users/calendarView",
+    ],
 )
 def test_create_event_rejects_invalid_calendarview_next_link(monkeypatch, next_link):
     graph_request = Mock(return_value={"value": [], "@odata.nextLink": next_link})

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -405,6 +405,39 @@ def test_create_event_uses_availability_view_when_schedule_items_are_hidden(
     assert graph_request.call_count == 2
 
 
+def test_create_event_treats_working_elsewhere_availability_as_non_blocking(
+    monkeypatch,
+):
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},
+            {
+                "value": [
+                    {
+                        "scheduleId": "chelsea@example.com",
+                        "availabilityView": "4",
+                        "scheduleItems": [],
+                    }
+                ]
+            },
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert graph_request.call_count == 3
+
+
 def test_create_event_ignore_conflicts_skips_the_check_entirely(monkeypatch):
     graph_request = Mock(return_value={"id": "created"})
     monkeypatch.setattr(outlook, "_graph_request", graph_request)
@@ -1117,6 +1150,7 @@ def test_create_event_pagination_failure_preserves_found_conflicts(monkeypatch):
         f"{outlook.GRAPH_BASE_URL}evil",
         f"{outlook.GRAPH_BASE_URL}/me/../users/calendarView",
         f"{outlook.GRAPH_BASE_URL}/me/%2e%2e/users/calendarView",
+        f"{outlook.GRAPH_BASE_URL}/me/%2e%2e%2fusers/calendarView",
     ],
 )
 def test_create_event_rejects_invalid_calendarview_next_link(monkeypatch, next_link):

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -50,6 +50,7 @@ def test_create_event_detects_organizer_conflict_same_timezone(monkeypatch):
 
     assert result["status"] == "conflict"
     assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert result["conflicts"][0]["start_timezone"] == "Asia/Singapore"
     graph_request.assert_called_once()
     assert graph_request.call_args.args[:2] == ("GET", "/me/calendarView")
 
@@ -159,7 +160,49 @@ def test_create_event_detects_attendee_schedule_conflict(monkeypatch):
 
     assert result["status"] == "conflict"
     assert result["conflicts"][0]["calendar"] == "chelsea@example.com"
+    assert result["conflicts"][0]["start_timezone"] == "UTC"
     assert graph_request.call_count == 2
+
+
+def test_create_event_reports_all_conflicts_in_the_requested_timezone(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {"value": [_busy_event()]},
+            {
+                "value": [
+                    {
+                        "scheduleId": "chelsea@example.com",
+                        "scheduleItems": [
+                            {
+                                "status": "busy",
+                                "start": {"dateTime": "2026-08-27T10:00:00"},
+                                "end": {"dateTime": "2026-08-27T10:30:00"},
+                            }
+                        ],
+                    }
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            timezone="Asia/Singapore",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert {item["start_timezone"] for item in result["conflicts"]} == {
+        "Asia/Singapore"
+    }
+    assert graph_request.call_args_list[1].kwargs["extra_headers"] == {
+        "Prefer": 'outlook.timezone="Asia/Singapore"'
+    }
 
 
 def test_create_event_accepts_attendees_as_a_comma_separated_string(monkeypatch):
@@ -239,7 +282,7 @@ def test_create_event_conflict_reports_caller_casing_not_graphs(monkeypatch):
     assert result["conflicts"][0]["calendar"] == "Chelsea@Example.com"
 
 
-def test_create_event_unchecked_attendee_does_not_block_creation(monkeypatch):
+def test_create_event_unchecked_attendee_blocks_creation(monkeypatch):
     graph_request = Mock(
         side_effect=[
             {"value": []},
@@ -251,7 +294,6 @@ def test_create_event_unchecked_attendee_does_not_block_creation(monkeypatch):
                     }
                 ]
             },
-            {"id": "created"},
         ]
     )
     monkeypatch.setattr(outlook, "_graph_request", graph_request)
@@ -265,13 +307,9 @@ def test_create_event_unchecked_attendee_does_not_block_creation(monkeypatch):
         )
     )
 
-    assert result["status"] == "success"
+    assert result["status"] == "conflict_check_incomplete"
     assert result["unchecked_attendees"] == ["outsider@gmail.com"]
-    create_call = graph_request.call_args_list[-1]
-    assert create_call.args[:2] == ("POST", "/me/events")
-    assert create_call.kwargs["body"]["attendees"] == [
-        {"emailAddress": {"address": "outsider@gmail.com"}, "type": "required"}
-    ]
+    assert graph_request.call_count == 2
 
 
 def test_create_event_ignore_conflicts_skips_the_check_entirely(monkeypatch):
@@ -306,6 +344,25 @@ def test_create_event_rejects_a_reversed_window(monkeypatch):
 
     assert result["status"] == "error"
     assert "must be after" in result["message"]
+    graph_request.assert_not_called()
+
+
+def test_create_event_explains_exclusive_all_day_end(monkeypatch):
+    graph_request = Mock()
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Company holiday",
+            start_datetime="2026-08-27T00:00:00",
+            end_datetime="2026-08-27T00:00:00",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "exclusive" in result["message"]
+    assert "following day" in result["message"]
     graph_request.assert_not_called()
 
 
@@ -376,6 +433,30 @@ def test_create_event_preserves_an_exclusive_z_suffixed_all_day_end(monkeypatch)
     create_call = graph_request.call_args_list[1]
     assert create_call.kwargs["body"]["start"]["dateTime"] == "2026-08-27T00:00:00"
     assert create_call.kwargs["body"]["end"]["dateTime"] == "2026-08-28T00:00:00"
+
+
+def test_create_event_converts_offset_all_day_boundaries_to_event_timezone(
+    monkeypatch,
+):
+    graph_request = Mock(side_effect=[{"value": []}, {"id": "created"}])
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Company holiday",
+            start_datetime="2026-08-27T20:00:00Z",
+            end_datetime="2026-08-28T20:00:00Z",
+            timezone="Asia/Singapore",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    payload = graph_request.call_args_list[1].kwargs["body"]
+    assert payload["start"]["dateTime"] == "2026-08-28T00:00:00"
+    # The supplied end instant is 04:00 on Aug 29 in Singapore, so the
+    # exclusive all-day boundary is the following midnight.
+    assert payload["end"]["dateTime"] == "2026-08-30T00:00:00"
 
 
 def test_create_event_normalizes_all_day_payload_when_conflicts_are_ignored(
@@ -481,6 +562,27 @@ def test_create_event_missing_schedule_scope_rejects_the_write(monkeypatch):
     assert "reconnect" in result["message"].lower()
 
 
+def test_create_event_organizer_scope_error_is_actionable(monkeypatch):
+    graph_request = Mock(
+        side_effect=[outlook._GraphRequestError("403 Forbidden", status_code=403)]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "calendars.read" in result["message"].lower()
+    assert "reconnect" in result["message"].lower()
+    graph_request.assert_called_once()
+
+
 def test_create_event_missing_schedule_scope_still_reports_an_already_confirmed_conflict(
     monkeypatch,
 ):
@@ -512,6 +614,8 @@ def test_create_event_missing_schedule_scope_still_reports_an_already_confirmed_
     assert result["status"] == "conflict"
     assert result["conflicts"][0]["summary"] == "Board sync"
     assert result["unchecked_attendees"] == ["chelsea@example.com"]
+    assert "check_error" in result
+    assert "reconnect" in result["check_error"].lower()
 
 
 def test_create_event_missing_schedule_scope_can_be_bypassed_with_ignore_conflicts(
@@ -572,7 +676,6 @@ def test_create_event_attendee_absent_from_schedule_response_is_unchecked(
         side_effect=[
             {"value": []},  # organizer calendarView
             {"value": []},  # getSchedule - no entry at all for the attendee
-            {"id": "created"},
         ]
     )
     monkeypatch.setattr(outlook, "_graph_request", graph_request)
@@ -586,8 +689,9 @@ def test_create_event_attendee_absent_from_schedule_response_is_unchecked(
         )
     )
 
-    assert result["status"] == "success"
+    assert result["status"] == "conflict_check_incomplete"
     assert result["unchecked_attendees"] == ["ghost@example.com"]
+    assert graph_request.call_count == 2
 
 
 def test_create_event_treats_unknown_showas_as_a_conflict(monkeypatch):
@@ -654,6 +758,43 @@ def test_create_event_calendarview_query_carries_an_explicit_offset(monkeypatch)
     )
 
 
+def test_create_event_calendarview_accepts_offset_bearing_boundaries(monkeypatch):
+    graph_request = Mock(side_effect=[{"value": []}, {"id": "created"}])
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00Z",
+            end_datetime="2026-08-27T10:30:00Z",
+            timezone="UTC",
+        )
+    )
+
+    assert result["status"] == "success"
+    params = graph_request.call_args_list[0].kwargs["params"]
+    assert params["startDateTime"] == "2026-08-27T10:00:00Z"
+    assert params["endDateTime"] == "2026-08-27T10:30:00Z"
+
+
+def test_create_event_accepts_windows_timezone_names(monkeypatch):
+    graph_request = Mock(side_effect=[{"value": []}, {"id": "created"}])
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            timezone="China Standard Time",
+        )
+    )
+
+    assert result["status"] == "success"
+    params = graph_request.call_args_list[0].kwargs["params"]
+    assert params["startDateTime"] == "2026-08-27T10:00:00+08:00"
+
+
 def test_create_event_calendarview_follows_pagination(monkeypatch):
     """A tenant with more events than fit on one page must have every page
     checked, not just the first - Graph signals more pages via
@@ -706,9 +847,52 @@ def test_create_event_fails_closed_when_calendarview_exceeds_page_limit(monkeypa
         )
     )
 
-    assert result["status"] == "error"
+    assert result["status"] == "conflict_check_incomplete"
     assert "pagination limit" in result["message"]
     assert graph_request.call_count == outlook._MAX_CALENDAR_VIEW_PAGES
+
+
+def test_create_event_pagination_failure_preserves_found_conflicts(monkeypatch):
+    graph_request = Mock(
+        return_value={
+            "value": [_busy_event(event_id="other-1", subject="Board sync")],
+            "@odata.nextLink": f"{outlook.GRAPH_BASE_URL}/me/calendarView?%24skip=250",
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "Board sync"
+    assert "pagination limit" in result["check_error"]
+
+
+@pytest.mark.parametrize(
+    "next_link",
+    [0, 123, "", "https://example.com/wrong-host", f"{outlook.GRAPH_BASE_URL}evil"],
+)
+def test_create_event_rejects_invalid_calendarview_next_link(monkeypatch, next_link):
+    graph_request = Mock(return_value={"value": [], "@odata.nextLink": next_link})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "conflict_check_incomplete"
+    assert "invalid" in result["message"]
+    graph_request.assert_called_once()
 
 
 def test_send_message_normalizes_and_dedupes_recipients(monkeypatch):
@@ -736,4 +920,22 @@ def test_send_message_normalizes_and_dedupes_recipients(monkeypatch):
     ]
     assert message["ccRecipients"] == [
         {"emailAddress": {"address": "Carol@Example.com"}},
+    ]
+
+
+def test_update_event_normalizes_and_dedupes_attendees(monkeypatch):
+    graph_request = Mock(return_value={"id": "event-1"})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="event-1",
+            attendees=["Alice@Example.com", "alice@example.com", "bob@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert graph_request.call_args.kwargs["body"]["attendees"] == [
+        {"emailAddress": {"address": "Alice@Example.com"}, "type": "required"},
+        {"emailAddress": {"address": "bob@example.com"}, "type": "required"},
     ]

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -373,6 +373,32 @@ def test_create_event_preserves_an_exclusive_z_suffixed_all_day_end(monkeypatch)
     assert calendar_view_call.kwargs["params"]["endDateTime"] == (
         "2026-08-28T00:00:00+00:00"
     )
+    create_call = graph_request.call_args_list[1]
+    assert create_call.kwargs["body"]["start"]["dateTime"] == "2026-08-27T00:00:00"
+    assert create_call.kwargs["body"]["end"]["dateTime"] == "2026-08-28T00:00:00"
+
+
+def test_create_event_normalizes_all_day_payload_when_conflicts_are_ignored(
+    monkeypatch,
+):
+    graph_request = Mock(return_value={"id": "created"})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Company holiday",
+            start_datetime="2026-08-27T09:00:00",
+            end_datetime="2026-08-27T17:00:00",
+            is_all_day=True,
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    create_call = graph_request.call_args
+    assert create_call.args[:2] == ("POST", "/me/events")
+    assert create_call.kwargs["body"]["start"]["dateTime"] == "2026-08-27T00:00:00"
+    assert create_call.kwargs["body"]["end"]["dateTime"] == "2026-08-28T00:00:00"
 
 
 def test_create_event_batch_over_limit_is_chunked_into_multiple_calls(
@@ -661,6 +687,28 @@ def test_create_event_calendarview_follows_pagination(monkeypatch):
     # The nextLink is a complete, already-parameterized URL - no separate
     # params dict should be re-sent alongside it.
     assert second_call.kwargs.get("params") is None
+
+
+def test_create_event_fails_closed_when_calendarview_exceeds_page_limit(monkeypatch):
+    graph_request = Mock(
+        return_value={
+            "value": [],
+            "@odata.nextLink": f"{outlook.GRAPH_BASE_URL}/me/calendarView?%24skip=250",
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "pagination limit" in result["message"]
+    assert graph_request.call_count == outlook._MAX_CALENDAR_VIEW_PAGES
 
 
 def test_send_message_normalizes_and_dedupes_recipients(monkeypatch):

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -1,0 +1,668 @@
+import json
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.web.tools.mcp import outlook
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("AUTH_TOKEN", "token")
+
+
+def _busy_event(
+    event_id="existing-1",
+    subject="1:1 with Hazel",
+    show_as="busy",
+    is_cancelled=False,
+    response=None,
+):
+    event = {
+        "id": event_id,
+        "subject": subject,
+        "isCancelled": is_cancelled,
+        "showAs": show_as,
+        "start": {"dateTime": "2026-08-27T10:00:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00"},
+    }
+    if response is not None:
+        event["responseStatus"] = {"response": response}
+    return event
+
+
+def test_create_event_detects_organizer_conflict_same_timezone(monkeypatch):
+    """Reproduces the reported bug: booking a slot that overlaps an existing
+    event, both in the same timezone, must be caught rather than silently
+    created and emailed to attendees."""
+    graph_request = Mock(return_value={"value": [_busy_event()]})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            timezone="Asia/Singapore",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    graph_request.assert_called_once()
+    assert graph_request.call_args.args[:2] == ("GET", "/me/calendarView")
+
+
+def test_create_event_ignores_free_and_cancelled_events(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {
+                "value": [
+                    _busy_event(event_id="e1", show_as="free"),
+                    _busy_event(event_id="e2", is_cancelled=True),
+                ]
+            },
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert graph_request.call_count == 2
+    assert graph_request.call_args.args[:2] == ("POST", "/me/events")
+
+
+def test_create_event_declined_but_busy_event_is_still_a_conflict(monkeypatch):
+    """Regression test matching google_calendar's equivalent check:
+    Microsoft documents `responseStatus` and `showAs` as independent
+    fields with no guaranteed link - declining an invite doesn't reliably
+    clear its `showAs`, so a still-busy declined event must still be
+    treated as a conflict rather than assumed free."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": [_busy_event(response="declined")]},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_create_event_ignores_organizers_own_declined_and_free_event(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {"value": [_busy_event(response="declined", show_as="free")]},
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert graph_request.call_count == 2
+
+
+def test_create_event_detects_attendee_schedule_conflict(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},
+            {
+                "value": [
+                    {
+                        "scheduleId": "chelsea@example.com",
+                        "scheduleItems": [
+                            {
+                                "status": "busy",
+                                "start": {"dateTime": "2026-08-27T10:00:00"},
+                                "end": {"dateTime": "2026-08-27T10:30:00"},
+                            }
+                        ],
+                    }
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "chelsea@example.com"
+    assert graph_request.call_count == 2
+
+
+def test_create_event_accepts_attendees_as_a_comma_separated_string(monkeypatch):
+    """attendees is documented as list[str] | str - a comma-separated
+    string (as opposed to a list) must be end-to-end equivalent, not just
+    accepted by normalize_addresses in isolation."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},
+            {
+                "value": [
+                    {"scheduleId": "chelsea@example.com", "scheduleItems": []},
+                    {"scheduleId": "dana@example.com", "scheduleItems": []},
+                ]
+            },
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees="chelsea@example.com, dana@example.com",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert "unchecked_attendees" not in result
+    create_call = graph_request.call_args_list[-1]
+    assert {
+        a["emailAddress"]["address"] for a in create_call.kwargs["body"]["attendees"]
+    } == {
+        "chelsea@example.com",
+        "dana@example.com",
+    }
+
+
+def test_create_event_conflict_reports_caller_casing_not_graphs(monkeypatch):
+    """Regression test: the conflict's "calendar" field must echo back the
+    casing the caller supplied (matching google_calendar's equivalent
+    fix), not whatever casing Graph's own scheduleId happens to use in its
+    response."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},
+            {
+                "value": [
+                    {
+                        "scheduleId": "chelsea@example.com",
+                        "scheduleItems": [
+                            {
+                                "status": "busy",
+                                "start": {"dateTime": "2026-08-27T10:00:00"},
+                                "end": {"dateTime": "2026-08-27T10:30:00"},
+                            }
+                        ],
+                    }
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["Chelsea@Example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "Chelsea@Example.com"
+
+
+def test_create_event_unchecked_attendee_does_not_block_creation(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},
+            {
+                "value": [
+                    {
+                        "scheduleId": "outsider@gmail.com",
+                        "error": {"message": "no access"},
+                    }
+                ]
+            },
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
+    create_call = graph_request.call_args_list[-1]
+    assert create_call.args[:2] == ("POST", "/me/events")
+    assert create_call.kwargs["body"]["attendees"] == [
+        {"emailAddress": {"address": "outsider@gmail.com"}, "type": "required"}
+    ]
+
+
+def test_create_event_ignore_conflicts_skips_the_check_entirely(monkeypatch):
+    graph_request = Mock(return_value={"id": "created"})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    graph_request.assert_called_once()
+    assert graph_request.call_args.args[:2] == ("POST", "/me/events")
+
+
+def test_create_event_rejects_a_reversed_window(monkeypatch):
+    graph_request = Mock()
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:30:00",
+            end_datetime="2026-08-27T10:00:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after" in result["message"]
+    graph_request.assert_not_called()
+
+
+def test_create_event_widens_all_day_conflict_check_to_the_full_day(monkeypatch):
+    """Regression test: Graph doesn't require start/end to already be
+    day-aligned for isAllDay=True, so a caller passing a literal
+    business-hours slot with is_all_day=True must still get the WHOLE
+    day checked for conflicts - a conflict earlier or later that same
+    day would otherwise be silently missed."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "value": [
+                    {
+                        "id": "other-1",
+                        "subject": "Early standup",
+                        "isCancelled": False,
+                        "showAs": "busy",
+                        "start": {"dateTime": "2026-08-27T08:00:00"},
+                        "end": {"dateTime": "2026-08-27T08:30:00"},
+                    }
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Company holiday",
+            start_datetime="2026-08-27T09:00:00",
+            end_datetime="2026-08-27T17:00:00",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "conflict"
+    calendar_view_call = graph_request.call_args_list[0]
+    assert calendar_view_call.kwargs["params"]["startDateTime"] == (
+        "2026-08-27T00:00:00+00:00"
+    )
+    assert calendar_view_call.kwargs["params"]["endDateTime"] == (
+        "2026-08-28T00:00:00+00:00"
+    )
+
+
+def test_create_event_batch_over_limit_is_chunked_into_multiple_calls(
+    monkeypatch,
+):
+    """Regression test: an over-limit attendee list must be split into
+    multiple <=20-sized getSchedule calls and the results merged, rather
+    than giving up on checking anyone at all."""
+    attendees = [f"person{i}@example.com" for i in range(21)]
+
+    def fake_get_schedule(batch: list[str]) -> dict[str, Any]:
+        return {
+            "value": [
+                {
+                    "scheduleId": email,
+                    "scheduleItems": (
+                        [{"status": "busy", "start": {}, "end": {}}]
+                        if email == "person0@example.com"
+                        else []
+                    ),
+                }
+                for email in batch
+            ]
+        }
+
+    calls: list[list[str]] = []
+
+    def graph_request(method, path, **kwargs):
+        if path == "/me/calendarView":
+            return {"value": []}
+        if path == "/me/calendar/getSchedule":
+            batch = kwargs["body"]["schedules"]
+            calls.append(batch)
+            return fake_get_schedule(batch)
+        assert (method, path) == ("POST", "/me/events")
+        return {"id": "created"}
+
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="All hands",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=attendees,
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "person0@example.com"
+    assert sorted(len(batch) for batch in calls) == [1, 20]
+
+
+def test_create_event_missing_schedule_scope_rejects_the_write(monkeypatch):
+    """A whole-batch 403 means our own credential/policy is insufficient,
+    not that a particular attendee's schedule is merely invisible -
+    proceeding would silently skip the entire conflict check, defeating
+    the feature. The write must be rejected rather than degraded to
+    unchecked."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},  # organizer calendarView
+            outlook._GraphRequestError("403 Forbidden", status_code=403),
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    # The message must give an LLM caller something actionable -
+    # reconnecting the connector - rather than a bare error string.
+    assert "reconnect" in result["message"].lower()
+
+
+def test_create_event_missing_schedule_scope_still_reports_an_already_confirmed_conflict(
+    monkeypatch,
+):
+    """Regression test: a real conflict already confirmed before the scope
+    error hit (here, the organizer's own calendar, which doesn't need the
+    schedule scope at all) must not be silently discarded just because a
+    later, unrelated attendee check then hit the same missing-scope 403 -
+    reporting a known conflict is always safe, and blindly rejecting
+    instead would tell the caller to retry with ignore_conflicts=true,
+    which would then book straight over the real conflict nobody ever
+    mentioned."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": [_busy_event(event_id="other-1", subject="Board sync")]},
+            outlook._GraphRequestError("403 Forbidden", status_code=403),
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "Board sync"
+    assert result["unchecked_attendees"] == ["chelsea@example.com"]
+
+
+def test_create_event_missing_schedule_scope_can_be_bypassed_with_ignore_conflicts(
+    monkeypatch,
+):
+    graph_request = Mock(return_value={"id": "created"})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert graph_request.call_count == 1
+
+
+def test_create_event_other_graph_errors_still_propagate(monkeypatch):
+    """Only a 403 is treated as a missing-scope signal; any other error must
+    still surface as a real failure. Asserting the actual message (not just
+    status="error") matters here - an exhausted mock raises its own
+    StopIteration on an unexpected extra call, which this same try/except
+    would also report as status="error", so a bare status check alone
+    could pass for the wrong reason if a future change altered the call
+    count instead of genuinely propagating this error."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},  # organizer calendarView
+            outlook._GraphRequestError("500 boom", status_code=500),
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "500 boom" in result["message"]
+
+
+def test_create_event_attendee_absent_from_schedule_response_is_unchecked(
+    monkeypatch,
+):
+    """An attendee simply missing from getSchedule's response (no entry at
+    all, not even an error) must not be silently reported as free."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},  # organizer calendarView
+            {"value": []},  # getSchedule - no entry at all for the attendee
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["ghost@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["ghost@example.com"]
+
+
+def test_create_event_treats_unknown_showas_as_a_conflict(monkeypatch):
+    """Graph's showAs enum documents "unknown" as simply unclassified (e.g.
+    an event synced from a third-party calendar that never set it) - it can
+    represent a genuinely busy block, so it must not be silently treated as
+    free. Missing a real conflict is worse than an occasional over-flag the
+    caller can dismiss with ignore_conflicts."""
+    graph_request = Mock(
+        return_value={
+            "value": [
+                {
+                    "id": "other-1",
+                    "subject": "Mystery event",
+                    "isCancelled": False,
+                    "showAs": "unknown",
+                    "start": {"dateTime": "2026-08-27T10:00:00"},
+                    "end": {"dateTime": "2026-08-27T10:30:00"},
+                }
+            ]
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "Mystery event"
+
+
+def test_create_event_calendarview_query_carries_an_explicit_offset(monkeypatch):
+    """Regression test for the critical review finding: calendarView's
+    startDateTime/endDateTime query parameters are, per Graph's own docs,
+    "interpreted using the timezone offset specified in the value" and
+    read as UTC if none is present - unlike the request body, they are
+    NOT affected by the Prefer header. A naive value there would silently
+    be checked against the wrong instant whenever the caller isn't in
+    UTC."""
+    graph_request = Mock(return_value={"value": []})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            timezone="Asia/Singapore",
+        )
+    )
+
+    assert result["status"] == "success"
+    calendar_view_call = graph_request.call_args_list[0]
+    assert calendar_view_call.kwargs["params"]["startDateTime"] == (
+        "2026-08-27T10:00:00+08:00"
+    )
+    assert calendar_view_call.kwargs["params"]["endDateTime"] == (
+        "2026-08-27T10:30:00+08:00"
+    )
+
+
+def test_create_event_calendarview_follows_pagination(monkeypatch):
+    """A tenant with more events than fit on one page must have every page
+    checked, not just the first - Graph signals more pages via
+    @odata.nextLink rather than ever returning everything at once."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "value": [],
+                "@odata.nextLink": (
+                    f"{outlook.GRAPH_BASE_URL}/me/calendarView?%24skip=250"
+                ),
+            },
+            {"value": [_busy_event(event_id="other-1", subject="Board sync")]},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "Board sync"
+    assert graph_request.call_count == 2
+    second_call = graph_request.call_args_list[1]
+    assert second_call.args[:2] == ("GET", "/me/calendarView?%24skip=250")
+    # The nextLink is a complete, already-parameterized URL - no separate
+    # params dict should be re-sent alongside it.
+    assert second_call.kwargs.get("params") is None
+
+
+def test_send_message_normalizes_and_dedupes_recipients(monkeypatch):
+    """Regression test: outlook_send_message's to/cc/bcc go through the same
+    normalize_addresses dedup as the calendar tools - a case-variant
+    duplicate must collapse to one recipient (keeping the first casing
+    seen), not be sent twice."""
+    graph_request = Mock(return_value={})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_send_message(
+            to=["Alice@Example.com", "alice@example.com", "bob@example.com"],
+            subject="Hi",
+            body="Hello",
+            cc=["Carol@Example.com", "carol@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    message = graph_request.call_args.kwargs["body"]["message"]
+    assert message["toRecipients"] == [
+        {"emailAddress": {"address": "Alice@Example.com"}},
+        {"emailAddress": {"address": "bob@example.com"}},
+    ]
+    assert message["ccRecipients"] == [
+        {"emailAddress": {"address": "Carol@Example.com"}},
+    ]

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -347,6 +347,25 @@ def test_create_event_rejects_a_reversed_window(monkeypatch):
     graph_request.assert_not_called()
 
 
+def test_create_event_rejects_a_reversed_mixed_offset_window(monkeypatch):
+    graph_request = Mock()
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:30:00Z",
+            end_datetime="2026-08-27T10:00:00",
+            timezone="UTC",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after" in result["message"]
+    graph_request.assert_not_called()
+
+
 def test_create_event_explains_exclusive_all_day_end(monkeypatch):
     graph_request = Mock()
     monkeypatch.setattr(outlook, "_graph_request", graph_request)
@@ -457,6 +476,28 @@ def test_create_event_converts_offset_all_day_boundaries_to_event_timezone(
     # The supplied end instant is 04:00 on Aug 29 in Singapore, so the
     # exclusive all-day boundary is the following midnight.
     assert payload["end"]["dateTime"] == "2026-08-30T00:00:00"
+
+
+def test_create_event_rejects_reversed_all_day_window_after_timezone_conversion(
+    monkeypatch,
+):
+    graph_request = Mock()
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Company holiday",
+            start_datetime="2026-08-27T20:00:00Z",
+            end_datetime="2026-08-27T00:00:00",
+            timezone="Asia/Singapore",
+            is_all_day=True,
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "exclusive" in result["message"]
+    graph_request.assert_not_called()
 
 
 def test_create_event_normalizes_all_day_payload_when_conflicts_are_ignored(
@@ -758,8 +799,23 @@ def test_create_event_calendarview_query_carries_an_explicit_offset(monkeypatch)
     )
 
 
-def test_create_event_calendarview_accepts_offset_bearing_boundaries(monkeypatch):
-    graph_request = Mock(side_effect=[{"value": []}, {"id": "created"}])
+def test_create_event_converts_offset_boundaries_to_datetime_timezone_shape(
+    monkeypatch,
+):
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},
+            {
+                "value": [
+                    {
+                        "scheduleId": "chelsea@example.com",
+                        "scheduleItems": [],
+                    }
+                ]
+            },
+            {"id": "created"},
+        ]
+    )
     monkeypatch.setattr(outlook, "_graph_request", graph_request)
 
     result = json.loads(
@@ -767,14 +823,33 @@ def test_create_event_calendarview_accepts_offset_bearing_boundaries(monkeypatch
             subject="Kickoff",
             start_datetime="2026-08-27T10:00:00Z",
             end_datetime="2026-08-27T10:30:00Z",
-            timezone="UTC",
+            timezone="Asia/Singapore",
+            attendees=["chelsea@example.com"],
         )
     )
 
     assert result["status"] == "success"
     params = graph_request.call_args_list[0].kwargs["params"]
-    assert params["startDateTime"] == "2026-08-27T10:00:00Z"
-    assert params["endDateTime"] == "2026-08-27T10:30:00Z"
+    assert params["startDateTime"] == "2026-08-27T18:00:00+08:00"
+    assert params["endDateTime"] == "2026-08-27T18:30:00+08:00"
+    schedule_body = graph_request.call_args_list[1].kwargs["body"]
+    assert schedule_body["startTime"] == {
+        "dateTime": "2026-08-27T18:00:00",
+        "timeZone": "Asia/Singapore",
+    }
+    assert schedule_body["endTime"] == {
+        "dateTime": "2026-08-27T18:30:00",
+        "timeZone": "Asia/Singapore",
+    }
+    payload = graph_request.call_args_list[2].kwargs["body"]
+    assert payload["start"] == {
+        "dateTime": "2026-08-27T18:00:00",
+        "timeZone": "Asia/Singapore",
+    }
+    assert payload["end"] == {
+        "dateTime": "2026-08-27T18:30:00",
+        "timeZone": "Asia/Singapore",
+    }
 
 
 def test_create_event_accepts_windows_timezone_names(monkeypatch):

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -352,6 +352,29 @@ def test_create_event_widens_all_day_conflict_check_to_the_full_day(monkeypatch)
     )
 
 
+def test_create_event_preserves_an_exclusive_z_suffixed_all_day_end(monkeypatch):
+    graph_request = Mock(side_effect=[{"value": []}, {"id": "created"}])
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Company holiday",
+            start_datetime="2026-08-27T00:00:00Z",
+            end_datetime="2026-08-28T00:00:00Z",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    calendar_view_call = graph_request.call_args_list[0]
+    assert calendar_view_call.kwargs["params"]["startDateTime"] == (
+        "2026-08-27T00:00:00+00:00"
+    )
+    assert calendar_view_call.kwargs["params"]["endDateTime"] == (
+        "2026-08-28T00:00:00+00:00"
+    )
+
+
 def test_create_event_batch_over_limit_is_chunked_into_multiple_calls(
     monkeypatch,
 ):


### PR DESCRIPTION
Adds Outlook conflict checks before event creation.

The connector now checks the signed-in primary/default calendar through `calendarView`, follows pagination, batches attendee `getSchedule` requests at Microsoft Graph's 20-schedule limit, preserves actionable Graph status codes, validates event windows, and normalizes all-day checks to full-day bounds. Conflict and incomplete-check responses prevent the event write unless the caller explicitly sets `ignore_conflicts=true` after user confirmation. Attendee responses use both detailed `scheduleItems` and the merged `availabilityView`, so availability-only sharing cannot be mistaken for a free calendar.

Event boundaries accept naive Outlook `dateTimeTimeZone` values and ISO values with explicit offsets, including `Z`. Inputs are restricted to Graph's extended `YYYY-MM-DDTHH:MM:SS` shape. Offset-bearing timed values are converted into the event timezone and sent as a naive `dateTime` plus separate `timeZone`; validation runs again after conversion so mixed aware/naive reversed windows cannot bypass the write guard. Timezone validity is checked even when availability checks are bypassed. The Windows timezone table includes all current Unicode CLDR global mappings plus legacy IDs already supported by this connector.

All-day values are converted before selecting calendar dates and then normalized to midnight for both the availability query and event payload. Same-date non-midnight ranges widen to one full day; for cross-date ranges, the end date remains the exclusive boundary and does not add an extra day. Organizer and attendee conflicts retain the timezone returned by Graph, and DST transitions are preserved in calendarView query offsets.

Calendar pagination fails closed if its safety cap is exhausted or Graph returns an invalid or dot-segment next link, while preserving conflicts already found. Organizer-side 403 responses provide reconnect and org-policy guidance. Moving Outlook address normalization to the shared helper also makes recipient and attendee deduplication case-insensitive for existing send and update operations; regression tests cover both paths.

Validation: `pytest -q tests/web/tools/test_outlook_mcp.py tests/web/tools/test_mcp_utils.py` — 203 passed; Ruff, formatting, isort, codespell, whitespace, and end-of-file hooks passed. Targeted mypy passed after suppressing the locally unavailable `dateutil` stubs; GitHub CI runs the complete pre-commit hook in a clean environment.



