### PR TITLE
feat: add shared execution data and event foundations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
         additional_dependencies:
           - "pydantic[mypy]"
           - aiohttp
+          - redis==6.4.0
           - types-PyYAML
           - types-beautifulsoup4
           - types-requests

--- a/docs/architecture/shared-worker-execution.md
+++ b/docs/architecture/shared-worker-execution.md
@@ -1,0 +1,31 @@
+# Shared task execution foundations
+
+This change contains the acceptance/data and event/recovery foundations for shared task execution. Application startup and task execution remain on the existing path. It does not start a shared worker or the Redis event bridge.
+
+## Acceptance and persistence
+
+`_AcceptedTurn` represents a persisted turn without an execution lease. The existing `_claim_turn_no_commit` still acquires the lease and returns `_ClaimedTurn` inside the same transaction before scheduling. Message and file binding, Workforce projection, commit reconciliation and local scheduling keep their existing contracts.
+
+`task_runtime_secrets` stores encrypted, single-turn connector secrets and auth selectors. Reads verify task, turn, run and the owner's stable subject. Storage, binding and cleanup operations are available to later ingress/worker integration; existing connector runtime paths do not use this store yet. No secret values are added to task APIs or event payloads.
+
+Nullable `reply_host_id` and `reply_origin` fields identify the creating ingress and its exact socket registration. They are stored when a command is created; duplicate submissions cannot overwrite the route. The migration preserves existing commands and can be downgraded independently.
+
+## Events and recovery
+
+The Redis bridge provides task fanout, origin-bound private replies, socket acknowledgements, bounded deduplication and reconnect notifications. Redis remains a Pub/Sub transport, not a task queue or replay log. A private-reply timeout is delivery-unknown and must not cause command execution to retry.
+
+State-bearing event enrichment is extracted from the WebSocket API so a future producer can capture the original run/version before transport. Each shared socket has a bounded writer queue; slow sockets cannot block the other recipients. Authorized task audiences can receive persistent state/output snapshots to reconcile missing events.
+
+The frontend handles unavailable/resync notifications and exact-run snapshots. It marks interrupted output, avoids appending tokens to a missing prefix, and replaces the display when complete persisted output is available. Existing local output remains unchanged when these events are absent.
+
+## Activation boundary
+
+`XAGENT_SHARED_TASK_EXECUTION_ENABLED` defaults to **false in this intermediate change**. Keep it false: this change does not wire the bridge into application startup and is not a deployable shared execution mode. Tests explicitly initialize the bridge to exercise its contracts.
+
+`XAGENT_TASK_EVENT_CHANNEL_PREFIX` defaults to `xagent:task-events:v1`. Redis logical DB numbers do not isolate Pub/Sub; separate deployments need different prefixes.
+
+Follow-up changes will implement START handoff and lease fencing, resume/existing-task and ingress adapters, channel bots, and worker/web lifecycle integration. The final integration will enable shared execution by default, after those paths are complete. No intermediate PR should turn it on prematurely.
+
+## Validation
+
+Tests accompany acceptance/rollback, immutable origin routing, encrypted input isolation, migration upgrade/downgrade, event identity and deduplication, ACK semantics, bounded socket queues, and frontend recovery. The Redis reconnect test accepts `XAGENT_TEST_REDIS_URL`; PostgreSQL migration tests accept `XAGENT_TEST_POSTGRES_URL` and create/drop their own disposable database. Missing service URLs skip only those external-service tests.

--- a/example.env
+++ b/example.env
@@ -1206,3 +1206,9 @@ ENCRYPTION_KEY="RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
 # sdk, a2a, trigger, widget, shared_link, channel. Native mode requires at
 # least one entry here.
 # XAGENT_INTERACTION_NATIVE_SOURCES=""
+
+# Shared task execution foundations. Keep disabled until host integration lands.
+# This release does not start the event bridge or a shared task worker.
+XAGENT_SHARED_TASK_EXECUTION_ENABLED=false
+# Redis Pub/Sub ignores logical DB numbers; namespace each deployment separately.
+XAGENT_TASK_EVENT_CHANNEL_PREFIX=xagent:task-events:v1

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -743,6 +743,11 @@ export function TaskConversationPanel({
         style={{ width: anyPreviewOpen ? `${leftWidth}%` : "100%" }}
         className={cn(anyPreviewOpen ? "" : "flex-1", "min-w-0 flex flex-col min-h-0 transition-[width] duration-0 relative")}
       >
+        {state.streamRecoveryTaskId === state.taskId && state.taskId !== null && (
+          <div role="status" className="mx-4 mt-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:bg-amber-950 dark:text-amber-100">
+            {t("sharedStream.interrupted")}
+          </div>
+        )}
         <div className="flex-1 overflow-y-auto">
           <main className={cn("mx-auto px-4 relative z-0 transition-all", mode === "page" ? "container max-w-4xl py-8" : "max-w-3xl py-4")}>
             <div className={cn(mode === "page" ? "space-y-6 pb-4" : "space-y-4 pb-4")}>

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -14,6 +14,8 @@ type TestWebSocketMessage = {
   task?: Record<string, unknown>
   status?: string
   run_id?: string | null
+  stream_run_id?: string | null
+  stream_attempt_id?: string | null
   state_version?: number
   control_state?: string
   request_id?: string
@@ -188,6 +190,7 @@ function StateProbe() {
           })
         )}
       </div>
+      <div data-testid="last-task-update">{state.lastTaskUpdate}</div>
       <div data-testid="task-status">{state.currentTask?.status || ""}</div>
       <div data-testid="waiting-request-id">{state.currentTask?.waitingRequestId || ""}</div>
       <div data-testid="waiting-interactions">{JSON.stringify(state.currentTask?.waitingInteractions || [])}</div>
@@ -214,6 +217,7 @@ function StateProbe() {
       <div data-testid="history-loading">{String(state.isHistoryLoading)}</div>
       <div data-testid="preview-open">{String(state.filePreview.isOpen)}</div>
       <div data-testid="processing">{String(state.isProcessing)}</div>
+      <div data-testid="stream-recovery">{state.streamRecoveryTaskId ?? ""}</div>
     </>
   )
 }
@@ -568,6 +572,126 @@ describe("AppProvider websocket message routing", () => {
   afterEach(() => {
     cleanup()
     localStorage.clear()
+  })
+
+  it.each([false, true])("rejects an initial shared delta and accepts a complete replacement (wrapped=%s)", (wrapped) => {
+    render(<AppProvider token="token"><SeedRunningTask /><StateProbe /></AppProvider>)
+    const send = (eventType: string, data: Record<string, unknown>) => act(() => {
+      webSocketOptions.current?.onMessage?.({
+        task_id: 1, timestamp: "2026-05-27T05:00:00Z",
+        stream_run_id: "run-1", stream_attempt_id: "attempt-1",
+        ...(wrapped ? { type: "trace_event", event_type: eventType, data: { data } } : { type: eventType, data }),
+      })
+    })
+    act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "task_started", task_id: 1, run_id: "run-1", state_version: 1,
+        status: "running", control_state: "running", timestamp: "2026-05-27T05:00:00Z",
+      })
+    })
+    // Joining a known active run can deliver a delta before either start or snapshot.
+    send("final_answer_delta", { message_id: "final_answer_1", delta: "WRONG SUFFIX" })
+    expect(screen.getByTestId("messages").textContent).not.toContain("WRONG SUFFIX")
+    expect(screen.getByTestId("stream-recovery").textContent).toBe("1")
+    send("final_answer_delta", { message_id: "final_answer_1", delta: "MORE SUFFIX" })
+    expect(screen.getByTestId("messages").textContent).not.toContain("MORE SUFFIX")
+    send("final_answer_end", { message_id: "final_answer_1", content: "complete answer" })
+    expect(screen.getByTestId("messages").textContent).toContain("complete answer")
+    expect(screen.getByTestId("stream-recovery").textContent).toBe("")
+    send("final_answer_delta", { message_id: "final_answer_1", delta: "LATE SUFFIX" })
+    expect(screen.getByTestId("messages").textContent).not.toContain("LATE SUFFIX")
+  })
+
+  it.each([false, true])("handles task completion after a shared answer ends (wrapped=%s)", (wrapped) => {
+    render(<AppProvider token="token"><SeedRunningTask /><StateProbe /></AppProvider>)
+    const send = (message: Partial<TestWebSocketMessage> & Record<string, unknown>) => act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "task_started", task_id: 1, timestamp: "2026-05-27T05:00:02Z",
+        stream_run_id: "run-1", stream_attempt_id: "attempt-1", ...message,
+      })
+    })
+    send({ run_id: "run-1", state_version: 1, status: "running", control_state: "running" })
+    send({ type: "trace_event", data: {
+      event_id: "dag-before-answer", event_type: "dag_execution",
+      data: { phase: "executing", turn_id: "run-1" },
+    } })
+    expect(screen.getByTestId("dag-phase").textContent).toBe("executing")
+    const answerFrame = (eventType: string, data: Record<string, unknown>) => send(
+      wrapped ? { type: "trace_event", event_type: eventType, data: { data } } : { type: eventType, data },
+    )
+    answerFrame("final_answer_start", { message_id: "final_answer_1" })
+    answerFrame("final_answer_end", { message_id: "final_answer_1", content: "complete answer" })
+    const previousUpdate = screen.getByTestId("last-task-update").textContent
+    send({ type: "task_completed", run_id: "run-1", state_version: 2,
+      control_state: "completed", task: { id: 1, status: "completed" }, success: true,
+    })
+    expect(screen.getByTestId("task-status").textContent).toBe("completed")
+    expect(screen.getByTestId("processing").textContent).toBe("false")
+    expect(screen.getByTestId("dag-phase").textContent).toBe("completed")
+    expect(screen.getByTestId("task-dag-terminated-at").textContent).not.toBe("")
+    expect(screen.getByTestId("last-task-update").textContent).not.toBe(previousUpdate)
+    answerFrame("final_answer_delta", { message_id: "final_answer_1", delta: "LATE SUFFIX" })
+    expect(screen.getByTestId("messages").textContent).toContain("complete answer")
+    expect(screen.getByTestId("messages").textContent).not.toContain("LATE SUFFIX")
+    expect(screen.getByTestId("stream-recovery").textContent).toBe("")
+  })
+
+  it("resumes shared deltas when a start establishes the missing prefix", () => {
+    render(<AppProvider token="token"><SeedRunningTask /><StateProbe /></AppProvider>)
+    const send = (type: string, data: Record<string, unknown>) => act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type, task_id: 1, timestamp: "2026-05-27T05:00:00Z",
+        stream_run_id: "run-1", stream_attempt_id: "attempt-1", data,
+      })
+    })
+    send("final_answer_delta", { message_id: "final_answer_1", delta: "WRONG SUFFIX" })
+    send("final_answer_start", { message_id: "final_answer_1" })
+    send("final_answer_delta", { message_id: "final_answer_1", delta: "answer from its beginning" })
+    expect(screen.getByTestId("messages").textContent).toContain("answer from its beginning")
+    expect(screen.getByTestId("messages").textContent).not.toContain("WRONG SUFFIX")
+    expect(screen.getByTestId("stream-recovery").textContent).toBe("")
+  })
+
+  it("streams a new answer whose prefix arrives after an active snapshot", () => {
+    render(<AppProvider token="token"><SeedRunningTask /><StateProbe /></AppProvider>)
+    const send = (message: Partial<TestWebSocketMessage>) => act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "task_stream_snapshot", task_id: 1,
+        timestamp: "2026-05-27T05:00:00Z", ...message,
+      })
+    })
+    send({ run_id: "run-1", state_version: 1, control_state: "running", status: "running", data: {} })
+    send({ type: "final_answer_start", stream_run_id: "run-1", data: { message_id: "final_answer_1" } })
+    send({ type: "final_answer_delta", stream_run_id: "run-1", data: { message_id: "final_answer_1", delta: "first visible answer" } })
+    expect(screen.getByTestId("messages").textContent).toContain("first visible answer")
+    send({ type: "task_started", stream_run_id: "run-2", run_id: "run-2", state_version: 2, status: "running", control_state: "running" })
+    send({ type: "final_answer_start", stream_run_id: "run-2", data: { message_id: "final_answer_2" } })
+    send({ type: "final_answer_delta", stream_run_id: "run-2", data: { message_id: "final_answer_2", delta: "second visible answer" } })
+    expect(screen.getByTestId("messages").textContent).toContain("second visible answer")
+  })
+
+  it("reconciles a gapped shared stream without appending later deltas or accepting an old run", () => {
+    render(<AppProvider token="token"><SeedRunningTask /><StateProbe /></AppProvider>)
+    const send = (message: Partial<TestWebSocketMessage>) => act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "task_stream_snapshot", task_id: 1,
+        timestamp: "2026-05-27T05:00:00Z", ...message,
+      })
+    })
+    send({ type: "task_started", run_id: "run-2", state_version: 2, control_state: "running", status: "running" })
+    send({ type: "final_answer_start", stream_run_id: "run-2", data: { message_id: "final_answer_2" } })
+    send({ type: "final_answer_delta", stream_run_id: "run-2", data: { message_id: "final_answer_2", delta: "prefix" } })
+    expect(screen.getByTestId("messages").textContent).toContain("prefix")
+    send({ type: "stream_unavailable" })
+    send({ type: "final_answer_delta", stream_run_id: "run-2", data: { message_id: "final_answer_2", delta: "WRONG SUFFIX" } })
+    expect(screen.getByTestId("messages").textContent).not.toContain("WRONG SUFFIX")
+    send({ run_id: "run-1", state_version: 1, status: "completed", control_state: "completed", data: { output: "OLD RESULT" } })
+    expect(screen.getByTestId("messages").textContent).not.toContain("OLD RESULT")
+    send({ run_id: "run-2", state_version: 3, status: "completed", control_state: "completed", data: { output: "complete persisted result" } })
+    expect(screen.getByTestId("messages").textContent).toContain("complete persisted result")
+    expect(screen.getByTestId("messages").textContent).not.toContain("prefix")
+    send({ type: "final_answer_delta", stream_run_id: "run-2", data: { message_id: "final_answer_2", delta: "LATE" } })
+    expect(screen.getByTestId("messages").textContent).not.toContain("LATE")
   })
 
   it("routes historical assistant transcript rows to chat and progress events to trace", async () => {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -28,6 +28,8 @@ interface WebSocketMessage {
   event_type?: string
   event_id?: string
   run_id?: string | null
+  stream_run_id?: string | null
+  stream_attempt_id?: string | null
   state_version?: number
   control_state?: TaskControlState
   status?: unknown
@@ -62,6 +64,7 @@ type TaskControlEnvelope = {
 }
 
 const VERSIONED_TASK_EVENT_TYPES = new Set([
+  "task_stream_snapshot",
   "agent_error",
   "error",
   "task_completed",
@@ -100,6 +103,8 @@ const TASK_SCOPED_ACTION_TYPES = new Set<AppAction["type"]>([
   "SET_HISTORY_LOADING",
   "ADD_MESSAGE",
   "UPSERT_STREAMING_FINAL_ANSWER",
+  "SET_STREAM_RECOVERY",
+  "RECONCILE_STREAM_OUTPUT",
   "ADD_TRACE_EVENT",
   "SET_CONTEXT_USAGE",
   "SET_PLAN_MEMORY_INFO",
@@ -1177,6 +1182,7 @@ const normalizeDagExecutionPayload = (raw: Record<string, unknown>): DAGExecutio
 }
 
 export interface AppState {
+  streamRecoveryTaskId?: number | null
   messages: Message[]
   currentTask: Task | null
   taskRuntimeExtensions: TaskRuntimeExtensions
@@ -1224,6 +1230,8 @@ export interface AppState {
 }
 
 type AppAction =
+  | { type: "SET_STREAM_RECOVERY"; payload: number | null }
+  | { type: "RECONCILE_STREAM_OUTPUT"; payload: { runId: string; output: string; timestamp: string; interrupted: boolean } }
   | { type: "SESSION_CONVERSATION"; payload: SessionConversationAction }
   | { type: "SET_TASK_ID"; payload: number | null }
   | { type: "ADOPT_SESSION_TASK"; payload: { taskId: number; task: Task } }
@@ -1506,6 +1514,40 @@ function projectAppState(state: AppState, action: AppAction): AppState {
         return normalizeTimestampMs(a.timestamp) - normalizeTimestampMs(b.timestamp)
       })
       return { ...state, messages: updatedMessages, traceEvents: newTraceEvents }
+    }
+
+    case "SET_STREAM_RECOVERY":
+      return { ...state, streamRecoveryTaskId: action.payload }
+
+    case "RECONCILE_STREAM_OUTPUT": {
+      const { runId, output, timestamp, interrupted } = action.payload
+      let resultIndex = -1
+      for (let index = state.messages.length - 1; index >= 0; index--) {
+        const message = state.messages[index]
+        if (message.role === "user") break
+        if (message.role === "assistant" && message.isResult) {
+          resultIndex = index
+          break
+        }
+      }
+      const existing = state.messages[resultIndex]
+      // Preserve richer live formatting/files when a complete result already
+      // arrived. A partial stream, or a missed result, needs the durable text.
+      if (existing?.status === "completed" && !interrupted) return state
+      const restored: Message = {
+        ...existing,
+        id: existing?.id ?? `final_answer_recovered_${runId}`,
+        role: "assistant",
+        content: output,
+        rawContent: output,
+        timestamp: existing?.timestamp ?? timestamp,
+        status: "completed",
+        isResult: true,
+      }
+      const messages = [...state.messages]
+      if (resultIndex >= 0) messages[resultIndex] = restored
+      else messages.push(restored)
+      return { ...state, messages, streamRecoveryTaskId: null }
     }
 
     case "UPSERT_STREAMING_FINAL_ANSWER": {
@@ -2237,6 +2279,14 @@ export function AppProvider({
   const { t } = useI18n()
   const router = useRouter()
   const lastConnectedTaskId = useRef<number | null>(null)
+  const sharedStreamRef = useRef<{
+    taskId?: number
+    runId?: string | null
+    attemptId?: string | null
+    interrupted: boolean
+    prefixSeen: boolean
+    complete: boolean
+  }>({ interrupted: false, prefixSeen: false, complete: false })
   const taskStateVersionsRef = useRef(
     new Map<number, TaskStateVersionEntry>()
   )
@@ -2741,6 +2791,102 @@ export function AppProvider({
         return
       }
       rawDispatch(action)
+    }
+    if (!isMessageForOtherTask && typeof messageTaskId === "number") {
+      let stream = sharedStreamRef.current
+      if (stream.taskId !== messageTaskId) {
+        stream = { taskId: messageTaskId, interrupted: false, prefixSeen: false, complete: false }
+        sharedStreamRef.current = stream
+      }
+      if (message.type === "stream_unavailable" || message.type === "stream_resync_required") {
+        stream.interrupted = true
+        dispatch({ type: "SET_STREAM_RECOVERY", payload: messageTaskId })
+        return
+      }
+      if (message.type === "task_stream_snapshot") {
+        if (isHistoricalDataLoadingRef.current) return
+        const envelope = extractTaskControlEnvelope(message)
+        if (!acceptTaskControlVersion(message, envelope, taskStateVersionsRef.current)) return
+        const data = asMessageRecord(message.data)
+        if (stream.runId !== envelope.runId) {
+          stream.runId = envelope.runId
+          stream.prefixSeen = false
+          stream.complete = false
+        }
+        stream.attemptId = typeof data.lease_attempt_id === "string" ? data.lease_attempt_id : null
+        const active = envelope.status === "running"
+        stream.interrupted = stream.interrupted || (active && !stream.prefixSeen)
+        if (envelope.status) {
+          dispatch({ type: "UPDATE_TASK_STATUS", payload: {
+            status: envelope.status, runId: envelope.runId,
+            stateVersion: envelope.stateVersion, controlState: envelope.controlState,
+            ...(envelope.status === "waiting_for_user" ? {
+              waitingQuestion: typeof data.question === "string" ? data.question : undefined,
+              waitingInteractions: normalizeInteractions(data.interactions),
+            } : {}),
+          } })
+          dispatch({ type: "SET_PROCESSING", payload: active })
+        }
+        if (typeof data.output === "string" && typeof envelope.runId === "string") {
+          dispatch({ type: "RECONCILE_STREAM_OUTPUT", payload: {
+            runId: envelope.runId, output: data.output,
+            timestamp: message.timestamp, interrupted: stream.interrupted,
+          } })
+          stream.interrupted = false
+          stream.complete = true
+        } else if (envelope.status && envelope.status !== "running") {
+          stream.interrupted = false
+        }
+        dispatch({ type: "SET_STREAM_RECOVERY", payload: stream.interrupted ? messageTaskId : null })
+        return
+      }
+      if (message.stream_run_id !== undefined) {
+        const known = taskStateVersionsRef.current.get(messageTaskId)
+        if (known?.runId !== undefined && known.runId !== message.stream_run_id) {
+          const envelope = extractTaskControlEnvelope(message)
+          if (!envelope.isStateEvent || envelope.runId !== message.stream_run_id
+            || envelope.stateVersion === undefined || envelope.stateVersion <= known.version) return
+        }
+        if (stream.runId !== message.stream_run_id) {
+          stream.runId = message.stream_run_id
+          stream.attemptId = message.stream_attempt_id
+          stream.prefixSeen = false
+          stream.interrupted = false
+          stream.complete = false
+          dispatch({ type: "SET_STREAM_RECOVERY", payload: null })
+        }
+        if (stream.attemptId && message.stream_attempt_id !== stream.attemptId) return
+      }
+      const streamType = getWebSocketEventType(message)
+      if (stream.complete && isFinalAnswerStreamEventType(streamType)) return
+      if (streamType === "final_answer_start") {
+        stream.prefixSeen = true
+        stream.interrupted = false
+        dispatch({ type: "SET_STREAM_RECOVERY", payload: null })
+      }
+      if (isFinalAnswerStreamEventType(streamType)) {
+        const sharedFrame = message.stream_run_id !== undefined
+        const data = asMessageRecord(message.data)
+        const eventData = message.type === "trace_event"
+          ? asMessageRecord(data.data ?? data)
+          : { ...data, ...message }
+        const replacesContent = sharedFrame && (
+          (streamType === "final_answer_end" && typeof eventData.content === "string")
+          || (streamType === "final_answer_error" && typeof eventData.error === "string")
+        )
+        if (sharedFrame && streamType === "final_answer_delta" && !stream.prefixSeen) {
+          stream.interrupted = true
+          dispatch({ type: "SET_STREAM_RECOVERY", payload: messageTaskId })
+          return
+        }
+        if (replacesContent) {
+          stream.prefixSeen = true
+          stream.interrupted = false
+          dispatch({ type: "SET_STREAM_RECOVERY", payload: null })
+        }
+        if (stream.interrupted || stream.complete) return
+        if (replacesContent) stream.complete = true
+      }
     }
     // The 30s dedup cache below is keyed on message content/type only, not
     // task id - several dedupKeys (e.g. dag-execute-end's "task end, this

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -42,6 +42,8 @@ interface WebSocketMessage {
   delta?: string
   content?: string
   run_id?: string | null
+  stream_run_id?: string | null
+  stream_attempt_id?: string | null
   state_version?: number
   control_state?: "idle" | "running" | "pause_requested" | "paused" | "resume_requested" | "waiting_for_user" | "completed" | "failed"
   status?: unknown
@@ -731,6 +733,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       const socket = protocols
         ? new WebSocket(connection.url, protocols)
         : new WebSocket(connection.url)
+      let sharedTaskId: number | undefined
       const owner: SocketOwner = {
         callbacks: callbacksRef.current,
         connection,
@@ -795,6 +798,12 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
 
       socket.onclose = (event) => {
         if (!isCurrentOwner(owner)) return
+        if (sharedTaskId !== undefined) {
+          owner.callbacks.onMessage?.({
+            type: "stream_unavailable", task_id: sharedTaskId,
+            data: {}, timestamp: new Date().toISOString(),
+          })
+        }
 
         const wasCurrent = retireOwnerCore(owner, {
           pendingError: deliveryError("Connection closed before the message was accepted.", "outcome_unknown"),
@@ -931,6 +940,9 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
         if (!isCurrentOwner(owner)) return
         try {
           const data = JSON.parse(event.data)
+          if (data.type === "task_stream_snapshot" || data.stream_run_id !== undefined) {
+            sharedTaskId = data.task_id
+          }
 
           if (data.type === 'message_accepted' || data.type === 'message_rejected') {
             const clientMessageId = data.client_message_id
@@ -1126,6 +1138,8 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
           // Preserve the canonical task-control envelope even when a message
           // type normalizes its payload into ``data`` above.
           message.run_id = data.run_id
+          message.stream_run_id = data.stream_run_id
+          message.stream_attempt_id = data.stream_attempt_id
           message.state_version = data.state_version
           message.control_state = data.control_state
           message.status = data.status

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1,4 +1,5 @@
 const en = {
+  sharedStream: { interrupted: "Live updates were interrupted. The displayed answer may be incomplete; saved results will appear when available." },
   clientErrors: {
     messageProcessingFailed: "The message could not be processed. Please try again.",
     taskExecutionFailed: "Task execution failed.",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1,4 +1,5 @@
 const zh = {
+  sharedStream: { interrupted: "实时更新已中断，当前显示的回答可能不完整；已保存的完整结果可用后会自动同步。" },
   clientErrors: {
     messageProcessingFailed: "消息处理失败，请重试。",
     taskExecutionFailed: "任务执行失败。",

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -40,6 +40,8 @@ EXTERNAL_SKILLS_LIBRARY_DIRS = "XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS"
 AGENT_RUNTIME = "XAGENT_AGENT_RUNTIME"
 INTERACTION_PROTOCOL_MODE = "XAGENT_INTERACTION_PROTOCOL_MODE"
 INTERACTION_NATIVE_SOURCES = "XAGENT_INTERACTION_NATIVE_SOURCES"
+SHARED_TASK_EXECUTION_ENABLED = "XAGENT_SHARED_TASK_EXECUTION_ENABLED"
+TASK_EVENT_CHANNEL_PREFIX = "XAGENT_TASK_EVENT_CHANNEL_PREFIX"
 TASK_LEASE_TTL_SECONDS = "XAGENT_TASK_LEASE_TTL_SECONDS"
 TASK_LEASE_HEARTBEAT_SECONDS = "XAGENT_TASK_LEASE_HEARTBEAT_SECONDS"
 TASK_LEASE_RECOVERY_INTERVAL_SECONDS = "XAGENT_TASK_LEASE_RECOVERY_INTERVAL_SECONDS"
@@ -742,6 +744,21 @@ def get_redis_url() -> str | None:
         return None
     value = value.strip()
     return value or None
+
+
+def get_shared_task_execution_enabled() -> bool:
+    """Enable durable task handoff and the shared event bridge when explicitly configured."""
+    return _get_bool_env(SHARED_TASK_EXECUTION_ENABLED, False)
+
+
+def get_task_event_channel_prefix() -> str:
+    """Redis Pub/Sub is not isolated by Redis DB number; namespace each deployment."""
+    prefix = os.getenv(TASK_EVENT_CHANNEL_PREFIX, "xagent:task-events:v1").strip()
+    if not prefix or not re.fullmatch(r"[A-Za-z0-9:._-]+", prefix):
+        raise ValueError(
+            f"{TASK_EVENT_CHANNEL_PREFIX} must be a nonempty channel prefix"
+        )
+    return prefix
 
 
 def get_hot_path_cache_enabled() -> bool:

--- a/src/xagent/migrations/versions/20260912_shared_task_execution.py
+++ b/src/xagent/migrations/versions/20260912_shared_task_execution.py
@@ -1,0 +1,74 @@
+"""Add single-turn encrypted inputs and immutable command reply routes.
+
+Revision ID: 20260912_shared_task_execution
+Revises: 20260911_update_onedrive_description
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260912_shared_task_execution"
+down_revision = "20260911_update_onedrive_description"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    # Core task tables are metadata-owned and can be absent when Alembic
+    # runs on an empty database. Match the existing task migrations.
+    if inspector.has_table("tasks") and not inspector.has_table("task_runtime_secrets"):
+        op.create_table(
+            "task_runtime_secrets",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "task_id",
+                sa.Integer(),
+                sa.ForeignKey("tasks.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("turn_id", sa.String(64), nullable=False),
+            sa.Column("run_id", sa.String(64), nullable=True),
+            sa.Column("owner_subject", sa.String(64), nullable=False),
+            sa.Column("ciphertext", sa.Text(), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.UniqueConstraint(
+                "task_id", "turn_id", name="uq_task_runtime_secret_turn"
+            ),
+        )
+        op.create_index(
+            "ix_task_runtime_secrets_task_id", "task_runtime_secrets", ["task_id"]
+        )
+    if inspector.has_table("task_execution_commands"):
+        columns = {
+            column["name"]
+            for column in inspector.get_columns("task_execution_commands")
+        }
+        for name in ("reply_host_id", "reply_origin"):
+            if name not in columns:
+                op.add_column(
+                    "task_execution_commands",
+                    sa.Column(name, sa.String(64), nullable=True),
+                )
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if inspector.has_table("task_execution_commands"):
+        columns = {
+            column["name"]
+            for column in inspector.get_columns("task_execution_commands")
+        }
+        for name in ("reply_origin", "reply_host_id"):
+            if name in columns:
+                op.drop_column("task_execution_commands", name)
+    if inspector.has_table("task_runtime_secrets"):
+        op.drop_index(
+            "ix_task_runtime_secrets_task_id", table_name="task_runtime_secrets"
+        )
+        op.drop_table("task_runtime_secrets")

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -123,6 +123,13 @@ from ..services.task_command_transport import (
     dispatch_task_command_promptly,
     enqueue_task_command,
 )
+from ..services.task_event_state import (
+    _is_versioned_task_event as _is_versioned_task_event,
+)
+from ..services.task_event_state import (
+    _with_current_task_control_state,
+    _with_task_control_state_snapshot,
+)
 from ..services.task_events import (
     CommandReply,
     discard_command_reply,
@@ -150,7 +157,9 @@ from ..services.task_execution import (
 )
 from ..services.task_execution_controller import (
     task_control_snapshot,
-    task_execution_controller,
+)
+from ..services.task_execution_controller import (
+    task_execution_controller as task_execution_controller,
 )
 from ..services.task_interaction_read import get_pending_interaction_question
 from ..services.task_runtime import (
@@ -984,150 +993,6 @@ async def redirect_legacy_preview(
     )
 
 
-_VERSIONED_TASK_EVENT_TYPES = {
-    "agent_error",
-    "error",
-    "task_completed",
-    "task_error",
-    "task_pause_requested",
-    "task_paused",
-    "task_resumed",
-    "task_started",
-    "task_waiting_for_user",
-}
-
-
-def _is_versioned_task_event(message: dict[str, Any]) -> bool:
-    message_type = str(message.get("type") or "")
-    if message_type in _VERSIONED_TASK_EVENT_TYPES:
-        return True
-    return (
-        message_type == "trace_event"
-        and str(
-            message.get("event_type")
-            or (
-                message.get("data", {}).get("event_type")
-                if isinstance(message.get("data"), dict)
-                else ""
-            )
-        )
-        == "task_info"
-    )
-
-
-def _event_task_id(message: dict[str, Any]) -> int | None:
-    candidates = [message.get("task_id")]
-    task_data = message.get("task")
-    if isinstance(task_data, dict):
-        candidates.append(task_data.get("id"))
-        candidates.append(task_data.get("task_id"))
-    data = message.get("data")
-    if isinstance(data, dict):
-        candidates.append(data.get("id"))
-        candidates.append(data.get("task_id"))
-    for candidate in candidates:
-        if candidate is None:
-            continue
-        try:
-            return int(candidate)
-        except (TypeError, ValueError):
-            continue
-    return None
-
-
-def _event_task_control_state(message: dict[str, Any]) -> dict[str, Any] | None:
-    sources = [message]
-    task_data = message.get("task")
-    if isinstance(task_data, dict):
-        sources.append(task_data)
-    data = message.get("data")
-    if isinstance(data, dict):
-        sources.append(data)
-
-    for source in sources:
-        version = source.get("state_version")
-        control_state = source.get("control_state")
-        status = source.get("status")
-        if (
-            isinstance(version, int)
-            and not isinstance(version, bool)
-            and version >= 0
-            and isinstance(control_state, str)
-            and isinstance(status, str)
-            and (isinstance(source.get("run_id"), str) or source.get("run_id") is None)
-        ):
-            return {
-                "run_id": source.get("run_id"),
-                "state_version": version,
-                "control_state": control_state,
-                "status": status,
-            }
-    return None
-
-
-def _with_task_control_state_snapshot(
-    message: dict[str, Any],
-    *,
-    task_id: int,
-    state: dict[str, Any],
-) -> dict[str, Any]:
-    """Attach one already-loaded control-state tuple without database I/O."""
-
-    if not _is_versioned_task_event(message):
-        return deepcopy(message)
-    resolved_state = _event_task_control_state(message) or state
-    enriched = deepcopy(message)
-    enriched.update(resolved_state)
-    enriched["task_id"] = task_id
-
-    if enriched.get("type") == "trace_event":
-        data = enriched.get("data")
-        enriched["data"] = {
-            **(data if isinstance(data, dict) else {}),
-            **resolved_state,
-        }
-
-    task_data = enriched.get("task")
-    if isinstance(task_data, dict):
-        enriched["task"] = {
-            **task_data,
-            **resolved_state,
-            "id": task_id,
-        }
-    return enriched
-
-
-async def _with_current_task_control_state(
-    message: dict[str, Any],
-    *,
-    fallback_task_id: int | None = None,
-) -> dict[str, Any]:
-    """Attach one canonical DB state tuple to a state-bearing event.
-
-    Event producers can finish out of order. Preserve a producer-captured
-    state tuple when present; otherwise attach the current row snapshot.
-    Clients compare the resulting ``run_id`` / ``state_version`` before
-    applying the event.
-    """
-
-    if not _is_versioned_task_event(message):
-        return message
-    task_id = _event_task_id(message) or fallback_task_id
-    if task_id is None:
-        return message
-    state = _event_task_control_state(message)
-    if state is None:
-        snapshot = await task_execution_controller.snapshot(task_id)
-        if snapshot is None:
-            return message
-        state = snapshot.as_dict()
-    return _with_task_control_state_snapshot(
-        message,
-        task_id=task_id,
-        state=state,
-    )
-
-
 # Connection manager
 class _CommandOriginRegistry:
     """(task_id, command_id) -> the exact socket that submitted the command.
@@ -1220,10 +1085,16 @@ class _CommandOriginRegistry:
 _command_origins = _CommandOriginRegistry()
 
 
+from ...config import get_shared_task_execution_enabled  # noqa: E402
+from ..services.task_socket_writer import TaskSocketWriter  # noqa: E402
+
+
 class ConnectionManager:
     def __init__(self) -> None:
         # task_id -> List[WebSocket]
         self.active_connections: Dict[int, List[WebSocket]] = {}
+        self._writers: dict[WebSocket, TaskSocketWriter] = {}
+        self._stream_reconciler: asyncio.Task[None] | None = None
         # WebSocket -> current task_id
         self._connection_task_ids: Dict[WebSocket, int] = {}
 
@@ -1241,6 +1112,10 @@ class ConnectionManager:
         if websocket not in self.active_connections[task_id]:
             self.active_connections[task_id].append(websocket)
         self._connection_task_ids[websocket] = task_id
+        if get_shared_task_execution_enabled() and websocket not in self._writers:
+            self._writers[websocket] = TaskSocketWriter(
+                websocket, lambda: self.disconnect(websocket)
+            )
 
     def _remove_from_task(self, websocket: WebSocket, task_id: int) -> None:
         if task_id in self.active_connections:
@@ -1252,6 +1127,13 @@ class ConnectionManager:
                 pass
 
     def disconnect(self, websocket: WebSocket) -> None:
+        writer = self._writers.pop(websocket, None)
+        if writer is not None:
+            writer.stop()
+        if get_shared_task_execution_enabled():
+            from ..services.task_event_bridge import get_task_event_bridge
+
+            get_task_event_bridge().discard_recipient(websocket)
         task_id = self._connection_task_ids.pop(websocket, None)
         if task_id is not None:
             self._remove_from_task(websocket, task_id)
@@ -1263,7 +1145,7 @@ class ConnectionManager:
         for connection in connections:
             if self._connection_task_ids.get(connection) == task_id:
                 del self._connection_task_ids[connection]
-            _command_origins.discard_socket(connection)
+            self.disconnect(connection)
         return connections
 
     def connections_for_task(self, task_id: int) -> List[WebSocket]:
@@ -1294,9 +1176,61 @@ class ConnectionManager:
 
     async def send_personal_message(self, message: dict, websocket: WebSocket) -> None:
         versioned_message = await _with_current_task_control_state(message)
-        await websocket.send_text(json.dumps(versioned_message))
+        writer = self._writers.get(websocket)
+        if writer is not None:
+            delivery = writer.enqueue(json.dumps(versioned_message), acknowledge=True)
+            await cast(asyncio.Future[None], delivery)
+        else:
+            await websocket.send_text(json.dumps(versioned_message))
+
+    async def deliver_shared_event(self, message: dict[str, Any], task_id: int) -> None:
+        encoded = json.dumps(message)
+        for connection in self.connections_for_task(task_id):
+            writer = self._writers.get(connection)
+            if writer is not None:
+                try:
+                    writer.enqueue(encoded)
+                except ConnectionError:
+                    self.disconnect(connection)
+
+    def start_stream_reconciliation(self) -> None:
+        self._stream_reconciler = asyncio.create_task(self._reconcile_streams())
+
+    async def stop_stream_reconciliation(self) -> None:
+        if self._stream_reconciler is not None:
+            self._stream_reconciler.cancel()
+            await asyncio.gather(self._stream_reconciler, return_exceptions=True)
+            self._stream_reconciler = None
+
+    async def _reconcile_streams(self) -> None:
+        from ..services.task_stream_snapshot import load_task_stream_snapshots
+
+        while True:
+            try:
+                task_ids = list(self.active_connections)
+                snapshots = await run_db_io_cancellation_safe(
+                    lambda: load_task_stream_snapshots(task_ids)
+                )
+                for snapshot in snapshots:
+                    await self.deliver_shared_event(snapshot, snapshot["task_id"])
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "Shared stream state reconciliation failed", exc_info=True
+                )
+            await asyncio.sleep(5)
+
+    async def shared_stream_status(self, kind: str) -> None:
+        for task_id in list(self.active_connections):
+            await self.deliver_shared_event({"type": kind, "task_id": task_id}, task_id)
 
     async def broadcast_to_task(self, message: dict, task_id: int) -> None:
+        if get_shared_task_execution_enabled():
+            from ..services.task_event_bridge import get_task_event_bridge
+
+            await get_task_event_bridge().publish(message, task_id)
+            return
         has_connections = self.has_connections_for_task(task_id)
         increment_performance_counter(
             "xagent.websocket.broadcast.calls",
@@ -1449,6 +1383,7 @@ async def handle_chat_message(
 
     try:
         enqueued = await _enqueue_websocket_task_command(
+            websocket=websocket,
             task_id=task_id,
             message_data=message_data,
             kind=TaskCommandKind.MESSAGE,
@@ -1533,7 +1468,7 @@ async def handle_chat_message(
         accepted=True,
     )
     if enqueued.command_id:
-        if enqueued.created:
+        if enqueued.created and not get_shared_task_execution_enabled():
             # Only the ingress that created the durable row owns the origin.
             # A payload-matching duplicate (created=False) - a co-tenant
             # resubmission, one arriving after the creator disconnected, or one
@@ -1556,6 +1491,8 @@ def _enqueue_websocket_task_command_sync(
     kind: TaskCommandKind,
     payload: dict[str, Any],
     allow_missing_task: bool,
+    reply_host_id: str | None = None,
+    reply_origin: str | None = None,
 ) -> EnqueuedTaskCommand | None:
     SessionLocal = get_session_local()
     with SessionLocal() as db:
@@ -1618,6 +1555,11 @@ def _enqueue_websocket_task_command_sync(
                 command_id=command_id,
                 kind=kind,
                 payload=payload,
+                **(
+                    {"reply_host_id": reply_host_id, "reply_origin": reply_origin}
+                    if reply_host_id is not None
+                    else {}
+                ),
             )
         except TaskCommandTaskMissing as exc:
             # The row was deleted after the check above, so route this through
@@ -1638,6 +1580,7 @@ def _enqueue_websocket_task_command_sync(
 
 async def _enqueue_websocket_task_command(
     *,
+    websocket: WebSocket | None = None,
     task_id: int,
     message_data: dict[str, Any],
     kind: TaskCommandKind,
@@ -1673,7 +1616,30 @@ async def _enqueue_websocket_task_command(
         # This remains stable across retries even when an API client omitted
         # or supplied an invalid client_message_id.
         payload["client_message_id"] = resolved_command_id
-    return await asyncio.to_thread(
+    route = {}
+    bridge = None
+    token = None
+    if get_shared_task_execution_enabled():
+        from ..services.task_event_bridge import TaskEventBridge, get_task_event_bridge
+
+        bridge = get_task_event_bridge()
+        if kind == TaskCommandKind.MESSAGE and not bridge.ready.is_set():
+            raise ClientVisibleValidationError(
+                "Task event transport is unavailable; retry after reconnection",
+                error_code=ClientErrorCode.TASK_UNAVAILABLE,
+            )
+        if websocket is not None and bridge.ready.is_set():
+
+            async def reply(message: dict[str, Any]) -> None:
+                if not manager.is_connection_registered(websocket, task_id):
+                    raise ConnectionError("Original task connection is unavailable")
+                await _make_command_reply(websocket)(message)
+
+            token = bridge.register_origin(
+                task_id, resolved_command_id, reply, recipient=websocket
+            )
+            route = {"reply_host_id": bridge.host_id, "reply_origin": token}
+    result = await asyncio.to_thread(
         _enqueue_websocket_task_command_sync,
         task_id=int(task_id),
         actor_user_id=int(user.id),
@@ -1682,7 +1648,11 @@ async def _enqueue_websocket_task_command(
         kind=kind,
         payload=payload,
         allow_missing_task=allow_missing_task,
+        **route,
     )
+    if token is not None and (result is None or not result.created):
+        cast(TaskEventBridge, bridge).discard_origin(token)
+    return result
 
 
 @dataclass(frozen=True)
@@ -2810,6 +2780,7 @@ async def handle_pause_task(
 
     try:
         enqueued = await _enqueue_websocket_task_command(
+            websocket=websocket,
             task_id=task_id,
             message_data=message_data,
             kind=TaskCommandKind.PAUSE,
@@ -2858,7 +2829,7 @@ async def handle_pause_task(
         },
         websocket,
     )
-    if enqueued.created:
+    if enqueued.created and not get_shared_task_execution_enabled():
         # Only the creating ingress owns the origin; a payload-matching
         # duplicate must never bind (see handle_chat_message). Registered
         # before dispatch so local execution cannot outrun the binding.
@@ -2876,6 +2847,7 @@ async def handle_resume_task(
 
     try:
         enqueued = await _enqueue_websocket_task_command(
+            websocket=websocket,
             task_id=task_id,
             message_data=message_data,
             kind=TaskCommandKind.RESUME,
@@ -2924,7 +2896,7 @@ async def handle_resume_task(
         },
         websocket,
     )
-    if enqueued.created:
+    if enqueued.created and not get_shared_task_execution_enabled():
         # Only the creating ingress owns the origin; a payload-matching
         # duplicate must never bind (see handle_chat_message). Registered
         # before dispatch so local execution cannot outrun the binding.

--- a/src/xagent/web/models/__init__.py
+++ b/src/xagent/web/models/__init__.py
@@ -24,6 +24,7 @@ from .task_command import TaskExecutionCommand
 from .task_command_terminal_event import TaskCommandTerminalEvent
 from .task_execution_event import TaskExecutionEvent
 from .task_interaction import TaskInteractionRequest
+from .task_runtime_secret import TaskRuntimeSecret
 from .template_stats import TemplateStats, UserTemplateRelation
 from .tool_config import ToolConfig, ToolUsage
 from .trigger import (
@@ -73,6 +74,7 @@ __all__ = [
     "TaskCommandTerminalEvent",
     "TaskExecutionEvent",
     "TaskInteractionRequest",
+    "TaskRuntimeSecret",
     "TaskConnectorRuntimeContext",
     "DAGExecution",
     "TemplateStats",

--- a/src/xagent/web/models/task_command.py
+++ b/src/xagent/web/models/task_command.py
@@ -50,6 +50,10 @@ class TaskExecutionCommand(Base):  # type: ignore
     kind = Column(String(32), nullable=False)
     payload = Column(JSON, nullable=False)
 
+    # Server-generated route, bound before the command becomes visible.
+    reply_host_id = Column(String(64), nullable=True)
+    reply_origin = Column(String(64), nullable=True)
+
     # The run/worker observed when the command was accepted. Commands aimed at
     # a live run stay with its lease owner; once that lease expires another
     # worker may recover them from the durable inbox.

--- a/src/xagent/web/models/task_runtime_secret.py
+++ b/src/xagent/web/models/task_runtime_secret.py
@@ -1,0 +1,33 @@
+"""Encrypted, single-turn connector values, never part of task serialization."""
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.sql import func
+
+from .database import Base
+
+
+class TaskRuntimeSecret(Base):  # type: ignore
+    __tablename__ = "task_runtime_secrets"
+    __table_args__ = (
+        UniqueConstraint("task_id", "turn_id", name="uq_task_runtime_secret_turn"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    task_id = Column(
+        Integer, ForeignKey("tasks.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    turn_id = Column(String(64), nullable=False)
+    run_id = Column(String(64), nullable=True)
+    owner_subject = Column(String(64), nullable=False)
+    ciphertext = Column(Text, nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -44,7 +44,7 @@ TERMINAL_JOB_STATUSES = frozenset(
 
 def _is_redis_broker_reachable(broker_url: str) -> bool:
     try:
-        import redis  # type: ignore[import-not-found]
+        import redis
     except ImportError:
         logger.warning("Redis Celery broker configured but redis package is missing")
         return False

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -331,6 +331,8 @@ def stage_task_command(
     command_id: str,
     kind: TaskCommandKind,
     payload: dict[str, Any],
+    reply_host_id: str | None = None,
+    reply_origin: str | None = None,
 ) -> StagedTaskCommand:
     """Add an idempotent command row to the session without ending its transaction.
 
@@ -468,6 +470,8 @@ def stage_task_command(
         target_run_id=snapshot.run_id,
         target_state_version=int(snapshot.state_version or 0),
         target_runner_id=active_runner_id,
+        reply_host_id=reply_host_id,
+        reply_origin=reply_origin,
         status=COMMAND_PENDING,
     )
     db.add(command)
@@ -565,6 +569,8 @@ def enqueue_task_command(
     command_id: str,
     kind: TaskCommandKind,
     payload: dict[str, Any],
+    reply_host_id: str | None = None,
+    reply_origin: str | None = None,
 ) -> EnqueuedTaskCommand:
     """Commit an idempotent command and return only after it is durable.
 
@@ -583,6 +589,8 @@ def enqueue_task_command(
             command_id=command_id,
             kind=kind,
             payload=payload,
+            reply_host_id=reply_host_id,
+            reply_origin=reply_origin,
         )
         # Only a newly created row is worth committing, and the commit stays
         # inside this try so that a constraint failure surfacing there rather

--- a/src/xagent/web/services/task_event_bridge.py
+++ b/src/xagent/web/services/task_event_bridge.py
@@ -1,0 +1,411 @@
+"""Redis task fanout and origin-bound replies; database commands remain the queue."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from time import monotonic
+from typing import Any
+from uuid import uuid4
+
+from redis.asyncio import Redis
+from redis.exceptions import RedisError
+
+from ...config import get_redis_url, get_task_event_channel_prefix
+from ..models.database import get_session_local
+from ..models.task_command import TaskExecutionCommand
+from .db_runtime import run_db_io_cancellation_safe
+from .task_events import CommandReply
+
+logger = logging.getLogger(__name__)
+
+EventDelivery = Callable[[dict[str, Any], int], Awaitable[None]]
+StreamStatus = Callable[[str], Awaitable[None]]
+
+
+@dataclass
+class _Origin:
+    task_id: int
+    command_id: str
+    reply: CommandReply
+    recipient: object | None = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    # A command can reply several times. Retain only its recent identities;
+    # entries disappear with the command or socket, and the registry is bounded.
+    delivered: OrderedDict[str, bool] = field(default_factory=OrderedDict)
+
+
+class TaskEventBridge:
+    """One process boot identity; combined hosts use the same Redis path."""
+
+    def __init__(
+        self,
+        *,
+        deliver: EventDelivery | None = None,
+        stream_status: StreamStatus | None = None,
+    ) -> None:
+        self.host_id = uuid4().hex
+        self.prefix = get_task_event_channel_prefix()
+        redis_url = get_redis_url()
+        if not redis_url:
+            raise ValueError("XAGENT_REDIS_URL must be configured for TaskEventBridge")
+        self.redis = Redis.from_url(
+            redis_url,
+            decode_responses=True,
+            socket_connect_timeout=3,
+            health_check_interval=10,
+        )
+        self.deliver = deliver
+        self.stream_status = stream_status
+        self.ready = asyncio.Event()
+        self._reader: asyncio.Task[None] | None = None
+        self._stopping = False
+        self._publish_lock = asyncio.Lock()
+        self._sequence = 0
+        self._seen: OrderedDict[str, int] = OrderedDict()
+        self._origins: OrderedDict[str, _Origin] = OrderedDict()
+        self._acks: dict[str, asyncio.Future[bool]] = {}
+        self._deliveries: set[asyncio.Task[None]] = set()
+        self._last_reply_overflow_warning: float | None = None
+
+    @property
+    def private_channel(self) -> str:
+        return f"{self.prefix}:host:{self.host_id}"
+
+    async def start(self) -> None:
+        self._reader = asyncio.create_task(self._listen())
+        try:
+            await asyncio.wait_for(self.ready.wait(), timeout=10)
+        except BaseException:
+            await self.close()
+            raise
+
+    async def close(self) -> None:
+        self._stopping = True
+        self.ready.clear()
+        if self._reader is not None:
+            self._reader.cancel()
+            await asyncio.gather(self._reader, return_exceptions=True)
+        for pending in self._deliveries:
+            pending.cancel()
+        await asyncio.gather(*self._deliveries, return_exceptions=True)
+        for future in self._acks.values():
+            if not future.done():
+                future.cancel()
+        self._origins.clear()
+        await self.redis.aclose()
+
+    def require_ready(self) -> None:
+        if not self.ready.is_set():
+            raise ConnectionError(
+                "Task event transport is unavailable; retry after reconnection"
+            )
+
+    def register_origin(
+        self,
+        task_id: int,
+        command_id: str,
+        reply: CommandReply,
+        *,
+        recipient: object | None = None,
+    ) -> str:
+        self.require_ready()
+        token = uuid4().hex
+        self._origins[token] = _Origin(task_id, command_id, reply, recipient)
+        while len(self._origins) > 4096:
+            self._origins.popitem(last=False)
+        return token
+
+    def discard_origin(self, token: str) -> None:
+        self._origins.pop(token, None)
+
+    def discard_recipient(self, recipient: object) -> None:
+        for token in [
+            token
+            for token, origin in self._origins.items()
+            if origin.recipient is recipient
+        ]:
+            self.discard_origin(token)
+
+    async def _publish(self, channel: str, body: str) -> None:
+        await asyncio.wait_for(self.redis.publish(channel, body), timeout=3)
+
+    async def _status(self, kind: str) -> None:
+        if self.stream_status is not None:
+            await self.stream_status(kind)
+
+    async def publish(self, message: dict[str, Any], task_id: int) -> None:
+        from .task_event_state import _with_current_task_control_state
+
+        # Enrich at the producer, before transport. Receivers never assign a
+        # newer run to an old frame. Sequence numbers also advance on failure.
+        async with self._publish_lock:
+            self._sequence += 1
+            try:
+                message = await _with_current_task_control_state(
+                    message, fallback_task_id=task_id
+                )
+                from .task_lease_service import current_task_lease
+
+                lease = current_task_lease()
+                message = dict(message)
+                message["transport_event_id"] = f"{self.host_id}:{self._sequence}"
+                if lease is not None and lease.task_id == task_id:
+                    message["stream_run_id"] = lease.run_id
+                    message["stream_attempt_id"] = lease.attempt_id
+                envelope = {
+                    "version": 1,
+                    "kind": "event",
+                    "host": self.host_id,
+                    "sequence": self._sequence,
+                    "task_id": task_id,
+                    "message": message,
+                }
+                await self._publish(f"{self.prefix}:events", json.dumps(envelope))
+            except Exception:
+                # Publication is observational. Even snapshot/serialization
+                # failures must not abort an accepted execution. The sequence
+                # gap and persistent-state checks trigger client recovery.
+                logger.warning(
+                    "Task event publication failed task_id=%s; stream requires resync",
+                    task_id,
+                    exc_info=True,
+                )
+
+    async def _listen(self) -> None:
+        channels = [self.private_channel]
+        if self.deliver is not None:
+            channels.append(f"{self.prefix}:events")
+        while not self._stopping:
+            try:
+                async with self.redis.pubsub() as pubsub:
+                    await pubsub.subscribe(*channels)
+                    subscribed: set[str] = set()
+                    async for frame in pubsub.listen():
+                        if frame["type"] == "subscribe":
+                            subscribed.add(frame["channel"])
+                            if len(subscribed) == len(channels):
+                                self.ready.set()
+                                await self._status("stream_resync_required")
+                            continue
+                        if frame["type"] != "message":
+                            continue
+                        try:
+                            body = json.loads(frame["data"])
+                            await self._receive(body)
+                        except (ValueError, TypeError, KeyError):
+                            logger.warning("Invalid task event bridge envelope")
+            except asyncio.CancelledError:
+                raise
+            except (TimeoutError, RedisError, OSError):
+                logger.warning("Task event subscription interrupted; reconnecting")
+            finally:
+                self.ready.clear()
+            await self._status("stream_unavailable")
+            await asyncio.sleep(1)
+
+    async def _receive(self, body: dict[str, Any]) -> None:
+        if body.get("version") != 1:
+            raise ValueError("Unsupported envelope")
+        kind = body["kind"]
+        if kind == "event" and self.deliver is not None:
+            host, sequence = body["host"], body["sequence"]
+            previous = self._seen.get(host)
+            if previous is not None and sequence <= previous:
+                return
+            if previous is not None and sequence != previous + 1:
+                await self._status("stream_resync_required")
+            self._seen[host] = sequence
+            self._seen.move_to_end(host)
+            while len(self._seen) > 4096:
+                self._seen.popitem(last=False)
+            await self.deliver(body["message"], body["task_id"])
+        elif kind == "ack":
+            future = self._acks.get(body["delivery_id"])
+            if future is not None and not future.done():
+                future.set_result(body["delivered"] is True)
+        elif kind == "reply":
+            # Never wait for a socket in the Redis reader. Its bounded writer
+            # queue preserves socket ordering while the reader accepts ACKs.
+            if len(self._deliveries) >= 4096:
+                now = monotonic()
+                # Bound log volume while the receiver remains overloaded.
+                if (
+                    self._last_reply_overflow_warning is None
+                    or now - self._last_reply_overflow_warning >= 60
+                ):
+                    logger.warning(
+                        "Task reply delivery dropped: pending deliveries queue is full (size=%s)",
+                        len(self._deliveries),
+                    )
+                    self._last_reply_overflow_warning = now
+                return  # sender records delivery unknown, never re-execution
+            pending = asyncio.create_task(self._deliver_reply(body))
+            self._deliveries.add(pending)
+            pending.add_done_callback(self._deliveries.discard)
+        elif kind == "cleanup":
+            origin = self._origins.get(body["origin"])
+            if origin is not None and (origin.task_id, origin.command_id) == (
+                body["task_id"],
+                body["command_id"],
+            ):
+                self.discard_origin(body["origin"])
+
+    async def _deliver_reply(self, body: dict[str, Any]) -> None:
+        origin = self._origins.get(body["origin"])
+        delivered = False
+        if origin is not None and (origin.task_id, origin.command_id) == (
+            body["task_id"],
+            body["command_id"],
+        ):
+            async with origin.lock:
+                delivery_id = body["delivery_id"]
+                if delivery_id in origin.delivered:
+                    delivered = origin.delivered[delivery_id]
+                else:
+                    try:
+                        await origin.reply(body["message"])
+                        delivered = True
+                    except ConnectionError:
+                        pass
+                    origin.delivered[delivery_id] = delivered
+                    while len(origin.delivered) > 128:
+                        origin.delivered.popitem(last=False)
+        try:
+            await self._publish(
+                f"{self.prefix}:host:{body['reply_host']}",
+                json.dumps(
+                    {
+                        "version": 1,
+                        "kind": "ack",
+                        "delivery_id": body["delivery_id"],
+                        "delivered": delivered,
+                    }
+                ),
+            )
+        except (TimeoutError, RedisError, OSError):
+            logger.warning("Task reply ACK could not be published")
+
+    def reply_for(self, command_id: str, task_id: int) -> CommandReply:
+        async def reply(message: dict[str, Any]) -> None:
+            route = await run_db_io_cancellation_safe(
+                lambda: _reply_route(task_id, command_id)
+            )
+            if route is None:
+                return
+            host_id, origin = route
+            delivery_id = uuid4().hex
+            future = asyncio.get_running_loop().create_future()
+            self._acks[delivery_id] = future
+            try:
+                await self._publish(
+                    f"{self.prefix}:host:{host_id}",
+                    json.dumps(
+                        {
+                            "version": 1,
+                            "kind": "reply",
+                            "task_id": task_id,
+                            "command_id": command_id,
+                            "origin": origin,
+                            "delivery_id": delivery_id,
+                            "reply_host": self.host_id,
+                            "message": message,
+                        }
+                    ),
+                )
+                delivered = await asyncio.wait_for(future, timeout=5)
+            except (TimeoutError, RedisError, OSError):
+                # A send may have completed and its ACK been lost. This is a
+                # transport outcome, never a reason to retry Agent execution.
+                logger.warning(
+                    "Task reply delivery unknown task_id=%s command_id=%s delivery_id=%s",
+                    task_id,
+                    command_id,
+                    delivery_id,
+                )
+                return
+            finally:
+                self._acks.pop(delivery_id, None)
+            if not delivered:
+                raise ConnectionError("Original task command connection is unavailable")
+
+        return reply
+
+    def discard_command(self, command_id: str, task_id: int) -> None:
+        async def cleanup() -> None:
+            route = await run_db_io_cancellation_safe(
+                lambda: _reply_route(task_id, command_id)
+            )
+            if route is None:
+                return
+            host, origin = route
+            try:
+                await self._publish(
+                    f"{self.prefix}:host:{host}",
+                    json.dumps(
+                        {
+                            "version": 1,
+                            "kind": "cleanup",
+                            "task_id": task_id,
+                            "command_id": command_id,
+                            "origin": origin,
+                        }
+                    ),
+                )
+            except (TimeoutError, RedisError, OSError):
+                logger.warning("Task origin cleanup deferred to registry eviction")
+
+        pending = asyncio.create_task(cleanup())
+        self._deliveries.add(pending)
+        pending.add_done_callback(self._deliveries.discard)
+
+
+def _reply_route(task_id: int, command_id: str) -> tuple[str, str] | None:
+    with get_session_local()() as db:
+        row = (
+            db.query(
+                TaskExecutionCommand.reply_host_id, TaskExecutionCommand.reply_origin
+            )
+            .filter(
+                TaskExecutionCommand.task_id == task_id,
+                TaskExecutionCommand.command_id == command_id,
+            )
+            .first()
+        )
+        if row is None or row.reply_host_id is None or row.reply_origin is None:
+            return None
+        return row.reply_host_id, row.reply_origin
+
+
+_bridge: TaskEventBridge | None = None
+
+
+def get_task_event_bridge() -> TaskEventBridge:
+    if _bridge is None:
+        raise ConnectionError("Task event bridge has not started")
+    return _bridge
+
+
+async def start_task_event_bridge(
+    *, deliver: EventDelivery | None = None, stream_status: StreamStatus | None = None
+) -> TaskEventBridge:
+    global _bridge
+    from .task_events import set_task_command_delivery, set_task_event_sink
+
+    bridge = TaskEventBridge(deliver=deliver, stream_status=stream_status)
+    await bridge.start()
+    _bridge = bridge
+    set_task_event_sink(bridge.publish)
+    set_task_command_delivery(bridge)
+    return bridge
+
+
+async def stop_task_event_bridge() -> None:
+    global _bridge
+    if _bridge is not None:
+        await _bridge.close()
+        _bridge = None

--- a/src/xagent/web/services/task_event_state.py
+++ b/src/xagent/web/services/task_event_state.py
@@ -1,0 +1,149 @@
+"""Capture task control identity before crossing an event transport."""
+
+from copy import deepcopy
+from typing import Any
+
+from .task_execution_controller import task_execution_controller
+
+_VERSIONED_TASK_EVENT_TYPES = {
+    "agent_error",
+    "error",
+    "task_completed",
+    "task_error",
+    "task_pause_requested",
+    "task_paused",
+    "task_resumed",
+    "task_started",
+    "task_waiting_for_user",
+}
+
+
+def _is_versioned_task_event(message: dict[str, Any]) -> bool:
+    message_type = str(message.get("type") or "")
+    if message_type in _VERSIONED_TASK_EVENT_TYPES:
+        return True
+    return (
+        message_type == "trace_event"
+        and str(
+            message.get("event_type")
+            or (
+                message.get("data", {}).get("event_type")
+                if isinstance(message.get("data"), dict)
+                else ""
+            )
+        )
+        == "task_info"
+    )
+
+
+def _event_task_id(message: dict[str, Any]) -> int | None:
+    candidates = [message.get("task_id")]
+    task_data = message.get("task")
+    if isinstance(task_data, dict):
+        candidates.append(task_data.get("id"))
+        candidates.append(task_data.get("task_id"))
+    data = message.get("data")
+    if isinstance(data, dict):
+        candidates.append(data.get("id"))
+        candidates.append(data.get("task_id"))
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            return int(candidate)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _event_task_control_state(message: dict[str, Any]) -> dict[str, Any] | None:
+    sources = [message]
+    task_data = message.get("task")
+    if isinstance(task_data, dict):
+        sources.append(task_data)
+    data = message.get("data")
+    if isinstance(data, dict):
+        sources.append(data)
+
+    for source in sources:
+        version = source.get("state_version")
+        control_state = source.get("control_state")
+        status = source.get("status")
+        if (
+            isinstance(version, int)
+            and not isinstance(version, bool)
+            and version >= 0
+            and isinstance(control_state, str)
+            and isinstance(status, str)
+            and (isinstance(source.get("run_id"), str) or source.get("run_id") is None)
+        ):
+            return {
+                "run_id": source.get("run_id"),
+                "state_version": version,
+                "control_state": control_state,
+                "status": status,
+            }
+    return None
+
+
+def _with_task_control_state_snapshot(
+    message: dict[str, Any],
+    *,
+    task_id: int,
+    state: dict[str, Any],
+) -> dict[str, Any]:
+    """Attach one already-loaded control-state tuple without database I/O."""
+
+    if not _is_versioned_task_event(message):
+        return deepcopy(message)
+    resolved_state = _event_task_control_state(message) or state
+    enriched = deepcopy(message)
+    enriched.update(resolved_state)
+    enriched["task_id"] = task_id
+
+    if enriched.get("type") == "trace_event":
+        data = enriched.get("data")
+        enriched["data"] = {
+            **(data if isinstance(data, dict) else {}),
+            **resolved_state,
+        }
+
+    task_data = enriched.get("task")
+    if isinstance(task_data, dict):
+        enriched["task"] = {
+            **task_data,
+            **resolved_state,
+            "id": task_id,
+        }
+    return enriched
+
+
+async def _with_current_task_control_state(
+    message: dict[str, Any],
+    *,
+    fallback_task_id: int | None = None,
+) -> dict[str, Any]:
+    """Attach one canonical DB state tuple to a state-bearing event.
+
+    Event producers can finish out of order. Preserve a producer-captured
+    state tuple when present; otherwise attach the current row snapshot.
+    Clients compare the resulting ``run_id`` / ``state_version`` before
+    applying the event.
+    """
+
+    if not _is_versioned_task_event(message):
+        return message
+    task_id = _event_task_id(message) or fallback_task_id
+    if task_id is None:
+        return message
+    state = _event_task_control_state(message)
+    if state is None:
+        snapshot = await task_execution_controller.snapshot(task_id)
+        if snapshot is None:
+            return message
+        state = snapshot.as_dict()
+    return _with_task_control_state_snapshot(
+        message,
+        task_id=task_id,
+        state=state,
+    )

--- a/src/xagent/web/services/task_execution.py
+++ b/src/xagent/web/services/task_execution.py
@@ -1666,6 +1666,16 @@ def _finalize_task_execution_result_isolated(
                         is_failure=task_updated.status == TaskStatus.FAILED,
                     )
                 )
+                # Shared readers may observe completion before scheduler
+                # cleanup runs. Publish its durable output in this same
+                # fenced transaction as the terminal state and transcript.
+                setattr(
+                    task_updated,
+                    "output",
+                    history_content
+                    if task_updated.status == TaskStatus.COMPLETED
+                    else None,
+                )
                 persist_assistant_message_no_commit(
                     finalize_db,
                     task_id=task_id,

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -48,7 +48,7 @@ import asyncio
 import enum
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
@@ -697,12 +697,7 @@ class TaskTurnOrchestrator:
 
 
 @dataclass(frozen=True)
-class _ClaimedTurn:
-    """Snapshot returned by ``_begin_turn_atomic_sync`` after the claim
-    commits, so ``begin_turn`` can build :class:`TurnStarted` without the
-    caller re-reading the ORM."""
-
-    task_lease: TaskLease
+class _AcceptedTurn:
     status: TaskStatus
     updated_at: Optional[datetime]
     before_message_id: Optional[int]
@@ -711,6 +706,11 @@ class _ClaimedTurn:
     state_version: int = 0
     control_state: str = TaskControlState.RUNNING.value
     agent_config: Optional[dict[str, Any]] = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class _ClaimedTurn(_AcceptedTurn):
+    task_lease: TaskLease
 
 
 async def _schedule_committed_turn(
@@ -966,15 +966,14 @@ def _turn_started_snapshot(
     )
 
 
-def _persist_claimed_turn_no_commit(
+def _persist_accepted_turn_no_commit(
     db: Session,
     *,
     task_id: int,
     task_owner_user_id: int,
     payload: TaskTurnPayload,
-    task_lease: TaskLease,
-) -> _ClaimedTurn:
-    """Persist the first message and snapshot one already-claimed turn."""
+) -> _AcceptedTurn:
+    """Persist the first message and snapshot one accepted turn."""
 
     from .chat_history_service import persist_user_message_no_commit
 
@@ -1014,8 +1013,7 @@ def _persist_claimed_turn_no_commit(
         .filter(Task.id == task_id)
         .one()
     )
-    return _ClaimedTurn(
-        task_lease=task_lease,
+    return _AcceptedTurn(
         status=status,
         updated_at=updated_at,
         before_message_id=before_message_id,
@@ -1064,15 +1062,15 @@ def _task_requires_actor_policy_sync(
         return _task_requires_actor_policy(db, task_id, task_owner_user_id)
 
 
-def _claim_turn_no_commit(
+def _accept_turn_no_commit(
     db: Session,
     task_id: int,
     task_owner_user_id: int,
     *,
     payload: TaskTurnPayload,
     kind: TurnKind,
-) -> _ClaimedTurn:
-    """Stage one atomic turn claim; the caller owns commit and rollback."""
+) -> _AcceptedTurn:
+    """Stage turn acceptance without a lease; the caller owns the transaction."""
 
     if kind == TurnKind.APPEND and _task_requires_actor_policy(
         db,
@@ -1125,22 +1123,11 @@ def _claim_turn_no_commit(
             raise TaskTurnError("interaction_response_required")
         raise TaskTurnError("busy")
 
-    task_lease = acquire_task_lease_no_commit(
-        db,
-        task_id,
-        expected_run_id=run_id,
-    )
-    if task_lease is None:
-        raise RuntimeError(
-            f"task {task_id} claim could not stage its exact execution lease"
-        )
-
-    result = _persist_claimed_turn_no_commit(
+    result = _persist_accepted_turn_no_commit(
         db,
         task_id=task_id,
         task_owner_user_id=task_owner_user_id,
         payload=payload,
-        task_lease=task_lease,
     )
     missing_bindings = bind_turn_files_no_commit(
         file_ids=list(payload.file_ids),
@@ -1172,7 +1159,7 @@ def _claim_turn_no_commit(
         except WorkforceTurnRejectedError as exc:
             raise TaskTurnError(exc.reason) from exc
         # Keep the WorkforceRun projection in the same transaction as the
-        # Task RUNNING claim and exact prelease. A later best-effort worker can
+        # Task RUNNING acceptance. A later best-effort worker can
         # otherwise arrive after completion and resurrect the projection.
         from .workforce_runtime import sync_workforce_run_status
 
@@ -1181,14 +1168,29 @@ def _claim_turn_no_commit(
             .filter(
                 Task.id == task_id,
                 Task.status == TaskStatus.RUNNING,
-                Task.runner_id == task_lease.runner_id,
-                task_lease_attempt_predicate(task_lease),
-                Task.run_id == task_lease.run_id,
+                Task.run_id == run_id,
             )
             .one()
         )
         sync_workforce_run_status(db, claimed_task, TaskStatus.RUNNING)
     return result
+
+
+def _claim_turn_no_commit(
+    db: Session,
+    task_id: int,
+    task_owner_user_id: int,
+    *,
+    payload: TaskTurnPayload,
+    kind: TurnKind,
+) -> _ClaimedTurn:
+    accepted = _accept_turn_no_commit(
+        db, task_id, task_owner_user_id, payload=payload, kind=kind
+    )
+    lease = acquire_task_lease_no_commit(db, task_id, expected_run_id=accepted.run_id)
+    if lease is None:
+        raise RuntimeError(f"task {task_id} could not stage its exact execution lease")
+    return _ClaimedTurn(**asdict(accepted), task_lease=lease)
 
 
 def _begin_turn_atomic_sync(

--- a/src/xagent/web/services/task_runtime_secrets.py
+++ b/src/xagent/web/services/task_runtime_secrets.py
@@ -1,0 +1,176 @@
+"""Single-turn encrypted storage shared by request and execution processes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+from cryptography.fernet import InvalidToken
+from sqlalchemy import delete, select, update
+from sqlalchemy.engine import CursorResult
+from sqlalchemy.orm import Session
+
+from ...core.tools.adapters.vibe.connector_runtime import (
+    ERROR_RUNTIME_SECRET_UNAVAILABLE,
+    RUNTIME_SECRET_REASON_STORE_LOST,
+    ConnectorRef,
+    ConnectorRuntimeError,
+)
+from ...core.utils.encryption import get_cipher
+from ..models.database import get_session_local
+from ..models.task import Task, TaskStatus
+from ..models.task_runtime_secret import TaskRuntimeSecret
+from ..models.user import User
+
+
+def _unavailable() -> ConnectorRuntimeError:
+    return ConnectorRuntimeError(
+        ERROR_RUNTIME_SECRET_UNAVAILABLE,
+        "Connector runtime values are unavailable.",
+        details={"reason": RUNTIME_SECRET_REASON_STORE_LOST},
+        status_code=503,
+    )
+
+
+def stage_runtime_values(
+    db: Session,
+    *,
+    task_id: int,
+    turn_id: str,
+    values_by_ref: dict[ConnectorRef, dict[str, dict[str, Any]]],
+) -> None:
+    """Stage encrypted inputs in the caller's acceptance transaction.
+
+    Bind them to the accepted run with ``bind_runtime_values_to_run`` before
+    committing this same transaction. Unbound inputs must not be committed.
+    """
+    if not values_by_ref:
+        return
+    owner_subject = db.execute(
+        select(User.actor_subject)
+        .join(Task, Task.user_id == User.id)
+        .where(Task.id == task_id)
+    ).scalar_one()
+    body = {
+        "task_id": task_id,
+        "turn_id": turn_id,
+        "owner_subject": owner_subject,
+        "values": {ref.storage_key: values for ref, values in values_by_ref.items()},
+    }
+    ciphertext = (
+        get_cipher().encrypt(json.dumps(body, allow_nan=False).encode()).decode()
+    )
+    db.add(
+        TaskRuntimeSecret(
+            task_id=task_id,
+            turn_id=turn_id,
+            owner_subject=owner_subject,
+            ciphertext=ciphertext,
+        )
+    )
+    db.flush()
+
+
+def bind_runtime_values_to_run(
+    db: Session, *, task_id: int, turn_id: str, run_id: str
+) -> bool:
+    result = db.execute(
+        update(TaskRuntimeSecret)
+        .where(
+            TaskRuntimeSecret.task_id == task_id, TaskRuntimeSecret.turn_id == turn_id
+        )
+        .values(run_id=run_id)
+    )
+    return cast(CursorResult, result).rowcount == 1
+
+
+def load_runtime_values(
+    db: Session,
+    *,
+    task: Task,
+    turn_id: str,
+    required: bool = False,
+) -> dict[str, Any] | None:
+    row = db.execute(
+        select(TaskRuntimeSecret).where(
+            TaskRuntimeSecret.task_id == task.id,
+            TaskRuntimeSecret.turn_id == turn_id,
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        if required:
+            raise _unavailable()
+        return None
+    owner = db.execute(
+        select(User.actor_subject).where(User.id == task.user_id)
+    ).scalar_one_or_none()
+    if owner != row.owner_subject or row.run_id != task.run_id:
+        raise _unavailable()
+    try:
+        body = json.loads(get_cipher().decrypt(row.ciphertext.encode()))
+    except (InvalidToken, ValueError, UnicodeError):
+        raise _unavailable() from None
+    if (
+        not isinstance(body, dict)
+        or body.get("task_id") != task.id
+        or body.get("turn_id") != turn_id
+        or body.get("owner_subject") != owner
+        or not isinstance(body.get("values"), dict)
+    ):
+        raise _unavailable()
+    return cast(dict[str, Any], body["values"])
+
+
+def delete_runtime_values_no_commit(
+    db: Session,
+    *,
+    task_id: int,
+    turn_id: str | None = None,
+    run_id: str | None = None,
+) -> None:
+    statement = delete(TaskRuntimeSecret).where(TaskRuntimeSecret.task_id == task_id)
+    if turn_id is not None:
+        statement = statement.where(TaskRuntimeSecret.turn_id == turn_id)
+    if run_id is not None:
+        statement = statement.where(TaskRuntimeSecret.run_id == run_id)
+    db.execute(statement)
+
+
+def delete_runtime_values(*, task_id: int, turn_id: str) -> None:
+    with get_session_local()() as db:
+        delete_runtime_values_no_commit(db, task_id=task_id, turn_id=turn_id)
+        db.commit()
+
+
+def clean_finished_runtime_values() -> None:
+    """Compensate interrupted cleanup without expiring queued or active inputs.
+
+    Accepted inputs already have a run binding at commit; another session
+    cannot observe the intermediate unbound rows in the acceptance transaction.
+    """
+    with get_session_local()() as db:
+        rows = (
+            db.execute(
+                select(TaskRuntimeSecret.id)
+                .join(Task)
+                .where(
+                    (TaskRuntimeSecret.run_id.is_distinct_from(Task.run_id))
+                    | (
+                        Task.runner_id.is_(None)
+                        & Task.status.in_(
+                            [
+                                TaskStatus.COMPLETED,
+                                TaskStatus.FAILED,
+                                TaskStatus.PAUSED,
+                                TaskStatus.WAITING_FOR_USER,
+                            ]
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if rows:
+            db.execute(delete(TaskRuntimeSecret).where(TaskRuntimeSecret.id.in_(rows)))
+        db.commit()

--- a/src/xagent/web/services/task_socket_writer.py
+++ b/src/xagent/web/services/task_socket_writer.py
@@ -1,0 +1,73 @@
+"""Bounded, ordered writes for a single shared-mode WebSocket."""
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+
+class TaskSocketWriter:
+    def __init__(self, socket: Any, disconnect: Callable[[], None]) -> None:
+        self.socket = socket
+        self.disconnect = disconnect
+        self.queue: asyncio.Queue[tuple[str, asyncio.Future[None] | None]] = (
+            asyncio.Queue(maxsize=256)
+        )
+        self.bytes = 0
+        self.closed = False
+        self.task = asyncio.create_task(self._run())
+
+    def enqueue(
+        self, text: str, *, acknowledge: bool = False
+    ) -> asyncio.Future[None] | None:
+        if self.closed:
+            raise ConnectionError("Task connection is closed")
+        if self.queue.full() or self.bytes + len(text.encode()) > 2 * 1024 * 1024:
+            self.stop()
+            self.disconnect()
+            asyncio.create_task(self._close_socket())
+            raise ConnectionError(
+                "Task connection is too slow; reconnect to synchronize"
+            )
+        future = asyncio.get_running_loop().create_future() if acknowledge else None
+        self.bytes += len(text.encode())
+        self.queue.put_nowait((text, future))
+        return future
+
+    async def _close_socket(self) -> None:
+        try:
+            await asyncio.wait_for(self.socket.close(code=1013), timeout=2)
+        except Exception:
+            pass
+
+    def stop(self) -> None:
+        self.closed = True
+        if self.task is not asyncio.current_task():
+            self.task.cancel()
+        while not self.queue.empty():
+            _, future = self.queue.get_nowait()
+            if future is not None and not future.done():
+                future.set_exception(ConnectionError("Task connection is closed"))
+        self.bytes = 0
+
+    async def _run(self) -> None:
+        pending = None
+        send_failed = False
+        try:
+            while True:
+                text, pending = await self.queue.get()
+                self.bytes -= len(text.encode())
+                await asyncio.wait_for(self.socket.send_text(text), timeout=5)
+                if pending is not None and not pending.done():
+                    pending.set_result(None)
+                pending = None
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            send_failed = True
+        finally:
+            if pending is not None and not pending.done():
+                pending.set_exception(ConnectionError("Task connection send failed"))
+            self.stop()
+            self.disconnect()
+            if send_failed:
+                await self._close_socket()

--- a/src/xagent/web/services/task_stream_snapshot.py
+++ b/src/xagent/web/services/task_stream_snapshot.py
@@ -1,0 +1,35 @@
+"""Read-only reconciliation for lossy shared event streams."""
+
+from typing import Any
+
+from ..models.database import get_session_local
+from ..models.task import Task
+from .task_execution_controller import task_control_snapshot
+
+
+def load_task_stream_snapshots(task_ids: list[int]) -> list[dict[str, Any]]:
+    """Capture identity and persisted output from the same task row read.
+
+    Callers supply only task IDs with an already-authorized local audience.
+    There is no token replay: output is the completed turn's durable text.
+    """
+    if not task_ids:
+        return []
+    with get_session_local()() as db:
+        snapshots = []
+        for task in db.query(Task).filter(Task.id.in_(task_ids)).all():
+            snapshot = {
+                "type": "task_stream_snapshot",
+                "task_id": int(task.id),
+                **task_control_snapshot(task).as_dict(),
+                "output": task.output if task.status.value == "completed" else None,
+                "lease_attempt_id": task.lease_attempt_id,
+            }
+            if task.status.value == "waiting_for_user":
+                from .task_interaction_read import get_pending_interaction_question
+
+                question, interactions = get_pending_interaction_question(db, task)
+                snapshot["question"] = question
+                snapshot["interactions"] = interactions
+            snapshots.append(snapshot)
+        return snapshots

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -2863,3 +2863,27 @@ def test_toby_personal_stdio_explicit_opt_in(monkeypatch, value):
     monkeypatch.setenv(config.TOBY_PERSONAL_STDIO_ENABLED, value)
 
     assert config.get_toby_personal_stdio_enabled() is True
+
+
+@pytest.mark.parametrize(
+    "value,expected", [(None, False), ("true", True), ("false", False)]
+)
+def test_shared_task_execution_is_dormant_by_default(monkeypatch, value, expected):
+    monkeypatch.delenv(config.SHARED_TASK_EXECUTION_ENABLED, raising=False)
+    if value is not None:
+        monkeypatch.setenv(config.SHARED_TASK_EXECUTION_ENABLED, value)
+    assert config.get_shared_task_execution_enabled() is expected
+
+
+@pytest.mark.parametrize("value", ["", " ", "deployment/channel"])
+def test_task_event_channel_prefix_rejects_invalid_namespace(monkeypatch, value):
+    monkeypatch.setenv(config.TASK_EVENT_CHANNEL_PREFIX, value)
+    with pytest.raises(ValueError, match="channel prefix"):
+        config.get_task_event_channel_prefix()
+
+
+def test_task_event_channel_prefix_default_and_override(monkeypatch):
+    monkeypatch.delenv(config.TASK_EVENT_CHANNEL_PREFIX, raising=False)
+    assert config.get_task_event_channel_prefix() == "xagent:task-events:v1"
+    monkeypatch.setenv(config.TASK_EVENT_CHANNEL_PREFIX, "xagent:staging:v1")
+    assert config.get_task_event_channel_prefix() == "xagent:staging:v1"

--- a/tests/migrations/test_shared_execution_foundations.py
+++ b/tests/migrations/test_shared_execution_foundations.py
@@ -1,0 +1,105 @@
+"""Shared input and reply-route migration is independently reversible."""
+
+from pathlib import Path
+
+import pytest
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, inspect, text
+
+from tests.shared.postgres_disposable import (
+    disposable_database_factory,
+    load_migration_module,
+)
+
+
+@pytest.fixture(
+    params=["sqlite", pytest.param("postgresql", marks=pytest.mark.postgresql)]
+)
+def migration_engine(request, tmp_path):
+    if request.param == "postgresql":
+        with disposable_database_factory("shared_foundations") as make_database:
+            yield make_database("migration")
+    else:
+        engine = create_engine(f"sqlite:///{tmp_path / 'migration.db'}")
+        try:
+            yield engine
+        finally:
+            engine.dispose()
+
+
+def test_shared_execution_migration_round_trip(migration_engine):
+    migration = load_migration_module(
+        Path("src/xagent/migrations/versions/20260912_shared_task_execution.py")
+    )
+    with migration_engine.begin() as connection:
+        connection.execute(text("CREATE TABLE tasks (id INTEGER PRIMARY KEY)"))
+        connection.execute(
+            text("CREATE TABLE task_execution_commands (id INTEGER PRIMARY KEY)")
+        )
+        connection.execute(text("INSERT INTO task_execution_commands (id) VALUES (1)"))
+        with Operations.context(MigrationContext.configure(connection)):
+            migration.upgrade()
+            migration.upgrade()
+        inspector = inspect(connection)
+        columns = {
+            column["name"]
+            for column in inspector.get_columns("task_execution_commands")
+        }
+        assert {"reply_host_id", "reply_origin"} <= columns
+        assert connection.execute(
+            text(
+                "SELECT reply_host_id, reply_origin FROM task_execution_commands WHERE id = 1"
+            )
+        ).one() == (None, None)
+        assert (
+            inspector.get_foreign_keys("task_runtime_secrets")[0]["options"]["ondelete"]
+            == "CASCADE"
+        )
+        assert any(
+            constraint["column_names"] == ["task_id", "turn_id"]
+            for constraint in inspector.get_unique_constraints("task_runtime_secrets")
+        )
+        with Operations.context(MigrationContext.configure(connection)):
+            migration.downgrade()
+            migration.downgrade()
+        assert not inspect(connection).has_table("task_runtime_secrets")
+        assert {
+            column["name"]
+            for column in inspect(connection).get_columns("task_execution_commands")
+        } == {"id"}
+        assert (
+            connection.execute(
+                text("SELECT id FROM task_execution_commands")
+            ).scalar_one()
+            == 1
+        )
+
+
+@pytest.mark.parametrize("parent_table", [None, "tasks", "task_execution_commands"])
+def test_migration_tolerates_absent_metadata_tables(migration_engine, parent_table):
+    migration = load_migration_module(
+        Path("src/xagent/migrations/versions/20260912_shared_task_execution.py")
+    )
+    with migration_engine.begin() as connection:
+        if parent_table == "tasks":
+            connection.execute(text("CREATE TABLE tasks (id INTEGER PRIMARY KEY)"))
+        elif parent_table == "task_execution_commands":
+            connection.execute(
+                text("CREATE TABLE task_execution_commands (id INTEGER PRIMARY KEY)")
+            )
+        original_tables = set(inspect(connection).get_table_names())
+        with Operations.context(MigrationContext.configure(connection)):
+            migration.upgrade()
+            migration.upgrade()
+        assert inspect(connection).has_table("task_runtime_secrets") == (
+            parent_table == "tasks"
+        )
+        if parent_table == "task_execution_commands":
+            assert {
+                col["name"] for col in inspect(connection).get_columns(parent_table)
+            } == {"id", "reply_host_id", "reply_origin"}
+        with Operations.context(MigrationContext.configure(connection)):
+            migration.downgrade()
+            migration.downgrade()
+        assert set(inspect(connection).get_table_names()) == original_tables

--- a/tests/web/api/test_task_output_storage_boundary.py
+++ b/tests/web/api/test_task_output_storage_boundary.py
@@ -303,6 +303,7 @@ async def test_output_staging_holds_no_pool_slot_or_task_lock(
         assert not finalized.late_result
         check_db = _direct_db_session()
         try:
+            assert check_db.get(Task, task_id).output == "done"
             assert (
                 check_db.query(UploadedFile)
                 .filter(UploadedFile.task_id == task_id)

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -2993,3 +2993,30 @@ def test_defer_budget_is_coupled_to_the_lease_ttl(
     # An invalid value falls back to the default TTL, not the floor.
     monkeypatch.setenv("XAGENT_TASK_LEASE_TTL_SECONDS", "not-a-number")
     assert max_command_defers() == 120
+
+
+def test_duplicate_command_cannot_replace_persisted_reply_origin(db_session):
+    user, task = _create_running_task(db_session)
+    arguments = dict(
+        task_id=int(task.id),
+        actor_user_id=int(user.id),
+        command_id="routed-pause",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+    )
+    original = enqueue_task_command(
+        db_session, **arguments, reply_host_id="web-a", reply_origin="socket-a"
+    )
+    duplicate = enqueue_task_command(
+        db_session, **arguments, reply_host_id="web-b", reply_origin="socket-b"
+    )
+    assert original.created
+    assert not duplicate.created
+    assert duplicate.payload_matches
+    db_session.expire_all()
+    row = (
+        db_session.query(TaskExecutionCommand)
+        .filter_by(command_id="routed-pause")
+        .one()
+    )
+    assert (row.reply_host_id, row.reply_origin) == ("web-a", "socket-a")

--- a/tests/web/services/test_task_event_bridge.py
+++ b/tests/web/services/test_task_event_bridge.py
@@ -1,0 +1,332 @@
+"""Cross-host routing, socket ACK semantics, and bounded fanout."""
+
+import asyncio
+import json
+import os
+from uuid import uuid4
+
+import pytest
+
+from xagent.web.services import task_event_bridge as module
+from xagent.web.services.task_socket_writer import TaskSocketWriter
+
+
+@pytest.fixture
+def bridge(monkeypatch):
+    monkeypatch.setenv("XAGENT_REDIS_URL", "redis://localhost:6379/0")
+    return module.TaskEventBridge()
+
+
+@pytest.mark.asyncio
+async def test_public_event_dedup_and_sequence_gap(bridge):
+    delivered, statuses = [], []
+
+    async def deliver(message, task_id):
+        delivered.append((task_id, message))
+
+    async def status(kind):
+        statuses.append(kind)
+
+    bridge.deliver = deliver
+    bridge.stream_status = status
+    body = {
+        "version": 1,
+        "kind": "event",
+        "host": "worker-1",
+        "sequence": 1,
+        "task_id": 42,
+        "message": {"type": "delta", "text": "hello"},
+    }
+    await bridge._receive(body)
+    await bridge._receive(body)
+    await bridge._receive({**body, "sequence": 3})
+    assert len(delivered) == 2
+    assert statuses == ["stream_resync_required"]
+    await bridge.close()
+
+
+@pytest.mark.asyncio
+async def test_reply_ack_waits_for_socket_and_same_delivery_is_deduplicated(
+    bridge, monkeypatch
+):
+    bridge.ready.set()
+    sent, acks = [], []
+    entered, release = asyncio.Event(), asyncio.Event()
+
+    async def reply(message):
+        entered.set()
+        await release.wait()
+        sent.append(message)
+
+    async def publish(channel, body):
+        acks.append(json.loads(body))
+
+    monkeypatch.setattr(bridge, "_publish", publish)
+    token = bridge.register_origin(42, "command-1", reply)
+    body = {
+        "version": 1,
+        "kind": "reply",
+        "origin": token,
+        "task_id": 42,
+        "command_id": "command-1",
+        "delivery_id": "delivery-1",
+        "reply_host": "worker",
+        "message": {"type": "private"},
+    }
+    first = asyncio.create_task(bridge._deliver_reply(body))
+    await entered.wait()
+    second = asyncio.create_task(bridge._deliver_reply(body))
+    assert not acks
+    release.set()
+    await asyncio.gather(first, second)
+    assert sent == [{"type": "private"}]
+    assert len(acks) == 2
+    assert all(ack["delivered"] for ack in acks)
+    await bridge.close()
+
+
+@pytest.mark.asyncio
+async def test_wrong_origin_identity_or_disconnected_recipient_cannot_receive(
+    bridge, monkeypatch
+):
+    bridge.ready.set()
+    sent, acks = [], []
+
+    async def reply(message):
+        sent.append(message)
+
+    async def publish(channel, body):
+        acks.append(json.loads(body))
+
+    monkeypatch.setattr(bridge, "_publish", publish)
+    socket = object()
+    token = bridge.register_origin(42, "command-1", reply, recipient=socket)
+    body = {
+        "version": 1,
+        "kind": "reply",
+        "origin": token,
+        "task_id": 43,
+        "command_id": "command-1",
+        "delivery_id": "delivery-1",
+        "reply_host": "worker",
+        "message": {},
+    }
+    await bridge._deliver_reply(body)
+    bridge.discard_recipient(socket)
+    await bridge._deliver_reply({**body, "task_id": 42})
+    assert sent == []
+    assert all(not ack["delivered"] for ack in acks)
+    await bridge.close()
+
+
+@pytest.mark.asyncio
+async def test_transport_timeout_is_unknown_not_command_failure(
+    bridge, monkeypatch, caplog
+):
+    monkeypatch.setattr(module, "_reply_route", lambda *args: ("web", "origin"))
+
+    async def fail(*args):
+        raise TimeoutError()
+
+    monkeypatch.setattr(bridge, "_publish", fail)
+    await bridge.reply_for("command-1", 42)({"type": "private"})
+    assert "delivery unknown" in caplog.text
+    assert not bridge._acks
+    await bridge.close()
+
+
+@pytest.mark.asyncio
+async def test_negative_socket_ack_preserves_connection_error(bridge, monkeypatch):
+    monkeypatch.setattr(module, "_reply_route", lambda *args: ("web", "origin"))
+
+    async def publish(channel, raw):
+        body = json.loads(raw)
+        await bridge._receive(
+            {
+                "version": 1,
+                "kind": "ack",
+                "delivery_id": body["delivery_id"],
+                "delivered": False,
+            }
+        )
+
+    monkeypatch.setattr(bridge, "_publish", publish)
+    with pytest.raises(ConnectionError):
+        await bridge.reply_for("command-1", 42)({"type": "private"})
+    await bridge.close()
+
+
+@pytest.mark.asyncio
+async def test_socket_writer_ack_follows_send_and_slow_queue_is_bounded():
+    class Socket:
+        def __init__(self):
+            self.release = asyncio.Event()
+            self.entered = asyncio.Event()
+            self.closed = False
+
+        async def send_text(self, text):
+            self.entered.set()
+            await self.release.wait()
+
+        async def close(self, code):
+            self.closed = True
+
+    socket = Socket()
+    writer = TaskSocketWriter(socket, lambda: None)
+    ack = writer.enqueue("first", acknowledge=True)
+    await socket.entered.wait()
+    assert not ack.done()
+    for _ in range(256):
+        writer.enqueue("queued")
+    with pytest.raises(ConnectionError):
+        writer.enqueue("overflow")
+    await asyncio.gather(writer.task)
+    with pytest.raises(ConnectionError):
+        await ack
+    assert writer.closed
+    assert writer.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_failure_does_not_abort_execution_and_advances_sequence(
+    bridge, monkeypatch, caplog
+):
+    from xagent.web.services import task_event_state
+
+    async def fail(*args, **kwargs):
+        raise RuntimeError("snapshot unavailable")
+
+    monkeypatch.setattr(task_event_state, "_with_current_task_control_state", fail)
+    await bridge.publish({"type": "task_completed"}, 42)
+    assert bridge._sequence == 1
+    assert "stream requires resync" in caplog.text
+    await bridge.close()
+
+
+@pytest.mark.asyncio
+async def test_stream_identity_comes_from_execution_attempt(bridge, monkeypatch):
+    from xagent.web.services.task_lease_service import (
+        TaskLease,
+        bind_task_lease_context,
+    )
+
+    events = []
+
+    async def publish(channel, body):
+        events.append(json.loads(body))
+
+    monkeypatch.setattr(bridge, "_publish", publish)
+    with bind_task_lease_context(TaskLease(42, "worker", "old-run", "attempt-1")):
+        await bridge.publish({"type": "final_answer_delta", "delta": "hello"}, 42)
+    frame = events[0]["message"]
+    assert frame["stream_run_id"] == "old-run"
+    assert frame["stream_attempt_id"] == "attempt-1"
+    assert frame["transport_event_id"] == f"{bridge.host_id}:1"
+    await bridge.close()
+
+
+@pytest.mark.asyncio
+async def test_real_redis_subscription_reconnect_exposes_gap(monkeypatch):
+    from xagent.web.services.task_event_bridge import TaskEventBridge
+
+    redis_url = os.getenv("XAGENT_TEST_REDIS_URL")
+    if not redis_url:
+        pytest.skip("XAGENT_TEST_REDIS_URL is not set")
+    monkeypatch.setenv("XAGENT_REDIS_URL", redis_url)
+    monkeypatch.setenv("XAGENT_TASK_EVENT_CHANNEL_PREFIX", f"reconnect:{uuid4().hex}")
+    delivered, statuses = [], []
+    unavailable = asyncio.Event()
+    received = asyncio.Event()
+
+    async def deliver(message, task_id):
+        delivered.append(message["text"])
+        received.set()
+
+    async def status(kind):
+        statuses.append(kind)
+        if kind == "stream_unavailable":
+            unavailable.set()
+
+    subscriber = TaskEventBridge(deliver=deliver, stream_status=status)
+    publisher = TaskEventBridge()
+    try:
+        await subscriber.start()
+        await publisher.start()
+        await publisher.publish({"type": "delta", "text": "before"}, 1)
+        await asyncio.wait_for(received.wait(), 5)
+        received.clear()
+        # Disconnect only this test subscriber's connections; other Redis
+        # clients and server data are untouched.
+        await subscriber.redis.connection_pool.disconnect()
+        await asyncio.wait_for(unavailable.wait(), 5)
+        await publisher.publish({"type": "delta", "text": "lost"}, 1)
+        await asyncio.wait_for(subscriber.ready.wait(), 5)
+        await publisher.publish({"type": "delta", "text": "after"}, 1)
+        await asyncio.wait_for(received.wait(), 5)
+        assert delivered == ["before", "after"]
+        assert "stream_unavailable" in statuses
+        assert statuses.count("stream_resync_required") >= 2
+    finally:
+        await subscriber.close()
+        await publisher.close()
+
+
+@pytest.mark.parametrize("redis_url", [None, "", "   "])
+def test_bridge_requires_explicit_redis_url(monkeypatch, redis_url):
+    monkeypatch.delenv("XAGENT_REDIS_URL", raising=False)
+    if redis_url is not None:
+        monkeypatch.setenv("XAGENT_REDIS_URL", redis_url)
+    with pytest.raises(ValueError, match="XAGENT_REDIS_URL must be configured"):
+        module.TaskEventBridge()
+
+
+@pytest.mark.asyncio
+async def test_reply_overflow_logs_are_rate_limited(bridge, monkeypatch, caplog):
+    from unittest.mock import AsyncMock
+
+    clock = iter([100.0, 100.1, 160.0])
+    monkeypatch.setattr(module, "monotonic", lambda: next(clock))
+    deliver = AsyncMock()
+    monkeypatch.setattr(bridge, "_deliver_reply", deliver)
+    blocked = asyncio.Event()
+    bridge._deliveries.update(asyncio.create_task(blocked.wait()) for _ in range(4096))
+    try:
+        for _ in range(3):
+            await bridge._receive({"version": 1, "kind": "reply"})
+        assert len(bridge._deliveries) == 4096
+        deliver.assert_not_called()
+        warnings = [
+            record for record in caplog.records if "queue is full" in record.message
+        ]
+        assert len(warnings) == 2
+        assert all("size=4096" in record.message for record in warnings)
+    finally:
+        await bridge.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["timeout", "exception"])
+async def test_single_send_failure_closes_socket_for_reconnection(failure):
+    class Socket:
+        def __init__(self):
+            self.close_codes = []
+
+        async def send_text(self, text):
+            if failure == "timeout":
+                await asyncio.Event().wait()
+            raise RuntimeError("send failed")
+
+        async def close(self, code):
+            self.close_codes.append(code)
+
+    socket = Socket()
+    disconnected = []
+    writer = TaskSocketWriter(socket, lambda: disconnected.append(True))
+    acknowledgement = writer.enqueue("one message", acknowledge=True)
+    await asyncio.wait_for(writer.task, timeout=8)
+    with pytest.raises(ConnectionError, match="send failed"):
+        await acknowledgement
+    assert socket.close_codes == [1013]
+    assert disconnected == [True]
+    assert writer.closed
+    assert writer.queue.empty()

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -4462,3 +4462,36 @@ async def test_cancelled_runner_drains_persistence_before_settlement(
             call.args[0].get("event_id") == turn_id
             for call in broadcast.await_args_list
         )
+
+
+@pytest.mark.parametrize("commit", [False, True])
+def test_acceptance_snapshot_stages_no_execution_lease(db_session, commit):
+    from xagent.web.services.task_orchestrator import _accept_turn_no_commit
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, int(user.id))
+    task_id = int(task.id)
+    accepted = _accept_turn_no_commit(
+        db_session,
+        task_id,
+        int(user.id),
+        payload=TaskTurnPayload(transcript_message="Accepted", turn_id="accept-only"),
+        kind=TurnKind.CREATE,
+    )
+    db_session.refresh(task)
+    assert accepted.run_id == task.run_id
+    assert accepted.status == TaskStatus.RUNNING
+    assert task.runner_id is None
+    assert task.lease_attempt_id is None
+    assert task.lease_expires_at is None
+    assert task.last_heartbeat_at is None
+    if commit:
+        db_session.commit()
+    else:
+        db_session.rollback()
+    db_session.expire_all()
+    task = db_session.get(Task, task_id)
+    assert task.status == (TaskStatus.RUNNING if commit else TaskStatus.PENDING)
+    assert db_session.query(TaskChatMessage).filter_by(task_id=task_id).count() == int(
+        commit
+    )

--- a/tests/web/services/test_task_runtime_secrets.py
+++ b/tests/web/services/test_task_runtime_secrets.py
@@ -1,0 +1,154 @@
+"""Single-turn runtime inputs remain encrypted, scoped and transactional."""
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.connector_runtime import (
+    ConnectorRef,
+    ConnectorRuntimeError,
+)
+from xagent.web.models.database import Base, get_engine, get_session_local, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task_runtime_secret import TaskRuntimeSecret
+from xagent.web.models.user import User
+from xagent.web.services.task_runtime_secrets import (
+    bind_runtime_values_to_run,
+    clean_finished_runtime_values,
+    load_runtime_values,
+    stage_runtime_values,
+)
+
+VALUES = {
+    ConnectorRef("mcp", 1): {
+        "secrets": {"token": "synthetic-secret"},
+        "auth_selector": {"account": "synthetic-account"},
+    }
+}
+
+
+@pytest.fixture
+def task_id(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'secrets.db'}")
+    with get_session_local()() as db:
+        user = User(username="owner", password_hash="unused")
+        db.add(user)
+        db.flush()
+        task = Task(
+            user_id=user.id,
+            title="Inputs",
+            status=TaskStatus.RUNNING,
+            run_id="run-1",
+            state_version=1,
+            control_state="running",
+        )
+        db.add(task)
+        db.commit()
+        yield task.id
+    Base.metadata.drop_all(bind=get_engine())
+
+
+def stage(db, task_id):
+    stage_runtime_values(db, task_id=task_id, turn_id="turn-1", values_by_ref=VALUES)
+    assert bind_runtime_values_to_run(
+        db, task_id=task_id, turn_id="turn-1", run_id="run-1"
+    )
+
+
+def test_ciphertext_round_trip_in_independent_session(task_id):
+    with get_session_local()() as db:
+        stage(db, task_id)
+        row = db.query(TaskRuntimeSecret).one()
+        assert "synthetic" not in row.ciphertext
+        db.commit()
+    with get_session_local()() as db:
+        task = db.get(Task, task_id)
+        assert load_runtime_values(db, task=task, turn_id="turn-1", required=True) == {
+            ref.storage_key: values for ref, values in VALUES.items()
+        }
+        assert load_runtime_values(db, task=task, turn_id="turn-1", required=True)
+
+
+def test_acceptance_rollback_removes_runtime_inputs(task_id):
+    with get_session_local()() as db:
+        stage(db, task_id)
+        db.rollback()
+    with get_session_local()() as db:
+        assert db.query(TaskRuntimeSecret).count() == 0
+
+
+@pytest.mark.parametrize("change", ["owner", "run", "ciphertext", "turn"])
+def test_missing_or_mismatched_values_fail_closed(task_id, change):
+    with get_session_local()() as db:
+        stage(db, task_id)
+        row = db.query(TaskRuntimeSecret).one()
+        if change == "owner":
+            db.get(
+                User, db.get(Task, task_id).user_id
+            ).actor_subject = "replacement-owner"
+        elif change == "run":
+            db.get(Task, task_id).run_id = "run-2"
+        elif change == "ciphertext":
+            row.ciphertext = "synthetic-plaintext"
+        db.commit()
+    with get_session_local()() as db:
+        with pytest.raises(ConnectorRuntimeError) as error:
+            load_runtime_values(
+                db,
+                task=db.get(Task, task_id),
+                turn_id="other-turn" if change == "turn" else "turn-1",
+                required=True,
+            )
+        assert "synthetic" not in str(error.value)
+
+
+def test_compensation_preserves_queued_and_active_inputs(task_id):
+    with get_session_local()() as db:
+        stage(db, task_id)
+        db.commit()
+    clean_finished_runtime_values()
+    with get_session_local()() as db:
+        assert db.query(TaskRuntimeSecret).count() == 1
+        db.get(Task, task_id).status = TaskStatus.PAUSED
+        db.commit()
+    clean_finished_runtime_values()
+    with get_session_local()() as db:
+        assert db.query(TaskRuntimeSecret).count() == 0
+
+
+def test_compensation_waits_for_waiting_execution_to_release_lease(task_id):
+    with get_session_local()() as db:
+        stage(db, task_id)
+        task = db.get(Task, task_id)
+        task.status = TaskStatus.WAITING_FOR_USER
+        task.runner_id = "worker"
+        db.commit()
+    clean_finished_runtime_values()
+    with get_session_local()() as db:
+        assert db.query(TaskRuntimeSecret).count() == 1
+        db.get(Task, task_id).runner_id = None
+        db.commit()
+    clean_finished_runtime_values()
+    with get_session_local()() as db:
+        assert db.query(TaskRuntimeSecret).count() == 0
+
+
+def test_cleanup_cannot_observe_inputs_before_transaction_binds_run(task_id):
+    with get_session_local()() as acceptance:
+        stage_runtime_values(
+            acceptance, task_id=task_id, turn_id="turn-1", values_by_ref=VALUES
+        )
+        assert acceptance.query(TaskRuntimeSecret).one().run_id is None
+        with get_session_local()() as observer:
+            assert observer.query(TaskRuntimeSecret).count() == 0
+        # Cleanup runs through its own session while acceptance is uncommitted.
+        clean_finished_runtime_values()
+        assert bind_runtime_values_to_run(
+            acceptance, task_id=task_id, turn_id="turn-1", run_id="run-1"
+        )
+        acceptance.commit()
+    clean_finished_runtime_values()
+    with get_session_local()() as observer:
+        row = observer.query(TaskRuntimeSecret).one()
+        assert row.run_id == "run-1"
+        assert load_runtime_values(
+            observer, task=observer.get(Task, task_id), turn_id="turn-1", required=True
+        )

--- a/tests/web/test_workforce_run_service.py
+++ b/tests/web/test_workforce_run_service.py
@@ -1101,7 +1101,7 @@ async def test_create_workforce_run_claim_timeout_rolls_back_created_records(
 
     monkeypatch.setattr(
         task_orchestrator_module,
-        "_persist_claimed_turn_no_commit",
+        "_persist_accepted_turn_no_commit",
         MagicMock(side_effect=synthetic_timeout),
     )
     monkeypatch.setattr(


### PR DESCRIPTION
Shared task execution needs acceptance data and reply routing that survive process boundaries, plus a way for clients to recover when live events are lost. This PR extracts a lease-free accepted-turn snapshot while keeping local acceptance, lease acquisition and scheduling in the same transaction. It adds encrypted per-turn runtime input storage and immutable command-origin routing through a reversible migration.

The event layer adds Redis fanout, origin-bound private replies and socket ACKs, bounded per-socket writers, producer-captured run identity, and persisted output snapshots. The frontend handles interrupted streams and restores available state/results without concatenating deltas onto a missing prefix. Completed output is persisted atomically with terminal state for snapshot readers.

This combines the data/acceptance and event/recovery portions of the larger shared-worker change. Shared execution remains disabled by default, with application startup using the existing execution path. START consumption, worker lifecycle, ingress/channel adapters, and final default enablement follow in later PRs.

Validation:
- Affected backend suites: 800 passed; the one PostgreSQL-only test skipped in that run passed separately in a disposable database.
- Full SQLite/PostgreSQL migration CI commands (upgrade, idempotence, incremental, downgrade) passed; 8 migration regression cases passed. Bridge tests include a real Redis reconnect.
- Frontend chat/WebSocket suites: 297 passed; TypeScript checking passed.
- All repository pre-commit hooks passed, including package-wide mypy, Ruff, isort, and frontend lint/type checks.

The feature branch contains one commit and is based on current main. See docs/architecture/shared-worker-execution.md for the split boundary and activation requirements.
