### PR TITLE
fix: address shared execution foundation review

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -386,6 +386,13 @@ jobs:
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
+      - name: Test shared execution foundations (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/migrations/test_shared_execution_foundations.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
       - name: Test MCP OAuth lifecycle fencing (Postgres-only)
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |

--- a/docs/architecture/shared-worker-execution.md
+++ b/docs/architecture/shared-worker-execution.md
@@ -4,15 +4,17 @@ This change contains the acceptance/data and event/recovery foundations for shar
 
 ## Acceptance and persistence
 
-`_AcceptedTurn` represents a persisted turn without an execution lease. The existing `_claim_turn_no_commit` still acquires the lease and returns `_ClaimedTurn` inside the same transaction before scheduling. Message and file binding, Workforce projection, commit reconciliation and local scheduling keep their existing contracts.
+`_AcceptedTurn` represents a persisted turn without an execution lease. The existing `_claim_turn_no_commit` still acquires the lease and returns `_ClaimedTurn` inside the same transaction before scheduling. Message and file binding, Workforce projection, commit reconciliation and local scheduling keep their existing contracts. Terminal finalization now also writes `Task.output` in the same transaction as the assistant transcript on the local path. This brings forward the same content (or failure clearing) that `finish_turn` writes later, allowing shared readers to observe terminal status and durable output together.
 
-`task_runtime_secrets` stores encrypted, single-turn connector secrets and auth selectors. Reads verify task, turn, run and the owner's stable subject. Storage, binding and cleanup operations are available to later ingress/worker integration; existing connector runtime paths do not use this store yet. No secret values are added to task APIs or event payloads.
+`task_runtime_secrets` stores encrypted, single-turn connector secrets and auth selectors. Reads verify task, turn, run and the owner's stable subject. Storage, binding and cleanup operations are available to later ingress/worker integration; existing connector runtime paths do not use this store yet. No secret values are added to task APIs or event payloads. The store requires a valid, explicitly configured `ENCRYPTION_KEY` and rejects the published development key, including when copied from `example.env`. Unavailable key configuration returns `connector_runtime_unavailable` before writing and also when reading an existing, correctly scoped row. If a different valid key cannot decrypt that row, the read returns `runtime_secret_unavailable` instead; both errors are HTTP 503, and neither returns credential contents.
+
+These inputs belong to one execution, not the lifetime of a paused conversation. After its lease is released into `paused` or `waiting_for_user`, cleanup removes them. A subsequent resume must supply fresh secret/auth-selector values through ingress; missing required values fail with `runtime_secret_unavailable`. Resuming must not silently reuse or omit an earlier execution's credentials. The integration that first enables staging must wire terminal deletion and the compensation sweep in the same change. There is no TTL or running sweep in this foundation PR.
 
 Nullable `reply_host_id` and `reply_origin` fields identify the creating ingress and its exact socket registration. They are stored when a command is created; duplicate submissions cannot overwrite the route. The migration preserves existing commands and can be downgraded independently.
 
 ## Events and recovery
 
-The Redis bridge provides task fanout, origin-bound private replies, socket acknowledgements, bounded deduplication and reconnect notifications. Redis remains a Pub/Sub transport, not a task queue or replay log. A private-reply timeout is delivery-unknown and must not cause command execution to retry.
+The Redis bridge provides task fanout, origin-bound private replies, socket acknowledgements, bounded deduplication and reconnect notifications. Redis remains a Pub/Sub transport, not a task queue or replay log. A private-reply timeout is delivery-unknown and must not cause command execution to retry. Replies without an origin route remain valid for non-socket ingress; they emit a warning and a `xagent.task.reply.delivery` counter with `outcome=no_route`, without logging the reply content.
 
 State-bearing event enrichment is extracted from the WebSocket API so a future producer can capture the original run/version before transport. Each shared socket has a bounded writer queue; slow sockets cannot block the other recipients. Authorized task audiences can receive persistent state/output snapshots to reconcile missing events.
 
@@ -20,7 +22,7 @@ The frontend handles unavailable/resync notifications and exact-run snapshots. I
 
 ## Activation boundary
 
-`XAGENT_SHARED_TASK_EXECUTION_ENABLED` defaults to **false in this intermediate change**. Keep it false: this change does not wire the bridge into application startup and is not a deployable shared execution mode. Tests explicitly initialize the bridge to exercise its contracts.
+`XAGENT_SHARED_TASK_EXECUTION_ENABLED` defaults to **false in this intermediate change**. Application startup refuses `true`: this change does not wire the bridge into application startup and is not a deployable shared execution mode. Treat the flag as process startup configuration; changing it inside a running process is unsupported. Tests explicitly initialize the bridge to exercise its contracts. Reconciliation lifecycle tests also start and stop `ConnectionManager`'s loop explicitly; production startup must wire both the bridge and the reconciliation loop together in the activation change.
 
 `XAGENT_TASK_EVENT_CHANNEL_PREFIX` defaults to `xagent:task-events:v1`. Redis logical DB numbers do not isolate Pub/Sub; separate deployments need different prefixes.
 

--- a/example.env
+++ b/example.env
@@ -985,6 +985,8 @@ XAGENT_ARTIFACT_VALIDATION_TIMEOUT_SECONDS=8
 
 # Database encryption key
 # Generate one with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# The published development key below is rejected by the single-turn connector
+# credential store. Configure a private Fernet key before integrating that store.
 ENCRYPTION_KEY="RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
 
 # ===========================================
@@ -1209,6 +1211,7 @@ ENCRYPTION_KEY="RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
 
 # Shared task execution foundations. Keep disabled until host integration lands.
 # This release does not start the event bridge or a shared task worker.
+# Startup refuses true until shared worker/bridge lifecycle integration lands.
 XAGENT_SHARED_TASK_EXECUTION_ENABLED=false
 # Redis Pub/Sub ignores logical DB numbers; namespace each deployment separately.
 XAGENT_TASK_EVENT_CHANNEL_PREFIX=xagent:task-events:v1

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -636,6 +636,41 @@ describe("AppProvider websocket message routing", () => {
     expect(screen.getByTestId("stream-recovery").textContent).toBe("")
   })
 
+  it.each([false, true])("keeps recovery after a completed answer receives a late start (wrapped=%s)", (wrapped) => {
+    render(<AppProvider token="token"><SeedRunningTask /><StateProbe /></AppProvider>)
+    const send = (message: Partial<TestWebSocketMessage> & Record<string, unknown>) => act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "task_started", task_id: 1, timestamp: "2026-05-27T05:00:02Z", ...message,
+      })
+    })
+    const answerFrame = (type: string, data: Record<string, unknown>) => send({
+      stream_run_id: "run-1", stream_attempt_id: "attempt-1",
+      ...(wrapped ? { type: "trace_event", event_type: type, data: { data } } : { type, data }),
+    })
+    send({ run_id: "run-1", state_version: 1, status: "running", control_state: "running" })
+    answerFrame("final_answer_start", { message_id: "final_answer_1" })
+    answerFrame("final_answer_end", { message_id: "final_answer_1", content: "richer live answer" })
+    const snapshot = {
+      type: "task_stream_snapshot", run_id: "run-1", state_version: 2,
+      status: "completed", control_state: "completed",
+      data: { output: "durable answer", lease_attempt_id: "attempt-1" },
+    }
+    // Healthy completed output keeps its richer live presentation.
+    send(snapshot)
+    expect(screen.getByTestId("messages").textContent).toContain("richer live answer")
+    send({ type: "stream_unavailable" })
+    expect(screen.getByTestId("stream-recovery").textContent).toBe("1")
+    answerFrame("final_answer_start", { message_id: "final_answer_1" })
+    expect(screen.getByTestId("stream-recovery").textContent).toBe("1")
+    answerFrame("final_answer_delta", { message_id: "final_answer_1", delta: "LATE SUFFIX" })
+    expect(screen.getByTestId("messages").textContent).not.toContain("LATE SUFFIX")
+    // An interruption lets durable output replace even an already-complete result.
+    send(snapshot)
+    expect(screen.getByTestId("messages").textContent).toContain("durable answer")
+    expect(screen.getByTestId("messages").textContent).not.toContain("richer live answer")
+    expect(screen.getByTestId("stream-recovery").textContent).toBe("")
+  })
+
   it("resumes shared deltas when a start establishes the missing prefix", () => {
     render(<AppProvider token="token"><SeedRunningTask /><StateProbe /></AppProvider>)
     const send = (type: string, data: Record<string, unknown>) => act(() => {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -2884,7 +2884,7 @@ export function AppProvider({
           stream.interrupted = false
           dispatch({ type: "SET_STREAM_RECOVERY", payload: null })
         }
-        if (stream.interrupted || stream.complete) return
+        if (stream.interrupted) return
         if (replacesContent) stream.complete = true
       }
     }

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -42,6 +42,9 @@ INTERACTION_PROTOCOL_MODE = "XAGENT_INTERACTION_PROTOCOL_MODE"
 INTERACTION_NATIVE_SOURCES = "XAGENT_INTERACTION_NATIVE_SOURCES"
 SHARED_TASK_EXECUTION_ENABLED = "XAGENT_SHARED_TASK_EXECUTION_ENABLED"
 TASK_EVENT_CHANNEL_PREFIX = "XAGENT_TASK_EVENT_CHANNEL_PREFIX"
+ENCRYPTION_KEY = "ENCRYPTION_KEY"
+# Public development fallback; runtime credential storage must reject it.
+DEV_FALLBACK_ENCRYPTION_KEY = "RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
 TASK_LEASE_TTL_SECONDS = "XAGENT_TASK_LEASE_TTL_SECONDS"
 TASK_LEASE_HEARTBEAT_SECONDS = "XAGENT_TASK_LEASE_HEARTBEAT_SECONDS"
 TASK_LEASE_RECOVERY_INTERVAL_SECONDS = "XAGENT_TASK_LEASE_RECOVERY_INTERVAL_SECONDS"
@@ -749,6 +752,18 @@ def get_redis_url() -> str | None:
 def get_shared_task_execution_enabled() -> bool:
     """Enable durable task handoff and the shared event bridge when explicitly configured."""
     return _get_bool_env(SHARED_TASK_EXECUTION_ENABLED, False)
+
+
+def get_task_runtime_secrets_encryption_key() -> str | None:
+    """Return an explicitly configured, non-default ENCRYPTION_KEY.
+
+    Single-turn connector credentials must never use the published development
+    fallback. Invalid Fernet keys are rejected by the store before any write.
+    """
+    key = os.getenv(ENCRYPTION_KEY)
+    if not key or key == DEV_FALLBACK_ENCRYPTION_KEY:
+        return None
+    return key
 
 
 def get_task_event_channel_prefix() -> str:

--- a/src/xagent/core/model/storage/db/db_models.py
+++ b/src/xagent/core/model/storage/db/db_models.py
@@ -7,6 +7,8 @@ from cryptography.fernet import Fernet
 from sqlalchemy import JSON, Boolean, Column, DateTime, Float, Integer, String, Text
 from sqlalchemy.sql import func
 
+from .....config import DEV_FALLBACK_ENCRYPTION_KEY
+
 
 def create_model_table(Base: Type[Any]) -> Type[Any]:
     """
@@ -68,7 +70,7 @@ def create_model_table(Base: Type[Any]) -> Type[Any]:
             encryption_key = os.getenv("ENCRYPTION_KEY")
             if not encryption_key:
                 # FIXME: For dev only
-                return "RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
+                return DEV_FALLBACK_ENCRYPTION_KEY
             return encryption_key
 
         @property

--- a/src/xagent/core/utils/encryption.py
+++ b/src/xagent/core/utils/encryption.py
@@ -7,6 +7,8 @@ from functools import lru_cache
 
 from cryptography.fernet import Fernet, InvalidToken
 
+from ...config import DEV_FALLBACK_ENCRYPTION_KEY
+
 logger = logging.getLogger(__name__)
 
 
@@ -19,7 +21,7 @@ def _get_encryption_key() -> str:
                 "ENCRYPTION_KEY environment variable is not set in non-development environment"
             )
         # FIXME: For dev only, same as in db_models.py
-        return "RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
+        return DEV_FALLBACK_ENCRYPTION_KEY
     return encryption_key
 
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -35,6 +35,7 @@ from sqlalchemy.orm import Session
 
 from ...config import (
     get_external_upload_dirs,
+    get_shared_task_execution_enabled,
     get_uploads_dir,
 )
 from ...core.agent.checkpoint import (
@@ -123,6 +124,8 @@ from ..services.task_command_transport import (
     dispatch_task_command_promptly,
     enqueue_task_command,
 )
+
+# The v1 SSE endpoint imports this shared predicate from this module.
 from ..services.task_event_state import (
     _is_versioned_task_event as _is_versioned_task_event,
 )
@@ -159,13 +162,14 @@ from ..services.task_execution_controller import (
     task_control_snapshot,
 )
 from ..services.task_execution_controller import (
-    task_execution_controller as task_execution_controller,
+    task_execution_controller as task_execution_controller,  # Tests patch this API module's controller.snapshot.
 )
 from ..services.task_interaction_read import get_pending_interaction_question
 from ..services.task_runtime import (
     mcp_runtime_authorization_policy_required,
     task_extension_bindings_from_agent_config,
 )
+from ..services.task_socket_writer import TaskSocketWriter
 from ..services.uploaded_file_store import (
     UploadedFileStore,
     UploadedFileVersionConflict,
@@ -1085,10 +1089,6 @@ class _CommandOriginRegistry:
 _command_origins = _CommandOriginRegistry()
 
 
-from ...config import get_shared_task_execution_enabled  # noqa: E402
-from ..services.task_socket_writer import TaskSocketWriter  # noqa: E402
-
-
 class ConnectionManager:
     def __init__(self) -> None:
         # task_id -> List[WebSocket]
@@ -1187,7 +1187,12 @@ class ConnectionManager:
         encoded = json.dumps(message)
         for connection in self.connections_for_task(task_id):
             writer = self._writers.get(connection)
-            if writer is not None:
+            if writer is None:
+                logger.warning(
+                    "Shared task event skipped: connection has no writer task_id=%s",
+                    task_id,
+                )
+            else:
                 try:
                     writer.enqueue(encoded)
                 except ConnectionError:

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -26,6 +26,7 @@ from ..config import (
     get_gmail_watch_renewal_interval_seconds,
     get_orphan_upload_sweep_interval_seconds,
     get_session_secret,
+    get_shared_task_execution_enabled,
     get_task_lease_recovery_batch_size,
     get_task_lease_recovery_interval_seconds,
     get_taskless_upload_ttl_seconds,
@@ -1328,6 +1329,11 @@ async def _initialize_database_and_admit_runtime(app_instance: FastAPI) -> None:
 async def startup_event() -> None:
     global _migration_task
     logger.info("Agent runtime configured: %s", get_agent_runtime())
+    if get_shared_task_execution_enabled():
+        raise RuntimeError(
+            "XAGENT_SHARED_TASK_EXECUTION_ENABLED must remain false: "
+            "shared worker and event bridge startup are not wired yet."
+        )
     validate_interaction_rollout_at_startup()
     await _initialize_database_and_admit_runtime(app)
 

--- a/src/xagent/web/models/user_channel.py
+++ b/src/xagent/web/models/user_channel.py
@@ -7,26 +7,26 @@ from sqlalchemy import JSON, Boolean, Column, DateTime, ForeignKey, Integer, Str
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
+from ...config import DEV_FALLBACK_ENCRYPTION_KEY
 from .database import Base
 
 # Dev-only fallback so local setups work without configuration. Production
 # deployments must set ENCRYPTION_KEY; has_production_channel_encryption_key()
 # gates features (such as Slack workspace OAuth) that persist third-party
 # tokens on a real key being configured.
-_DEV_FALLBACK_ENCRYPTION_KEY = "RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
 
 
 def has_production_channel_encryption_key() -> bool:
     """Report whether a non-default channel-config encryption key is set."""
     encryption_key = os.getenv("ENCRYPTION_KEY")
-    return bool(encryption_key) and encryption_key != _DEV_FALLBACK_ENCRYPTION_KEY
+    return bool(encryption_key) and encryption_key != DEV_FALLBACK_ENCRYPTION_KEY
 
 
 def _get_cipher() -> Fernet:
     encryption_key = os.getenv("ENCRYPTION_KEY")
     if not encryption_key:
         # FIXME: For dev only
-        encryption_key = _DEV_FALLBACK_ENCRYPTION_KEY
+        encryption_key = DEV_FALLBACK_ENCRYPTION_KEY
     return Fernet(
         encryption_key.encode() if isinstance(encryption_key, str) else encryption_key
     )

--- a/src/xagent/web/services/task_event_bridge.py
+++ b/src/xagent/web/services/task_event_bridge.py
@@ -16,6 +16,7 @@ from redis.asyncio import Redis
 from redis.exceptions import RedisError
 
 from ...config import get_redis_url, get_task_event_channel_prefix
+from ...core.runtime_performance import increment_counter
 from ..models.database import get_session_local
 from ..models.task_command import TaskExecutionCommand
 from .db_runtime import run_db_io_cancellation_safe
@@ -296,6 +297,14 @@ class TaskEventBridge:
                 lambda: _reply_route(task_id, command_id)
             )
             if route is None:
+                logger.warning(
+                    "Task reply has no origin route task_id=%s command_id=%s",
+                    task_id,
+                    command_id,
+                )
+                increment_counter(
+                    "xagent.task.reply.delivery", attributes={"outcome": "no_route"}
+                )
                 return
             host_id, origin = route
             delivery_id = uuid4().hex

--- a/src/xagent/web/services/task_execution.py
+++ b/src/xagent/web/services/task_execution.py
@@ -1669,6 +1669,8 @@ def _finalize_task_execution_result_isolated(
                 # Shared readers may observe completion before scheduler
                 # cleanup runs. Publish its durable output in this same
                 # fenced transaction as the terminal state and transcript.
+                # This also runs locally: finish_turn later writes the same
+                # assistant content (or clears output on failure).
                 setattr(
                     task_updated,
                     "output",

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -48,7 +48,7 @@ import asyncio
 import enum
 import logging
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
@@ -1190,7 +1190,7 @@ def _claim_turn_no_commit(
     lease = acquire_task_lease_no_commit(db, task_id, expected_run_id=accepted.run_id)
     if lease is None:
         raise RuntimeError(f"task {task_id} could not stage its exact execution lease")
-    return _ClaimedTurn(**asdict(accepted), task_lease=lease)
+    return _ClaimedTurn(**vars(accepted), task_lease=lease)
 
 
 def _begin_turn_atomic_sync(

--- a/src/xagent/web/services/task_runtime_secrets.py
+++ b/src/xagent/web/services/task_runtime_secrets.py
@@ -5,18 +5,19 @@ from __future__ import annotations
 import json
 from typing import Any, cast
 
-from cryptography.fernet import InvalidToken
+from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy import delete, select, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import Session
 
+from ...config import get_task_runtime_secrets_encryption_key
 from ...core.tools.adapters.vibe.connector_runtime import (
+    ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
     ERROR_RUNTIME_SECRET_UNAVAILABLE,
     RUNTIME_SECRET_REASON_STORE_LOST,
     ConnectorRef,
     ConnectorRuntimeError,
 )
-from ...core.utils.encryption import get_cipher
 from ..models.database import get_session_local
 from ..models.task import Task, TaskStatus
 from ..models.task_runtime_secret import TaskRuntimeSecret
@@ -32,6 +33,23 @@ def _unavailable() -> ConnectorRuntimeError:
     )
 
 
+def _runtime_cipher() -> Fernet:
+    key = get_task_runtime_secrets_encryption_key()
+    if key is not None:
+        try:
+            return Fernet(key.encode())
+        except (ValueError, UnicodeError):
+            pass
+    # Do not reuse get_cipher(): another feature may have cached the public
+    # development fallback. Never include the configured key in this error.
+    raise ConnectorRuntimeError(
+        ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+        "Connector runtime storage requires a valid, non-default ENCRYPTION_KEY.",
+        details={"reason": "encryption_key_unavailable"},
+        status_code=503,
+    )
+
+
 def stage_runtime_values(
     db: Session,
     *,
@@ -43,9 +61,12 @@ def stage_runtime_values(
 
     Bind them to the accepted run with ``bind_runtime_values_to_run`` before
     committing this same transaction. Unbound inputs must not be committed.
+    The ingress that first wires these writes must also wire terminal cleanup
+    and the compensation sweep in the same change; there is no independent TTL.
     """
     if not values_by_ref:
         return
+    cipher = _runtime_cipher()
     owner_subject = db.execute(
         select(User.actor_subject)
         .join(Task, Task.user_id == User.id)
@@ -57,9 +78,7 @@ def stage_runtime_values(
         "owner_subject": owner_subject,
         "values": {ref.storage_key: values for ref, values in values_by_ref.items()},
     }
-    ciphertext = (
-        get_cipher().encrypt(json.dumps(body, allow_nan=False).encode()).decode()
-    )
+    ciphertext = cipher.encrypt(json.dumps(body, allow_nan=False).encode()).decode()
     db.add(
         TaskRuntimeSecret(
             task_id=task_id,
@@ -91,6 +110,12 @@ def load_runtime_values(
     turn_id: str,
     required: bool = False,
 ) -> dict[str, Any] | None:
+    """Read scoped inputs; both configuration and stored-value errors are 503.
+
+    An unavailable key raises connector_runtime_unavailable. A valid key that
+    cannot decrypt the row raises runtime_secret_unavailable, as do missing
+    required inputs or mismatched ownership/run bindings.
+    """
     row = db.execute(
         select(TaskRuntimeSecret).where(
             TaskRuntimeSecret.task_id == task.id,
@@ -107,7 +132,7 @@ def load_runtime_values(
     if owner != row.owner_subject or row.run_id != task.run_id:
         raise _unavailable()
     try:
-        body = json.loads(get_cipher().decrypt(row.ciphertext.encode()))
+        body = json.loads(_runtime_cipher().decrypt(row.ciphertext.encode()))
     except (InvalidToken, ValueError, UnicodeError):
         raise _unavailable() from None
     if (
@@ -147,6 +172,9 @@ def clean_finished_runtime_values() -> None:
 
     Accepted inputs already have a run binding at commit; another session
     cannot observe the intermediate unbound rows in the acceptance transaction.
+    PAUSED and WAITING_FOR_USER end this execution's access once its lease is
+    released. Resuming requires freshly supplied values; required loads of
+    removed inputs fail with runtime_secret_unavailable, never an empty secret.
     """
     with get_session_local()() as db:
         rows = (

--- a/src/xagent/web/services/task_socket_writer.py
+++ b/src/xagent/web/services/task_socket_writer.py
@@ -14,6 +14,7 @@ class TaskSocketWriter:
         )
         self.bytes = 0
         self.closed = False
+        self.close_task: asyncio.Task[None] | None = None
         self.task = asyncio.create_task(self._run())
 
     def enqueue(
@@ -23,8 +24,9 @@ class TaskSocketWriter:
             raise ConnectionError("Task connection is closed")
         if self.queue.full() or self.bytes + len(text.encode()) > 2 * 1024 * 1024:
             self.stop()
-            self.disconnect()
-            asyncio.create_task(self._close_socket())
+            # Overflow can happen before _run starts, so its finally cannot
+            # own this close. Retain the bounded task until it completes.
+            self.close_task = asyncio.create_task(self._close_socket())
             raise ConnectionError(
                 "Task connection is too slow; reconnect to synchronize"
             )
@@ -40,6 +42,8 @@ class TaskSocketWriter:
             pass
 
     def stop(self) -> None:
+        if self.closed:
+            return
         self.closed = True
         if self.task is not asyncio.current_task():
             self.task.cancel()
@@ -48,6 +52,7 @@ class TaskSocketWriter:
             if future is not None and not future.done():
                 future.set_exception(ConnectionError("Task connection is closed"))
         self.bytes = 0
+        self.disconnect()
 
     async def _run(self) -> None:
         pending = None
@@ -68,6 +73,5 @@ class TaskSocketWriter:
             if pending is not None and not pending.done():
                 pending.set_exception(ConnectionError("Task connection send failed"))
             self.stop()
-            self.disconnect()
             if send_failed:
                 await self._close_socket()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -2887,3 +2887,21 @@ def test_task_event_channel_prefix_default_and_override(monkeypatch):
     assert config.get_task_event_channel_prefix() == "xagent:task-events:v1"
     monkeypatch.setenv(config.TASK_EVENT_CHANNEL_PREFIX, "xagent:staging:v1")
     assert config.get_task_event_channel_prefix() == "xagent:staging:v1"
+
+
+@pytest.mark.parametrize(
+    "key", [None, "", "RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="]
+)
+def test_task_runtime_secrets_reject_unconfigured_or_public_key(monkeypatch, key):
+    monkeypatch.delenv(config.ENCRYPTION_KEY, raising=False)
+    if key is not None:
+        monkeypatch.setenv(config.ENCRYPTION_KEY, key)
+    assert config.get_task_runtime_secrets_encryption_key() is None
+
+
+def test_task_runtime_secrets_use_explicit_key(monkeypatch):
+    from cryptography.fernet import Fernet
+
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv(config.ENCRYPTION_KEY, key)
+    assert config.get_task_runtime_secrets_encryption_key() == key

--- a/tests/web/api/test_websocket_task_control_state.py
+++ b/tests/web/api/test_websocket_task_control_state.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from anyio import BrokenResourceError, ClosedResourceError
@@ -611,3 +611,139 @@ def test_detach_task_connections_removes_forward_and_reverse_membership() -> Non
     assert detached == [first_websocket, second_websocket]
     assert connection_manager.active_connections == {other_task_id: [other_websocket]}
     assert connection_manager._connection_task_ids == {other_websocket: other_task_id}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status", [TaskStatus.RUNNING, TaskStatus.COMPLETED, TaskStatus.WAITING_FOR_USER]
+)
+async def test_shared_reconciliation_reads_persisted_state_and_stops(
+    current_task, monkeypatch, status
+):
+    import threading
+
+    from xagent.web.models.database import get_session_local
+    from xagent.web.services import task_event_bridge, task_stream_snapshot
+
+    with get_session_local()() as db:
+        task = db.get(Task, current_task.id)
+        task.status = status
+        task.control_state = status.value
+        task.output = "complete durable result"
+        task.lease_attempt_id = "attempt-current"
+        db.commit()
+    monkeypatch.setenv("XAGENT_SHARED_TASK_EXECUTION_ENABLED", "true")
+    monkeypatch.setattr(
+        task_event_bridge, "_bridge", SimpleNamespace(discard_recipient=lambda ws: None)
+    )
+    loop_thread = threading.get_ident()
+    read_threads = []
+    load = task_stream_snapshot.load_task_stream_snapshots
+
+    def load_off_loop(task_ids):
+        read_threads.append(threading.get_ident())
+        return load(task_ids)
+
+    monkeypatch.setattr(
+        task_stream_snapshot, "load_task_stream_snapshots", load_off_loop
+    )
+    received = asyncio.Event()
+
+    class Socket(_RecordingWebSocket):
+        async def send_text(self, message):
+            await super().send_text(message)
+            received.set()
+
+    socket = Socket()
+    manager = ConnectionManager()
+    manager.register_connection(socket, current_task.id)
+    writer = manager._writers[socket]
+    manager.start_stream_reconciliation()
+    reconciler = manager._stream_reconciler
+    try:
+        await asyncio.wait_for(received.wait(), timeout=2)
+        frame = json.loads(socket.messages[0])
+        assert frame["type"] == "task_stream_snapshot"
+        assert frame["task_id"] == current_task.id
+        assert frame["run_id"] == "run-current"
+        assert frame["state_version"] == 7
+        assert frame["status"] == status.value
+        assert frame["lease_attempt_id"] == "attempt-current"
+        assert frame["output"] == (
+            "complete durable result" if status == TaskStatus.COMPLETED else None
+        )
+        if status == TaskStatus.WAITING_FOR_USER:
+            assert "question" in frame and "interactions" in frame
+        assert read_threads and loop_thread not in read_threads
+    finally:
+        await asyncio.wait_for(manager.stop_stream_reconciliation(), timeout=2)
+        manager.disconnect(socket)
+        await asyncio.wait_for(
+            asyncio.gather(writer.task, return_exceptions=True), timeout=2
+        )
+    assert reconciler.done()
+    assert manager._stream_reconciler is None
+    assert not manager.active_connections
+
+
+@pytest.mark.asyncio
+async def test_shared_delivery_logs_connection_without_writer(monkeypatch, caplog):
+    monkeypatch.setenv("XAGENT_SHARED_TASK_EXECUTION_ENABLED", "false")
+    manager = ConnectionManager()
+    socket = _RecordingWebSocket()
+    manager.register_connection(socket, 42)
+    await manager.deliver_shared_event(
+        {"type": "diagnostic", "content": "private content"}, 42
+    )
+    assert "connection has no writer task_id=42" in caplog.text
+    assert "private content" not in caplog.text
+    manager.disconnect(socket)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("started", [False, True])
+async def test_manager_disconnect_reentry_cleans_writer_and_both_origin_registries(
+    monkeypatch, started
+):
+    from xagent.web.services import task_event_bridge
+
+    monkeypatch.setenv("XAGENT_SHARED_TASK_EXECUTION_ENABLED", "true")
+    monkeypatch.setenv("XAGENT_REDIS_URL", "redis://localhost:6379/0")
+    bridge = task_event_bridge.TaskEventBridge()
+    bridge.ready.set()
+    monkeypatch.setattr(task_event_bridge, "_bridge", bridge)
+    origins = websocket_api._CommandOriginRegistry()
+    monkeypatch.setattr(websocket_api, "_command_origins", origins)
+    manager = ConnectionManager()
+    disconnect = Mock(wraps=manager.disconnect)
+    monkeypatch.setattr(manager, "disconnect", disconnect)
+    socket = _BlockingSendWebSocket()
+    manager.register_connection(socket, 42)
+    writer = manager._writers[socket]
+    origins.register("command-1", socket, 42)
+    origin = bridge.register_origin(42, "command-1", AsyncMock(), recipient=socket)
+    acknowledgement = writer.enqueue("pending", acknowledge=True)
+    try:
+        if started:
+            await asyncio.wait_for(socket.send_started.wait(), timeout=1)
+        manager.disconnect(socket)
+        await asyncio.wait_for(
+            asyncio.gather(writer.task, return_exceptions=True), timeout=2
+        )
+        with pytest.raises(ConnectionError):
+            await asyncio.wait_for(acknowledgement, timeout=1)
+        # stop() re-enters the real manager once; the writer has already been
+        # popped, so this must terminate and leave both origin registries clean.
+        assert disconnect.call_count == 2
+        assert writer.closed and writer.queue.empty()
+        assert not manager._writers
+        assert not manager._connection_task_ids
+        assert not manager.active_connections
+        assert not origins.has("command-1", 42)
+        assert origin not in bridge._origins
+        manager.disconnect(socket)
+        assert disconnect.call_count == 3
+    finally:
+        manager.disconnect(socket)
+        await asyncio.gather(writer.task, return_exceptions=True)
+        await bridge.close()

--- a/tests/web/services/test_task_event_bridge.py
+++ b/tests/web/services/test_task_event_bridge.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
@@ -157,34 +158,48 @@ async def test_negative_socket_ack_preserves_connection_error(bridge, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_socket_writer_ack_follows_send_and_slow_queue_is_bounded():
+@pytest.mark.parametrize("started", [False, True])
+async def test_socket_writer_ack_follows_send_and_slow_queue_is_bounded(started):
     class Socket:
         def __init__(self):
-            self.release = asyncio.Event()
             self.entered = asyncio.Event()
-            self.closed = False
+            self.close_codes = []
 
         async def send_text(self, text):
             self.entered.set()
-            await self.release.wait()
+            await asyncio.Event().wait()
 
         async def close(self, code):
-            self.closed = True
+            self.close_codes.append(code)
 
     socket = Socket()
-    writer = TaskSocketWriter(socket, lambda: None)
+    disconnected = []
+
+    def disconnect():
+        disconnected.append(True)
+        # ConnectionManager.disconnect also stops the writer it removes.
+        writer.stop()
+
+    writer = TaskSocketWriter(socket, disconnect)
     ack = writer.enqueue("first", acknowledge=True)
-    await socket.entered.wait()
+    if started:
+        await asyncio.wait_for(socket.entered.wait(), timeout=1)
     assert not ack.done()
-    for _ in range(256):
+    while not writer.queue.full():
         writer.enqueue("queued")
     with pytest.raises(ConnectionError):
         writer.enqueue("overflow")
-    await asyncio.gather(writer.task)
+    await asyncio.wait_for(
+        asyncio.gather(writer.task, return_exceptions=True), timeout=2
+    )
+    assert writer.close_task is not None
+    await asyncio.wait_for(writer.close_task, timeout=1)
     with pytest.raises(ConnectionError):
-        await ack
+        await asyncio.wait_for(ack, timeout=1)
     assert writer.closed
     assert writer.queue.empty()
+    assert socket.close_codes == [1013]
+    assert disconnected == [True]
 
 
 @pytest.mark.asyncio
@@ -325,8 +340,28 @@ async def test_single_send_failure_closes_socket_for_reconnection(failure):
     acknowledgement = writer.enqueue("one message", acknowledge=True)
     await asyncio.wait_for(writer.task, timeout=8)
     with pytest.raises(ConnectionError, match="send failed"):
-        await acknowledgement
+        await asyncio.wait_for(acknowledgement, timeout=1)
     assert socket.close_codes == [1013]
     assert disconnected == [True]
     assert writer.closed
     assert writer.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_reply_without_route_is_observable_without_publishing(
+    bridge, monkeypatch, caplog
+):
+    monkeypatch.setattr(module, "_reply_route", lambda *args: None)
+    publish = AsyncMock()
+    counter = Mock()
+    monkeypatch.setattr(bridge, "_publish", publish)
+    monkeypatch.setattr(module, "increment_counter", counter)
+    await bridge.reply_for("command-1", 42)({"content": "private reply content"})
+    publish.assert_not_awaited()
+    counter.assert_called_once_with(
+        "xagent.task.reply.delivery", attributes={"outcome": "no_route"}
+    )
+    assert "no origin route task_id=42 command_id=command-1" in caplog.text
+    assert "private reply content" not in caplog.text
+    assert not bridge._acks
+    await bridge.close()

--- a/tests/web/services/test_task_runtime_secrets.py
+++ b/tests/web/services/test_task_runtime_secrets.py
@@ -1,8 +1,11 @@
 """Single-turn runtime inputs remain encrypted, scoped and transactional."""
 
 import pytest
+from cryptography.fernet import Fernet, InvalidToken
 
 from xagent.core.tools.adapters.vibe.connector_runtime import (
+    ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+    ERROR_RUNTIME_SECRET_UNAVAILABLE,
     ConnectorRef,
     ConnectorRuntimeError,
 )
@@ -23,6 +26,13 @@ VALUES = {
         "auth_selector": {"account": "synthetic-account"},
     }
 }
+
+
+@pytest.fixture(autouse=True)
+def private_encryption_key(monkeypatch):
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("ENCRYPTION_KEY", key)
+    return key
 
 
 @pytest.fixture
@@ -114,11 +124,16 @@ def test_compensation_preserves_queued_and_active_inputs(task_id):
         assert db.query(TaskRuntimeSecret).count() == 0
 
 
-def test_compensation_waits_for_waiting_execution_to_release_lease(task_id):
+@pytest.mark.parametrize(
+    "resting_status", [TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER]
+)
+def test_resumed_execution_requires_fresh_values_after_lease_release(
+    task_id, resting_status
+):
     with get_session_local()() as db:
         stage(db, task_id)
         task = db.get(Task, task_id)
-        task.status = TaskStatus.WAITING_FOR_USER
+        task.status = resting_status
         task.runner_id = "worker"
         db.commit()
     clean_finished_runtime_values()
@@ -129,6 +144,14 @@ def test_compensation_waits_for_waiting_execution_to_release_lease(task_id):
     clean_finished_runtime_values()
     with get_session_local()() as db:
         assert db.query(TaskRuntimeSecret).count() == 0
+        task = db.get(Task, task_id)
+        task.status = TaskStatus.RUNNING
+        task.runner_id = "resumed-worker"
+        with pytest.raises(ConnectorRuntimeError) as error:
+            load_runtime_values(db, task=task, turn_id="turn-1", required=True)
+        assert error.value.code == ERROR_RUNTIME_SECRET_UNAVAILABLE
+        stage(db, task_id)
+        assert load_runtime_values(db, task=task, turn_id="turn-1", required=True)
 
 
 def test_cleanup_cannot_observe_inputs_before_transaction_binds_run(task_id):
@@ -152,3 +175,85 @@ def test_cleanup_cannot_observe_inputs_before_transaction_binds_run(task_id):
         assert load_runtime_values(
             observer, task=observer.get(Task, task_id), turn_id="turn-1", required=True
         )
+
+
+@pytest.mark.parametrize(
+    "key",
+    [None, "", "RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc=", "invalid-key", "非密钥"],
+)
+def test_invalid_key_refuses_staging_without_writing(task_id, monkeypatch, key):
+    monkeypatch.delenv("ENCRYPTION_KEY", raising=False)
+    if key is not None:
+        monkeypatch.setenv("ENCRYPTION_KEY", key)
+    with get_session_local()() as db:
+        with pytest.raises(ConnectorRuntimeError) as error:
+            stage(db, task_id)
+        assert error.value.code == ERROR_CONNECTOR_RUNTIME_UNAVAILABLE
+        assert error.value.status_code == 503
+        assert "synthetic-secret" not in str(error.value)
+        db.commit()
+    with get_session_local()() as observer:
+        assert observer.query(TaskRuntimeSecret).count() == 0
+
+
+def test_store_does_not_reuse_cached_development_cipher(
+    task_id, monkeypatch, private_encryption_key
+):
+    from xagent.core.utils.encryption import get_cipher
+
+    get_cipher.cache_clear()
+    try:
+        monkeypatch.delenv("ENCRYPTION_KEY")
+        development_cipher = get_cipher()
+        monkeypatch.setenv("ENCRYPTION_KEY", private_encryption_key)
+        with get_session_local()() as db:
+            stage(db, task_id)
+            ciphertext = db.query(TaskRuntimeSecret).one().ciphertext.encode()
+            assert b"synthetic-secret" in Fernet(
+                private_encryption_key.encode()
+            ).decrypt(ciphertext)
+            with pytest.raises(InvalidToken):
+                development_cipher.decrypt(ciphertext)
+            assert load_runtime_values(
+                db, task=db.get(Task, task_id), turn_id="turn-1", required=True
+            )
+    finally:
+        get_cipher.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "key_state", ["unset", "empty", "default", "malformed", "rotated"]
+)
+def test_read_distinguishes_key_configuration_from_decryption_failure(
+    task_id, monkeypatch, key_state
+):
+    from xagent.config import DEV_FALLBACK_ENCRYPTION_KEY
+
+    with get_session_local()() as db:
+        stage(db, task_id)
+        db.commit()
+    if key_state == "unset":
+        monkeypatch.delenv("ENCRYPTION_KEY")
+    else:
+        monkeypatch.setenv(
+            "ENCRYPTION_KEY",
+            {
+                "empty": "",
+                "default": DEV_FALLBACK_ENCRYPTION_KEY,
+                "malformed": "not-a-fernet-key",
+                "rotated": Fernet.generate_key().decode(),
+            }[key_state],
+        )
+    with get_session_local()() as db:
+        with pytest.raises(ConnectorRuntimeError) as error:
+            load_runtime_values(
+                db, task=db.get(Task, task_id), turn_id="turn-1", required=True
+            )
+        assert error.value.code == (
+            ERROR_RUNTIME_SECRET_UNAVAILABLE
+            if key_state == "rotated"
+            else ERROR_CONNECTOR_RUNTIME_UNAVAILABLE
+        )
+        assert error.value.status_code == 503
+        assert "synthetic-secret" not in str(error.value)
+        assert db.query(TaskRuntimeSecret).count() == 1

--- a/tests/web/test_startup_admission.py
+++ b/tests/web/test_startup_admission.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
@@ -206,3 +207,17 @@ async def test_failed_admission_with_due_trigger_launches_no_background_work(
             assert persisted.last_run_at is None
     finally:
         drop_all_tables(get_engine())
+
+
+@pytest.mark.asyncio
+async def test_unwired_shared_execution_refuses_startup_before_database(monkeypatch):
+    monkeypatch.setenv("XAGENT_SHARED_TASK_EXECUTION_ENABLED", "true")
+    initialize = AsyncMock()
+    monkeypatch.setattr(
+        app_module, "_initialize_database_and_admit_runtime", initialize
+    )
+    with pytest.raises(
+        RuntimeError, match="XAGENT_SHARED_TASK_EXECUTION_ENABLED must remain false"
+    ):
+        await app_module.startup_event()
+    initialize.assert_not_awaited()


### PR DESCRIPTION
Follow-up to #2372 addressing Alex’s review. Shared execution foundations previously allowed connector inputs to be encrypted with the public development key, lacked PostgreSQL migration coverage in CI, and left several socket cleanup and stream recovery cases untested.

- Reject missing, default, or invalid encryption keys before storing runtime credentials, including when another feature has cached the development cipher. Runtime consumers share one development-key constant; reads distinguish invalid key configuration from failure to decrypt stored inputs. Document that paused/waiting executions require fresh inputs on resume and that ingress integration must wire cleanup alongside writes.
- Refuse application startup while the unwired shared-execution flag is enabled. Add diagnostics for missing reply routes and socket writers, retain overflow close tasks, and unregister each writer once, including overflow before its run loop starts. Integration tests also cover the real manager/writer disconnect re-entry and both origin registries.
- Add the PostgreSQL migration CI step, real reconciliation lifecycle coverage, bounded ACK waits, and completed-answer recovery/late-start regressions. Remove the redundant stream completion check and the accepted-turn deep copy; clarify local output persistence and retain the re-export used by the v1 SSE endpoint.

Validation: 609 focused backend, configuration, encryption, and model tests passed for the current changes. The unchanged frontend and migration paths have 304 frontend tests and 8 SQLite/PostgreSQL migration tests passing from the preceding validation. All applicable pre-commit hooks passed, including mypy. Mutation checks verified the recovery guards and ACK regression fail when their protections are removed. The earlier real Redis reconnect test was skipped because its service URL was not configured.
