### PR TITLE
fix(kb): give one filter input one predicate on every search path

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -154,57 +154,81 @@ def _condition_fields(conditions: Sequence[FilterExpression]) -> list[str]:
     return [c.field for c in conditions if isinstance(c, FilterCondition)]
 
 
-def _condition_row_mask(batch_df: Any, conditions: Sequence[FilterExpression]) -> Any:
-    """AND the conditions into a pandas mask, skipping absent columns.
+def _require_flat_condition(condition: FilterExpression) -> FilterCondition:
+    """A scan evaluates plain conditions only; a nested group has no column."""
+    if not isinstance(condition, FilterCondition):
+        raise ValueError(
+            "Scan fallback cannot evaluate a nested filter expression: "
+            f"{type(condition).__name__}"
+        )
+    return condition
 
-    The sync fallback cannot push predicates down and the async one pushes only
-    scalar equality, so what is left is evaluated here against the same parsed
-    conditions the indexed paths hand to the backend, though a scan cannot
-    reproduce every backend semantic exactly. A column the batch does not carry
-    is skipped, matching the pre-parse behaviour.
-    """
-    mask = None
-    for condition in conditions:
-        if not isinstance(condition, FilterCondition):
-            raise ValueError(
-                "Scan fallback cannot evaluate a nested filter expression: "
-                f"{type(condition).__name__}"
-            )
-        field = condition.field
-        if field not in batch_df.columns:
-            continue
-        column = batch_df[field]
-        operator = condition.operator
-        value = condition.value
+
+def _single_condition_mask(batch_df: Any, condition: FilterCondition) -> Any:
+    """Evaluate one condition against a batch, or say why it cannot be."""
+    field = condition.field
+    if field not in batch_df.columns:
+        raise ValueError(
+            f"Scan fallback cannot filter on {field!r}: the table does not "
+            "carry that column"
+        )
+    column = batch_df[field]
+    operator = condition.operator
+    value = condition.value
+    try:
         if operator is FilterOperator.IN or (
             operator is FilterOperator.EQ and isinstance(value, (list, tuple, set))
         ):
-            column_mask = column.isin(list(value))
-        elif operator is FilterOperator.EQ:
-            column_mask = column == value
-        elif operator is FilterOperator.NE:
+            return column.isin(list(value))
+        if operator is FilterOperator.EQ:
+            return column == value
+        if operator is FilterOperator.NE:
+            if value is None:
+                # SQL reads `field != NULL` as NULL, which selects nothing.
+                return pd.Series(False, index=column.index)
             # SQL drops NULL rows on `!=`; pandas would keep them.
-            column_mask = (column != value) & column.notna()
-        elif operator is FilterOperator.GT:
-            column_mask = column > value
-        elif operator is FilterOperator.GTE:
-            column_mask = column >= value
-        elif operator is FilterOperator.LT:
-            column_mask = column < value
-        elif operator is FilterOperator.LTE:
-            column_mask = column <= value
-        elif operator is FilterOperator.IS_NULL:
-            column_mask = column.isna()
-        elif operator is FilterOperator.IS_NOT_NULL:
-            column_mask = column.notna()
-        elif operator is FilterOperator.CONTAINS:
+            return (column != value) & column.notna()
+        if operator is FilterOperator.GT:
+            return column > value
+        if operator is FilterOperator.GTE:
+            return column >= value
+        if operator is FilterOperator.LT:
+            return column < value
+        if operator is FilterOperator.LTE:
+            return column <= value
+        if operator is FilterOperator.IS_NULL:
+            return column.isna()
+        if operator is FilterOperator.IS_NOT_NULL:
+            return column.notna()
+        if operator is FilterOperator.CONTAINS:
             # astype(str) renders NULL as "None"/"nan", which a short needle
             # would then match; drop those rows before comparing.
-            column_mask = column.notna() & column.astype(str).str.contains(
+            return column.notna() & column.astype(str).str.contains(
                 str(value), na=False, regex=False
             )
-        else:
-            raise ValueError(f"Unsupported filter operator for scan: {operator}")
+    except TypeError as exc:
+        # The backend rejects a mismatched comparison too; say which one.
+        raise ValueError(
+            f"Scan fallback cannot compare {field!r} ({column.dtype}) with "
+            f"{value!r}: {exc}"
+        ) from exc
+    raise ValueError(f"Unsupported filter operator for scan: {operator}")
+
+
+def _condition_row_mask(batch_df: Any, conditions: Sequence[FilterExpression]) -> Any:
+    """AND the conditions into a pandas mask.
+
+    The sync fallback cannot push predicates down and the async one pushes only
+    scalar equality, so what is left is evaluated here against the same parsed
+    conditions the indexed paths hand to the backend. A condition the scan
+    cannot evaluate raises: dropping it would hand back rows the caller
+    filtered out.
+    """
+    mask = None
+    for condition in conditions:
+        column_mask = _single_condition_mask(
+            batch_df, _require_flat_condition(condition)
+        )
         mask = column_mask if mask is None else (mask & column_mask)
     return mask
 
@@ -2491,12 +2515,8 @@ class LanceDBCollectionHandle(KBCollectionHandle):
         # cannot express the operator conditions, so those are scanned here.
         query_filters: Dict[str, Any] = {"collection": collection}
         scan_conditions: list[FilterCondition] = []
-        for condition in normalize_filter_conditions(filters):
-            if not isinstance(condition, FilterCondition):
-                raise ValueError(
-                    "Scan fallback cannot evaluate a nested filter expression: "
-                    f"{type(condition).__name__}"
-                )
+        for raw_condition in normalize_filter_conditions(filters):
+            condition = _require_flat_condition(raw_condition)
             if condition.operator is FilterOperator.EQ and not isinstance(
                 condition.value, (list, tuple, set)
             ):

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -81,7 +81,10 @@ from ..storage.contracts import (
     VectorIndexStore,
 )
 from ..utils import check_file_type, compute_file_hash
-from ..utils.filter_utils import parse_legacy_filters, validate_filter_depth
+from ..utils.filter_utils import (
+    normalize_filter_conditions,
+    validate_filter_depth,
+)
 from ..utils.hash_utils import compute_chunk_hash
 from ..utils.metadata_utils import deserialize_metadata, serialize_metadata
 from ..utils.string_utils import generate_deterministic_doc_id
@@ -136,6 +139,72 @@ def _safe_optional_str(value: Any) -> str | None:
     except Exception:  # noqa: BLE001
         pass
     return str(value)
+
+
+def _table_column_names(table: Any) -> set[str] | None:
+    """Column names the table carries, or None when the schema is unreadable."""
+    try:
+        return {str(name) for name in table.schema.names}
+    except Exception:
+        return None
+
+
+def _condition_fields(conditions: Sequence[FilterExpression]) -> list[str]:
+    """Columns a scan must project so every condition can be evaluated."""
+    return [c.field for c in conditions if isinstance(c, FilterCondition)]
+
+
+def _condition_row_mask(batch_df: Any, conditions: Sequence[FilterExpression]) -> Any:
+    """AND the conditions into a pandas mask, skipping absent columns.
+
+    The sync fallback cannot push predicates down and the async one pushes only
+    scalar equality, so what is left is evaluated here against the same parsed
+    conditions the indexed paths hand to the backend, though a scan cannot
+    reproduce every backend semantic exactly. A column the batch does not carry
+    is skipped, matching the pre-parse behaviour.
+    """
+    mask = None
+    for condition in conditions:
+        if not isinstance(condition, FilterCondition):
+            raise ValueError(
+                "Scan fallback cannot evaluate a nested filter expression: "
+                f"{type(condition).__name__}"
+            )
+        field = condition.field
+        if field not in batch_df.columns:
+            continue
+        column = batch_df[field]
+        operator = condition.operator
+        value = condition.value
+        if operator is FilterOperator.IN or (
+            operator is FilterOperator.EQ and isinstance(value, (list, tuple, set))
+        ):
+            column_mask = column.isin(list(value))
+        elif operator is FilterOperator.EQ:
+            column_mask = column == value
+        elif operator is FilterOperator.NE:
+            # SQL drops NULL rows on `!=`; pandas would keep them.
+            column_mask = (column != value) & column.notna()
+        elif operator is FilterOperator.GT:
+            column_mask = column > value
+        elif operator is FilterOperator.GTE:
+            column_mask = column >= value
+        elif operator is FilterOperator.LT:
+            column_mask = column < value
+        elif operator is FilterOperator.LTE:
+            column_mask = column <= value
+        elif operator is FilterOperator.IS_NULL:
+            column_mask = column.isna()
+        elif operator is FilterOperator.IS_NOT_NULL:
+            column_mask = column.notna()
+        elif operator is FilterOperator.CONTAINS:
+            column_mask = column.astype(str).str.contains(
+                str(value), na=False, regex=False
+            )
+        else:
+            raise ValueError(f"Unsupported filter operator for scan: {operator}")
+        mask = column_mask if mask is None else (mask & column_mask)
+    return mask
 
 
 def validate_query_vector_format(query_vector: list[float]) -> None:
@@ -2008,17 +2077,7 @@ class LanceDBCollectionHandle(KBCollectionHandle):
                             value=collection,
                         )
                     )
-                if filters:
-                    parsed = (
-                        parse_legacy_filters(filters)
-                        if isinstance(filters, dict)
-                        else None
-                    )
-                    if parsed is not None:
-                        if isinstance(parsed, tuple):
-                            conditions.extend(parsed)
-                        else:
-                            conditions.append(parsed)
+                conditions.extend(normalize_filter_conditions(filters))
                 if len(conditions) == 1:
                     filter_expr = conditions[0]
                 elif len(conditions) > 1:
@@ -2087,17 +2146,7 @@ class LanceDBCollectionHandle(KBCollectionHandle):
                             value=collection,
                         )
                     )
-                if filters:
-                    parsed = (
-                        parse_legacy_filters(filters)
-                        if isinstance(filters, dict)
-                        else None
-                    )
-                    if parsed is not None:
-                        if isinstance(parsed, tuple):
-                            conditions.extend(parsed)
-                        else:
-                            conditions.append(parsed)
+                conditions.extend(normalize_filter_conditions(filters))
                 if len(conditions) == 1:
                     filter_expr = conditions[0]
                 elif len(conditions) > 1:
@@ -2333,8 +2382,14 @@ class LanceDBCollectionHandle(KBCollectionHandle):
             "created_at",
             "metadata",
         }
-        if filters and isinstance(filters, dict):
-            desired_columns.update(filters.keys())
+        scan_conditions = normalize_filter_conditions(filters)
+        # A filtered column absent from the projection would be skipped by the
+        # mask below rather than applied. Projecting one the table does not have
+        # would fail the whole scan, so ask only for what the schema carries.
+        desired_columns.update(_condition_fields(scan_conditions))
+        table_columns = _table_column_names(table)
+        if table_columns is not None:
+            desired_columns &= table_columns
 
         results: List[SearchResult] = []
 
@@ -2359,14 +2414,9 @@ class LanceDBCollectionHandle(KBCollectionHandle):
             batch_df = batch.to_pandas()
 
             mask = batch_df["collection"] == collection
-            if filters and isinstance(filters, dict):
-                for key, value in filters.items():
-                    if key not in batch_df.columns:
-                        continue
-                    if isinstance(value, (list, tuple, set)):
-                        mask &= batch_df[key].isin(list(value))
-                    else:
-                        mask &= batch_df[key] == value
+            condition_mask = _condition_row_mask(batch_df, scan_conditions)
+            if condition_mask is not None:
+                mask &= condition_mask
 
             if not mask.any():
                 continue
@@ -2435,10 +2485,22 @@ class LanceDBCollectionHandle(KBCollectionHandle):
         vector_store = self.vector_index_store
         results: List[SearchResult] = []
 
-        # Build query filters
+        # Only plain scalar equality can be pushed down; the store's dict form
+        # cannot express the operator conditions, so those are scanned here.
         query_filters: Dict[str, Any] = {"collection": collection}
-        if filters and isinstance(filters, dict):
-            query_filters.update(filters)
+        scan_conditions: list[FilterCondition] = []
+        for condition in normalize_filter_conditions(filters):
+            if not isinstance(condition, FilterCondition):
+                raise ValueError(
+                    "Scan fallback cannot evaluate a nested filter expression: "
+                    f"{type(condition).__name__}"
+                )
+            if condition.operator is FilterOperator.EQ and not isinstance(
+                condition.value, (list, tuple, set)
+            ):
+                query_filters[condition.field] = condition.value
+            else:
+                scan_conditions.append(condition)
 
         _table = None
         try:
@@ -2451,14 +2513,23 @@ class LanceDBCollectionHandle(KBCollectionHandle):
                 AsyncIterator[Any],
                 vector_store.iter_batches_async(
                     table_name=table_name,
-                    columns=[
-                        "doc_id",
-                        "chunk_id",
-                        "text",
-                        "parse_hash",
-                        "created_at",
-                        "metadata",
-                    ],
+                    # Scanned conditions need their column present, or the mask
+                    # below would skip them. A repeat of a base column would
+                    # make to_pandas() return duplicate labels, which breaks
+                    # every mask built from it.
+                    columns=list(
+                        dict.fromkeys(
+                            [
+                                "doc_id",
+                                "chunk_id",
+                                "text",
+                                "parse_hash",
+                                "created_at",
+                                "metadata",
+                                *_condition_fields(scan_conditions),
+                            ]
+                        )
+                    ),
                     batch_size=batch_size,
                     filters=query_filters,
                     user_id=user_id,
@@ -2473,6 +2544,9 @@ class LanceDBCollectionHandle(KBCollectionHandle):
                     .astype(str)
                     .str.contains(query_text, na=False, regex=False)
                 )
+                condition_mask = _condition_row_mask(batch_df, scan_conditions)
+                if condition_mask is not None:
+                    text_mask &= condition_mask
                 matching_rows = batch_df[text_mask]
 
                 # Early exit: stop processing if we already have enough results
@@ -2595,26 +2669,7 @@ class LanceDBCollectionHandle(KBCollectionHandle):
                     )
 
                 # Add custom filters
-                if filters:
-                    if isinstance(filters, dict):
-                        # Legacy format: use parser
-                        parsed_filters = parse_legacy_filters(filters)
-                        # parsed_filters can be FilterCondition or tuple (AND combination)
-                        if parsed_filters is not None:
-                            if isinstance(parsed_filters, tuple):
-                                # Type narrowing: tuple of FilterConditions
-                                conditions.extend(parsed_filters)
-                            else:
-                                # Type narrowing: single FilterCondition
-                                conditions.append(parsed_filters)
-                    elif isinstance(filters, (tuple, list)):
-                        # Already FilterExpression
-                        conditions.extend(
-                            filters if isinstance(filters, tuple) else list(filters)
-                        )
-                    else:
-                        # Single FilterCondition
-                        conditions.append(filters)
+                conditions.extend(normalize_filter_conditions(filters))
 
                 # Combine conditions with AND
                 if len(conditions) == 1:
@@ -2782,20 +2837,7 @@ class LanceDBCollectionHandle(KBCollectionHandle):
                         )
                     )
 
-                if filters:
-                    if isinstance(filters, dict):
-                        parsed_filters = parse_legacy_filters(filters)
-                        if parsed_filters is not None:
-                            if isinstance(parsed_filters, tuple):
-                                conditions.extend(parsed_filters)
-                            else:
-                                conditions.append(parsed_filters)
-                    elif isinstance(filters, (tuple, list)):
-                        conditions.extend(
-                            filters if isinstance(filters, tuple) else list(filters)
-                        )
-                    else:
-                        conditions.append(filters)
+                conditions.extend(normalize_filter_conditions(filters))
 
                 if len(conditions) == 1:
                     filter_expr = conditions[0]

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -198,7 +198,9 @@ def _condition_row_mask(batch_df: Any, conditions: Sequence[FilterExpression]) -
         elif operator is FilterOperator.IS_NOT_NULL:
             column_mask = column.notna()
         elif operator is FilterOperator.CONTAINS:
-            column_mask = column.astype(str).str.contains(
+            # astype(str) renders NULL as "None"/"nan", which a short needle
+            # would then match; drop those rows before comparing.
+            column_mask = column.notna() & column.astype(str).str.contains(
                 str(value), na=False, regex=False
             )
         else:

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_filter_utils.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_filter_utils.py
@@ -35,6 +35,9 @@ def translate_condition(condition: FilterCondition) -> str:
     elif op == FilterOperator.LTE:
         return f"{field} <= {format_value(value)}"
     elif op == FilterOperator.IN:
+        if not value:
+            # `field IN ()` is a syntax error; an empty membership is just false.
+            return "FALSE"
         values = ", ".join(format_value(v) for v in value)
         return f"{field} IN ({values})"
     elif op == FilterOperator.CONTAINS:

--- a/src/xagent/core/tools/core/RAG_tools/utils/filter_utils.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/filter_utils.py
@@ -99,6 +99,13 @@ def parse_legacy_filters(
                     field=field, operator=op_map[op_str], value=spec["value"]
                 )
             )
+        elif isinstance(spec, (list, tuple, set)):
+            # Membership, not equality: EQ would translate to `field == '[...]'`.
+            conditions.append(
+                FilterCondition(
+                    field=field, operator=FilterOperator.IN, value=list(spec)
+                )
+            )
         else:
             conditions.append(
                 FilterCondition(field=field, operator=FilterOperator.EQ, value=spec)
@@ -107,3 +114,32 @@ def parse_legacy_filters(
     if len(conditions) == 1:
         return conditions[0]
     return tuple(conditions)
+
+
+def normalize_filter_conditions(
+    filters: Any,
+    max_depth: int = 10,
+) -> list[FilterExpression]:
+    """Return the conditions to AND together for any accepted filter shape.
+
+    Accepts the legacy dict form, an already-built ``FilterExpression``, or a
+    tuple/list of them. Search engines differed on which shapes they honoured
+    (#671); routing every engine through this keeps one answer per input.
+
+    A tuple is an AND group, so it flattens into the returned list; a list is an
+    OR group (``contracts.FilterExpression``), so it stays one element and keeps
+    its disjunction.
+    """
+    if not filters:
+        return []
+
+    if isinstance(filters, dict):
+        parsed = parse_legacy_filters(filters, max_depth=max_depth)
+        if parsed is None:
+            return []
+        return list(parsed) if isinstance(parsed, tuple) else [parsed]
+
+    if isinstance(filters, tuple):
+        return list(filters)
+
+    return [filters]

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_handle_search_filter_parity.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_handle_search_filter_parity.py
@@ -409,26 +409,25 @@ def test_scan_evaluates_every_operator_it_accepts(
     assert [r.chunk_id for r in results] == expected
 
 
-def test_scan_skips_a_filter_on_a_column_the_table_lacks() -> None:
-    """A missing column is skipped, not turned into an empty result set.
+def test_scan_refuses_a_filter_on_a_column_the_table_lacks() -> None:
+    """Dropping an unapplicable filter would return rows the caller excluded.
 
-    The embeddings schema carries no arbitrary metadata columns, so projecting
-    one would fail the whole scan inside the swallowing except.
+    The embeddings schema carries no arbitrary metadata columns, so a filter on
+    one cannot be evaluated by a scan; failing beats widening the result set.
     """
     handle, _ctx, _store = _make_handle()
     table = _projecting_table(_operator_frame())
 
-    results = handle._substring_fallback(
-        table=table,
-        collection="docs",
-        query_text="alpha",
-        model_tag="model-a",
-        top_k=10,
-        filters={"page_number": {"operator": "gte", "value": 2}},
-        current_warnings=[],
-    )
-
-    assert [r.chunk_id for r in results] == ["c1", "c2", "c3", "c4"]
+    with pytest.raises(ValueError, match="page_number"):
+        handle._substring_fallback(
+            table=table,
+            collection="docs",
+            query_text="alpha",
+            model_tag="model-a",
+            top_k=10,
+            filters={"page_number": {"operator": "gte", "value": 2}},
+            current_warnings=[],
+        )
 
 
 def test_a_list_value_reaches_the_backend_as_membership() -> None:
@@ -468,4 +467,59 @@ def test_contains_does_not_match_the_rendering_of_a_null() -> None:
         )
         assert "c2" not in [r.chunk_id for r in results], (
             f"needle {needle!r} matched the NULL row"
+        )
+
+
+def test_an_empty_membership_filter_stays_valid_sql() -> None:
+    """`IN ()` is a syntax error; an empty membership is simply false."""
+    from xagent.core.tools.core.RAG_tools.storage.lancedb_filter_utils import (
+        translate_filter_expression,
+    )
+    from xagent.core.tools.core.RAG_tools.utils.filter_utils import (
+        parse_legacy_filters,
+    )
+
+    expression = parse_legacy_filters({"doc_id": []})
+
+    assert translate_filter_expression(expression) == "FALSE"
+
+
+def test_scan_reads_ne_against_null_the_way_sql_does() -> None:
+    """`field != NULL` is NULL in SQL, so it selects nothing."""
+    handle, _ctx, _store = _make_handle()
+    frame = _operator_frame()
+    frame["label"] = ["a", None, "b", "c"]
+    table = _projecting_table(frame)
+
+    results = handle._substring_fallback(
+        table=table,
+        collection="docs",
+        query_text="alpha",
+        model_tag="model-a",
+        top_k=10,
+        filters=FilterCondition(field="label", operator=FilterOperator.NE, value=None),
+        current_warnings=[],
+    )
+
+    assert results == []
+
+
+def test_scan_names_the_column_when_a_comparison_cannot_be_made() -> None:
+    """A dtype mismatch fails on the backend too; say which column and value."""
+    handle, _ctx, _store = _make_handle()
+    frame = _operator_frame()
+    frame["created_at"] = pd.to_datetime(
+        ["2020-01-01", "2021-01-01", "2022-01-01", "2023-01-01"]
+    )
+    table = _projecting_table(frame)
+
+    with pytest.raises(ValueError, match="created_at"):
+        handle._substring_fallback(
+            table=table,
+            collection="docs",
+            query_text="alpha",
+            model_tag="model-a",
+            top_k=10,
+            filters={"created_at": {"operator": "gte", "value": 2}},
+            current_warnings=[],
         )

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_handle_search_filter_parity.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_handle_search_filter_parity.py
@@ -1,0 +1,447 @@
+"""#671 - one filter input must mean one predicate on every search path.
+
+Dense dropped every non-dict filter shape that sparse honoured, and both
+substring fallbacks answered an operator filter with zero rows: the sync one
+compared a column against the operator dict, the async one pushed the dict at a
+store that rejects it and swallowed the error.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pandas as pd
+import pytest
+
+from xagent.core.tools.core.RAG_tools.kb.collection_handle import (
+    LanceDBCollectionHandle,
+)
+from xagent.core.tools.core.RAG_tools.storage.contracts import (
+    FilterCondition,
+    FilterOperator,
+)
+
+
+def _make_handle():
+    handle = LanceDBCollectionHandle.__new__(LanceDBCollectionHandle)
+    ctx = MagicMock()
+    ctx.collection = "docs"
+    object.__setattr__(handle, "context", ctx)
+    store = MagicMock()
+    ctx.vector_index_store = store
+    caps = MagicMock()
+    caps.supports_search = True
+    ctx.capabilities = caps
+    return handle, ctx, store
+
+
+def _index_result():
+    obj = MagicMock()
+    obj.status = "index_ready"
+    obj.advice = None
+    obj.fts_enabled = True
+    return obj
+
+
+def _conditions(expr: Any) -> list[tuple[Any, Any, Any]]:
+    if expr is None:
+        return []
+    if isinstance(expr, (tuple, list)):
+        out: list[tuple[Any, Any, Any]] = []
+        for item in expr:
+            out.extend(_conditions(item))
+        return out
+    operator = getattr(expr, "operator", None)
+    return [(expr.field, getattr(operator, "value", operator), expr.value)]
+
+
+PAGE_GTE_2 = FilterCondition(field="page_number", operator=FilterOperator.GTE, value=2)
+
+# Every shape the engines accept, and the triples it must become.
+FILTER_SHAPES = [
+    ("legacy_dict", {"page_number": {"operator": "gte", "value": 2}}),
+    ("single_condition", PAGE_GTE_2),
+    ("tuple_of_conditions", (PAGE_GTE_2,)),
+    ("list_of_conditions", [PAGE_GTE_2]),
+]
+
+
+@pytest.mark.parametrize(
+    ("shape", "filters"), FILTER_SHAPES, ids=[row[0] for row in FILTER_SHAPES]
+)
+def test_dense_honours_every_filter_shape(shape: str, filters: Any) -> None:
+    handle, _ctx, store = _make_handle()
+    store.create_index.return_value = _index_result()
+    store.search_vectors_by_model.return_value = []
+
+    handle.search_dense("model-a", [0.5], top_k=5, filters=filters)
+
+    conditions = _conditions(store.search_vectors_by_model.call_args.kwargs["filters"])
+    assert ("page_number", "gte", 2) in conditions, f"dense dropped the {shape} filter"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("shape", "filters"), FILTER_SHAPES, ids=[row[0] for row in FILTER_SHAPES]
+)
+async def test_dense_async_honours_every_filter_shape(shape: str, filters: Any) -> None:
+    handle, _ctx, store = _make_handle()
+    store.create_index.return_value = _index_result()
+    store.search_vectors_by_model_async = AsyncMock(return_value=[])
+
+    await handle.search_dense_async("model-a", [0.5], top_k=5, filters=filters)
+
+    kwargs = store.search_vectors_by_model_async.call_args.kwargs
+    assert ("page_number", "gte", 2) in _conditions(kwargs["filters"]), (
+        f"async dense dropped the {shape} filter"
+    )
+
+
+@pytest.mark.parametrize(
+    ("shape", "filters"), FILTER_SHAPES, ids=[row[0] for row in FILTER_SHAPES]
+)
+def test_sparse_agrees_with_dense_on_every_shape(shape: str, filters: Any) -> None:
+    handle, _ctx, store = _make_handle()
+    store.open_embeddings_table.return_value = (MagicMock(), "embeddings_model_a")
+    store.create_index.return_value = _index_result()
+    store.build_filter_expression.return_value = None
+    fts_table = store.open_embeddings_table.return_value[0]
+    fts_table.search.return_value.limit.return_value.to_pandas.return_value = (
+        pd.DataFrame()
+    )
+
+    handle.search_sparse("model-a", "q", top_k=5, filters=filters)
+
+    kwargs = store.build_filter_expression.call_args.kwargs
+    assert ("page_number", "gte", 2) in _conditions(kwargs["filters"]), (
+        f"sparse dropped the {shape} filter"
+    )
+
+
+def _fallback_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "collection": ["docs", "docs", "docs"],
+            "doc_id": ["d1", "d2", "d3"],
+            "chunk_id": ["c1", "c2", "c3"],
+            "text": ["alpha hit", "alpha hit", "alpha hit"],
+            "parse_hash": ["h", "h", "h"],
+            "created_at": [1, 2, 3],
+            "metadata": [None, None, None],
+            "page_number": [1, 2, 3],
+        }
+    )
+
+
+def _batch_for(frame: pd.DataFrame, columns: Any = None) -> MagicMock:
+    """A batch that projects like the real one: repeated labels stay repeated."""
+    batch = MagicMock()
+    if columns is not None:
+        frame = pd.concat([frame[name] for name in columns], axis=1)
+    batch.to_pandas.return_value = frame
+    return batch
+
+
+def _projecting_table(frame: pd.DataFrame) -> MagicMock:
+    table = MagicMock()
+    table.schema.names = list(frame.columns)
+    table.to_batches.side_effect = lambda columns, batch_size: [
+        _batch_for(frame, columns)
+    ]
+    return table
+
+
+def test_sync_substring_fallback_applies_an_operator_filter() -> None:
+    """The operator form must select rows, not compare a column to a dict."""
+    handle, _ctx, _store = _make_handle()
+    table = _projecting_table(_fallback_frame())
+    warnings: list[Any] = []
+
+    results = handle._substring_fallback(
+        table=table,
+        collection="docs",
+        query_text="alpha",
+        model_tag="model-a",
+        top_k=10,
+        filters={"page_number": {"operator": "gte", "value": 2}},
+        current_warnings=warnings,
+    )
+
+    assert [r.chunk_id for r in results] == ["c2", "c3"]
+
+
+def test_sync_substring_fallback_still_applies_plain_equality() -> None:
+    handle, _ctx, _store = _make_handle()
+    table = _projecting_table(_fallback_frame())
+
+    results = handle._substring_fallback(
+        table=table,
+        collection="docs",
+        query_text="alpha",
+        model_tag="model-a",
+        top_k=10,
+        filters={"doc_id": "d2"},
+        current_warnings=[],
+    )
+
+    assert [r.chunk_id for r in results] == ["c2"]
+
+
+def test_sync_substring_fallback_still_applies_a_list_as_membership() -> None:
+    """A list value kept its IN semantics from before the parse was introduced."""
+    handle, _ctx, _store = _make_handle()
+    table = _projecting_table(_fallback_frame())
+
+    results = handle._substring_fallback(
+        table=table,
+        collection="docs",
+        query_text="alpha",
+        model_tag="model-a",
+        top_k=10,
+        filters={"doc_id": ["d1", "d3"]},
+        current_warnings=[],
+    )
+
+    assert [r.chunk_id for r in results] == ["c1", "c3"]
+
+
+@pytest.mark.asyncio
+async def test_async_substring_fallback_applies_an_operator_filter() -> None:
+    """The async path must not hand the operator dict to the store."""
+    handle, _ctx, store = _make_handle()
+    store.open_embeddings_table.return_value = (MagicMock(), "embeddings_model_a")
+
+    captured: dict[str, Any] = {}
+
+    async def _iter_batches_async(**kwargs: Any):
+        captured.update(kwargs)
+        yield _batch_for(_fallback_frame(), kwargs["columns"])
+
+    store.iter_batches_async = _iter_batches_async
+
+    results = await handle._substring_fallback_async(
+        model_tag="model-a",
+        collection="docs",
+        query_text="alpha",
+        top_k=10,
+        filters={"page_number": {"operator": "gte", "value": 2}},
+        current_warnings=[],
+    )
+
+    assert [r.chunk_id for r in results] == ["c2", "c3"]
+    # The operator condition must not be pushed down as a dict value.
+    assert captured["filters"] == {"collection": "docs"}
+    # ...and its column must be requested, or the scan would skip it silently.
+    assert "page_number" in captured["columns"]
+
+
+@pytest.mark.asyncio
+async def test_async_substring_fallback_still_pushes_plain_equality_down() -> None:
+    handle, _ctx, store = _make_handle()
+    store.open_embeddings_table.return_value = (MagicMock(), "embeddings_model_a")
+
+    captured: dict[str, Any] = {}
+
+    async def _iter_batches_async(**kwargs: Any):
+        captured.update(kwargs)
+        yield _batch_for(_fallback_frame(), kwargs["columns"])
+
+    store.iter_batches_async = _iter_batches_async
+
+    await handle._substring_fallback_async(
+        model_tag="model-a",
+        collection="docs",
+        query_text="alpha",
+        top_k=10,
+        filters={"doc_id": "d2"},
+        current_warnings=[],
+    )
+
+    assert captured["filters"] == {"collection": "docs", "doc_id": "d2"}
+
+
+CREATED_AT_GTE_2 = FilterCondition(
+    field="created_at", operator=FilterOperator.GTE, value=2
+)
+
+
+@pytest.mark.asyncio
+async def test_async_fallback_filters_on_a_column_it_already_projects() -> None:
+    """A filter on a base column must not request that column twice.
+
+    Duplicate labels make ``to_pandas`` hand back a DataFrame per label, and
+    every mask built from it then raises into the swallowing except -- the same
+    silent zero-result this change exists to remove.
+    """
+    handle, _ctx, store = _make_handle()
+    store.open_embeddings_table.return_value = (MagicMock(), "embeddings_model_a")
+
+    captured: dict[str, Any] = {}
+
+    async def _iter_batches_async(**kwargs: Any):
+        captured.update(kwargs)
+        yield _batch_for(_fallback_frame(), kwargs["columns"])
+
+    store.iter_batches_async = _iter_batches_async
+
+    results = await handle._substring_fallback_async(
+        model_tag="model-a",
+        collection="docs",
+        query_text="alpha",
+        top_k=10,
+        filters={"created_at": {"operator": "gte", "value": 2}},
+        current_warnings=[],
+    )
+
+    assert len(captured["columns"]) == len(set(captured["columns"]))
+    assert [r.chunk_id for r in results] == ["c2", "c3"]
+
+
+@pytest.mark.parametrize(
+    ("shape", "filters"),
+    [
+        # page_number is outside the fallback's base projection, so the columns
+        # must come from the parsed conditions for these shapes to apply.
+        ("single_condition", PAGE_GTE_2),
+        ("tuple_of_conditions", (PAGE_GTE_2,)),
+    ],
+    ids=["single_condition", "tuple_of_conditions"],
+)
+def test_sync_fallback_projects_columns_for_non_dict_shapes(
+    shape: str, filters: Any
+) -> None:
+    """The projection must follow the parsed conditions, not just dict keys."""
+    handle, _ctx, _store = _make_handle()
+    table = _projecting_table(_fallback_frame())
+
+    results = handle._substring_fallback(
+        table=table,
+        collection="docs",
+        query_text="alpha",
+        model_tag="model-a",
+        top_k=10,
+        filters=filters,
+        current_warnings=[],
+    )
+
+    assert [r.chunk_id for r in results] == ["c2", "c3"], (
+        f"the {shape} filter was dropped by the scan"
+    )
+
+
+def test_a_top_level_list_stays_a_disjunction() -> None:
+    """``contracts.FilterExpression`` reads a list as OR; it must not flatten."""
+    handle, _ctx, store = _make_handle()
+    store.create_index.return_value = _index_result()
+    store.search_vectors_by_model.return_value = []
+    or_group = [
+        FilterCondition(field="doc_id", operator=FilterOperator.EQ, value="d1"),
+        FilterCondition(field="doc_id", operator=FilterOperator.EQ, value="d3"),
+    ]
+
+    handle.search_dense("model-a", [0.5], top_k=5, filters=or_group)
+
+    passed = store.search_vectors_by_model.call_args.kwargs["filters"]
+    # collection AND (d1 OR d3): the disjunction survives as one element.
+    assert isinstance(passed, tuple)
+    assert any(isinstance(item, list) for item in passed), (
+        f"the OR group was flattened into the AND list: {passed}"
+    )
+
+
+def _operator_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "collection": ["docs"] * 4,
+            "doc_id": ["d1", "d2", "d3", "d4"],
+            "chunk_id": ["c1", "c2", "c3", "c4"],
+            "text": ["alpha"] * 4,
+            "parse_hash": ["h"] * 4,
+            "created_at": [1, 2, 3, 4],
+            "metadata": [None] * 4,
+            "label": ["a", None, "b%c", "bXc"],
+        }
+    )
+
+
+# Every operator the mask claims to evaluate, and the chunks it must select.
+OPERATOR_CASES = [
+    (FilterOperator.EQ, "label", "a", ["c1"]),
+    # SQL drops NULL rows on `!=`; so must the scan.
+    (FilterOperator.NE, "label", "a", ["c3", "c4"]),
+    (FilterOperator.GT, "created_at", 3, ["c4"]),
+    (FilterOperator.GTE, "created_at", 3, ["c3", "c4"]),
+    (FilterOperator.LT, "created_at", 2, ["c1"]),
+    (FilterOperator.LTE, "created_at", 2, ["c1", "c2"]),
+    (FilterOperator.IN, "doc_id", ["d1", "d4"], ["c1", "c4"]),
+    (FilterOperator.IN, "doc_id", [], []),
+    # A literal substring, not a LIKE pattern and not a regex.
+    (FilterOperator.CONTAINS, "label", "b%c", ["c3"]),
+    # '.' is a regex metacharacter: as a pattern this would also take c4.
+    (FilterOperator.CONTAINS, "label", "b.c", []),
+    (FilterOperator.IS_NULL, "label", None, ["c2"]),
+    (FilterOperator.IS_NOT_NULL, "label", None, ["c1", "c3", "c4"]),
+]
+
+
+@pytest.mark.parametrize(
+    ("operator", "field", "value", "expected"),
+    OPERATOR_CASES,
+    ids=[f"{row[0].value}-{row[1]}-{row[2]}" for row in OPERATOR_CASES],
+)
+def test_scan_evaluates_every_operator_it_accepts(
+    operator: FilterOperator, field: str, value: Any, expected: list[str]
+) -> None:
+    handle, _ctx, _store = _make_handle()
+    table = _projecting_table(_operator_frame())
+
+    results = handle._substring_fallback(
+        table=table,
+        collection="docs",
+        query_text="alpha",
+        model_tag="model-a",
+        top_k=10,
+        filters=FilterCondition(field=field, operator=operator, value=value),
+        current_warnings=[],
+    )
+
+    assert [r.chunk_id for r in results] == expected
+
+
+def test_scan_skips_a_filter_on_a_column_the_table_lacks() -> None:
+    """A missing column is skipped, not turned into an empty result set.
+
+    The embeddings schema carries no arbitrary metadata columns, so projecting
+    one would fail the whole scan inside the swallowing except.
+    """
+    handle, _ctx, _store = _make_handle()
+    table = _projecting_table(_operator_frame())
+
+    results = handle._substring_fallback(
+        table=table,
+        collection="docs",
+        query_text="alpha",
+        model_tag="model-a",
+        top_k=10,
+        filters={"page_number": {"operator": "gte", "value": 2}},
+        current_warnings=[],
+    )
+
+    assert [r.chunk_id for r in results] == ["c1", "c2", "c3", "c4"]
+
+
+def test_a_list_value_reaches_the_backend_as_membership() -> None:
+    """``{"doc_id": [...]}`` is membership on both paths.
+
+    As equality it translated to ``doc_id == '['d1', 'd3']'`` -- not valid SQL,
+    while the scan path read the same input as ``isin``.
+    """
+    handle, _ctx, store = _make_handle()
+    store.create_index.return_value = _index_result()
+    store.search_vectors_by_model.return_value = []
+
+    handle.search_dense("model-a", [0.5], top_k=5, filters={"doc_id": ["d1", "d3"]})
+
+    conditions = _conditions(store.search_vectors_by_model.call_args.kwargs["filters"])
+    assert ("doc_id", "in", ["d1", "d3"]) in conditions, conditions

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_handle_search_filter_parity.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_handle_search_filter_parity.py
@@ -445,3 +445,27 @@ def test_a_list_value_reaches_the_backend_as_membership() -> None:
 
     conditions = _conditions(store.search_vectors_by_model.call_args.kwargs["filters"])
     assert ("doc_id", "in", ["d1", "d3"]) in conditions, conditions
+
+
+def test_contains_does_not_match_the_rendering_of_a_null() -> None:
+    """`astype(str)` renders NULL as "None"/"nan"; a short needle must not hit it."""
+    handle, _ctx, _store = _make_handle()
+    frame = _operator_frame()
+    frame["label"] = ["alpha", None, "beta", "gamma"]
+    table = _projecting_table(frame)
+
+    for needle in ("on", "an", "No", "na"):
+        results = handle._substring_fallback(
+            table=table,
+            collection="docs",
+            query_text="alpha",
+            model_tag="model-a",
+            top_k=10,
+            filters=FilterCondition(
+                field="label", operator=FilterOperator.CONTAINS, value=needle
+            ),
+            current_warnings=[],
+        )
+        assert "c2" not in [r.chunk_id for r in results], (
+            f"needle {needle!r} matched the NULL row"
+        )


### PR DESCRIPTION
**Invariant**: one filter input produces one predicate on every search path -- dense, sparse, and the scan fallbacks.

## Why

`_dense_engine` and `_dense_engine_async` parsed custom filters only when `isinstance(filters, dict)` and assigned `None` otherwise, so a pre-built `FilterExpression`, or a tuple/list of them, was **silently dropped**. `search_sparse` handled all three shapes. The same filter argument therefore applied on sparse and vanished on dense, with no error.

The scan fallbacks had the matching defect for the legacy operator form (`{"page_number": {"operator": "gte", "value": 2}}`). The sync one compared the whole column against that dict, which is `False` for every row, so it answered zero results instead of applying `gte`. The async one pushed the dict down to the store, where `build_filter_from_dict` rejects a dict value with `TypeError`; the fallback's own `except Exception` swallowed it, giving zero results again.

All three share a cause: the same three-branch block was copied into four engines and the two dense copies were missing a branch.

## What changed

Review widened this past its original shape twice, and the body below reflects where it ended up rather than where it started. Two of the changes are in the backend translator (`lancedb_filter_utils.py`), which an earlier version of this description wrongly listed as untouched.

- **`utils/filter_utils.py`** -- new `normalize_filter_conditions`, which turns every accepted shape into a condition list. A tuple is an AND group and flattens; a list is an OR group per `contracts.FilterExpression`, so it stays one element and keeps its disjunction. The four engines now call it instead of each carrying a copy.
- **`parse_legacy_filters`** -- a list/tuple/set value in the dict form now maps to `IN` rather than `EQ`. As equality it translated to `doc_id == '['d1', 'd3']'`, which is not valid SQL, while the scan path read the same input as `isin`.
- **`collection_handle.py`** -- new `_condition_row_mask` evaluates the parsed conditions into a pandas mask, covering all ten operators. The sync fallback uses it. The async fallback pushes only scalar equality down to the store and evaluates the rest locally.
- Scan projection now follows the parsed conditions and is intersected with the table schema. Projecting a column the table lacks fails the whole scan, and the embeddings schema carries no arbitrary metadata columns.

## Entry points

`LanceDBCollectionHandle.search_dense/_async`, `search_sparse/_async`, `_substring_fallback/_async`.

## Known scan-vs-backend semantics

Backend predicates are evaluated by LanceDB, scan predicates by pandas:

- `NE` against NULL rows: the mask adds an explicit `notna()` so it drops them the way SQL's three-valued logic does.
- `CONTAINS` matches a literal substring on both paths. The backend renders it as `LIKE`, whose `%` and `_` are wildcards, so the needle's own metacharacters are escaped with an explicit `ESCAPE` clause. A non-string column is refused rather than coerced, because `LIKE` cannot take one.

## Non-goals

- Issue 3 of #671 (public-boundary validation for sparse/hybrid) is **not** here. It adds rejections at a public boundary, which is a different blast radius, and gets its own PR.
- No change to the public `search_dense` / `search_sparse` signatures (still `dict | None`); the non-dict shapes serve external callers.
- No behaviour change beyond filter evaluation itself.

## Known limitation, not fixed here

The async fallback is unreachable with the pinned dependency. `lancedb_stores.py:2439` calls `table.to_batches(...)`, but `AsyncTable` in lancedb 0.33.0 has no such method (it lives on `table.query()`). The `AttributeError` is swallowed by that function's own `except`, so the generator yields nothing and `_substring_fallback_async` returns empty regardless of filters. The async half of this change therefore cannot be observed in production; its tests substitute the store method. **Do not read this PR as making the async fallback return rows.** Filed separately.

## Verification

- 35 new tests. Stashing the source changes and running them against the unfixed code turns 8 red.
- Mutation matrix, every one caught: drop the column de-duplication, revert the projection to dict keys only, flatten a list back into AND, drop the EQ+collection→isin case, drop the push-down split, drop `NE`'s NULL handling, invert `IS_NULL`, `GT`→`GTE`, `LT`→`LTE`, turn on regex in `CONTAINS`, revert `EQ`→`IN`. Two of these (`CONTAINS`, `EQ`→`IN`) **survived** the first version of the tests and needed sharper cases before they bit.
- Full `tests/core/tools/core/RAG_tools`: one pre-existing failure, `test_process_document_rejects_absolute_paths_outside_allowed_dir` (local model-hub sqlite missing the `models.managed_by` column), identical on a branch without this change.
- `pre-commit run --files` green: ruff check, ruff format, mypy, isort, codespell.
- Two independent review rounds. The first found that the async projection could repeat a base column, which reintroduced the silent zero-result this change exists to remove. The second found `NE`'s NULL semantics, that projecting an absent column empties the scan, and that `IS_NULL`/`IS_NOT_NULL` would fail the whole search. All fixed, each with a test.

Part of #494. Refs #671 (Issue 3 stays open).

